### PR TITLE
chore(process-blueprint): drop BP-012 to match methodology PR #15

### DIFF
--- a/packages/diagrams/src/process-blueprint/__tests__/validate.test.ts
+++ b/packages/diagrams/src/process-blueprint/__tests__/validate.test.ts
@@ -284,16 +284,9 @@ describe('validateProcessBlueprint', () => {
     expect(r.valid).toBe(true);
   });
 
-  it('BP-012: warns when an aspect entry references a single stage', () => {
-    const r = validateProcessBlueprint({
-      ...VALID_BLUEPRINT,
-      process_blueprint: {
-        ...VALID_BLUEPRINT.process_blueprint,
-        systems: [{ id: 'APPLICATION-OMS-1', name: 'OMS', stages: ['STAGE-1'] }],
-      },
-    });
-    expect(r.warnings.some(w => w.code === 'BP-012')).toBe(true);
-  });
+  // BP-012 was removed from the spec on 2026-05-21 (methodology PR #15):
+  // a single-stage aspect entry is normal, valid blueprint content and the
+  // warning fired on the common case. Studio side dropped to match.
 
   it('happy path: surfaces no warnings on a well-formed multi-stage blueprint', () => {
     const r = validateProcessBlueprint(VALID_BLUEPRINT);

--- a/packages/diagrams/src/process-blueprint/validate.ts
+++ b/packages/diagrams/src/process-blueprint/validate.ts
@@ -147,13 +147,6 @@ export function validateProcessBlueprint(input: unknown): ValidationResult {
             usedStageIds.add(refTrimmed);
           }
         }
-
-        if (entryStages.length === 1) {
-          warnings.push({
-            code: 'BP-012',
-            message: `${path}.stages references a single stage — entry may be a candidate for inlining into the stage description`,
-          });
-        }
       }
 
       const entryId = e['id'];


### PR DESCRIPTION
## Summary

Aligns the Studio Process Blueprint validator with the upcoming methodology spec change. `transitrix/methodology` PR #15 removes BP-012 from `notations/13-process-blueprint.md` §6.

## Why

**BP-012** warned on every aspect entry whose `stages:` referenced a single stage and suggested inlining the entry into the stage's `description`. A single-stage aspect is **normal, valid blueprint content** — one OMS used only in `STAGE-1`, one packing station only in `STAGE-2`. So the rule fired on the common case and buried the warning panel in noise. During 2026-05-21 hand-testing a valid 3-stage blueprint produced 8 BP-012 warnings; legitimate warnings would have been hidden behind that.

Decision was taken by Valerii on 2026-05-21 and recorded in the methodology repo.

## Changes

| File | Change |
|---|---|
| [packages/diagrams/src/process-blueprint/validate.ts](packages/diagrams/src/process-blueprint/validate.ts) | Removed the `if (entryStages.length === 1) { warnings.push({ code: 'BP-012', … }) }` block. |
| [packages/diagrams/src/process-blueprint/\_\_tests\_\_/validate.test.ts](packages/diagrams/src/process-blueprint/__tests__/validate.test.ts) | Removed the BP-012 test case; replaced with a short pointer comment to methodology PR #15. |

No other repo call sites or docs reference BP-012 (grepped clean). The example fixture `examples/process-blueprint/order-fulfilment.process-blueprint.transitrix.yaml` already validates cleanly with or without BP-012 (it never had `valid: false` blocking on a warning).

## Tests

- process-blueprint suite: **38 / 38** passing (was 39; one BP-012 case deliberately dropped).
- `tsc --noEmit` in `packages/diagrams` — clean.

## Test plan

- [x] `npx vitest run src/process-blueprint/` in `packages/diagrams` — 38 passing.
- [x] `tsc --noEmit` in `packages/diagrams` — clean.
- [x] Conformance test `examples/process-blueprint/order-fulfilment…` still validates clean.
- [ ] Manual (post-merge): re-run the hand-test on a 3-stage blueprint, confirm the warning panel is no longer flooded with BP-012 entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)