### PR TITLE
fix(pre-release): 8 blockers ahead of the 1.0.0 build

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -32,7 +32,17 @@
   "activationEvents": [
     "workspaceContains:**/*.cervin.yaml",
     "workspaceContains:**/*.bpmn.yaml",
-    "workspaceContains:**/*.goals.transitrix.yaml"
+    "workspaceContains:**/*.goals.transitrix.yaml",
+    "workspaceContains:**/*.fgca.transitrix.yaml",
+    "workspaceContains:**/*.fga.transitrix.yaml",
+    "workspaceContains:**/*.activities.transitrix.yaml",
+    "workspaceContains:**/*.blocks.transitrix.txt",
+    "workspaceContains:**/*.applications.transitrix.yaml",
+    "workspaceContains:**/*.products.transitrix.yaml",
+    "workspaceContains:**/*.process-map.transitrix.yaml",
+    "workspaceContains:**/*.scenarios.transitrix.yaml",
+    "workspaceContains:**/*.capability-map.transitrix.yaml",
+    "workspaceContains:**/*.process-blueprint.transitrix.yaml"
   ],
   "contributes": {
     "configuration": {

--- a/extension/src/goals-preview.ts
+++ b/extension/src/goals-preview.ts
@@ -74,7 +74,7 @@ function validateGoalTree(input: unknown): ValidationResult {
   }
 
   if (errors.length === 0) {
-    checkCycles(raw.goals_tree as unknown as GoalsTreeRoot['root'] & { children?: TreeNode[] }, new Set());
+    checkCycles(tree.root as unknown as TreeNode, new Set());
   }
 
   return { valid: errors.length === 0, errors, warnings };

--- a/packages/diagrams/src/applications/__tests__/validate.test.ts
+++ b/packages/diagrams/src/applications/__tests__/validate.test.ts
@@ -227,4 +227,30 @@ describe('validateApplicationsCatalogue', () => {
     const r = validateApplicationsCatalogue({ ...VALID_CATALOGUE, applications_catalogue: cat });
     expect(r.valid).toBe(true);
   });
+
+  // Pre-release blocker regression (orchestrator review 2026-05-21).
+  it('[blocker] tolerates a null element in applications[] without throwing', () => {
+    const cat = { ...VALID_CATALOGUE.applications_catalogue, applications: [null] };
+    const r = validateApplicationsCatalogue({ ...VALID_CATALOGUE, applications_catalogue: cat });
+    expect(r.valid).toBe(false);
+    expect(r.errors.some(e => e.code === 'APP-003')).toBe(true);
+  });
+
+  it('[blocker] tolerates a string element in applications[] without throwing', () => {
+    const cat = { ...VALID_CATALOGUE.applications_catalogue, applications: ['x'] };
+    const r = validateApplicationsCatalogue({ ...VALID_CATALOGUE, applications_catalogue: cat });
+    expect(r.valid).toBe(false);
+    expect(r.errors.some(e => e.code === 'APP-003')).toBe(true);
+  });
+
+  it('[blocker] tolerates a null integration entry without throwing', () => {
+    const apps = [{
+      app_id: 'A1', name: 'X', type: 'application', status: 'Active',
+      integrations: [null],
+    }];
+    const cat = { ...VALID_CATALOGUE.applications_catalogue, applications: apps };
+    const r = validateApplicationsCatalogue({ ...VALID_CATALOGUE, applications_catalogue: cat });
+    expect(r.valid).toBe(false);
+    expect(r.errors.some(e => e.code === 'APP-009')).toBe(true);
+  });
 });

--- a/packages/diagrams/src/applications/validate.ts
+++ b/packages/diagrams/src/applications/validate.ts
@@ -67,8 +67,14 @@ export function validateApplicationsCatalogue(input: unknown): ValidationResult 
   const seenIds = new Set<string>();
 
   for (let i = 0; i < applications.length; i++) {
-    const a = applications[i] as Record<string, unknown>;
+    const rawApp = applications[i];
     const idx = `applications[${i}]`;
+
+    if (!rawApp || typeof rawApp !== 'object') {
+      errors.push({ code: 'APP-003', message: `${idx} must be an object` });
+      continue;
+    }
+    const a = rawApp as Record<string, unknown>;
 
     // APP-003: required per-application fields
     if (!a['app_id'] || typeof a['app_id'] !== 'string' || !(a['app_id'] as string).trim()) {
@@ -111,9 +117,14 @@ export function validateApplicationsCatalogue(input: unknown): ValidationResult 
 
     // APP-009: integrations[].direction enum
     if (Array.isArray(a['integrations'])) {
-      const integrations = a['integrations'] as Record<string, unknown>[];
+      const integrations = a['integrations'] as unknown[];
       for (let j = 0; j < integrations.length; j++) {
-        const intg = integrations[j];
+        const rawIntg = integrations[j];
+        if (!rawIntg || typeof rawIntg !== 'object') {
+          errors.push({ code: 'APP-009', message: `${idx}.integrations[${j}] must be an object` });
+          continue;
+        }
+        const intg = rawIntg as Record<string, unknown>;
         if (intg['direction'] !== undefined && !VALID_DIRECTIONS.has(intg['direction'] as IntegrationDirection)) {
           errors.push({ code: 'APP-009', message: `${idx}.integrations[${j}]: direction "${intg['direction']}" must be one of: inbound, outbound, bidirectional` });
         }

--- a/packages/diagrams/src/capability-map/__tests__/validate.test.ts
+++ b/packages/diagrams/src/capability-map/__tests__/validate.test.ts
@@ -192,6 +192,24 @@ describe('validateCapabilityMap', () => {
     const r = validateCapabilityMap({ ...VALID_MAP, capability_map: map });
     expect(r.valid).toBe(true);
   });
+
+  // Pre-release blocker regression (orchestrator review 2026-05-21).
+  it('[blocker] tolerates a null element in capabilities[] without throwing', () => {
+    const map = { ...VALID_MAP.capability_map, capabilities: [null] };
+    const r = validateCapabilityMap({ ...VALID_MAP, capability_map: map });
+    expect(r.valid).toBe(false);
+    expect(r.errors.some(e => e.code === 'CMAP-003')).toBe(true);
+  });
+
+  it('[blocker] tolerates a null child capability without throwing', () => {
+    const map = {
+      ...VALID_MAP.capability_map,
+      capabilities: [{ id: 'V1', name: 'X', current_maturity: 2, children: [null] }],
+    };
+    const r = validateCapabilityMap({ ...VALID_MAP, capability_map: map });
+    expect(r.valid).toBe(false);
+    expect(r.errors.some(e => e.code === 'CMAP-003')).toBe(true);
+  });
 });
 
 describe('capability-map examples (regression)', () => {

--- a/packages/diagrams/src/capability-map/validate.ts
+++ b/packages/diagrams/src/capability-map/validate.ts
@@ -66,8 +66,14 @@ function validateCapabilityTree(
   seenIds: Set<string>,
 ): void {
   for (let i = 0; i < nodes.length; i++) {
-    const node = nodes[i] as Record<string, unknown>;
+    const rawNode = nodes[i];
     const nodePath = `${pathPrefix}[${i}]`;
+
+    if (!rawNode || typeof rawNode !== 'object') {
+      errors.push({ code: 'CMAP-003', message: `${nodePath} must be an object` });
+      continue;
+    }
+    const node = rawNode as Record<string, unknown>;
 
     if (!node['id'] || typeof node['id'] !== 'string' || !(node['id'] as string).trim()) {
       errors.push({ code: 'CMAP-003', message: `${nodePath}: id is required` });

--- a/packages/diagrams/src/fgca/__tests__/layout.test.ts
+++ b/packages/diagrams/src/fgca/__tests__/layout.test.ts
@@ -166,4 +166,14 @@ describe("buildFGCALayout — columns are positioned left to right", () => {
     const a = nodes.find((n) => n.type === "fgcaActivity")!;
     expect(c.position.x).toBeLessThan(a.position.x);
   });
+
+  // Pre-release blocker regression (orchestrator review 2026-05-21).
+  it("[blocker] tolerates a change with no activity_ids (optional per validator)", () => {
+    const changesNoIds: BdnChangeWithActivities[] = [
+      { id: 100, name: "No activities", goal_id: 10 } as BdnChangeWithActivities,
+    ];
+    expect(() =>
+      buildFGCALayout({ factors, goals, changes: changesNoIds, activities, visibleColumns: ALL_COLS }),
+    ).not.toThrow();
+  });
 });

--- a/packages/diagrams/src/fgca/__tests__/validate.test.ts
+++ b/packages/diagrams/src/fgca/__tests__/validate.test.ts
@@ -117,4 +117,26 @@ describe('validateFGCADoc', () => {
     const result = validateFGCADoc({ ...VALID_DOC, spec_version: '0.1' });
     expect(result.valid).toBe(true);
   });
+
+  // Pre-release blocker regression (orchestrator review 2026-05-21).
+  it('[blocker] tolerates a null element in goals[] without throwing', () => {
+    const r = validateFGCADoc({ ...VALID_DOC, goals: [null] });
+    expect(r.valid).toBe(false);
+    expect(r.errors.some(e => e.code === 'SCHEMA_INVALID')).toBe(true);
+  });
+  it('[blocker] tolerates a string element in factors[] without throwing', () => {
+    const r = validateFGCADoc({ ...VALID_DOC, factors: ['x'] });
+    expect(r.valid).toBe(false);
+    expect(r.errors.some(e => e.code === 'SCHEMA_INVALID')).toBe(true);
+  });
+  it('[blocker] tolerates a null element in changes[] without throwing', () => {
+    const r = validateFGCADoc({ ...VALID_DOC, changes: [null] });
+    expect(r.valid).toBe(false);
+    expect(r.errors.some(e => e.code === 'SCHEMA_INVALID')).toBe(true);
+  });
+  it('[blocker] tolerates a null element in activities[] without throwing', () => {
+    const r = validateFGCADoc({ ...VALID_DOC, activities: [null] });
+    expect(r.valid).toBe(false);
+    expect(r.errors.some(e => e.code === 'SCHEMA_INVALID')).toBe(true);
+  });
 });

--- a/packages/diagrams/src/fgca/layout.ts
+++ b/packages/diagrams/src/fgca/layout.ts
@@ -167,7 +167,7 @@ export function buildFGCALayout({
   // Change→Activity edges
   if (visibleColumns.has("change") && visibleColumns.has("activity")) {
     changes.forEach((c) => {
-      c.activity_ids.forEach((aid) => {
+      (c.activity_ids ?? []).forEach((aid) => {
         edges.push({
           id: `edge_c${c.id}_a${aid}`,
           source: `change_${c.id}`,
@@ -183,7 +183,7 @@ export function buildFGCALayout({
   // Goal→Activity direct edges (only for activities not already covered via a Change link)
   if (visibleColumns.has("goal") && visibleColumns.has("activity")) {
     const coveredActivityIds = visibleColumns.has("change")
-      ? new Set(changes.flatMap((c) => c.activity_ids))
+      ? new Set(changes.flatMap((c) => c.activity_ids ?? []))
       : new Set<number>();
     activities.forEach((a) => {
       const gid = a.goal_id;

--- a/packages/diagrams/src/fgca/validate.ts
+++ b/packages/diagrams/src/fgca/validate.ts
@@ -53,45 +53,79 @@ export function validateFGCADoc(input: unknown): FGCAValidationResult {
   if (errors.length > 0) return { valid: false, errors, warnings };
 
   const doc = raw as unknown as FGCADoc;
-  const factorIds = new Set(doc.factors.map(f => f.id));
-  const goalIds = new Set(doc.goals.map(g => g.id));
-  const activityIds = new Set(doc.activities.map(a => a.id));
+  const collectIds = (arr: unknown[]): Set<number> => {
+    const out = new Set<number>();
+    for (const el of arr) {
+      if (el && typeof el === 'object') {
+        const id = (el as { id?: unknown }).id;
+        if (typeof id === 'number') out.add(id);
+      }
+    }
+    return out;
+  };
+  const factorIds = collectIds(doc.factors as unknown as unknown[]);
+  const goalIds = collectIds(doc.goals as unknown as unknown[]);
+  const activityIds = collectIds(doc.activities as unknown as unknown[]);
 
   for (let i = 0; i < doc.factors.length; i++) {
-    const f = doc.factors[i];
-    if (typeof f.id !== 'number') errors.push({ code: 'SCHEMA_INVALID', message: 'factor id must be a number', path: `factors[${i}]` });
-    if (!f.name?.trim()) errors.push({ code: 'EMPTY_NAME', message: `Factor ${f.id} has empty name`, path: `factors[${i}]` });
+    const f = doc.factors[i] as unknown;
+    if (!f || typeof f !== 'object') {
+      errors.push({ code: 'SCHEMA_INVALID', message: 'factor entry must be an object', path: `factors[${i}]` });
+      continue;
+    }
+    const factor = f as { id?: unknown; name?: unknown };
+    if (typeof factor.id !== 'number') errors.push({ code: 'SCHEMA_INVALID', message: 'factor id must be a number', path: `factors[${i}]` });
+    if (typeof factor.name !== 'string' || !factor.name.trim()) errors.push({ code: 'EMPTY_NAME', message: `Factor ${String(factor.id)} has empty name`, path: `factors[${i}]` });
   }
 
   for (let i = 0; i < doc.goals.length; i++) {
-    const g = doc.goals[i];
-    if (typeof g.id !== 'number') errors.push({ code: 'SCHEMA_INVALID', message: 'goal id must be a number', path: `goals[${i}]` });
-    if (!g.name?.trim()) errors.push({ code: 'EMPTY_NAME', message: `Goal ${g.id} has empty name`, path: `goals[${i}]` });
-    for (const f of (g.factor ?? [])) {
-      if (!factorIds.has(f.id)) {
-        warnings.push({ code: 'BROKEN_REF', message: `Goal ${g.id} references missing factor ${f.id}`, path: `goals[${i}].factor` });
+    const g = doc.goals[i] as unknown;
+    if (!g || typeof g !== 'object') {
+      errors.push({ code: 'SCHEMA_INVALID', message: 'goal entry must be an object', path: `goals[${i}]` });
+      continue;
+    }
+    const goal = g as { id?: unknown; name?: unknown; factor?: unknown };
+    if (typeof goal.id !== 'number') errors.push({ code: 'SCHEMA_INVALID', message: 'goal id must be a number', path: `goals[${i}]` });
+    if (typeof goal.name !== 'string' || !goal.name.trim()) errors.push({ code: 'EMPTY_NAME', message: `Goal ${String(goal.id)} has empty name`, path: `goals[${i}]` });
+    const factorRefs = Array.isArray(goal.factor) ? (goal.factor as unknown[]) : [];
+    for (const fr of factorRefs) {
+      if (!fr || typeof fr !== 'object') continue;
+      const fid = (fr as { id?: unknown }).id;
+      if (typeof fid === 'number' && !factorIds.has(fid)) {
+        warnings.push({ code: 'BROKEN_REF', message: `Goal ${String(goal.id)} references missing factor ${fid}`, path: `goals[${i}].factor` });
       }
     }
   }
 
   for (let i = 0; i < doc.changes.length; i++) {
-    const c = doc.changes[i];
-    if (typeof c.id !== 'number') errors.push({ code: 'SCHEMA_INVALID', message: 'change id must be a number', path: `changes[${i}]` });
-    if (!c.name?.trim()) errors.push({ code: 'EMPTY_NAME', message: `Change ${c.id} has empty name`, path: `changes[${i}]` });
-    if (!goalIds.has(c.goal_id)) {
-      warnings.push({ code: 'BROKEN_REF', message: `Change ${c.id} references missing goal ${c.goal_id}`, path: `changes[${i}].goal_id` });
+    const c = doc.changes[i] as unknown;
+    if (!c || typeof c !== 'object') {
+      errors.push({ code: 'SCHEMA_INVALID', message: 'change entry must be an object', path: `changes[${i}]` });
+      continue;
     }
-    for (const aid of (c.activity_ids ?? [])) {
-      if (!activityIds.has(aid)) {
-        warnings.push({ code: 'BROKEN_REF', message: `Change ${c.id} references missing activity ${aid}`, path: `changes[${i}].activity_ids` });
+    const change = c as { id?: unknown; name?: unknown; goal_id?: unknown; activity_ids?: unknown };
+    if (typeof change.id !== 'number') errors.push({ code: 'SCHEMA_INVALID', message: 'change id must be a number', path: `changes[${i}]` });
+    if (typeof change.name !== 'string' || !change.name.trim()) errors.push({ code: 'EMPTY_NAME', message: `Change ${String(change.id)} has empty name`, path: `changes[${i}]` });
+    if (typeof change.goal_id === 'number' && !goalIds.has(change.goal_id)) {
+      warnings.push({ code: 'BROKEN_REF', message: `Change ${String(change.id)} references missing goal ${change.goal_id}`, path: `changes[${i}].goal_id` });
+    }
+    const aids = Array.isArray(change.activity_ids) ? (change.activity_ids as unknown[]) : [];
+    for (const aid of aids) {
+      if (typeof aid === 'number' && !activityIds.has(aid)) {
+        warnings.push({ code: 'BROKEN_REF', message: `Change ${String(change.id)} references missing activity ${aid}`, path: `changes[${i}].activity_ids` });
       }
     }
   }
 
   for (let i = 0; i < doc.activities.length; i++) {
-    const a = doc.activities[i];
-    if (typeof a.id !== 'number') errors.push({ code: 'SCHEMA_INVALID', message: 'activity id must be a number', path: `activities[${i}]` });
-    if (!a.name?.trim()) errors.push({ code: 'EMPTY_NAME', message: `Activity ${a.id} has empty name`, path: `activities[${i}]` });
+    const a = doc.activities[i] as unknown;
+    if (!a || typeof a !== 'object') {
+      errors.push({ code: 'SCHEMA_INVALID', message: 'activity entry must be an object', path: `activities[${i}]` });
+      continue;
+    }
+    const activity = a as { id?: unknown; name?: unknown };
+    if (typeof activity.id !== 'number') errors.push({ code: 'SCHEMA_INVALID', message: 'activity id must be a number', path: `activities[${i}]` });
+    if (typeof activity.name !== 'string' || !activity.name.trim()) errors.push({ code: 'EMPTY_NAME', message: `Activity ${String(activity.id)} has empty name`, path: `activities[${i}]` });
   }
 
   return { valid: errors.length === 0, errors, warnings };

--- a/packages/diagrams/src/goals/__tests__/layout.test.ts
+++ b/packages/diagrams/src/goals/__tests__/layout.test.ts
@@ -75,4 +75,25 @@ describe('layoutGoalTree', () => {
     // Level 2 nodes (id 3, 4) should be hidden
     expect(layout.nodes.every(n => n.data.level <= 1)).toBe(true);
   });
+
+  // Pre-release blocker regression (orchestrator review 2026-05-21).
+  it('[blocker] does not stack-overflow on a self-parent cycle', () => {
+    const cyclic: GoalTree = {
+      goal_types: [{ name: 'X', level: 0 }],
+      goals: [{ id: 1, name: 'self-parent', type: 'X', level: 0, parent_id: 1 }],
+    };
+    // Without a visited-set inside placeSubtree, this recurses forever.
+    expect(() => layoutGoalTree(cyclic)).not.toThrow();
+  });
+
+  it('[blocker] does not stack-overflow on a 2-node mutual cycle', () => {
+    const cyclic: GoalTree = {
+      goal_types: [{ name: 'X', level: 0 }, { name: 'Y', level: 1 }],
+      goals: [
+        { id: 1, name: 'A', type: 'X', level: 0, parent_id: 2 },
+        { id: 2, name: 'B', type: 'Y', level: 1, parent_id: 1 },
+      ],
+    };
+    expect(() => layoutGoalTree(cyclic)).not.toThrow();
+  });
 });

--- a/packages/diagrams/src/goals/__tests__/validate.test.ts
+++ b/packages/diagrams/src/goals/__tests__/validate.test.ts
@@ -91,4 +91,39 @@ describe('validateGoalTree', () => {
     };
     expect(validateGoalTree(tree).errors.some(e => e.code === 'CYCLE_DETECTED')).toBe(true);
   });
+
+  // Pre-release blocker regression tests (orchestrator review 2026-05-21).
+  it('[blocker] tolerates a null element in goals[] without throwing', () => {
+    const tree = { ...VALID_TREE, goals: [null] };
+    const r = validateGoalTree(tree);
+    expect(r.valid).toBe(false);
+    expect(r.errors.some(e => e.code === 'SCHEMA_INVALID')).toBe(true);
+  });
+
+  it('[blocker] tolerates a non-object element in goals[] without throwing', () => {
+    const tree = { ...VALID_TREE, goals: ['x'] };
+    const r = validateGoalTree(tree);
+    expect(r.valid).toBe(false);
+    expect(r.errors.some(e => e.code === 'SCHEMA_INVALID')).toBe(true);
+  });
+
+  it('[blocker] rejects non-numeric level (does not silently slip a string compare)', () => {
+    const tree = {
+      ...VALID_TREE,
+      goals: [{ id: 1, name: 'A', type: 'Strategy', level: '5', parent_id: 0 }],
+    };
+    const r = validateGoalTree(tree);
+    expect(r.valid).toBe(false);
+    expect(r.errors.some(e => e.code === 'SCHEMA_INVALID' && /level/.test(e.message))).toBe(true);
+  });
+
+  it('[blocker] rejects missing level (does not silently slip undefined > N)', () => {
+    const tree = {
+      ...VALID_TREE,
+      goals: [{ id: 1, name: 'A', type: 'Strategy', parent_id: 0 }],
+    };
+    const r = validateGoalTree(tree);
+    expect(r.valid).toBe(false);
+    expect(r.errors.some(e => e.code === 'SCHEMA_INVALID' && /level/.test(e.message))).toBe(true);
+  });
 });

--- a/packages/diagrams/src/goals/layout.ts
+++ b/packages/diagrams/src/goals/layout.ts
@@ -59,12 +59,19 @@ export function layoutGoalTree(tree: GoalTree, options: LayoutOptions = {}): Goa
     columnNextY.set(col, (columnNextY.get(col) ?? 0) + delta);
   }
 
+  const placed = new Set<number>();
+
   function placeSubtree(id: number): { top: number; bottom: number } {
     const goal = goalById.get(id);
     if (!goal || hiddenSubtrees.has(id)) return { top: 0, bottom: 0 };
+    // Guard against cycles (parent-of-itself, mutual parenting). Without
+    // validateGoalTree() upstream, layoutGoalTree must not stack-overflow on
+    // malformed input — drop any subtree we've already placed.
+    if (placed.has(id)) return { top: 0, bottom: 0 };
+    placed.add(id);
 
     const col = goal.level;
-    const childIds = (children.get(id) ?? []).filter(c => !hiddenSubtrees.has(c));
+    const childIds = (children.get(id) ?? []).filter(c => !hiddenSubtrees.has(c) && !placed.has(c));
     const isCollapsedRoot = hiddenSet.has(id) && childIds.length > 0;
     const hasHiddenChildren = childIds.length < (children.get(id) ?? []).length;
 
@@ -101,7 +108,7 @@ export function layoutGoalTree(tree: GoalTree, options: LayoutOptions = {}): Goa
   }
 
   for (const root of roots) {
-    if (!hiddenSubtrees.has(root.id)) {
+    if (!hiddenSubtrees.has(root.id) && !placed.has(root.id)) {
       placeSubtree(root.id);
       // Add inter-root gap
       for (const [col, y] of columnNextY) {

--- a/packages/diagrams/src/goals/validate.ts
+++ b/packages/diagrams/src/goals/validate.ts
@@ -24,30 +24,40 @@ export function validateGoalTree(input: unknown): ValidationResult {
   const idSet = new Set<number>();
 
   for (let i = 0; i < tree.goals.length; i++) {
-    const g = tree.goals[i];
+    const g = tree.goals[i] as unknown;
     const path = `goals[${i}]`;
 
-    if (typeof g.id !== 'number') {
+    if (!g || typeof g !== 'object') {
+      errors.push({ code: 'SCHEMA_INVALID', message: 'goal entry must be an object', path });
+      continue;
+    }
+    const goal = g as { id?: unknown; name?: unknown; level?: unknown; type?: unknown };
+
+    if (typeof goal.id !== 'number') {
       errors.push({ code: 'SCHEMA_INVALID', message: 'goal id must be a number', path });
       continue;
     }
-    if (!g.name || typeof g.name !== 'string' || g.name.trim() === '') {
-      errors.push({ code: 'EMPTY_NAME', message: `Goal ${g.id} has empty name`, path });
+    if (!goal.name || typeof goal.name !== 'string' || goal.name.trim() === '') {
+      errors.push({ code: 'EMPTY_NAME', message: `Goal ${goal.id} has empty name`, path });
     }
 
-    if (idSet.has(g.id)) {
-      errors.push({ code: 'DUPLICATE_ID', message: `Duplicate goal id: ${g.id}`, path });
+    if (idSet.has(goal.id)) {
+      errors.push({ code: 'DUPLICATE_ID', message: `Duplicate goal id: ${goal.id}`, path });
     } else {
-      idSet.add(g.id);
+      idSet.add(goal.id);
     }
 
-    if (g.level > maxLevel) {
-      errors.push({ code: 'MAX_LEVEL_EXCEEDED', message: `Goal ${g.id} level ${g.level} exceeds max ${maxLevel}`, path });
+    if (typeof goal.level !== 'number' || !Number.isFinite(goal.level)) {
+      errors.push({ code: 'SCHEMA_INVALID', message: `Goal ${goal.id} level must be a finite number`, path });
+      continue;
+    }
+    if (goal.level > maxLevel) {
+      errors.push({ code: 'MAX_LEVEL_EXCEEDED', message: `Goal ${goal.id} level ${goal.level} exceeds max ${maxLevel}`, path });
     }
 
-    const expectedLevel = typeMap.get(g.type);
-    if (expectedLevel !== undefined && expectedLevel !== g.level) {
-      warnings.push({ code: 'TYPE_LEVEL_MISMATCH', message: `Goal ${g.id} type "${g.type}" expects level ${expectedLevel}, got ${g.level}`, path });
+    const expectedLevel = typeof goal.type === 'string' ? typeMap.get(goal.type) : undefined;
+    if (expectedLevel !== undefined && expectedLevel !== goal.level) {
+      warnings.push({ code: 'TYPE_LEVEL_MISMATCH', message: `Goal ${goal.id} type "${String(goal.type)}" expects level ${expectedLevel}, got ${goal.level}`, path });
     }
   }
 
@@ -57,6 +67,7 @@ export function validateGoalTree(input: unknown): ValidationResult {
   for (let i = 0; i < tree.goals.length; i++) {
     const g = tree.goals[i];
     const path = `goals[${i}]`;
+    if (!g || typeof g !== 'object') continue;
     if (g.parent_id !== 0 && !idSet.has(g.parent_id)) {
       warnings.push({ code: 'BROKEN_PARENT_REF', message: `Goal ${g.id} references missing parent ${g.parent_id} — moved to backlog`, path });
     }

--- a/packages/diagrams/src/process-map/__tests__/validate.test.ts
+++ b/packages/diagrams/src/process-map/__tests__/validate.test.ts
@@ -188,6 +188,24 @@ describe('validateProcessMap', () => {
     const r = validateProcessMap({ ...VALID_MAP, process_map: map });
     expect(r.valid).toBe(true);
   });
+
+  // Pre-release blocker regression (orchestrator review 2026-05-21).
+  it('[blocker] tolerates a null element in groups[] without throwing', () => {
+    const map = { ...VALID_MAP.process_map, groups: [null] };
+    const r = validateProcessMap({ ...VALID_MAP, process_map: map });
+    expect(r.valid).toBe(false);
+    expect(r.errors.some(e => e.code === 'PMAP-003')).toBe(true);
+  });
+
+  it('[blocker] tolerates a null element in processes[] without throwing', () => {
+    const map = {
+      ...VALID_MAP.process_map,
+      groups: [{ id: 'g1', name: 'G', type: 'operating', processes: [null] }],
+    };
+    const r = validateProcessMap({ ...VALID_MAP, process_map: map });
+    expect(r.valid).toBe(false);
+    expect(r.errors.some(e => e.code === 'PMAP-005')).toBe(true);
+  });
 });
 
 describe('process-map examples (regression)', () => {

--- a/packages/diagrams/src/process-map/validate.ts
+++ b/packages/diagrams/src/process-map/validate.ts
@@ -63,8 +63,14 @@ export function validateProcessMap(input: unknown): ValidationResult {
   const seenProcessIds = new Set<string>();
 
   for (let gi = 0; gi < groups.length; gi++) {
-    const g = groups[gi] as Record<string, unknown>;
+    const rawGroup = groups[gi];
     const gIdx = `groups[${gi}]`;
+
+    if (!rawGroup || typeof rawGroup !== 'object') {
+      errors.push({ code: 'PMAP-003', message: `${gIdx} must be an object` });
+      continue;
+    }
+    const g = rawGroup as Record<string, unknown>;
 
     if (!g['id'] || typeof g['id'] !== 'string' || !(g['id'] as string).trim()) {
       errors.push({ code: 'PMAP-003', message: `${gIdx}: id is required` });
@@ -93,8 +99,14 @@ export function validateProcessMap(input: unknown): ValidationResult {
 
     const list = (processes ?? []) as unknown[];
     for (let pi = 0; pi < list.length; pi++) {
-      const p = list[pi] as Record<string, unknown>;
+      const rawProcess = list[pi];
       const pIdx = `${gIdx}.processes[${pi}]`;
+
+      if (!rawProcess || typeof rawProcess !== 'object') {
+        errors.push({ code: 'PMAP-005', message: `${pIdx} must be an object` });
+        continue;
+      }
+      const p = rawProcess as Record<string, unknown>;
 
       if (!p['process_id'] || typeof p['process_id'] !== 'string' || !(p['process_id'] as string).trim()) {
         errors.push({ code: 'PMAP-005', message: `${pIdx}: process_id is required` });

--- a/packages/diagrams/src/products/__tests__/validate.test.ts
+++ b/packages/diagrams/src/products/__tests__/validate.test.ts
@@ -221,4 +221,19 @@ describe('validateProductsCatalogue', () => {
     const r = validateProductsCatalogue({ ...VALID_CATALOGUE, products_catalogue: cat });
     expect(r.valid).toBe(true);
   });
+
+  // Pre-release blocker regression (orchestrator review 2026-05-21).
+  it('[blocker] tolerates a null element in products[] without throwing', () => {
+    const cat = { ...VALID_CATALOGUE.products_catalogue, products: [null] };
+    const r = validateProductsCatalogue({ ...VALID_CATALOGUE, products_catalogue: cat });
+    expect(r.valid).toBe(false);
+    expect(r.errors.some(e => e.code === 'PROD-003')).toBe(true);
+  });
+
+  it('[blocker] tolerates a string element in products[] without throwing', () => {
+    const cat = { ...VALID_CATALOGUE.products_catalogue, products: ['x'] };
+    const r = validateProductsCatalogue({ ...VALID_CATALOGUE, products_catalogue: cat });
+    expect(r.valid).toBe(false);
+    expect(r.errors.some(e => e.code === 'PROD-003')).toBe(true);
+  });
 });

--- a/packages/diagrams/src/products/validate.ts
+++ b/packages/diagrams/src/products/validate.ts
@@ -64,8 +64,14 @@ export function validateProductsCatalogue(input: unknown): ValidationResult {
   const seenIds = new Set<string>();
 
   for (let i = 0; i < products.length; i++) {
-    const p = products[i] as Record<string, unknown>;
+    const rawProduct = products[i];
     const idx = `products[${i}]`;
+
+    if (!rawProduct || typeof rawProduct !== 'object') {
+      errors.push({ code: 'PROD-003', message: `${idx} must be an object` });
+      continue;
+    }
+    const p = rawProduct as Record<string, unknown>;
 
     // PROD-003: required per-product fields
     if (!p['product_id'] || typeof p['product_id'] !== 'string' || !(p['product_id'] as string).trim()) {

--- a/packages/diagrams/src/scenarios/__tests__/validate.test.ts
+++ b/packages/diagrams/src/scenarios/__tests__/validate.test.ts
@@ -170,6 +170,28 @@ describe('validateScenario', () => {
     const r = validateScenario({ ...VALID_SCENARIO, scenario: scn });
     expect(r.valid).toBe(true);
   });
+
+  // Pre-release blocker regression (orchestrator review 2026-05-21).
+  it('[blocker] tolerates a null element in factors_view[] without throwing', () => {
+    const scn = { ...VALID_SCENARIO.scenario, factors_view: [null] };
+    const r = validateScenario({ ...VALID_SCENARIO, scenario: scn });
+    expect(r.valid).toBe(false);
+    expect(r.errors.some(e => e.code === 'SCN-005')).toBe(true);
+  });
+
+  it('[blocker] tolerates a null element in goals[] without throwing', () => {
+    const scn = { ...VALID_SCENARIO.scenario, goals: [null] };
+    const r = validateScenario({ ...VALID_SCENARIO, scenario: scn });
+    expect(r.valid).toBe(false);
+    expect(r.errors.some(e => e.code === 'SCN-007')).toBe(true);
+  });
+
+  it('[blocker] tolerates a string element in applications[] without throwing', () => {
+    const scn = { ...VALID_SCENARIO.scenario, applications: ['x'] };
+    const r = validateScenario({ ...VALID_SCENARIO, scenario: scn });
+    expect(r.valid).toBe(false);
+    expect(r.errors.some(e => e.code === 'SCN-012')).toBe(true);
+  });
 });
 
 describe('scenarios examples (regression)', () => {

--- a/packages/diagrams/src/scenarios/validate.ts
+++ b/packages/diagrams/src/scenarios/validate.ts
@@ -75,8 +75,13 @@ export function validateScenario(input: unknown): ValidationResult {
       const seen = new Set<string>();
       const fv = s['factors_view'] as unknown[];
       for (let i = 0; i < fv.length; i++) {
-        const f = fv[i] as Record<string, unknown>;
+        const rawFactor = fv[i];
         const idx = `factors_view[${i}]`;
+        if (!rawFactor || typeof rawFactor !== 'object') {
+          errors.push({ code: 'SCN-005', message: `${idx} must be an object` });
+          continue;
+        }
+        const f = rawFactor as Record<string, unknown>;
         if (!f['factor_id'] || typeof f['factor_id'] !== 'string' || !(f['factor_id'] as string).trim()) {
           errors.push({ code: 'SCN-005', message: `${idx}: factor_id is required` });
         } else {
@@ -100,9 +105,14 @@ export function validateScenario(input: unknown): ValidationResult {
     }
     const seen = new Set<string>();
     for (let i = 0; i < list.length; i++) {
-      const item = list[i] as Record<string, unknown>;
+      const rawItem = list[i];
       const idx = `${spec.field}[${i}]`;
-      const id = item?.[spec.idField];
+      if (!rawItem || typeof rawItem !== 'object') {
+        errors.push({ code: spec.errorCode, message: `${idx} must be an object` });
+        continue;
+      }
+      const item = rawItem as Record<string, unknown>;
+      const id = item[spec.idField];
       if (!id || typeof id !== 'string' || !(id as string).trim()) {
         errors.push({ code: spec.errorCode, message: `${idx}: ${spec.idField} is required` });
       } else {

--- a/src/serve-ui.ts
+++ b/src/serve-ui.ts
@@ -2,7 +2,7 @@ import { createReadStream, existsSync } from 'node:fs'
 import { readFile, stat } from 'node:fs/promises'
 import { createServer } from 'node:http'
 import process from 'node:process'
-import { basename, dirname, extname, relative, resolve as pathResolve } from 'node:path'
+import { basename, dirname, extname, resolve as pathResolve, sep as pathSep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import type { IncomingMessage, ServerResponse } from 'node:http'
@@ -54,9 +54,14 @@ function resolveUiDist(): string {
   )
 }
 
-function isInsideRoot(staticRoot: string, candidateAbs: string): boolean {
-  const rel = relative(pathResolve(staticRoot), pathResolve(candidateAbs))
-  return rel === '' || !rel.startsWith('..')
+export function isInsideRoot(staticRoot: string, candidateAbs: string): boolean {
+  // path.relative() returns the raw second argument when the two paths live on
+  // different Windows drives — and that does not start with `..`, so a naive
+  // relative-based check would silently let `D:\b` "live inside" `C:\a`.
+  // A direct prefix comparison with the path separator catches that.
+  const root = pathResolve(staticRoot)
+  const candidate = pathResolve(candidateAbs)
+  return candidate === root || candidate.startsWith(root + pathSep)
 }
 
 async function serveFile(res: ServerResponse, filePath: string): Promise<void> {
@@ -66,7 +71,16 @@ async function serveFile(res: ServerResponse, filePath: string): Promise<void> {
     'Content-Length': String(st.size),
     'Cache-Control': 'no-cache',
   })
-  createReadStream(filePath).pipe(res)
+  const stream = createReadStream(filePath)
+  stream.on('error', (err) => {
+    // Stream errors fire after headers are already written; the client cannot
+    // be told via status code, so abort the socket instead of letting the
+    // unhandled error crash the process.
+    // eslint-disable-next-line no-console
+    console.error('serveFile: read stream error', err)
+    res.destroy(err)
+  })
+  stream.pipe(res)
 }
 
 export async function handleCompile(req: IncomingMessage, res: ServerResponse): Promise<void> {

--- a/tests/serve-ui.test.ts
+++ b/tests/serve-ui.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 
 import { MAX_COMPILE_BODY_BYTES } from '../src/http-body-limit.js';
-import { handleBlocksCompile, handleCompile } from '../src/serve-ui.js';
+import { handleBlocksCompile, handleCompile, isInsideRoot } from '../src/serve-ui.js';
 
 // Minimal YAML that compiles successfully (two elements + one flow).
 const VALID_YAML = `
@@ -161,5 +161,35 @@ describe('handleBlocksCompile', () => {
     const res = mockRes();
     await handleBlocksCompile(req, res);
     expect(res.captured.statusCode).toBe(413);
+  });
+});
+
+// Pre-release blocker regression (orchestrator review 2026-05-21).
+describe('isInsideRoot', () => {
+  it('accepts the root itself', () => {
+    expect(isInsideRoot('/srv/ui', '/srv/ui')).toBe(true);
+  });
+
+  it('accepts a descendant', () => {
+    expect(isInsideRoot('/srv/ui', '/srv/ui/index.html')).toBe(true);
+    expect(isInsideRoot('/srv/ui', '/srv/ui/assets/app.js')).toBe(true);
+  });
+
+  it('rejects a parent-traversal path', () => {
+    expect(isInsideRoot('/srv/ui', '/srv/secret.txt')).toBe(false);
+    expect(isInsideRoot('/srv/ui', '/etc/passwd')).toBe(false);
+  });
+
+  it('rejects a sibling whose name starts with the root name (prefix-only attack)', () => {
+    // "/srv/ui-evil/..." shares the prefix "/srv/ui" but is a different directory.
+    expect(isInsideRoot('/srv/ui', '/srv/ui-evil/file.txt')).toBe(false);
+  });
+
+  it('[blocker] rejects a path on a different Windows drive', () => {
+    // path.relative('C:\\a', 'D:\\b') returns 'D:\\b' which does not start with '..';
+    // a relative-based check passes that as "inside the root". The fix uses a
+    // direct prefix comparison so cross-drive paths are correctly rejected.
+    if (process.platform !== 'win32') return; // path semantics differ on POSIX
+    expect(isInsideRoot('C:\\srv\\ui', 'D:\\evil\\file.txt')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Addresses the **pre-release code review (orchestrator, 2026-05-21)** — eight crash- or panel-breaking issues that Valerii's manual hand-test of every notation would have hit. Hand-test → build → release runs through `main`; landing this before that build means the hand-test doesn't keep tripping over the same class of bug.

Out of scope by orchestrator instruction:
- `process-blueprint` validator — the reference pattern for blocker 1, already correct.
- TX-R001 — confirmed working.

## Blockers

1. **Validators crash on `null` / non-object array elements** — all 7 notation validators (`goals`, `fgca`, `capability-map`, `process-map`, `applications`, `products`, `scenarios`) read element fields after `Array.isArray(...)` passes but with no per-element object guard. `goals: [null]` or `goals: ['x']` threw `TypeError` instead of returning `valid:false`. Added `if (!el || typeof el !== 'object')` at the top of every element loop, matching the `process-blueprint` pattern. `fgca/validate.ts` also pre-computed id sets via `doc.factors.map(f => f.id)` before any guard — switched to a filtering `collectIds` helper.

2. **`goals/validate.ts` — non-numeric `level` slipped through.** `g.level > maxLevel` did string/number compares on string levels (silently wrong) and `undefined > N` on missing levels (always false). Now validates `level` as required-and-finite and bails on the entry.

3. **`goals/layout.ts` — `placeSubtree` recurses without a visited set.** `layoutGoalTree` is exported and reachable without `validateGoalTree`, so a parent-of-itself or mutual cycle caused a stack overflow. Added a `placed` Set; subsequent placements for the same id short-circuit, and the child list filters out already-placed ids. Tests cover self-parent and 2-node mutual cycle.

4. **`fgca/layout.ts` — `c.activity_ids` unguarded.** `validateFGCADoc` treats `activity_ids` as optional (`?? []`), but the renderer's `c.activity_ids.forEach` and `changes.flatMap(c => c.activity_ids)` threw on a change with no activity_ids. Defaulted both spots to `?? []`.

5. **`extension/src/goals-preview.ts` — `checkCycles` passed the wrapper instead of `.root`.** The dead-code cycle detector never fired for duplicated `goal_id`s. Fixed to pass `tree.root`.

6. **`extension/package.json` — `activationEvents` listed only 3 of 11 notations.** In a cold VS Code window the extension never activated for fgca, fga, activities, blocks, applications, products, process-map, scenarios, capability-map, or process-blueprint — previews, auto-preview, and editor-title buttons all failed to appear. Added `workspaceContains:` entries for every notation file extension.

7. **`src/serve-ui.ts` — `createReadStream(...).pipe(res)` had no error handler.** A disk error mid-stream (headers already sent) crashed the process. Attached an `error` handler that logs and destroys the response socket — the only safe action once headers are out.

8. **`src/serve-ui.ts` — `isInsideRoot` accepted a different Windows drive.** `path.relative('C:\a','D:\b')` returns `D:\b`, which does not start with `..`, so the containment check passed. Replaced the relative-based test with a direct prefix comparison using `path.sep`. Exported `isInsideRoot` for direct unit testing.

## Tests

23 new regression tests across the diagrams package and the serve-ui core module:

| Test file | New tests | Covers |
|---|---|---|
| `packages/diagrams/src/goals/__tests__/validate.test.ts` | 4 | blocker 1 (goals), blocker 2 |
| `packages/diagrams/src/goals/__tests__/layout.test.ts` | 2 | blocker 3 |
| `packages/diagrams/src/fgca/__tests__/validate.test.ts` | 4 | blocker 1 (fgca) |
| `packages/diagrams/src/fgca/__tests__/layout.test.ts` | 1 | blocker 4 |
| `packages/diagrams/src/capability-map/__tests__/validate.test.ts` | 2 | blocker 1 (capability-map) |
| `packages/diagrams/src/process-map/__tests__/validate.test.ts` | 2 | blocker 1 (process-map) |
| `packages/diagrams/src/applications/__tests__/validate.test.ts` | 3 | blocker 1 (applications + integrations) |
| `packages/diagrams/src/products/__tests__/validate.test.ts` | 2 | blocker 1 (products) |
| `packages/diagrams/src/scenarios/__tests__/validate.test.ts` | 3 | blocker 1 (factors_view, REF_SPECS) |
| `tests/serve-ui.test.ts` | 5 | blocker 8 (incl. Windows cross-drive guard) |

Counts:
- **diagrams: 303 / 303** passing (was 280; +23 new tests).
- **core: 247 / 247** passing.
- `tsc --noEmit` clean across root / `packages/diagrams` / `extension`.

## Test plan

- [x] `npx vitest run --pool=forks --poolOptions.forks.singleFork=true` in `packages/diagrams` — 303 passing.
- [x] `npx vitest run --pool=forks --poolOptions.forks.singleFork=true` at repo root — 247 passing.
- [x] `tsc --noEmit` at root, in `packages/diagrams`, and in `extension` — clean.
- [ ] Manual (after merge): build the extension and confirm the activation events fire for every notation in a fresh VS Code window.
- [ ] Manual (after merge): feed each preview a malformed YAML (`goals: [null]`, missing fields, a self-parent goal) and verify the error panel appears instead of a crash.

## Note on scope

This is one connected concern — preflight robustness for the hand-test — so it ships as one PR per the "one concern, one PR" rule. The `should-fix` and nit items from the same review will follow as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)