### PR TITLE
feat(notations): Process Blueprint render module + preview (#26)

### DIFF
--- a/examples/process-blueprint/README.md
+++ b/examples/process-blueprint/README.md
@@ -1,0 +1,56 @@
+# Process Blueprint notation — examples
+
+File extension: **`.process-blueprint.transitrix.yaml`**
+
+## Format overview
+
+A process blueprint is a wide, single-page diagram that maps each stage of a value chain to its supporting operational context — systems, actors, equipment, and information entities — together with the stage's goal and result. Stages are laid out left to right; each stage is a column, and the aspect categories are fixed rows that align horizontally across columns.
+
+The data shape is **flat**: a single `process_blueprint:` root with parallel arrays for `stages[]` and the four aspect categories. Each aspect entry carries a `stages: [STAGE-…]` cross-reference listing every stage it appears in. The nested-box visual is derived from this flat shape by the renderer — entries spanning consecutive stages render as a single pill; entries on non-consecutive stages render as one pill per stage.
+
+## Files in this folder
+
+| File | Description |
+|---|---|
+| [`order-fulfilment.process-blueprint.transitrix.yaml`](order-fulfilment.process-blueprint.transitrix.yaml) | Three-stage retail order-fulfilment blueprint (Receive → Pick & pack → Ship) with all four aspect categories populated |
+
+## Notation header
+
+Every file must start with:
+
+```yaml
+notation: process-blueprint
+```
+
+## Required fields
+
+| Field | Description |
+|---|---|
+| `process_blueprint.id` | Pattern `PROCESS_BLUEPRINT-[<middle>-]<INTEGER>` |
+| `process_blueprint.name` | Display name |
+| `process_blueprint.stages` | Non-empty array of stage entries |
+| `stages[].id` | Pattern `STAGE-[<middle>-]<INTEGER>`; unique within the document |
+| `stages[].name` | Stage name |
+| `stages[].goal` | What the stage should achieve, one short sentence |
+| `stages[].result` | The deliverable that exits the stage, one short sentence |
+
+## Optional fields
+
+| Field | Description |
+|---|---|
+| `process_blueprint.description` / `period` / `version` / `date` / `author` | Document metadata |
+| `process_blueprint.process` / `scenario` | Cross-references to a `PROCESS-…` or `SCENARIO-…` element |
+| `process_blueprint.systems[]` | Applications used in the stages — entries with `id` must use the `APPLICATION-` prefix |
+| `process_blueprint.actors[]` | Roles carrying out the stages — entries with `id` must use the `ROLE-` prefix |
+| `process_blueprint.equipment[]` | Physical instruments — free-form labels in v0.1 |
+| `process_blueprint.information_entities[]` | Data, documents, records — free-form labels in v0.1 |
+
+Every aspect entry has `name` and `stages: [STAGE-…]` (non-empty). An entry's `id` is optional; when present it must match the canonical grammar `<TYPE>-[<middle>-]<INTEGER>`.
+
+## Preview
+
+Open any `.process-blueprint.transitrix.yaml` file in VS Code with Transitrix Studio installed — the preview panel opens automatically showing the value chain as a horizontal grid: stages across the top, goal/result rows above the fixed aspect rows (systems → actors → equipment → information). Entries spanning consecutive stages render as a single pill; entries on non-consecutive stages render as one pill per stage.
+
+## Canonical reference
+
+The canonical spec lives in the [methodology repo](https://github.com/transitrix/methodology) at [`notations/13-process-blueprint.md`](https://github.com/transitrix/methodology/blob/main/notations/13-process-blueprint.md).

--- a/examples/process-blueprint/order-fulfilment.process-blueprint.transitrix.yaml
+++ b/examples/process-blueprint/order-fulfilment.process-blueprint.transitrix.yaml
@@ -1,0 +1,63 @@
+notation: process-blueprint
+spec_version: "0.1"
+
+process_blueprint:
+  id: PROCESS_BLUEPRINT-FULFIL-1
+  name: "Order fulfilment blueprint"
+  description: "End-to-end blueprint of the order fulfilment value chain."
+  period: "2026"
+  version: "0.1"
+  date: "2026-05-21"
+  author: "Valerii Korobeinikov"
+
+  stages:
+    - id: STAGE-1
+      name: "Receive order"
+      goal: "Capture a validated customer order."
+      result: "Validated order record in OMS."
+    - id: STAGE-2
+      name: "Pick & pack"
+      goal: "Assemble the physical order from inventory."
+      result: "Packed shipment ready for carrier handover."
+    - id: STAGE-3
+      name: "Ship"
+      goal: "Hand the shipment to the carrier and notify the customer."
+      result: "In-transit shipment with tracking number sent to the customer."
+
+  systems:
+    - id: APPLICATION-OMS-1
+      name: "Order Management"
+      stages: [STAGE-1, STAGE-2, STAGE-3]
+    - name: "Legacy CRM"
+      stages: [STAGE-1]
+    - id: APPLICATION-WMS-1
+      name: "Warehouse Management"
+      stages: [STAGE-2]
+    - id: APPLICATION-CARRIER-API-1
+      name: "Carrier integration"
+      stages: [STAGE-3]
+
+  actors:
+    - id: ROLE-CUSTOMER-SVC-1
+      name: "Customer service"
+      stages: [STAGE-1]
+    - id: ROLE-WAREHOUSE-OP-1
+      name: "Warehouse operator"
+      stages: [STAGE-2, STAGE-3]
+    - id: ROLE-LOGISTICS-COORD-1
+      name: "Logistics coordinator"
+      stages: [STAGE-3]
+
+  equipment:
+    - name: "Barcode scanner"
+      stages: [STAGE-2, STAGE-3]
+    - name: "Packing station"
+      stages: [STAGE-2]
+
+  information_entities:
+    - name: "Customer order"
+      stages: [STAGE-1, STAGE-2, STAGE-3]
+    - name: "Inventory record"
+      stages: [STAGE-2]
+    - name: "Shipment manifest"
+      stages: [STAGE-3]

--- a/extension/package.json
+++ b/extension/package.json
@@ -170,6 +170,17 @@
           ".capability-map.transitrix.yaml"
         ],
         "configuration": "./language-configuration.json"
+      },
+      {
+        "id": "transitrix-process-blueprint",
+        "aliases": [
+          "Transitrix Process Blueprint",
+          "Process Blueprint"
+        ],
+        "extensions": [
+          ".process-blueprint.transitrix.yaml"
+        ],
+        "configuration": "./language-configuration.json"
       }
     ],
     "commands": [
@@ -286,6 +297,18 @@
         "title": "Transitrix: Preview capability map",
         "category": "Transitrix",
         "icon": "$(type-hierarchy)"
+      },
+      {
+        "command": "transitrixStudio.previewProcessBlueprint",
+        "title": "Transitrix: Preview process blueprint",
+        "category": "Transitrix",
+        "icon": "$(layout)"
+      },
+      {
+        "command": "transitrixStudio.saveProcessBlueprintAsSvg",
+        "title": "Transitrix: Save process blueprint as SVG",
+        "category": "Transitrix",
+        "icon": "$(save)"
       }
     ],
     "menus": {
@@ -394,6 +417,21 @@
           "when": "resourceFilename =~ /\\.capability-map\\.transitrix\\.yaml$/",
           "command": "transitrixStudio.previewCapabilityMap",
           "group": "navigation@-10"
+        },
+        {
+          "when": "resourceFilename =~ /\\.process-blueprint\\.transitrix\\.yaml$/",
+          "command": "transitrixStudio.previewProcessBlueprint",
+          "group": "navigation@-10"
+        },
+        {
+          "when": "resourceFilename =~ /\\.process-blueprint\\.transitrix\\.yaml$/",
+          "command": "transitrixStudio.saveProcessBlueprintAsSvg",
+          "group": "navigation@-9"
+        },
+        {
+          "when": "activeWebviewPanelId == processBlueprintPreview",
+          "command": "transitrixStudio.saveProcessBlueprintAsSvg",
+          "group": "navigation@-9"
         }
       ]
     }

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -13,6 +13,7 @@ import { ProductsPreview } from './products-preview.js';
 import { ProcessMapPreview } from './process-map-preview.js';
 import { ScenariosPreview } from './scenarios-preview.js';
 import { CapabilityMapPreview } from './capability-map-preview.js';
+import { ProcessBlueprintPreview } from './process-blueprint-preview.js';
 import type { LayoutMetrics, ValidationReport } from './types.js';
 import {
   documentMatchesCervinSource,
@@ -58,6 +59,10 @@ function isScenariosFile(doc: vscode.TextDocument): boolean {
 
 function isCapabilityMapFile(doc: vscode.TextDocument): boolean {
   return doc.fileName.endsWith('.capability-map.transitrix.yaml');
+}
+
+function isProcessBlueprintFile(doc: vscode.TextDocument): boolean {
+  return doc.fileName.endsWith('.process-blueprint.transitrix.yaml');
 }
 
 async function loadCompiler(ext: vscode.ExtensionContext): Promise<CompileFn> {
@@ -117,6 +122,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   const processMapPreview = new ProcessMapPreview();
   const scenariosPreview = new ScenariosPreview();
   const capabilityMapPreview = new CapabilityMapPreview();
+  const processBlueprintPreview = new ProcessBlueprintPreview();
 
   context.subscriptions.push(
     vscode.commands.registerCommand('cervin.openPreview', async () => {
@@ -228,6 +234,17 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       }
       await capabilityMapPreview.showOrReveal(doc);
     }),
+    vscode.commands.registerCommand('transitrixStudio.previewProcessBlueprint', async () => {
+      const doc = vscode.window.activeTextEditor?.document;
+      if (!doc || !isProcessBlueprintFile(doc)) {
+        vscode.window.showWarningMessage('Open a *.process-blueprint.transitrix.yaml file first.');
+        return;
+      }
+      await processBlueprintPreview.showOrReveal(doc);
+    }),
+    vscode.commands.registerCommand('transitrixStudio.saveProcessBlueprintAsSvg', async () => {
+      await processBlueprintPreview.saveAsSvg();
+    }),
     vscode.workspace.onDidSaveTextDocument((doc) => {
       if (isGoalsFile(doc)) { void goalsPreview.refreshSaved(doc); return; }
       if (isFGCAFile(doc)) { void fgcaPreview.refreshSaved(doc); return; }
@@ -239,6 +256,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       if (isProcessMapFile(doc)) { void processMapPreview.refreshSaved(doc); return; }
       if (isScenariosFile(doc)) { void scenariosPreview.refreshSaved(doc); return; }
       if (isCapabilityMapFile(doc)) { void capabilityMapPreview.refreshSaved(doc); return; }
+      if (isProcessBlueprintFile(doc)) { void processBlueprintPreview.refreshSaved(doc); return; }
       if (!documentMatchesCervinSource(doc)) return;
       void preview.refreshSaved(doc);
     }),
@@ -252,7 +270,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       if (isProductsFile(doc)) { await productsPreview.showOrReveal(doc); return; }
       if (isProcessMapFile(doc)) { await processMapPreview.showOrReveal(doc); return; }
       if (isScenariosFile(doc)) { await scenariosPreview.showOrReveal(doc); return; }
-      if (isCapabilityMapFile(doc)) { await capabilityMapPreview.showOrReveal(doc); }
+      if (isCapabilityMapFile(doc)) { await capabilityMapPreview.showOrReveal(doc); return; }
+      if (isProcessBlueprintFile(doc)) { await processBlueprintPreview.showOrReveal(doc); }
     }),
   );
 }

--- a/extension/src/process-blueprint-preview.ts
+++ b/extension/src/process-blueprint-preview.ts
@@ -2,334 +2,23 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, prepareSvgForExport, type ThemeId } from './diagram-frame.js';
-
-// ── Inline types (mirror packages/diagrams/src/process-blueprint/types.ts) ───
-
-type AspectCategory = 'systems' | 'actors' | 'equipment' | 'information_entities';
-
-interface Stage {
-  id: string;
-  name: string;
-  goal: string;
-  result: string;
-}
-
-interface AspectEntry {
-  id?: string;
-  name: string;
-  stages: string[];
-}
-
-interface ProcessBlueprintHeader {
-  id: string;
-  name: string;
-  stages: Stage[];
-  systems?: AspectEntry[];
-  actors?: AspectEntry[];
-  equipment?: AspectEntry[];
-  information_entities?: AspectEntry[];
-}
-
-interface ProcessBlueprintFile {
-  notation: string;
-  spec_version?: string;
-  process_blueprint: ProcessBlueprintHeader;
-}
-
-interface ValidationError { code: string; message: string; }
-interface ValidationResult {
-  valid: boolean;
-  errors: ValidationError[];
-  warnings: Array<{ code: string; message: string }>;
-}
-
-// ── Inline validation (mirrors packages/diagrams/src/process-blueprint/validate.ts) ─
-
-const ID_GRAMMAR_RE = /^[A-Z][A-Z_]*(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
-const PROCESS_BLUEPRINT_ID_RE = /^PROCESS_BLUEPRINT(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
-const STAGE_ID_RE = /^STAGE(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
-const APPLICATION_ID_RE = /^APPLICATION(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
-const ROLE_ID_RE = /^ROLE(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
-const ASPECT_CATEGORIES: AspectCategory[] = ['systems', 'actors', 'equipment', 'information_entities'];
-
-function isNonEmptyString(v: unknown): v is string {
-  return typeof v === 'string' && v.trim().length > 0;
-}
-
-function validateProcessBlueprint(input: unknown): ValidationResult {
-  const errors: ValidationError[] = [];
-  const warnings: Array<{ code: string; message: string }> = [];
-
-  if (!input || typeof input !== 'object') {
-    return { valid: false, errors: [{ code: 'BP-001', message: 'Input must be an object' }], warnings };
-  }
-  const raw = input as Record<string, unknown>;
-
-  if ('notation' in raw && raw['notation'] !== 'process-blueprint') {
-    errors.push({ code: 'BP-001', message: `notation must be "process-blueprint", got "${String(raw['notation'])}"` });
-  }
-
-  if (!('process_blueprint' in raw) || !raw['process_blueprint'] || typeof raw['process_blueprint'] !== 'object') {
-    errors.push({ code: 'BP-001', message: 'Missing required root key: process_blueprint' });
-    return { valid: false, errors, warnings };
-  }
-  const pb = raw['process_blueprint'] as Record<string, unknown>;
-
-  if (!isNonEmptyString(pb['id'])) {
-    errors.push({ code: 'BP-002', message: 'process_blueprint.id is required' });
-  } else if (!PROCESS_BLUEPRINT_ID_RE.test(pb['id'])) {
-    errors.push({ code: 'BP-002', message: `process_blueprint.id "${pb['id']}" must match PROCESS_BLUEPRINT-[<middle>-]<INTEGER>` });
-  }
-  if (!isNonEmptyString(pb['name'])) {
-    errors.push({ code: 'BP-003', message: 'process_blueprint.name is required' });
-  }
-
-  const stagesRaw = pb['stages'];
-  if (!Array.isArray(stagesRaw) || stagesRaw.length === 0) {
-    errors.push({ code: 'BP-004', message: 'process_blueprint.stages must be a non-empty array' });
-    return { valid: false, errors, warnings };
-  }
-
-  const stageIds = new Set<string>();
-  for (let i = 0; i < stagesRaw.length; i++) {
-    const s = stagesRaw[i] as Record<string, unknown> | undefined;
-    const p = `stages[${i}]`;
-    if (!s || typeof s !== 'object') {
-      errors.push({ code: 'BP-005', message: `${p} must be an object` });
-      continue;
-    }
-    if (!isNonEmptyString(s['id'])) {
-      errors.push({ code: 'BP-005', message: `${p}.id is required` });
-    } else {
-      const sid = s['id'];
-      if (stageIds.has(sid)) errors.push({ code: 'BP-006', message: `Duplicate stage id: "${sid}"` });
-      else stageIds.add(sid);
-      if (!STAGE_ID_RE.test(sid)) errors.push({ code: 'BP-006', message: `${p}.id "${sid}" must match STAGE-[<middle>-]<INTEGER>` });
-    }
-    if (!isNonEmptyString(s['name'])) errors.push({ code: 'BP-005', message: `${p}.name is required` });
-    if (!isNonEmptyString(s['goal'])) errors.push({ code: 'BP-005', message: `${p}.goal is required` });
-    if (!isNonEmptyString(s['result'])) errors.push({ code: 'BP-005', message: `${p}.result is required` });
-  }
-
-  const usedStageIds = new Set<string>();
-  for (const category of ASPECT_CATEGORIES) {
-    const arr = pb[category];
-    if (arr === undefined) continue;
-    if (!Array.isArray(arr)) {
-      errors.push({ code: 'BP-007', message: `process_blueprint.${category} must be an array` });
-      continue;
-    }
-    for (let i = 0; i < arr.length; i++) {
-      const e = arr[i] as Record<string, unknown> | undefined;
-      const p = `${category}[${i}]`;
-      if (!e || typeof e !== 'object') { errors.push({ code: 'BP-007', message: `${p} must be an object` }); continue; }
-      if (!isNonEmptyString(e['name'])) errors.push({ code: 'BP-007', message: `${p}.name is required` });
-      const entryStages = e['stages'];
-      if (!Array.isArray(entryStages) || entryStages.length === 0) {
-        errors.push({ code: 'BP-007', message: `${p}.stages must be a non-empty array of STAGE-… ids` });
-      } else {
-        for (let j = 0; j < entryStages.length; j++) {
-          const ref = entryStages[j];
-          if (typeof ref !== 'string') { errors.push({ code: 'BP-008', message: `${p}.stages[${j}] must be a string` }); continue; }
-          if (!stageIds.has(ref)) errors.push({ code: 'BP-008', message: `${p}.stages[${j}] references undeclared stage "${ref}"` });
-          else usedStageIds.add(ref);
-        }
-        if (entryStages.length === 1) {
-          warnings.push({ code: 'BP-012', message: `${p}.stages references a single stage — entry may be a candidate for inlining` });
-        }
-      }
-      const entryId = e['id'];
-      if (entryId !== undefined) {
-        if (typeof entryId !== 'string') errors.push({ code: 'BP-009', message: `${p}.id must be a string` });
-        else if (!ID_GRAMMAR_RE.test(entryId)) errors.push({ code: 'BP-009', message: `${p}.id "${entryId}" must match <TYPE>-[<middle>-]<INTEGER>` });
-        else if (category === 'systems' && !APPLICATION_ID_RE.test(entryId)) errors.push({ code: 'BP-010', message: `${p}.id "${entryId}" must use the APPLICATION- prefix` });
-        else if (category === 'actors' && !ROLE_ID_RE.test(entryId)) errors.push({ code: 'BP-010', message: `${p}.id "${entryId}" must use the ROLE- prefix` });
-      }
-    }
-  }
-
-  for (const sid of stageIds) {
-    if (!usedStageIds.has(sid)) {
-      warnings.push({ code: 'BP-011', message: `Stage "${sid}" has no aspect entries pointing at it — structurally empty` });
-    }
-  }
-
-  return { valid: errors.length === 0, errors, warnings };
-}
-
-// ── Inline layout (mirrors packages/diagrams/src/process-blueprint/layout.ts) ─
-
-interface RawPill {
-  category: AspectCategory;
-  name: string;
-  id?: string;
-  startStageIndex: number;
-  endStageIndex: number;
-}
-
-interface AspectPill extends RawPill {
-  x: number; y: number; width: number; height: number;
-}
-
-interface AspectRow {
-  category: AspectCategory;
-  y: number;
-  height: number;
-  pills: AspectPill[];
-}
-
-interface StageCell { stageIndex: number; x: number; y: number; width: number; height: number; }
-interface StageHeader extends StageCell { id: string; name: string; }
-interface StageText extends StageCell { text: string; }
-interface LegendCell { label: string; y: number; height: number; }
-
-interface PBLayout {
-  bounds: { x: number; y: number; width: number; height: number };
-  legendColumnWidth: number;
-  stageColumnWidth: number;
-  legend: LegendCell[];
-  stageHeaders: StageHeader[];
-  goalCells: StageText[];
-  resultCells: StageText[];
-  aspectRows: AspectRow[];
-}
-
-const LEGEND_W = 140;
-const STAGE_W = 220;
-const HEADER_H = 40;
-const GOAL_H = 56;
-const RESULT_H = 56;
-const ASPECT_MIN_H = 60;
-const PILL_H = 28;
-const PILL_GAP = 4;
-const PAD = 8;
-
-const ASPECT_LABEL: Record<AspectCategory, string> = {
-  systems: 'Systems',
-  actors: 'Actors',
-  equipment: 'Equipment',
-  information_entities: 'Information',
-};
-
-function pillsForEntry(category: AspectCategory, entry: AspectEntry, stageIndexById: Map<string, number>): RawPill[] {
-  if (!Array.isArray(entry.stages)) return [];
-  const idxs: number[] = [];
-  const seen = new Set<number>();
-  for (const ref of entry.stages) {
-    if (typeof ref !== 'string') continue;
-    const i = stageIndexById.get(ref);
-    if (i === undefined || seen.has(i)) continue;
-    seen.add(i);
-    idxs.push(i);
-  }
-  idxs.sort((a, b) => a - b);
-  const out: RawPill[] = [];
-  let s: number | null = null, e: number | null = null;
-  for (const i of idxs) {
-    if (s === null || e === null) { s = i; e = i; continue; }
-    if (i === e + 1) { e = i; } else {
-      out.push({ category, name: entry.name, id: entry.id, startStageIndex: s, endStageIndex: e });
-      s = i; e = i;
-    }
-  }
-  if (s !== null && e !== null) {
-    out.push({ category, name: entry.name, id: entry.id, startStageIndex: s, endStageIndex: e });
-  }
-  return out;
-}
-
-function packIntoSlots(pills: RawPill[]): { slot: number[]; maxSlot: number } {
-  const order = pills.map((_, i) => i).sort((a, b) => pills[a].startStageIndex - pills[b].startStageIndex || pills[a].endStageIndex - pills[b].endStageIndex);
-  const slotEnd: number[] = [];
-  const slot = new Array<number>(pills.length).fill(0);
-  let maxSlot = 0;
-  for (const i of order) {
-    const p = pills[i];
-    let placed = false;
-    for (let s = 0; s < slotEnd.length; s++) {
-      if (slotEnd[s] < p.startStageIndex) { slot[i] = s; slotEnd[s] = p.endStageIndex; placed = true; break; }
-    }
-    if (!placed) { slot[i] = slotEnd.length; slotEnd.push(p.endStageIndex); }
-    if (slot[i] > maxSlot) maxSlot = slot[i];
-  }
-  return { slot, maxSlot };
-}
-
-function layoutProcessBlueprint(file: ProcessBlueprintFile): PBLayout {
-  const pb = file.process_blueprint;
-  const stages = Array.isArray(pb?.stages) ? pb.stages : [];
-  const stageIndexById = new Map<string, number>();
-  for (let i = 0; i < stages.length; i++) {
-    const sid = stages[i]?.id;
-    if (typeof sid === 'string' && sid.length > 0 && !stageIndexById.has(sid)) stageIndexById.set(sid, i);
-  }
-
-  const stageHeaders: StageHeader[] = stages.map((s, i) => ({
-    stageIndex: i, id: s?.id ?? '', name: s?.name ?? '',
-    x: LEGEND_W + i * STAGE_W, y: 0, width: STAGE_W, height: HEADER_H,
-  }));
-  const goalRowY = HEADER_H;
-  const resultRowY = goalRowY + GOAL_H;
-  const goalCells: StageText[] = stages.map((s, i) => ({
-    stageIndex: i, text: s?.goal ?? '',
-    x: LEGEND_W + i * STAGE_W, y: goalRowY, width: STAGE_W, height: GOAL_H,
-  }));
-  const resultCells: StageText[] = stages.map((s, i) => ({
-    stageIndex: i, text: s?.result ?? '',
-    x: LEGEND_W + i * STAGE_W, y: resultRowY, width: STAGE_W, height: RESULT_H,
-  }));
-
-  let cursorY = resultRowY + RESULT_H;
-  const aspectRows: AspectRow[] = [];
-  for (const category of ASPECT_CATEGORIES) {
-    const arr = pb?.[category];
-    if (!Array.isArray(arr) || arr.length === 0) continue;
-    const raw: RawPill[] = [];
-    for (const e of arr) {
-      if (!e || typeof e !== 'object') continue;
-      raw.push(...pillsForEntry(category, e as AspectEntry, stageIndexById));
-    }
-    if (raw.length === 0) continue;
-    const { slot, maxSlot } = packIntoSlots(raw);
-    const contentH = (maxSlot + 1) * (PILL_H + PILL_GAP) - PILL_GAP;
-    const rowH = Math.max(ASPECT_MIN_H, contentH + 2 * PAD);
-    const pills: AspectPill[] = raw.map((p, i) => ({
-      ...p,
-      x: LEGEND_W + p.startStageIndex * STAGE_W + PAD,
-      width: (p.endStageIndex - p.startStageIndex + 1) * STAGE_W - 2 * PAD,
-      y: cursorY + PAD + slot[i] * (PILL_H + PILL_GAP),
-      height: PILL_H,
-    }));
-    aspectRows.push({ category, y: cursorY, height: rowH, pills });
-    cursorY += rowH;
-  }
-
-  const legend: LegendCell[] = [
-    { label: 'Goal', y: goalRowY, height: GOAL_H },
-    { label: 'Result', y: resultRowY, height: RESULT_H },
-    ...aspectRows.map(r => ({ label: ASPECT_LABEL[r.category], y: r.y, height: r.height })),
-  ];
-
-  return {
-    bounds: { x: 0, y: 0, width: LEGEND_W + stages.length * STAGE_W, height: cursorY },
-    legendColumnWidth: LEGEND_W,
-    stageColumnWidth: STAGE_W,
-    legend, stageHeaders, goalCells, resultCells, aspectRows,
-  };
-}
-
-// ── SVG renderer ─────────────────────────────────────────────────────────────
+import {
+  validateProcessBlueprint,
+  layoutProcessBlueprint,
+  type ProcessBlueprintFile,
+  type ProcessBlueprintLayout,
+} from '../../packages/diagrams/src/process-blueprint/index.js';
 
 function escXml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
 
-function wrapText(text: string, maxChars: number): string {
+function truncate(text: string, maxChars: number): string {
   if (text.length <= maxChars) return text;
-  return text.slice(0, maxChars - 1) + '…';
+  return text.slice(0, Math.max(0, maxChars - 1)) + '…';
 }
 
-function layoutToSvg(layout: PBLayout): string {
+function layoutToSvg(layout: ProcessBlueprintLayout): string {
   const pad = 24;
   const w = layout.bounds.width + pad * 2;
   const h = layout.bounds.height + pad * 2;
@@ -338,46 +27,65 @@ function layoutToSvg(layout: PBLayout): string {
 
   const parts: string[] = [];
 
-  // Outer container
-  parts.push(`<rect class="diagram-node level-0" x="${ox}" y="${oy}" width="${layout.bounds.width}" height="${layout.bounds.height}" rx="6"/>`);
+  parts.push(
+    `<rect class="diagram-node level-0" x="${ox}" y="${oy}" width="${layout.bounds.width}" height="${layout.bounds.height}" rx="6"/>`,
+  );
 
-  // Stage headers
   for (const s of layout.stageHeaders) {
-    parts.push(`<rect class="diagram-node level-1" x="${s.x + ox}" y="${s.y + oy}" width="${s.width}" height="${s.height}"/>`);
-    parts.push(`<text class="text-primary" x="${s.x + ox + s.width / 2}" y="${s.y + oy + s.height / 2 + 4}" text-anchor="middle" font-size="13" font-weight="600" font-family="system-ui,sans-serif">${escXml(wrapText(s.name, 28))}</text>`);
+    parts.push(
+      `<rect class="diagram-node level-1" x="${s.x + ox}" y="${s.y + oy}" width="${s.width}" height="${s.height}"/>`,
+    );
+    parts.push(
+      `<text class="text-primary" x="${s.x + ox + s.width / 2}" y="${s.y + oy + s.height / 2 + 4}" text-anchor="middle" font-size="13" font-weight="600" font-family="system-ui,sans-serif">${escXml(truncate(s.name, 28))}</text>`,
+    );
   }
 
-  // Legend column labels
   for (const l of layout.legend) {
-    parts.push(`<rect class="diagram-node level-2" x="${ox}" y="${l.y + oy}" width="${layout.legendColumnWidth}" height="${l.height}"/>`);
-    parts.push(`<text class="text-secondary" x="${ox + 12}" y="${l.y + oy + l.height / 2 + 4}" font-size="12" font-weight="600" font-family="system-ui,sans-serif">${escXml(l.label)}</text>`);
+    parts.push(
+      `<rect class="diagram-node level-2" x="${ox}" y="${l.y + oy}" width="${layout.legendColumnWidth}" height="${l.height}"/>`,
+    );
+    parts.push(
+      `<text class="text-secondary" x="${ox + 12}" y="${l.y + oy + l.height / 2 + 4}" font-size="12" font-weight="600" font-family="system-ui,sans-serif">${escXml(l.label)}</text>`,
+    );
   }
 
-  // Goal + result cells
   for (const c of layout.goalCells) {
-    parts.push(`<rect class="diagram-node level-3" x="${c.x + ox}" y="${c.y + oy}" width="${c.width}" height="${c.height}"/>`);
-    parts.push(`<text class="text-primary" x="${c.x + ox + 10}" y="${c.y + oy + 22}" font-size="12" font-family="system-ui,sans-serif">${escXml(wrapText(c.text, 32))}</text>`);
+    parts.push(
+      `<rect class="diagram-node level-3" x="${c.x + ox}" y="${c.y + oy}" width="${c.width}" height="${c.height}"/>`,
+    );
+    parts.push(
+      `<text class="text-primary" x="${c.x + ox + 10}" y="${c.y + oy + 22}" font-size="12" font-family="system-ui,sans-serif">${escXml(truncate(c.text, 32))}</text>`,
+    );
   }
   for (const c of layout.resultCells) {
-    parts.push(`<rect class="diagram-node level-4" x="${c.x + ox}" y="${c.y + oy}" width="${c.width}" height="${c.height}"/>`);
-    parts.push(`<text class="text-primary" x="${c.x + ox + 10}" y="${c.y + oy + 22}" font-size="12" font-family="system-ui,sans-serif">${escXml(wrapText(c.text, 32))}</text>`);
+    parts.push(
+      `<rect class="diagram-node level-4" x="${c.x + ox}" y="${c.y + oy}" width="${c.width}" height="${c.height}"/>`,
+    );
+    parts.push(
+      `<text class="text-primary" x="${c.x + ox + 10}" y="${c.y + oy + 22}" font-size="12" font-family="system-ui,sans-serif">${escXml(truncate(c.text, 32))}</text>`,
+    );
   }
 
-  // Aspect rows + pills
   for (let r = 0; r < layout.aspectRows.length; r++) {
     const row = layout.aspectRows[r];
     const level = 5 + (r % 3);
-    // Row backdrop spanning all stage columns
-    parts.push(`<rect class="diagram-node level-${level}" x="${layout.legendColumnWidth + ox}" y="${row.y + oy}" width="${layout.bounds.width - layout.legendColumnWidth}" height="${row.height}" opacity="0.15"/>`);
-    // Column dividers
+    parts.push(
+      `<rect class="diagram-node level-${level}" x="${layout.legendColumnWidth + ox}" y="${row.y + oy}" width="${layout.bounds.width - layout.legendColumnWidth}" height="${row.height}" opacity="0.15"/>`,
+    );
     for (let i = 1; i < layout.stageHeaders.length; i++) {
       const x = layout.legendColumnWidth + i * layout.stageColumnWidth + ox;
-      parts.push(`<line class="diagram-edge" x1="${x}" y1="${row.y + oy}" x2="${x}" y2="${row.y + row.height + oy}" opacity="0.3"/>`);
+      parts.push(
+        `<line class="diagram-edge" x1="${x}" y1="${row.y + oy}" x2="${x}" y2="${row.y + row.height + oy}" opacity="0.3"/>`,
+      );
     }
     for (const p of row.pills) {
-      parts.push(`<rect class="diagram-node level-${level}" x="${p.x + ox}" y="${p.y + oy}" width="${p.width}" height="${p.height}" rx="6"/>`);
+      parts.push(
+        `<rect class="diagram-node level-${level}" x="${p.x + ox}" y="${p.y + oy}" width="${p.width}" height="${p.height}" rx="6"/>`,
+      );
       const label = p.id ? `${p.name} · ${p.id}` : p.name;
-      parts.push(`<text class="text-primary" x="${p.x + ox + p.width / 2}" y="${p.y + oy + p.height / 2 + 4}" text-anchor="middle" font-size="11" font-weight="500" font-family="system-ui,sans-serif">${escXml(wrapText(label, Math.floor(p.width / 8)))}</text>`);
+      parts.push(
+        `<text class="text-primary" x="${p.x + ox + p.width / 2}" y="${p.y + oy + p.height / 2 + 4}" text-anchor="middle" font-size="11" font-weight="500" font-family="system-ui,sans-serif">${escXml(truncate(label, Math.floor(p.width / 8)))}</text>`,
+      );
     }
   }
 
@@ -385,8 +93,6 @@ function layoutToSvg(layout: PBLayout): string {
 ${parts.join('\n')}
 </svg>`;
 }
-
-// ── ProcessBlueprintPreview webview class ────────────────────────────────────
 
 export class ProcessBlueprintPreview {
   readonly panelTitle = 'Process Blueprint Preview';

--- a/extension/src/process-blueprint-preview.ts
+++ b/extension/src/process-blueprint-preview.ts
@@ -1,0 +1,476 @@
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+import yaml from 'js-yaml';
+import { buildDiagramFrame, prepareSvgForExport, type ThemeId } from './diagram-frame.js';
+
+// ── Inline types (mirror packages/diagrams/src/process-blueprint/types.ts) ───
+
+type AspectCategory = 'systems' | 'actors' | 'equipment' | 'information_entities';
+
+interface Stage {
+  id: string;
+  name: string;
+  goal: string;
+  result: string;
+}
+
+interface AspectEntry {
+  id?: string;
+  name: string;
+  stages: string[];
+}
+
+interface ProcessBlueprintHeader {
+  id: string;
+  name: string;
+  stages: Stage[];
+  systems?: AspectEntry[];
+  actors?: AspectEntry[];
+  equipment?: AspectEntry[];
+  information_entities?: AspectEntry[];
+}
+
+interface ProcessBlueprintFile {
+  notation: string;
+  spec_version?: string;
+  process_blueprint: ProcessBlueprintHeader;
+}
+
+interface ValidationError { code: string; message: string; }
+interface ValidationResult {
+  valid: boolean;
+  errors: ValidationError[];
+  warnings: Array<{ code: string; message: string }>;
+}
+
+// ── Inline validation (mirrors packages/diagrams/src/process-blueprint/validate.ts) ─
+
+const ID_GRAMMAR_RE = /^[A-Z][A-Z_]*(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
+const PROCESS_BLUEPRINT_ID_RE = /^PROCESS_BLUEPRINT(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
+const STAGE_ID_RE = /^STAGE(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
+const APPLICATION_ID_RE = /^APPLICATION(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
+const ROLE_ID_RE = /^ROLE(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
+const ASPECT_CATEGORIES: AspectCategory[] = ['systems', 'actors', 'equipment', 'information_entities'];
+
+function isNonEmptyString(v: unknown): v is string {
+  return typeof v === 'string' && v.trim().length > 0;
+}
+
+function validateProcessBlueprint(input: unknown): ValidationResult {
+  const errors: ValidationError[] = [];
+  const warnings: Array<{ code: string; message: string }> = [];
+
+  if (!input || typeof input !== 'object') {
+    return { valid: false, errors: [{ code: 'BP-001', message: 'Input must be an object' }], warnings };
+  }
+  const raw = input as Record<string, unknown>;
+
+  if ('notation' in raw && raw['notation'] !== 'process-blueprint') {
+    errors.push({ code: 'BP-001', message: `notation must be "process-blueprint", got "${String(raw['notation'])}"` });
+  }
+
+  if (!('process_blueprint' in raw) || !raw['process_blueprint'] || typeof raw['process_blueprint'] !== 'object') {
+    errors.push({ code: 'BP-001', message: 'Missing required root key: process_blueprint' });
+    return { valid: false, errors, warnings };
+  }
+  const pb = raw['process_blueprint'] as Record<string, unknown>;
+
+  if (!isNonEmptyString(pb['id'])) {
+    errors.push({ code: 'BP-002', message: 'process_blueprint.id is required' });
+  } else if (!PROCESS_BLUEPRINT_ID_RE.test(pb['id'])) {
+    errors.push({ code: 'BP-002', message: `process_blueprint.id "${pb['id']}" must match PROCESS_BLUEPRINT-[<middle>-]<INTEGER>` });
+  }
+  if (!isNonEmptyString(pb['name'])) {
+    errors.push({ code: 'BP-003', message: 'process_blueprint.name is required' });
+  }
+
+  const stagesRaw = pb['stages'];
+  if (!Array.isArray(stagesRaw) || stagesRaw.length === 0) {
+    errors.push({ code: 'BP-004', message: 'process_blueprint.stages must be a non-empty array' });
+    return { valid: false, errors, warnings };
+  }
+
+  const stageIds = new Set<string>();
+  for (let i = 0; i < stagesRaw.length; i++) {
+    const s = stagesRaw[i] as Record<string, unknown> | undefined;
+    const p = `stages[${i}]`;
+    if (!s || typeof s !== 'object') {
+      errors.push({ code: 'BP-005', message: `${p} must be an object` });
+      continue;
+    }
+    if (!isNonEmptyString(s['id'])) {
+      errors.push({ code: 'BP-005', message: `${p}.id is required` });
+    } else {
+      const sid = s['id'];
+      if (stageIds.has(sid)) errors.push({ code: 'BP-006', message: `Duplicate stage id: "${sid}"` });
+      else stageIds.add(sid);
+      if (!STAGE_ID_RE.test(sid)) errors.push({ code: 'BP-006', message: `${p}.id "${sid}" must match STAGE-[<middle>-]<INTEGER>` });
+    }
+    if (!isNonEmptyString(s['name'])) errors.push({ code: 'BP-005', message: `${p}.name is required` });
+    if (!isNonEmptyString(s['goal'])) errors.push({ code: 'BP-005', message: `${p}.goal is required` });
+    if (!isNonEmptyString(s['result'])) errors.push({ code: 'BP-005', message: `${p}.result is required` });
+  }
+
+  const usedStageIds = new Set<string>();
+  for (const category of ASPECT_CATEGORIES) {
+    const arr = pb[category];
+    if (arr === undefined) continue;
+    if (!Array.isArray(arr)) {
+      errors.push({ code: 'BP-007', message: `process_blueprint.${category} must be an array` });
+      continue;
+    }
+    for (let i = 0; i < arr.length; i++) {
+      const e = arr[i] as Record<string, unknown> | undefined;
+      const p = `${category}[${i}]`;
+      if (!e || typeof e !== 'object') { errors.push({ code: 'BP-007', message: `${p} must be an object` }); continue; }
+      if (!isNonEmptyString(e['name'])) errors.push({ code: 'BP-007', message: `${p}.name is required` });
+      const entryStages = e['stages'];
+      if (!Array.isArray(entryStages) || entryStages.length === 0) {
+        errors.push({ code: 'BP-007', message: `${p}.stages must be a non-empty array of STAGE-… ids` });
+      } else {
+        for (let j = 0; j < entryStages.length; j++) {
+          const ref = entryStages[j];
+          if (typeof ref !== 'string') { errors.push({ code: 'BP-008', message: `${p}.stages[${j}] must be a string` }); continue; }
+          if (!stageIds.has(ref)) errors.push({ code: 'BP-008', message: `${p}.stages[${j}] references undeclared stage "${ref}"` });
+          else usedStageIds.add(ref);
+        }
+        if (entryStages.length === 1) {
+          warnings.push({ code: 'BP-012', message: `${p}.stages references a single stage — entry may be a candidate for inlining` });
+        }
+      }
+      const entryId = e['id'];
+      if (entryId !== undefined) {
+        if (typeof entryId !== 'string') errors.push({ code: 'BP-009', message: `${p}.id must be a string` });
+        else if (!ID_GRAMMAR_RE.test(entryId)) errors.push({ code: 'BP-009', message: `${p}.id "${entryId}" must match <TYPE>-[<middle>-]<INTEGER>` });
+        else if (category === 'systems' && !APPLICATION_ID_RE.test(entryId)) errors.push({ code: 'BP-010', message: `${p}.id "${entryId}" must use the APPLICATION- prefix` });
+        else if (category === 'actors' && !ROLE_ID_RE.test(entryId)) errors.push({ code: 'BP-010', message: `${p}.id "${entryId}" must use the ROLE- prefix` });
+      }
+    }
+  }
+
+  for (const sid of stageIds) {
+    if (!usedStageIds.has(sid)) {
+      warnings.push({ code: 'BP-011', message: `Stage "${sid}" has no aspect entries pointing at it — structurally empty` });
+    }
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}
+
+// ── Inline layout (mirrors packages/diagrams/src/process-blueprint/layout.ts) ─
+
+interface RawPill {
+  category: AspectCategory;
+  name: string;
+  id?: string;
+  startStageIndex: number;
+  endStageIndex: number;
+}
+
+interface AspectPill extends RawPill {
+  x: number; y: number; width: number; height: number;
+}
+
+interface AspectRow {
+  category: AspectCategory;
+  y: number;
+  height: number;
+  pills: AspectPill[];
+}
+
+interface StageCell { stageIndex: number; x: number; y: number; width: number; height: number; }
+interface StageHeader extends StageCell { id: string; name: string; }
+interface StageText extends StageCell { text: string; }
+interface LegendCell { label: string; y: number; height: number; }
+
+interface PBLayout {
+  bounds: { x: number; y: number; width: number; height: number };
+  legendColumnWidth: number;
+  stageColumnWidth: number;
+  legend: LegendCell[];
+  stageHeaders: StageHeader[];
+  goalCells: StageText[];
+  resultCells: StageText[];
+  aspectRows: AspectRow[];
+}
+
+const LEGEND_W = 140;
+const STAGE_W = 220;
+const HEADER_H = 40;
+const GOAL_H = 56;
+const RESULT_H = 56;
+const ASPECT_MIN_H = 60;
+const PILL_H = 28;
+const PILL_GAP = 4;
+const PAD = 8;
+
+const ASPECT_LABEL: Record<AspectCategory, string> = {
+  systems: 'Systems',
+  actors: 'Actors',
+  equipment: 'Equipment',
+  information_entities: 'Information',
+};
+
+function pillsForEntry(category: AspectCategory, entry: AspectEntry, stageIndexById: Map<string, number>): RawPill[] {
+  if (!Array.isArray(entry.stages)) return [];
+  const idxs: number[] = [];
+  const seen = new Set<number>();
+  for (const ref of entry.stages) {
+    if (typeof ref !== 'string') continue;
+    const i = stageIndexById.get(ref);
+    if (i === undefined || seen.has(i)) continue;
+    seen.add(i);
+    idxs.push(i);
+  }
+  idxs.sort((a, b) => a - b);
+  const out: RawPill[] = [];
+  let s: number | null = null, e: number | null = null;
+  for (const i of idxs) {
+    if (s === null || e === null) { s = i; e = i; continue; }
+    if (i === e + 1) { e = i; } else {
+      out.push({ category, name: entry.name, id: entry.id, startStageIndex: s, endStageIndex: e });
+      s = i; e = i;
+    }
+  }
+  if (s !== null && e !== null) {
+    out.push({ category, name: entry.name, id: entry.id, startStageIndex: s, endStageIndex: e });
+  }
+  return out;
+}
+
+function packIntoSlots(pills: RawPill[]): { slot: number[]; maxSlot: number } {
+  const order = pills.map((_, i) => i).sort((a, b) => pills[a].startStageIndex - pills[b].startStageIndex || pills[a].endStageIndex - pills[b].endStageIndex);
+  const slotEnd: number[] = [];
+  const slot = new Array<number>(pills.length).fill(0);
+  let maxSlot = 0;
+  for (const i of order) {
+    const p = pills[i];
+    let placed = false;
+    for (let s = 0; s < slotEnd.length; s++) {
+      if (slotEnd[s] < p.startStageIndex) { slot[i] = s; slotEnd[s] = p.endStageIndex; placed = true; break; }
+    }
+    if (!placed) { slot[i] = slotEnd.length; slotEnd.push(p.endStageIndex); }
+    if (slot[i] > maxSlot) maxSlot = slot[i];
+  }
+  return { slot, maxSlot };
+}
+
+function layoutProcessBlueprint(file: ProcessBlueprintFile): PBLayout {
+  const pb = file.process_blueprint;
+  const stages = Array.isArray(pb?.stages) ? pb.stages : [];
+  const stageIndexById = new Map<string, number>();
+  for (let i = 0; i < stages.length; i++) {
+    const sid = stages[i]?.id;
+    if (typeof sid === 'string' && sid.length > 0 && !stageIndexById.has(sid)) stageIndexById.set(sid, i);
+  }
+
+  const stageHeaders: StageHeader[] = stages.map((s, i) => ({
+    stageIndex: i, id: s?.id ?? '', name: s?.name ?? '',
+    x: LEGEND_W + i * STAGE_W, y: 0, width: STAGE_W, height: HEADER_H,
+  }));
+  const goalRowY = HEADER_H;
+  const resultRowY = goalRowY + GOAL_H;
+  const goalCells: StageText[] = stages.map((s, i) => ({
+    stageIndex: i, text: s?.goal ?? '',
+    x: LEGEND_W + i * STAGE_W, y: goalRowY, width: STAGE_W, height: GOAL_H,
+  }));
+  const resultCells: StageText[] = stages.map((s, i) => ({
+    stageIndex: i, text: s?.result ?? '',
+    x: LEGEND_W + i * STAGE_W, y: resultRowY, width: STAGE_W, height: RESULT_H,
+  }));
+
+  let cursorY = resultRowY + RESULT_H;
+  const aspectRows: AspectRow[] = [];
+  for (const category of ASPECT_CATEGORIES) {
+    const arr = pb?.[category];
+    if (!Array.isArray(arr) || arr.length === 0) continue;
+    const raw: RawPill[] = [];
+    for (const e of arr) {
+      if (!e || typeof e !== 'object') continue;
+      raw.push(...pillsForEntry(category, e as AspectEntry, stageIndexById));
+    }
+    if (raw.length === 0) continue;
+    const { slot, maxSlot } = packIntoSlots(raw);
+    const contentH = (maxSlot + 1) * (PILL_H + PILL_GAP) - PILL_GAP;
+    const rowH = Math.max(ASPECT_MIN_H, contentH + 2 * PAD);
+    const pills: AspectPill[] = raw.map((p, i) => ({
+      ...p,
+      x: LEGEND_W + p.startStageIndex * STAGE_W + PAD,
+      width: (p.endStageIndex - p.startStageIndex + 1) * STAGE_W - 2 * PAD,
+      y: cursorY + PAD + slot[i] * (PILL_H + PILL_GAP),
+      height: PILL_H,
+    }));
+    aspectRows.push({ category, y: cursorY, height: rowH, pills });
+    cursorY += rowH;
+  }
+
+  const legend: LegendCell[] = [
+    { label: 'Goal', y: goalRowY, height: GOAL_H },
+    { label: 'Result', y: resultRowY, height: RESULT_H },
+    ...aspectRows.map(r => ({ label: ASPECT_LABEL[r.category], y: r.y, height: r.height })),
+  ];
+
+  return {
+    bounds: { x: 0, y: 0, width: LEGEND_W + stages.length * STAGE_W, height: cursorY },
+    legendColumnWidth: LEGEND_W,
+    stageColumnWidth: STAGE_W,
+    legend, stageHeaders, goalCells, resultCells, aspectRows,
+  };
+}
+
+// ── SVG renderer ─────────────────────────────────────────────────────────────
+
+function escXml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+function wrapText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  return text.slice(0, maxChars - 1) + '…';
+}
+
+function layoutToSvg(layout: PBLayout): string {
+  const pad = 24;
+  const w = layout.bounds.width + pad * 2;
+  const h = layout.bounds.height + pad * 2;
+  const ox = pad;
+  const oy = pad;
+
+  const parts: string[] = [];
+
+  // Outer container
+  parts.push(`<rect class="diagram-node level-0" x="${ox}" y="${oy}" width="${layout.bounds.width}" height="${layout.bounds.height}" rx="6"/>`);
+
+  // Stage headers
+  for (const s of layout.stageHeaders) {
+    parts.push(`<rect class="diagram-node level-1" x="${s.x + ox}" y="${s.y + oy}" width="${s.width}" height="${s.height}"/>`);
+    parts.push(`<text class="text-primary" x="${s.x + ox + s.width / 2}" y="${s.y + oy + s.height / 2 + 4}" text-anchor="middle" font-size="13" font-weight="600" font-family="system-ui,sans-serif">${escXml(wrapText(s.name, 28))}</text>`);
+  }
+
+  // Legend column labels
+  for (const l of layout.legend) {
+    parts.push(`<rect class="diagram-node level-2" x="${ox}" y="${l.y + oy}" width="${layout.legendColumnWidth}" height="${l.height}"/>`);
+    parts.push(`<text class="text-secondary" x="${ox + 12}" y="${l.y + oy + l.height / 2 + 4}" font-size="12" font-weight="600" font-family="system-ui,sans-serif">${escXml(l.label)}</text>`);
+  }
+
+  // Goal + result cells
+  for (const c of layout.goalCells) {
+    parts.push(`<rect class="diagram-node level-3" x="${c.x + ox}" y="${c.y + oy}" width="${c.width}" height="${c.height}"/>`);
+    parts.push(`<text class="text-primary" x="${c.x + ox + 10}" y="${c.y + oy + 22}" font-size="12" font-family="system-ui,sans-serif">${escXml(wrapText(c.text, 32))}</text>`);
+  }
+  for (const c of layout.resultCells) {
+    parts.push(`<rect class="diagram-node level-4" x="${c.x + ox}" y="${c.y + oy}" width="${c.width}" height="${c.height}"/>`);
+    parts.push(`<text class="text-primary" x="${c.x + ox + 10}" y="${c.y + oy + 22}" font-size="12" font-family="system-ui,sans-serif">${escXml(wrapText(c.text, 32))}</text>`);
+  }
+
+  // Aspect rows + pills
+  for (let r = 0; r < layout.aspectRows.length; r++) {
+    const row = layout.aspectRows[r];
+    const level = 5 + (r % 3);
+    // Row backdrop spanning all stage columns
+    parts.push(`<rect class="diagram-node level-${level}" x="${layout.legendColumnWidth + ox}" y="${row.y + oy}" width="${layout.bounds.width - layout.legendColumnWidth}" height="${row.height}" opacity="0.15"/>`);
+    // Column dividers
+    for (let i = 1; i < layout.stageHeaders.length; i++) {
+      const x = layout.legendColumnWidth + i * layout.stageColumnWidth + ox;
+      parts.push(`<line class="diagram-edge" x1="${x}" y1="${row.y + oy}" x2="${x}" y2="${row.y + row.height + oy}" opacity="0.3"/>`);
+    }
+    for (const p of row.pills) {
+      parts.push(`<rect class="diagram-node level-${level}" x="${p.x + ox}" y="${p.y + oy}" width="${p.width}" height="${p.height}" rx="6"/>`);
+      const label = p.id ? `${p.name} · ${p.id}` : p.name;
+      parts.push(`<text class="text-primary" x="${p.x + ox + p.width / 2}" y="${p.y + oy + p.height / 2 + 4}" text-anchor="middle" font-size="11" font-weight="500" font-family="system-ui,sans-serif">${escXml(wrapText(label, Math.floor(p.width / 8)))}</text>`);
+    }
+  }
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">
+${parts.join('\n')}
+</svg>`;
+}
+
+// ── ProcessBlueprintPreview webview class ────────────────────────────────────
+
+export class ProcessBlueprintPreview {
+  readonly panelTitle = 'Process Blueprint Preview';
+  private panel: vscode.WebviewPanel | undefined;
+  private trackedUri: string | undefined;
+  private lastSvg = '';
+
+  isShowingDocument(uri: vscode.Uri): boolean {
+    return this.panel != null && this.trackedUri === uri.toString();
+  }
+
+  async showOrReveal(doc: vscode.TextDocument): Promise<void> {
+    this.trackedUri = doc.uri.toString();
+    if (this.panel) {
+      this.panel.title = `${this.panelTitle} — ${path.basename(doc.fileName)}`;
+      this.panel.reveal(vscode.ViewColumn.Beside, true);
+    } else {
+      this.panel = vscode.window.createWebviewPanel(
+        'processBlueprintPreview',
+        `${this.panelTitle} — ${path.basename(doc.fileName)}`,
+        { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
+        { enableScripts: false, retainContextWhenHidden: true },
+      );
+      this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
+    }
+    await this.pushDocument(doc);
+  }
+
+  async refreshSaved(doc: vscode.TextDocument): Promise<void> {
+    if (!this.isShowingDocument(doc.uri)) return;
+    await this.pushDocument(doc);
+  }
+
+  private async pushDocument(doc: vscode.TextDocument): Promise<void> {
+    if (!this.panel) return;
+    this.panel.webview.html = this.buildHtml(doc.getText(), path.basename(doc.fileName));
+  }
+
+  private buildHtml(yamlText: string, filename: string): string {
+    let svgContent = '';
+    let errorMsg = '';
+    let warnings: string[] = [];
+
+    try {
+      const parsed = yaml.load(yamlText) as unknown;
+      const v = validateProcessBlueprint(parsed);
+      warnings = v.warnings.map(w => `${w.code}: ${w.message}`);
+      if (!v.valid) {
+        errorMsg = v.errors.map(e => `${e.code}: ${e.message}`).join('\n');
+      } else {
+        const file = parsed as ProcessBlueprintFile;
+        const layout = layoutProcessBlueprint(file);
+        svgContent = layoutToSvg(layout);
+      }
+    } catch (e) {
+      errorMsg = (e as Error).message ?? 'Parse error';
+    }
+
+    this.lastSvg = svgContent;
+
+    const themeId = vscode.workspace
+      .getConfiguration('transitrix')
+      .get<ThemeId>('theme', 'transitrix');
+
+    return buildDiagramFrame({ filename, notation: 'Process Blueprint', svgContent, errorMsg, warnings, themeId });
+  }
+
+  async saveAsSvg(): Promise<void> {
+    if (!this.lastSvg) {
+      vscode.window.showWarningMessage('No diagram rendered yet. Open a *.process-blueprint.transitrix.yaml file first.');
+      return;
+    }
+    const sourceUri = this.trackedUri ? vscode.Uri.parse(this.trackedUri) : undefined;
+    const stem = sourceUri
+      ? path.basename(sourceUri.fsPath).replace(/\.process-blueprint\.transitrix\.yaml$/, '')
+      : 'diagram';
+    const defaultUri = sourceUri
+      ? vscode.Uri.file(path.join(path.dirname(sourceUri.fsPath), `${stem}.svg`))
+      : vscode.Uri.file(`${stem}.svg`);
+    const target = await vscode.window.showSaveDialog({ defaultUri, filters: { 'SVG Image': ['svg'] } });
+    if (!target) return;
+    const themeId = vscode.workspace.getConfiguration('transitrix').get<ThemeId>('theme', 'transitrix');
+    const svg = prepareSvgForExport(this.lastSvg, themeId);
+    await vscode.workspace.fs.writeFile(target, Buffer.from(svg, 'utf-8'));
+    vscode.window.showInformationMessage(`Saved: ${path.basename(target.fsPath)}`);
+  }
+}

--- a/packages/diagrams/src/index.ts
+++ b/packages/diagrams/src/index.ts
@@ -3,6 +3,7 @@ export * from "./applications/index";
 export * from "./capability-map/index";
 export * from "./fgca/index";
 export * from "./goals/index";
+export * from "./process-blueprint/index";
 export * from "./process-map/index";
 export * from "./products/index";
 export * from "./scenarios/index";

--- a/packages/diagrams/src/process-blueprint/__tests__/layout.test.ts
+++ b/packages/diagrams/src/process-blueprint/__tests__/layout.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect } from 'vitest';
+import { layoutProcessBlueprint } from '../layout.js';
+import type { ProcessBlueprintFile } from '../types.js';
+
+function build(file: Partial<ProcessBlueprintFile['process_blueprint']>): ProcessBlueprintFile {
+  return {
+    notation: 'process-blueprint',
+    process_blueprint: {
+      id: 'PROCESS_BLUEPRINT-T-1',
+      name: 'Test',
+      stages: [],
+      ...file,
+    } as ProcessBlueprintFile['process_blueprint'],
+  };
+}
+
+describe('layoutProcessBlueprint', () => {
+  it('lays out stage headers in input order across the legend offset', () => {
+    const layout = layoutProcessBlueprint(
+      build({
+        stages: [
+          { id: 'STAGE-1', name: 'A', goal: 'g', result: 'r' },
+          { id: 'STAGE-2', name: 'B', goal: 'g', result: 'r' },
+          { id: 'STAGE-3', name: 'C', goal: 'g', result: 'r' },
+        ],
+      }),
+    );
+    expect(layout.stageHeaders).toHaveLength(3);
+    expect(layout.stageHeaders[0].x).toBe(layout.legendColumnWidth);
+    expect(layout.stageHeaders[1].x).toBe(layout.legendColumnWidth + layout.stageColumnWidth);
+    expect(layout.stageHeaders[2].x).toBe(layout.legendColumnWidth + 2 * layout.stageColumnWidth);
+    expect(layout.stageHeaders[0].name).toBe('A');
+  });
+
+  it('produces goal and result cells aligned under each stage column', () => {
+    const layout = layoutProcessBlueprint(
+      build({
+        stages: [
+          { id: 'STAGE-1', name: 'A', goal: 'gA', result: 'rA' },
+          { id: 'STAGE-2', name: 'B', goal: 'gB', result: 'rB' },
+        ],
+      }),
+    );
+    expect(layout.goalCells.map(c => c.text)).toEqual(['gA', 'gB']);
+    expect(layout.resultCells.map(c => c.text)).toEqual(['rA', 'rB']);
+    expect(layout.goalCells[0].y).toBeLessThan(layout.resultCells[0].y);
+    expect(layout.goalCells[0].x).toBe(layout.stageHeaders[0].x);
+  });
+
+  it('omits aspect rows for categories without any entries', () => {
+    const layout = layoutProcessBlueprint(
+      build({
+        stages: [{ id: 'STAGE-1', name: 'A', goal: 'g', result: 'r' }],
+      }),
+    );
+    expect(layout.aspectRows).toHaveLength(0);
+  });
+
+  it('merges consecutive stages into a single spanning pill', () => {
+    const layout = layoutProcessBlueprint(
+      build({
+        stages: [
+          { id: 'STAGE-1', name: 'A', goal: 'g', result: 'r' },
+          { id: 'STAGE-2', name: 'B', goal: 'g', result: 'r' },
+          { id: 'STAGE-3', name: 'C', goal: 'g', result: 'r' },
+        ],
+        systems: [
+          { id: 'APPLICATION-OMS-1', name: 'OMS', stages: ['STAGE-1', 'STAGE-2', 'STAGE-3'] },
+        ],
+      }),
+    );
+    expect(layout.aspectRows).toHaveLength(1);
+    const row = layout.aspectRows[0];
+    expect(row.category).toBe('systems');
+    expect(row.pills).toHaveLength(1);
+    expect(row.pills[0].startStageIndex).toBe(0);
+    expect(row.pills[0].endStageIndex).toBe(2);
+    expect(row.pills[0].width).toBeGreaterThan(layout.stageColumnWidth);
+  });
+
+  it('splits non-consecutive stages into separate pills', () => {
+    const layout = layoutProcessBlueprint(
+      build({
+        stages: [
+          { id: 'STAGE-1', name: 'A', goal: 'g', result: 'r' },
+          { id: 'STAGE-2', name: 'B', goal: 'g', result: 'r' },
+          { id: 'STAGE-3', name: 'C', goal: 'g', result: 'r' },
+          { id: 'STAGE-4', name: 'D', goal: 'g', result: 'r' },
+        ],
+        systems: [
+          { id: 'APPLICATION-X-1', name: 'X', stages: ['STAGE-1', 'STAGE-3', 'STAGE-4'] },
+        ],
+      }),
+    );
+    const pills = layout.aspectRows[0].pills;
+    expect(pills).toHaveLength(2);
+    expect(pills[0].startStageIndex).toBe(0);
+    expect(pills[0].endStageIndex).toBe(0);
+    expect(pills[1].startStageIndex).toBe(2);
+    expect(pills[1].endStageIndex).toBe(3);
+  });
+
+  it('stacks overlapping pills into vertical slots inside the same row', () => {
+    const layout = layoutProcessBlueprint(
+      build({
+        stages: [
+          { id: 'STAGE-1', name: 'A', goal: 'g', result: 'r' },
+          { id: 'STAGE-2', name: 'B', goal: 'g', result: 'r' },
+        ],
+        systems: [
+          { id: 'APPLICATION-A-1', name: 'A', stages: ['STAGE-1', 'STAGE-2'] },
+          { id: 'APPLICATION-B-1', name: 'B', stages: ['STAGE-1'] },
+        ],
+      }),
+    );
+    const row = layout.aspectRows[0];
+    expect(row.pills).toHaveLength(2);
+    // The two pills overlap at STAGE-1, so they should sit at different y.
+    expect(row.pills[0].y).not.toBe(row.pills[1].y);
+    // Row height must be tall enough for two stacked pills.
+    expect(row.height).toBeGreaterThan(row.pills[0].height);
+  });
+
+  it('preserves the fixed category order: systems, actors, equipment, information_entities', () => {
+    const layout = layoutProcessBlueprint(
+      build({
+        stages: [{ id: 'STAGE-1', name: 'A', goal: 'g', result: 'r' }],
+        information_entities: [{ name: 'Doc', stages: ['STAGE-1'] }],
+        actors: [{ id: 'ROLE-X-1', name: 'X', stages: ['STAGE-1'] }],
+        systems: [{ id: 'APPLICATION-X-1', name: 'X', stages: ['STAGE-1'] }],
+        equipment: [{ name: 'Scanner', stages: ['STAGE-1'] }],
+      }),
+    );
+    expect(layout.aspectRows.map(r => r.category)).toEqual([
+      'systems',
+      'actors',
+      'equipment',
+      'information_entities',
+    ]);
+  });
+
+  it('builds the legend in row order: goal, result, then aspect categories', () => {
+    const layout = layoutProcessBlueprint(
+      build({
+        stages: [{ id: 'STAGE-1', name: 'A', goal: 'g', result: 'r' }],
+        systems: [{ id: 'APPLICATION-X-1', name: 'X', stages: ['STAGE-1'] }],
+      }),
+    );
+    expect(layout.legend.map(l => l.kind)).toEqual(['goal', 'result', 'aspect']);
+    expect(layout.legend[2].category).toBe('systems');
+  });
+
+  it('total bounds cover the legend column plus every stage column', () => {
+    const layout = layoutProcessBlueprint(
+      build({
+        stages: [
+          { id: 'STAGE-1', name: 'A', goal: 'g', result: 'r' },
+          { id: 'STAGE-2', name: 'B', goal: 'g', result: 'r' },
+        ],
+      }),
+    );
+    expect(layout.bounds.width).toBe(layout.legendColumnWidth + 2 * layout.stageColumnWidth);
+    expect(layout.bounds.height).toBeGreaterThan(0);
+  });
+
+  it('ignores aspect entries that reference undeclared stages', () => {
+    const layout = layoutProcessBlueprint(
+      build({
+        stages: [{ id: 'STAGE-1', name: 'A', goal: 'g', result: 'r' }],
+        systems: [
+          { id: 'APPLICATION-X-1', name: 'X', stages: ['STAGE-1', 'STAGE-999'] },
+        ],
+      }),
+    );
+    const pills = layout.aspectRows[0].pills;
+    expect(pills).toHaveLength(1);
+    expect(pills[0].startStageIndex).toBe(0);
+    expect(pills[0].endStageIndex).toBe(0);
+  });
+
+  it('honours overridden LayoutOptions', () => {
+    const layout = layoutProcessBlueprint(
+      build({
+        stages: [
+          { id: 'STAGE-1', name: 'A', goal: 'g', result: 'r' },
+          { id: 'STAGE-2', name: 'B', goal: 'g', result: 'r' },
+        ],
+      }),
+      { legendColumnWidth: 200, stageColumnWidth: 300 },
+    );
+    expect(layout.legendColumnWidth).toBe(200);
+    expect(layout.stageColumnWidth).toBe(300);
+    expect(layout.stageHeaders[1].x).toBe(200 + 300);
+  });
+});

--- a/packages/diagrams/src/process-blueprint/__tests__/validate.test.ts
+++ b/packages/diagrams/src/process-blueprint/__tests__/validate.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import yaml from 'js-yaml';
 import { validateProcessBlueprint } from '../validate.js';
+
+const EXAMPLES_DIR = path.resolve(process.cwd(), '..', '..', 'examples', 'process-blueprint');
 
 const VALID_BLUEPRINT = {
   notation: 'process-blueprint',
@@ -128,6 +133,35 @@ describe('validateProcessBlueprint', () => {
       },
     });
     expect(r.errors.some(e => e.code === 'BP-006' && /Duplicate/.test(e.message))).toBe(true);
+  });
+
+  it('BP-006: treats ids that differ only in surrounding whitespace as duplicates', () => {
+    const r = validateProcessBlueprint({
+      ...VALID_BLUEPRINT,
+      process_blueprint: {
+        ...VALID_BLUEPRINT.process_blueprint,
+        stages: [
+          { id: 'STAGE-1', name: 'A', goal: 'G', result: 'R' },
+          { id: 'STAGE-1 ', name: 'B', goal: 'G', result: 'R' },
+        ],
+      },
+    });
+    expect(r.errors.some(e => e.code === 'BP-006' && /Duplicate/.test(e.message))).toBe(true);
+  });
+
+  it('BP-008: tolerates whitespace around aspect stage refs (matches trimmed stage ids)', () => {
+    const r = validateProcessBlueprint({
+      ...VALID_BLUEPRINT,
+      process_blueprint: {
+        ...VALID_BLUEPRINT.process_blueprint,
+        stages: [{ id: 'STAGE-1', name: 'A', goal: 'G', result: 'R' }],
+        systems: [{ id: 'APPLICATION-X-1', name: 'X', stages: [' STAGE-1 '] }],
+        actors: undefined,
+        equipment: undefined,
+        information_entities: undefined,
+      },
+    });
+    expect(r.errors.some(e => e.code === 'BP-008')).toBe(false);
   });
 
   it('BP-006: rejects stage id that does not match STAGE grammar', () => {
@@ -266,4 +300,18 @@ describe('validateProcessBlueprint', () => {
     expect(r.valid).toBe(true);
     expect(r.warnings).toHaveLength(0);
   });
+});
+
+describe('process-blueprint examples (regression)', () => {
+  const files = fs.readdirSync(EXAMPLES_DIR).filter(f => f.endsWith('.yaml'));
+  expect(files.length).toBeGreaterThan(0);
+  for (const file of files) {
+    it(`validates examples/process-blueprint/${file}`, () => {
+      const text = fs.readFileSync(path.join(EXAMPLES_DIR, file), 'utf8');
+      const parsed = yaml.load(text);
+      const r = validateProcessBlueprint(parsed);
+      expect(r.errors).toEqual([]);
+      expect(r.valid).toBe(true);
+    });
+  }
 });

--- a/packages/diagrams/src/process-blueprint/__tests__/validate.test.ts
+++ b/packages/diagrams/src/process-blueprint/__tests__/validate.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect } from 'vitest';
+import { validateProcessBlueprint } from '../validate.js';
+
+const VALID_BLUEPRINT = {
+  notation: 'process-blueprint',
+  spec_version: '0.1',
+  process_blueprint: {
+    id: 'PROCESS_BLUEPRINT-FULFIL-1',
+    name: 'Order fulfilment blueprint',
+    stages: [
+      { id: 'STAGE-1', name: 'Receive', goal: 'Capture order', result: 'Validated order' },
+      { id: 'STAGE-2', name: 'Pack', goal: 'Assemble', result: 'Packed shipment' },
+      { id: 'STAGE-3', name: 'Ship', goal: 'Hand to carrier', result: 'In transit' },
+    ],
+    systems: [
+      { id: 'APPLICATION-OMS-1', name: 'OMS', stages: ['STAGE-1', 'STAGE-2', 'STAGE-3'] },
+    ],
+    actors: [
+      { id: 'ROLE-WAREHOUSE-1', name: 'Warehouse op', stages: ['STAGE-2', 'STAGE-3'] },
+    ],
+    equipment: [
+      { name: 'Barcode scanner', stages: ['STAGE-2', 'STAGE-3'] },
+    ],
+    information_entities: [
+      { name: 'Customer order', stages: ['STAGE-1', 'STAGE-2', 'STAGE-3'] },
+    ],
+  },
+};
+
+describe('validateProcessBlueprint', () => {
+  it('passes on a valid blueprint', () => {
+    const r = validateProcessBlueprint(VALID_BLUEPRINT);
+    expect(r.valid).toBe(true);
+    expect(r.errors).toHaveLength(0);
+  });
+
+  it('BP-001: rejects non-object input', () => {
+    expect(validateProcessBlueprint(null).valid).toBe(false);
+    expect(validateProcessBlueprint(null).errors[0].code).toBe('BP-001');
+    expect(validateProcessBlueprint('string').errors[0].code).toBe('BP-001');
+  });
+
+  it('BP-001: rejects missing process_blueprint root key', () => {
+    const r = validateProcessBlueprint({ notation: 'process-blueprint' });
+    expect(r.errors.some(e => e.code === 'BP-001')).toBe(true);
+  });
+
+  it('BP-001: rejects wrong notation value', () => {
+    const r = validateProcessBlueprint({ ...VALID_BLUEPRINT, notation: 'goals' });
+    expect(r.errors.some(e => e.code === 'BP-001')).toBe(true);
+  });
+
+  it('BP-001: tolerates a missing notation field (header check is contract-level)', () => {
+    const { notation: _, ...rest } = VALID_BLUEPRINT;
+    const r = validateProcessBlueprint(rest);
+    expect(r.errors.some(e => e.code === 'BP-001')).toBe(false);
+  });
+
+  it('BP-002: rejects missing id', () => {
+    const r = validateProcessBlueprint({
+      ...VALID_BLUEPRINT,
+      process_blueprint: { ...VALID_BLUEPRINT.process_blueprint, id: '' },
+    });
+    expect(r.errors.some(e => e.code === 'BP-002')).toBe(true);
+  });
+
+  it('BP-002: rejects id that does not match PROCESS_BLUEPRINT grammar', () => {
+    const r = validateProcessBlueprint({
+      ...VALID_BLUEPRINT,
+      process_blueprint: { ...VALID_BLUEPRINT.process_blueprint, id: 'PB-1' },
+    });
+    expect(r.errors.some(e => e.code === 'BP-002')).toBe(true);
+  });
+
+  it('BP-003: rejects missing name', () => {
+    const r = validateProcessBlueprint({
+      ...VALID_BLUEPRINT,
+      process_blueprint: { ...VALID_BLUEPRINT.process_blueprint, name: '' },
+    });
+    expect(r.errors.some(e => e.code === 'BP-003')).toBe(true);
+  });
+
+  it('BP-004: rejects missing stages', () => {
+    const { stages: _, ...rest } = VALID_BLUEPRINT.process_blueprint;
+    const r = validateProcessBlueprint({ ...VALID_BLUEPRINT, process_blueprint: rest });
+    expect(r.errors.some(e => e.code === 'BP-004')).toBe(true);
+  });
+
+  it('BP-004: rejects empty stages array', () => {
+    const r = validateProcessBlueprint({
+      ...VALID_BLUEPRINT,
+      process_blueprint: { ...VALID_BLUEPRINT.process_blueprint, stages: [] },
+    });
+    expect(r.errors.some(e => e.code === 'BP-004')).toBe(true);
+  });
+
+  it('BP-005: rejects stage missing goal', () => {
+    const r = validateProcessBlueprint({
+      ...VALID_BLUEPRINT,
+      process_blueprint: {
+        ...VALID_BLUEPRINT.process_blueprint,
+        stages: [{ id: 'STAGE-1', name: 'X', goal: '', result: 'R' }],
+      },
+    });
+    expect(r.errors.some(e => e.code === 'BP-005' && /goal/.test(e.message))).toBe(true);
+  });
+
+  it('BP-005: rejects stage missing result', () => {
+    const r = validateProcessBlueprint({
+      ...VALID_BLUEPRINT,
+      process_blueprint: {
+        ...VALID_BLUEPRINT.process_blueprint,
+        stages: [{ id: 'STAGE-1', name: 'X', goal: 'G', result: '' }],
+      },
+    });
+    expect(r.errors.some(e => e.code === 'BP-005' && /result/.test(e.message))).toBe(true);
+  });
+
+  it('BP-006: rejects duplicate stage ids', () => {
+    const r = validateProcessBlueprint({
+      ...VALID_BLUEPRINT,
+      process_blueprint: {
+        ...VALID_BLUEPRINT.process_blueprint,
+        stages: [
+          { id: 'STAGE-1', name: 'A', goal: 'G', result: 'R' },
+          { id: 'STAGE-1', name: 'B', goal: 'G', result: 'R' },
+        ],
+      },
+    });
+    expect(r.errors.some(e => e.code === 'BP-006' && /Duplicate/.test(e.message))).toBe(true);
+  });
+
+  it('BP-006: rejects stage id that does not match STAGE grammar', () => {
+    const r = validateProcessBlueprint({
+      ...VALID_BLUEPRINT,
+      process_blueprint: {
+        ...VALID_BLUEPRINT.process_blueprint,
+        stages: [{ id: 'STG-1', name: 'A', goal: 'G', result: 'R' }],
+      },
+    });
+    expect(r.errors.some(e => e.code === 'BP-006')).toBe(true);
+  });
+
+  it('BP-007: rejects aspect entry missing name', () => {
+    const r = validateProcessBlueprint({
+      ...VALID_BLUEPRINT,
+      process_blueprint: {
+        ...VALID_BLUEPRINT.process_blueprint,
+        systems: [{ name: '', stages: ['STAGE-1'] }],
+      },
+    });
+    expect(r.errors.some(e => e.code === 'BP-007' && /name/.test(e.message))).toBe(true);
+  });
+
+  it('BP-007: rejects aspect entry with empty stages array', () => {
+    const r = validateProcessBlueprint({
+      ...VALID_BLUEPRINT,
+      process_blueprint: {
+        ...VALID_BLUEPRINT.process_blueprint,
+        systems: [{ name: 'X', stages: [] }],
+      },
+    });
+    expect(r.errors.some(e => e.code === 'BP-007' && /stages/.test(e.message))).toBe(true);
+  });
+
+  it('BP-008: rejects aspect entry referencing undeclared stage', () => {
+    const r = validateProcessBlueprint({
+      ...VALID_BLUEPRINT,
+      process_blueprint: {
+        ...VALID_BLUEPRINT.process_blueprint,
+        systems: [{ name: 'X', stages: ['STAGE-1', 'STAGE-999'] }],
+      },
+    });
+    expect(r.errors.some(e => e.code === 'BP-008')).toBe(true);
+  });
+
+  it('BP-009: rejects aspect entry id that does not match canonical grammar', () => {
+    const r = validateProcessBlueprint({
+      ...VALID_BLUEPRINT,
+      process_blueprint: {
+        ...VALID_BLUEPRINT.process_blueprint,
+        equipment: [{ id: 'lowercase-1', name: 'X', stages: ['STAGE-1'] }],
+      },
+    });
+    expect(r.errors.some(e => e.code === 'BP-009')).toBe(true);
+  });
+
+  it('BP-009: accepts an id for equipment as long as it matches general grammar', () => {
+    const r = validateProcessBlueprint({
+      ...VALID_BLUEPRINT,
+      process_blueprint: {
+        ...VALID_BLUEPRINT.process_blueprint,
+        equipment: [{ id: 'EQUIPMENT-SCANNER-1', name: 'Barcode scanner', stages: ['STAGE-2'] }],
+      },
+    });
+    expect(r.errors.some(e => e.code === 'BP-009')).toBe(false);
+    expect(r.errors.some(e => e.code === 'BP-010')).toBe(false);
+  });
+
+  it('BP-010: rejects systems entry id without APPLICATION- prefix', () => {
+    const r = validateProcessBlueprint({
+      ...VALID_BLUEPRINT,
+      process_blueprint: {
+        ...VALID_BLUEPRINT.process_blueprint,
+        systems: [{ id: 'SERVICE-OMS-1', name: 'OMS', stages: ['STAGE-1'] }],
+      },
+    });
+    expect(r.errors.some(e => e.code === 'BP-010')).toBe(true);
+  });
+
+  it('BP-010: rejects actors entry id without ROLE- prefix', () => {
+    const r = validateProcessBlueprint({
+      ...VALID_BLUEPRINT,
+      process_blueprint: {
+        ...VALID_BLUEPRINT.process_blueprint,
+        actors: [{ id: 'PERSON-1', name: 'X', stages: ['STAGE-1'] }],
+      },
+    });
+    expect(r.errors.some(e => e.code === 'BP-010')).toBe(true);
+  });
+
+  it('BP-010: accepts free-form aspect entries without id', () => {
+    const r = validateProcessBlueprint({
+      ...VALID_BLUEPRINT,
+      process_blueprint: {
+        ...VALID_BLUEPRINT.process_blueprint,
+        systems: [{ name: 'Legacy app', stages: ['STAGE-1'] }],
+      },
+    });
+    expect(r.errors.some(e => e.code === 'BP-009')).toBe(false);
+    expect(r.errors.some(e => e.code === 'BP-010')).toBe(false);
+  });
+
+  it('BP-011: warns when a stage has no aspect entries pointing at it', () => {
+    const r = validateProcessBlueprint({
+      ...VALID_BLUEPRINT,
+      process_blueprint: {
+        ...VALID_BLUEPRINT.process_blueprint,
+        stages: [
+          { id: 'STAGE-1', name: 'A', goal: 'G', result: 'R' },
+          { id: 'STAGE-99', name: 'Orphan', goal: 'G', result: 'R' },
+        ],
+        systems: [{ id: 'APPLICATION-OMS-1', name: 'OMS', stages: ['STAGE-1'] }],
+        actors: undefined,
+        equipment: undefined,
+        information_entities: undefined,
+      },
+    });
+    expect(r.warnings.some(w => w.code === 'BP-011' && /STAGE-99/.test(w.message))).toBe(true);
+    expect(r.valid).toBe(true);
+  });
+
+  it('BP-012: warns when an aspect entry references a single stage', () => {
+    const r = validateProcessBlueprint({
+      ...VALID_BLUEPRINT,
+      process_blueprint: {
+        ...VALID_BLUEPRINT.process_blueprint,
+        systems: [{ id: 'APPLICATION-OMS-1', name: 'OMS', stages: ['STAGE-1'] }],
+      },
+    });
+    expect(r.warnings.some(w => w.code === 'BP-012')).toBe(true);
+  });
+
+  it('happy path: surfaces no warnings on a well-formed multi-stage blueprint', () => {
+    const r = validateProcessBlueprint(VALID_BLUEPRINT);
+    expect(r.valid).toBe(true);
+    expect(r.warnings).toHaveLength(0);
+  });
+});

--- a/packages/diagrams/src/process-blueprint/index.ts
+++ b/packages/diagrams/src/process-blueprint/index.ts
@@ -1,0 +1,24 @@
+export type {
+  AspectCategory,
+  Stage,
+  AspectEntry,
+  ProcessBlueprintHeader,
+  ProcessBlueprintFile,
+  ProcessBlueprintLayoutOptions,
+  LayoutBounds,
+  LegendCell,
+  StageHeaderCell,
+  StageTextCell,
+  AspectPill,
+  AspectRow,
+  ProcessBlueprintLayout,
+} from './types.js';
+
+export { validateProcessBlueprint } from './validate.js';
+export type {
+  ValidationError as ProcessBlueprintValidationError,
+  ValidationWarning as ProcessBlueprintValidationWarning,
+  ValidationResult as ProcessBlueprintValidationResult,
+} from './validate.js';
+
+export { layoutProcessBlueprint } from './layout.js';

--- a/packages/diagrams/src/process-blueprint/layout.ts
+++ b/packages/diagrams/src/process-blueprint/layout.ts
@@ -49,8 +49,8 @@ function resolveOptions(options: ProcessBlueprintLayoutOptions | undefined): Req
 function buildStageIndex(stages: Stage[]): Map<string, number> {
   const idx = new Map<string, number>();
   for (let i = 0; i < stages.length; i++) {
-    const sid = stages[i]?.id;
-    if (typeof sid === 'string' && sid.length > 0 && !idx.has(sid)) {
+    const sid = typeof stages[i]?.id === 'string' ? stages[i].id.trim() : '';
+    if (sid.length > 0 && !idx.has(sid)) {
       idx.set(sid, i);
     }
   }
@@ -69,7 +69,7 @@ function pillsForEntry(
   const seen = new Set<number>();
   for (const ref of entry.stages) {
     if (typeof ref !== 'string') continue;
-    const i = stageIndexById.get(ref);
+    const i = stageIndexById.get(ref.trim());
     if (i === undefined) continue;
     if (seen.has(i)) continue;
     seen.add(i);

--- a/packages/diagrams/src/process-blueprint/layout.ts
+++ b/packages/diagrams/src/process-blueprint/layout.ts
@@ -1,0 +1,277 @@
+import type {
+  AspectCategory,
+  AspectEntry,
+  AspectPill,
+  AspectRow,
+  ProcessBlueprintLayoutOptions,
+  LegendCell,
+  ProcessBlueprintFile,
+  ProcessBlueprintLayout,
+  Stage,
+  StageHeaderCell,
+  StageTextCell,
+} from './types.js';
+
+const ASPECT_CATEGORIES: AspectCategory[] = ['systems', 'actors', 'equipment', 'information_entities'];
+
+const ASPECT_LABEL: Record<AspectCategory, string> = {
+  systems: 'Systems',
+  actors: 'Actors',
+  equipment: 'Equipment',
+  information_entities: 'Information',
+};
+
+const DEFAULTS: Required<ProcessBlueprintLayoutOptions> = {
+  legendColumnWidth: 140,
+  stageColumnWidth: 220,
+  stageHeaderHeight: 40,
+  goalRowHeight: 56,
+  resultRowHeight: 56,
+  aspectRowMinHeight: 60,
+  pillHeight: 28,
+  pillGap: 4,
+  cellPadding: 8,
+};
+
+interface RawPill {
+  category: AspectCategory;
+  entryIndex: number;
+  name: string;
+  id?: string;
+  startStageIndex: number;
+  endStageIndex: number;
+}
+
+function resolveOptions(options: ProcessBlueprintLayoutOptions | undefined): Required<ProcessBlueprintLayoutOptions> {
+  return { ...DEFAULTS, ...(options ?? {}) };
+}
+
+function buildStageIndex(stages: Stage[]): Map<string, number> {
+  const idx = new Map<string, number>();
+  for (let i = 0; i < stages.length; i++) {
+    const sid = stages[i]?.id;
+    if (typeof sid === 'string' && sid.length > 0 && !idx.has(sid)) {
+      idx.set(sid, i);
+    }
+  }
+  return idx;
+}
+
+function pillsForEntry(
+  category: AspectCategory,
+  entryIndex: number,
+  entry: AspectEntry,
+  stageIndexById: Map<string, number>,
+): RawPill[] {
+  if (!Array.isArray(entry.stages)) return [];
+
+  const idxs: number[] = [];
+  const seen = new Set<number>();
+  for (const ref of entry.stages) {
+    if (typeof ref !== 'string') continue;
+    const i = stageIndexById.get(ref);
+    if (i === undefined) continue;
+    if (seen.has(i)) continue;
+    seen.add(i);
+    idxs.push(i);
+  }
+  idxs.sort((a, b) => a - b);
+
+  const pills: RawPill[] = [];
+  let runStart: number | null = null;
+  let runEnd: number | null = null;
+  for (const i of idxs) {
+    if (runStart === null || runEnd === null) {
+      runStart = i;
+      runEnd = i;
+      continue;
+    }
+    if (i === runEnd + 1) {
+      runEnd = i;
+    } else {
+      pills.push({
+        category,
+        entryIndex,
+        name: entry.name,
+        id: entry.id,
+        startStageIndex: runStart,
+        endStageIndex: runEnd,
+      });
+      runStart = i;
+      runEnd = i;
+    }
+  }
+  if (runStart !== null && runEnd !== null) {
+    pills.push({
+      category,
+      entryIndex,
+      name: entry.name,
+      id: entry.id,
+      startStageIndex: runStart,
+      endStageIndex: runEnd,
+    });
+  }
+  return pills;
+}
+
+function packPillsIntoSlots(pills: RawPill[]): { slot: number[]; maxSlot: number } {
+  // Greedy interval scheduling: stable order by startStageIndex.
+  const order = pills
+    .map((_, i) => i)
+    .sort((a, b) => {
+      const ds = pills[a].startStageIndex - pills[b].startStageIndex;
+      if (ds !== 0) return ds;
+      return pills[a].endStageIndex - pills[b].endStageIndex;
+    });
+
+  const slotEndByLevel: number[] = []; // slotEndByLevel[s] = last endStageIndex placed in slot s
+  const slot = new Array<number>(pills.length).fill(0);
+  let maxSlot = 0;
+
+  for (const i of order) {
+    const p = pills[i];
+    let placed = false;
+    for (let s = 0; s < slotEndByLevel.length; s++) {
+      if (slotEndByLevel[s] < p.startStageIndex) {
+        slot[i] = s;
+        slotEndByLevel[s] = p.endStageIndex;
+        placed = true;
+        break;
+      }
+    }
+    if (!placed) {
+      slot[i] = slotEndByLevel.length;
+      slotEndByLevel.push(p.endStageIndex);
+    }
+    if (slot[i] > maxSlot) maxSlot = slot[i];
+  }
+
+  return { slot, maxSlot };
+}
+
+export function layoutProcessBlueprint(
+  file: ProcessBlueprintFile,
+  options?: ProcessBlueprintLayoutOptions,
+): ProcessBlueprintLayout {
+  const opts = resolveOptions(options);
+
+  const pb = file.process_blueprint;
+  const stages = Array.isArray(pb?.stages) ? pb.stages : [];
+  const stageIndexById = buildStageIndex(stages);
+
+  // Stage headers
+  const stageHeaders: StageHeaderCell[] = stages.map((s, i) => ({
+    stageIndex: i,
+    id: s?.id ?? '',
+    name: s?.name ?? '',
+    x: opts.legendColumnWidth + i * opts.stageColumnWidth,
+    y: 0,
+    width: opts.stageColumnWidth,
+    height: opts.stageHeaderHeight,
+  }));
+
+  // Goal + result rows
+  const goalRowY = opts.stageHeaderHeight;
+  const resultRowY = goalRowY + opts.goalRowHeight;
+
+  const goalCells: StageTextCell[] = stages.map((s, i) => ({
+    stageIndex: i,
+    text: s?.goal ?? '',
+    x: opts.legendColumnWidth + i * opts.stageColumnWidth,
+    y: goalRowY,
+    width: opts.stageColumnWidth,
+    height: opts.goalRowHeight,
+  }));
+
+  const resultCells: StageTextCell[] = stages.map((s, i) => ({
+    stageIndex: i,
+    text: s?.result ?? '',
+    x: opts.legendColumnWidth + i * opts.stageColumnWidth,
+    y: resultRowY,
+    width: opts.stageColumnWidth,
+    height: opts.resultRowHeight,
+  }));
+
+  const aspectsStartY = resultRowY + opts.resultRowHeight;
+
+  // Aspect rows: only categories with at least one entry, in fixed order.
+  const aspectRows: AspectRow[] = [];
+  let aspectCursorY = aspectsStartY;
+
+  for (const category of ASPECT_CATEGORIES) {
+    const arr = pb?.[category];
+    if (!Array.isArray(arr) || arr.length === 0) continue;
+
+    const rawPills: RawPill[] = [];
+    for (let i = 0; i < arr.length; i++) {
+      const entry = arr[i];
+      if (!entry || typeof entry !== 'object') continue;
+      rawPills.push(...pillsForEntry(category, i, entry as AspectEntry, stageIndexById));
+    }
+
+    // If every entry in this category had no resolvable stage refs, drop the row.
+    if (rawPills.length === 0) continue;
+
+    const { slot, maxSlot } = packPillsIntoSlots(rawPills);
+    const contentHeight = (maxSlot + 1) * (opts.pillHeight + opts.pillGap) - opts.pillGap;
+    const rowHeight = Math.max(
+      opts.aspectRowMinHeight,
+      contentHeight + 2 * opts.cellPadding,
+    );
+
+    const pills: AspectPill[] = rawPills.map((p, i) => {
+      const x = opts.legendColumnWidth + p.startStageIndex * opts.stageColumnWidth + opts.cellPadding;
+      const width =
+        (p.endStageIndex - p.startStageIndex + 1) * opts.stageColumnWidth - 2 * opts.cellPadding;
+      const y = aspectCursorY + opts.cellPadding + slot[i] * (opts.pillHeight + opts.pillGap);
+      return {
+        category: p.category,
+        entryIndex: p.entryIndex,
+        name: p.name,
+        id: p.id,
+        startStageIndex: p.startStageIndex,
+        endStageIndex: p.endStageIndex,
+        x,
+        y,
+        width,
+        height: opts.pillHeight,
+      };
+    });
+
+    aspectRows.push({
+      category,
+      y: aspectCursorY,
+      height: rowHeight,
+      pills,
+    });
+
+    aspectCursorY += rowHeight;
+  }
+
+  // Legend (left column labels): one entry per row.
+  const legend: LegendCell[] = [
+    { kind: 'goal', label: 'Goal', y: goalRowY, height: opts.goalRowHeight },
+    { kind: 'result', label: 'Result', y: resultRowY, height: opts.resultRowHeight },
+    ...aspectRows.map<LegendCell>(row => ({
+      kind: 'aspect',
+      category: row.category,
+      label: ASPECT_LABEL[row.category],
+      y: row.y,
+      height: row.height,
+    })),
+  ];
+
+  const totalWidth = opts.legendColumnWidth + stages.length * opts.stageColumnWidth;
+  const totalHeight = aspectCursorY;
+
+  return {
+    bounds: { x: 0, y: 0, width: totalWidth, height: totalHeight },
+    legendColumnWidth: opts.legendColumnWidth,
+    stageColumnWidth: opts.stageColumnWidth,
+    legend,
+    stageHeaders,
+    goalCells,
+    resultCells,
+    aspectRows,
+  };
+}

--- a/packages/diagrams/src/process-blueprint/types.ts
+++ b/packages/diagrams/src/process-blueprint/types.ts
@@ -1,0 +1,116 @@
+export type AspectCategory = 'systems' | 'actors' | 'equipment' | 'information_entities';
+
+export interface Stage {
+  id: string;
+  name: string;
+  goal: string;
+  result: string;
+  description?: string;
+}
+
+export interface AspectEntry {
+  id?: string;
+  name: string;
+  stages: string[];
+  description?: string;
+}
+
+export interface ProcessBlueprintHeader {
+  id: string;
+  name: string;
+  description?: string;
+  period?: string;
+  version?: string;
+  date?: string;
+  author?: string;
+  process?: string;
+  scenario?: string;
+  stages: Stage[];
+  systems?: AspectEntry[];
+  actors?: AspectEntry[];
+  equipment?: AspectEntry[];
+  information_entities?: AspectEntry[];
+}
+
+export interface ProcessBlueprintFile {
+  notation: string;
+  spec_version?: string;
+  process_blueprint: ProcessBlueprintHeader;
+}
+
+export interface ProcessBlueprintLayoutOptions {
+  legendColumnWidth?: number;
+  stageColumnWidth?: number;
+  stageHeaderHeight?: number;
+  goalRowHeight?: number;
+  resultRowHeight?: number;
+  aspectRowMinHeight?: number;
+  pillHeight?: number;
+  pillGap?: number;
+  cellPadding?: number;
+}
+
+export interface LayoutBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface LegendCell {
+  kind: 'goal' | 'result' | 'aspect';
+  category?: AspectCategory;
+  label: string;
+  y: number;
+  height: number;
+}
+
+export interface StageHeaderCell {
+  stageIndex: number;
+  id: string;
+  name: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface StageTextCell {
+  stageIndex: number;
+  text: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface AspectPill {
+  category: AspectCategory;
+  entryIndex: number;
+  name: string;
+  id?: string;
+  startStageIndex: number;
+  endStageIndex: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface AspectRow {
+  category: AspectCategory;
+  y: number;
+  height: number;
+  pills: AspectPill[];
+}
+
+export interface ProcessBlueprintLayout {
+  bounds: LayoutBounds;
+  legendColumnWidth: number;
+  stageColumnWidth: number;
+  legend: LegendCell[];
+  stageHeaders: StageHeaderCell[];
+  goalCells: StageTextCell[];
+  resultCells: StageTextCell[];
+  aspectRows: AspectRow[];
+}

--- a/packages/diagrams/src/process-blueprint/validate.ts
+++ b/packages/diagrams/src/process-blueprint/validate.ts
@@ -78,7 +78,7 @@ export function validateProcessBlueprint(input: unknown): ValidationResult {
     if (!isNonEmptyString(s['id'])) {
       errors.push({ code: 'BP-005', message: `${path}.id is required` });
     } else {
-      const sid = s['id'];
+      const sid = s['id'].trim();
       if (stageIds.has(sid)) {
         errors.push({ code: 'BP-006', message: `Duplicate stage id: "${sid}"` });
       } else {
@@ -137,13 +137,14 @@ export function validateProcessBlueprint(input: unknown): ValidationResult {
             errors.push({ code: 'BP-008', message: `${path}.stages[${j}] must be a string` });
             continue;
           }
-          if (!stageIds.has(ref)) {
+          const refTrimmed = ref.trim();
+          if (!stageIds.has(refTrimmed)) {
             errors.push({
               code: 'BP-008',
               message: `${path}.stages[${j}] references undeclared stage "${ref}"`,
             });
           } else {
-            usedStageIds.add(ref);
+            usedStageIds.add(refTrimmed);
           }
         }
 

--- a/packages/diagrams/src/process-blueprint/validate.ts
+++ b/packages/diagrams/src/process-blueprint/validate.ts
@@ -1,0 +1,192 @@
+import type { AspectCategory } from './types.js';
+
+export interface ValidationError { code: string; message: string; }
+export interface ValidationWarning { code: string; message: string; }
+export interface ValidationResult {
+  valid: boolean;
+  errors: ValidationError[];
+  warnings: ValidationWarning[];
+}
+
+const ID_GRAMMAR_RE = /^[A-Z][A-Z_]*(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
+const PROCESS_BLUEPRINT_ID_RE = /^PROCESS_BLUEPRINT(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
+const STAGE_ID_RE = /^STAGE(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
+const APPLICATION_ID_RE = /^APPLICATION(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
+const ROLE_ID_RE = /^ROLE(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
+
+const ASPECT_CATEGORIES: AspectCategory[] = ['systems', 'actors', 'equipment', 'information_entities'];
+
+function isNonEmptyString(v: unknown): v is string {
+  return typeof v === 'string' && v.trim().length > 0;
+}
+
+export function validateProcessBlueprint(input: unknown): ValidationResult {
+  const errors: ValidationError[] = [];
+  const warnings: ValidationWarning[] = [];
+
+  if (!input || typeof input !== 'object') {
+    return {
+      valid: false,
+      errors: [{ code: 'BP-001', message: 'Input must be an object' }],
+      warnings,
+    };
+  }
+
+  const raw = input as Record<string, unknown>;
+
+  if ('notation' in raw && raw['notation'] !== 'process-blueprint') {
+    errors.push({
+      code: 'BP-001',
+      message: `notation must be "process-blueprint", got "${String(raw['notation'])}"`,
+    });
+  }
+
+  if (!('process_blueprint' in raw) || !raw['process_blueprint'] || typeof raw['process_blueprint'] !== 'object') {
+    errors.push({ code: 'BP-001', message: 'Missing required root key: process_blueprint' });
+    return { valid: false, errors, warnings };
+  }
+
+  const pb = raw['process_blueprint'] as Record<string, unknown>;
+
+  if (!isNonEmptyString(pb['id'])) {
+    errors.push({ code: 'BP-002', message: 'process_blueprint.id is required' });
+  } else if (!PROCESS_BLUEPRINT_ID_RE.test(pb['id'])) {
+    errors.push({
+      code: 'BP-002',
+      message: `process_blueprint.id "${pb['id']}" must match PROCESS_BLUEPRINT-[<middle>-]<INTEGER>`,
+    });
+  }
+
+  if (!isNonEmptyString(pb['name'])) {
+    errors.push({ code: 'BP-003', message: 'process_blueprint.name is required' });
+  }
+
+  const stagesRaw = pb['stages'];
+  if (!Array.isArray(stagesRaw) || stagesRaw.length === 0) {
+    errors.push({ code: 'BP-004', message: 'process_blueprint.stages must be a non-empty array' });
+    return { valid: false, errors, warnings };
+  }
+
+  const stageIds = new Set<string>();
+  for (let i = 0; i < stagesRaw.length; i++) {
+    const s = stagesRaw[i] as Record<string, unknown> | undefined;
+    const path = `stages[${i}]`;
+    if (!s || typeof s !== 'object') {
+      errors.push({ code: 'BP-005', message: `${path} must be an object` });
+      continue;
+    }
+    if (!isNonEmptyString(s['id'])) {
+      errors.push({ code: 'BP-005', message: `${path}.id is required` });
+    } else {
+      const sid = s['id'];
+      if (stageIds.has(sid)) {
+        errors.push({ code: 'BP-006', message: `Duplicate stage id: "${sid}"` });
+      } else {
+        stageIds.add(sid);
+      }
+      if (!STAGE_ID_RE.test(sid)) {
+        errors.push({
+          code: 'BP-006',
+          message: `${path}.id "${sid}" must match STAGE-[<middle>-]<INTEGER>`,
+        });
+      }
+    }
+    if (!isNonEmptyString(s['name'])) {
+      errors.push({ code: 'BP-005', message: `${path}.name is required` });
+    }
+    if (!isNonEmptyString(s['goal'])) {
+      errors.push({ code: 'BP-005', message: `${path}.goal is required` });
+    }
+    if (!isNonEmptyString(s['result'])) {
+      errors.push({ code: 'BP-005', message: `${path}.result is required` });
+    }
+  }
+
+  const usedStageIds = new Set<string>();
+
+  for (const category of ASPECT_CATEGORIES) {
+    const arr = pb[category];
+    if (arr === undefined) continue;
+    if (!Array.isArray(arr)) {
+      errors.push({ code: 'BP-007', message: `process_blueprint.${category} must be an array` });
+      continue;
+    }
+
+    for (let i = 0; i < arr.length; i++) {
+      const e = arr[i] as Record<string, unknown> | undefined;
+      const path = `${category}[${i}]`;
+      if (!e || typeof e !== 'object') {
+        errors.push({ code: 'BP-007', message: `${path} must be an object` });
+        continue;
+      }
+
+      if (!isNonEmptyString(e['name'])) {
+        errors.push({ code: 'BP-007', message: `${path}.name is required` });
+      }
+
+      const entryStages = e['stages'];
+      if (!Array.isArray(entryStages) || entryStages.length === 0) {
+        errors.push({
+          code: 'BP-007',
+          message: `${path}.stages must be a non-empty array of STAGE-… ids`,
+        });
+      } else {
+        for (let j = 0; j < entryStages.length; j++) {
+          const ref = entryStages[j];
+          if (typeof ref !== 'string') {
+            errors.push({ code: 'BP-008', message: `${path}.stages[${j}] must be a string` });
+            continue;
+          }
+          if (!stageIds.has(ref)) {
+            errors.push({
+              code: 'BP-008',
+              message: `${path}.stages[${j}] references undeclared stage "${ref}"`,
+            });
+          } else {
+            usedStageIds.add(ref);
+          }
+        }
+
+        if (entryStages.length === 1) {
+          warnings.push({
+            code: 'BP-012',
+            message: `${path}.stages references a single stage — entry may be a candidate for inlining into the stage description`,
+          });
+        }
+      }
+
+      const entryId = e['id'];
+      if (entryId !== undefined) {
+        if (typeof entryId !== 'string') {
+          errors.push({ code: 'BP-009', message: `${path}.id must be a string` });
+        } else if (!ID_GRAMMAR_RE.test(entryId)) {
+          errors.push({
+            code: 'BP-009',
+            message: `${path}.id "${entryId}" must match <TYPE>-[<middle>-]<INTEGER>`,
+          });
+        } else if (category === 'systems' && !APPLICATION_ID_RE.test(entryId)) {
+          errors.push({
+            code: 'BP-010',
+            message: `${path}.id "${entryId}" must use the APPLICATION- prefix`,
+          });
+        } else if (category === 'actors' && !ROLE_ID_RE.test(entryId)) {
+          errors.push({
+            code: 'BP-010',
+            message: `${path}.id "${entryId}" must use the ROLE- prefix`,
+          });
+        }
+      }
+    }
+  }
+
+  for (const sid of stageIds) {
+    if (!usedStageIds.has(sid)) {
+      warnings.push({
+        code: 'BP-011',
+        message: `Stage "${sid}" has no aspect entries pointing at it — structurally empty`,
+      });
+    }
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}


### PR DESCRIPTION
## Summary

Closes hub task **#26** — Process Blueprint render module + preview. This is the
1.0.0 release gate for epic transitrix/strategy#24 (Process Blueprint notation).

Implements against the canonical spec at
[`transitrix/methodology` `notations/13-process-blueprint.md`](https://github.com/transitrix/methodology/blob/main/notations/13-process-blueprint.md)
(spec merged in [methodology PR #12](https://github.com/transitrix/methodology/pull/12)).

### Module — `packages/diagrams/src/process-blueprint/`

- **`types.ts`** — `ProcessBlueprintFile` / `Stage` / `AspectEntry` plus layout types
  (`AspectPill`, `AspectRow`, `ProcessBlueprintLayout`, etc.).
- **`validate.ts`** — full coverage of the spec's validation rules:

  | Rule | What it checks |
  |---|---|
  | BP-001 | root + `notation:` header |
  | BP-002 | document `id` grammar |
  | BP-003 | document `name` |
  | BP-004 | `stages[]` array shape |
  | BP-005 | per-stage required fields |
  | BP-006 | stage id uniqueness (whitespace-trimmed) + grammar |
  | BP-007 | aspect entry shape |
  | BP-008 | aspect → stage cross-refs (whitespace-trimmed on both sides) |
  | BP-009 | aspect id canonical grammar |
  | BP-010 | systems → APPLICATION-, actors → ROLE- prefix |
  | BP-011 (warn) | structurally empty stage |
  | BP-012 (warn) | singleton-stage aspect entry |

- **`layout.ts`** — flat YAML → nested-box grid:
  - Stages laid out left-to-right in input order.
  - Legend column on the left; goal + result rows above the aspect rows.
  - Aspect rows in the fixed spec order (systems → actors → equipment → information_entities). Categories empty document-wide are dropped.
  - Entries spanning **consecutive** stages merge into a single pill that visually spans the columns. Entries spanning **non-consecutive** stages render as one pill per run (per spec §7 MUST).
  - Overlapping pills inside one row pack into vertical slots (greedy interval scheduling); row height grows with the max stack depth.
  - Stage-id lookups trim whitespace symmetrically with the validator, so identity matches across the validate → layout pipeline.

### Studio preview

- **`extension/src/process-blueprint-preview.ts`** — webview class that **imports** `validateProcessBlueprint`, `layoutProcessBlueprint`, and the layout types from `@transitrix/diagrams` (via the same relative path pattern `diagram-frame.ts` already uses); the file contains only the SVG renderer and the webview wiring. Theming comes from the shared `diagram-frame` module, so blueprints sit in the same visual family as Goals trees. No inlined types / validate / layout copy — the 39 module tests cover the exact code path the preview runs.
- **`extension/src/extension.ts`** — file detector, command registration, save/open dispatch.
- **`extension/package.json`** — language declaration for `*.process-blueprint.transitrix.yaml`, two commands (`transitrixStudio.previewProcessBlueprint`, `transitrixStudio.saveProcessBlueprintAsSvg`), and editor/title menu entries for the file extension and the webview panel.

### Engine reuse

Per the standing rule, all notation render / validation logic lives in `@transitrix/diagrams` and is **consumed** by Studio, not duplicated. The preview imports the package's `validateProcessBlueprint` and `layoutProcessBlueprint` directly; only the SVG drawing layer is Studio-side. No Svgbob path; blueprint converges on the JS-native renderer used by Goals (spec §7).

### Example fixture + conformance test

- **`examples/process-blueprint/order-fulfilment.process-blueprint.transitrix.yaml`** — three-stage retail blueprint exercising all four aspect categories, consecutive-spanning entries (OMS, Customer order), and non-consecutive singletons. Mirrors the spec's complete example, expanded.
- **`examples/process-blueprint/README.md`** — format overview, required / optional fields, link to the canonical spec.
- **Conformance test** — the validate suite now reads every `.yaml` under `examples/process-blueprint/` and asserts `r.valid === true` with no errors, matching the capability-map / process-map / scenarios pattern.

### Tests

- **39 new tests pass**: 28 validate (incl. trim regression cases for BP-006 / BP-008 and the example conformance check) + 11 layout, all under `packages/diagrams/src/process-blueprint/__tests__/`.
- Full diagrams suite: **280 / 280** passing.
- `tsc --noEmit` passes for both `packages/diagrams` and `extension`.

## Test plan

- [x] `npx vitest run` in `packages/diagrams` — 280 passing.
- [x] `tsc --noEmit` in `packages/diagrams` — clean.
- [x] `tsc --noEmit` in `extension` — clean.
- [x] Conformance: `examples/process-blueprint/order-fulfilment.process-blueprint.transitrix.yaml` validates clean.
- [ ] Manual: open a `.process-blueprint.transitrix.yaml` file in VS Code, confirm the preview opens to the side, renders stage columns + aspect rows with pills spanning consecutive stages.
- [ ] Manual: invalid YAML (missing `process_blueprint`, bad id grammar, undeclared stage ref) surfaces BP-NNN errors in the preview.
- [ ] Manual: "Save as SVG" command produces a self-contained SVG.

## Branch state

Rebased on current `main` after PR #4 (0.4.19 release) merged at `22ab09f`. No conflicts during rebase — the version bump from 0.4.19 and this PR's `extension/package.json` additions sit side-by-side. Head: `833e471`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)