### PR TITLE
feat(activities): Gantt view alongside the PSND network (#20)

### DIFF
--- a/examples/activities/README.md
+++ b/examples/activities/README.md
@@ -1,7 +1,9 @@
-# Activity network diagram (AoN / PSND)
+# Activities — network diagram (PSND/AoN) and Gantt view
 
-Precedence diagram (Activity-on-Node) showing activities, durations, dependencies, and the computed critical path.
-The critical path is highlighted automatically in the preview.
+A Transitrix Activities document describes a project schedule as a DAG of activities. The same document renders as **two coexisting views**:
+
+- **Network view (PSND / Activity-on-Node)** — always rendered. Shows activities, durations, dependencies, and the computed critical path (PMBoK forward/backward pass).
+- **Gantt view** — rendered when the document supplies either a `project.start_date` (computed from CPM) or per-activity `start_date` + `end_date` (pinned). Otherwise the Gantt section shows a non-blocking notice and only the network view is drawn.
 
 **File extension:** `*.activities.transitrix.yaml`
 
@@ -37,6 +39,23 @@ date: "2026-05-12"
 author: "Your Name"
 ```
 
+## Project block — enables the Gantt view
+
+Adding a top-level `project:` block anchors the schedule on a calendar so the Gantt view also renders:
+
+```yaml
+project:
+  start_date: "2026-06-01"
+  calendar:
+    working_days: [mon, tue, wed, thu, fri]
+    holidays:
+      - "2026-07-04"
+```
+
+Without the `project:` block, the Gantt section in the preview shows a non-blocking notice ("Gantt view will not render: …") and only the network view is drawn — see [`discovery-research.activities.transitrix.yaml`](discovery-research.activities.transitrix.yaml) for that case.
+
+A document can alternatively pin per-activity dates (`start_date` + `end_date` on every leaf) for a fixed-date Gantt without CPM projection.
+
 ## Optional fields per activity
 
 | Field | Type | Description |
@@ -47,6 +66,14 @@ author: "Your Name"
 | `tags` | string[] | Labels for grouping or highlighting |
 | `unit` | string | Organisational unit responsible |
 | `delivers_changes` | string[] | Change IDs delivered by this activity |
+| `start_date` | YYYY-MM-DD | Pinned start (enables the pinned-Gantt mode when all leaves carry it) |
+| `end_date` | YYYY-MM-DD | Pinned end (must be ≥ start_date) |
+| `parent` | string | WBS parent activity id — renders as a summary bar on the Gantt |
+
+## Special activity kinds
+
+- **Milestone** — a leaf activity with `duration: 0`. Renders as a diamond on the Gantt and a distinct shape on the network. Both pinned dates, if present, must be equal (ACT-016).
+- **Phase** — an activity referenced by another activity's `parent` field. Phases roll up: earliest descendant start → latest descendant end. Phases SHOULD omit their own duration and dates (ACT-017).
 
 ## Rules
 
@@ -54,10 +81,11 @@ author: "Your Name"
 - Activities without `predecessors` are treated as start nodes.
 - Multiple predecessors create a merge point (all must finish before the activity starts).
 - The critical path is computed automatically using the PMBoK forward/backward pass (ES, EF, LS, LF, float).
-- Duration unit is not enforced — use the same unit consistently throughout the file.
+- Duration unit is not enforced — use the same unit consistently throughout the file. Default-day semantics on the Gantt advance one day per working day per the project calendar.
 
 ## Examples in this folder
 
-| File | Description |
-|---|---|
-| `platform-launch.activities.transitrix.yaml` | 10-activity platform launch; two parallel paths merge at integration testing; 3-activity critical path tail |
+| File | Renders as | Description |
+|---|---|---|
+| [`platform-launch.activities.transitrix.yaml`](platform-launch.activities.transitrix.yaml) | **Network + Gantt** (computed mode) | 10-activity platform launch with a `project:` block — Mon–Fri working calendar, one holiday. The Gantt section shows CPM offsets projected onto the calendar, with the critical-path tail highlighted. |
+| [`discovery-research.activities.transitrix.yaml`](discovery-research.activities.transitrix.yaml) | **Network only** (Gantt unavailable) | Early discovery work, no committed dates. Demonstrates the graceful network-only fallback — the Gantt section shows a notice explaining what is missing, the network still renders with the critical path. Includes a go/no-go milestone (`duration: 0`). |

--- a/examples/activities/discovery-research.activities.transitrix.yaml
+++ b/examples/activities/discovery-research.activities.transitrix.yaml
@@ -1,0 +1,61 @@
+notation: activities
+spec_version: "0.1"
+
+title: Discovery research — Q4 backlog
+description: |
+  Early-stage discovery work whose dates are not yet committed. Activities
+  carry durations and predecessors, so the network view (PSND/AoN) renders
+  with the critical path. The Gantt view degrades gracefully — no
+  project.start_date and no per-activity pinned dates — and the preview
+  shows a non-blocking notice instead of erroring.
+
+  Use this file as the network-only companion to
+  `platform-launch.activities.transitrix.yaml`, which carries a `project:`
+  block and renders the Gantt view as well.
+version: "0.1"
+date: "2026-05-22"
+author: "Valerii Korobeinikov"
+
+# No `project:` block — dates are deliberately not committed at the
+# discovery stage. The Gantt view will not render; the network view does.
+
+activities:
+  - id: D-001
+    name: Stakeholder interviews
+    duration: 8
+    sort: 10
+    tags: [discovery, research]
+
+  - id: D-002
+    name: Competitive landscape scan
+    duration: 5
+    sort: 20
+    tags: [discovery, research]
+
+  - id: D-003
+    name: Synthesise findings
+    duration: 4
+    sort: 30
+    predecessors: [D-001, D-002]
+    tags: [discovery, synthesis]
+
+  - id: D-004
+    name: Concept options workshop
+    duration: 3
+    sort: 40
+    predecessors: [D-003]
+    tags: [discovery, workshop]
+
+  - id: D-005
+    name: Feasibility assessment
+    duration: 6
+    sort: 50
+    predecessors: [D-004]
+    tags: [discovery, feasibility]
+
+  - id: M-DECISION
+    name: Go / no-go decision
+    duration: 0                # milestone — zero-duration leaf
+    sort: 60
+    predecessors: [D-005]
+    tags: [milestone, gate]

--- a/examples/activities/platform-launch.activities.transitrix.yaml
+++ b/examples/activities/platform-launch.activities.transitrix.yaml
@@ -10,6 +10,18 @@ version: "0.1"
 date: "2026-05-12"
 author: "Valerii Korobeinikov"
 
+# Project anchor for Gantt rendering — see spec §5.8.
+# Days are the default duration unit; the calendar restricts work to Mon–Fri
+# with the listed holidays excluded. Without this block the document still
+# renders as a network view; with it, the Gantt view also renders (computed
+# mode — CPM offsets projected onto the working calendar).
+project:
+  start_date: "2026-06-01"
+  calendar:
+    working_days: [mon, tue, wed, thu, fri]
+    holidays:
+      - "2026-07-04"
+
 activities:
   - id: A-001
     name: Requirements analysis

--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -207,10 +207,21 @@ function ganttSvg(layout: GanttLayout): string {
     }
   }
 
-  // Link lines — Finish-to-Start elbow with the vertical anchored at the
-  // midpoint of the inter-bar gap (looks balanced regardless of gap width).
-  // A 4px gap on each side stops the line from fusing with the bar edges,
-  // and the arrowhead lives in that gap so it doesn't overlap the target.
+  // Link lines — Finish-to-Start.
+  //
+  // Routing rule: the vertical sits at the source bar's right edge (x = sx),
+  // which is also the column-grid boundary. Successor bars start at that
+  // same boundary in computed mode, so the vertical runs along their LEFT
+  // EDGE rather than crossing their interior. This is the MS Project /
+  // Primavera convention — links travel along column rails, not through bar
+  // bodies.
+  //
+  // - Comfortable gap (tx well past sx): midpoint elbow inside the gap.
+  // - Adjacent (tx == sx, no weekend between source.end+1 and target.start):
+  //   vertical at the column boundary; short horizontal stub into target.
+  // - True overlap (tx < sx, possible in pinned mode where a successor's
+  //   pinned start_date precedes its predecessor's end_date): detour BELOW
+  //   both rows so the link doesn't run through either bar.
   const linkParts: string[] = [];
   const LINK_GAP = 4;
   const LINK_MIN_STUB = 6;
@@ -227,22 +238,27 @@ function ganttSvg(layout: GanttLayout): string {
     const cls = link.isCritical ? 'diagram-edge critical-edge' : 'diagram-edge';
     const marker = link.isCritical ? 'gantt-arrow-crit' : 'gantt-arrow';
 
-    const sxStart = sx + LINK_GAP;
-    const txEnd = tx - LINK_GAP;
     let d: string;
-    if (txEnd - sxStart >= LINK_MIN_STUB * 2) {
-      // Forward link with comfortable gap: midpoint vertical.
+    if (tx > sx + LINK_MIN_STUB * 2) {
+      // Comfortable gap — midpoint elbow inside the gap so the vertical sits
+      // visually between source-end and target-start, away from both bars.
+      const sxStart = sx + LINK_GAP;
+      const txEnd = tx - LINK_GAP;
       const midX = (sxStart + txEnd) / 2;
       d = `M${sxStart},${sy} L${midX},${sy} L${midX},${ty} L${txEnd},${ty}`;
-    } else if (txEnd > sxStart) {
-      // Tight gap: keep the stub but distribute it.
-      const stubX = sxStart + Math.max(0, (txEnd - sxStart) / 2);
-      d = `M${sxStart},${sy} L${stubX},${sy} L${stubX},${ty} L${txEnd},${ty}`;
+    } else if (tx >= sx) {
+      // Adjacent or near-adjacent — vertical at the column boundary x = sx.
+      // The final horizontal stub lands at min(sx + 6, tx + 6) so the arrow
+      // sits a few px inside the target bar's left edge zone (bars are ≥1 day
+      // = 24px wide, so the stub never reaches the right edge).
+      const finalX = Math.max(sx + LINK_MIN_STUB, tx + LINK_MIN_STUB - LINK_GAP);
+      d = `M${sx},${sy} L${sx},${ty} L${finalX},${ty}`;
     } else {
-      // Backward/overlap (target starts at or before source ends): route
-      // below both rows so the link doesn't cross the source bar.
+      // True backward (tx < sx, pinned-mode overlap): detour below both rows.
       const hookY = Math.max(sy, ty) + G_ROW_H / 2 + 6;
-      d = `M${sxStart},${sy} L${sxStart + LINK_MIN_STUB},${sy} L${sxStart + LINK_MIN_STUB},${hookY} L${txEnd - LINK_MIN_STUB},${hookY} L${txEnd - LINK_MIN_STUB},${ty} L${txEnd},${ty}`;
+      const sxOut = sx + LINK_GAP;
+      const txIn = tx + LINK_MIN_STUB;
+      d = `M${sxOut},${sy} L${sxOut},${hookY} L${txIn},${hookY} L${txIn},${ty}`;
     }
     linkParts.push(
       `<path d="${d}" class="${cls}" fill="none" marker-end="url(#${marker})"/>`,

--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -2,266 +2,19 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, prepareSvgForExport, type ThemeId } from './diagram-frame.js';
+import {
+  validateActivities,
+  layoutActivities,
+  computeCpm,
+  computeGanttLayout,
+  isGanttUnavailable,
+  type ActivityDoc,
+  type ActivitiesLayout,
+  type GanttLayout,
+  type GanttResult,
+} from '../../packages/diagrams/src/activities/index.js';
 
-// ── Inline types (mirror packages/diagrams/src/activities/types.ts) ───────────
-
-interface Activity {
-  id: string;
-  name: string;
-  duration?: number;
-  predecessors?: string[];
-  goals?: string[];
-  sort?: number;
-  tags?: string[];
-  owner?: string;
-  unit?: string;
-}
-
-interface ActivityDoc {
-  notation: string;
-  title?: string;
-  description?: string;
-  version?: string;
-  date?: string;
-  author?: string;
-  activities: Activity[];
-}
-
-interface CpmValues {
-  es: number;
-  ef: number;
-  ls: number;
-  lf: number;
-  slack: number;
-  isCritical: boolean;
-}
-
-interface ValidationError { code: string; message: string; }
-interface ValidationResult { valid: boolean; errors: ValidationError[]; warnings: Array<{ code: string; message: string }> }
-
-// ── Inline validation ─────────────────────────────────────────────────────────
-
-function validateActivities(input: unknown): ValidationResult {
-  const errors: ValidationError[] = [];
-  const warnings: Array<{ code: string; message: string }> = [];
-
-  if (!input || typeof input !== 'object') {
-    return { valid: false, errors: [{ code: 'ACT-001', message: 'Input must be an object' }], warnings };
-  }
-
-  const raw = input as Record<string, unknown>;
-
-  if (raw.notation === undefined) {
-    errors.push({ code: 'ACT-001', message: 'notation field is required' });
-    return { valid: false, errors, warnings };
-  }
-  if (raw.notation !== 'activities') {
-    errors.push({ code: 'ACT-001', message: `notation must be "activities", got "${String(raw.notation)}"` });
-    return { valid: false, errors, warnings };
-  }
-  if (!Array.isArray(raw.activities)) {
-    errors.push({ code: 'SCHEMA_INVALID', message: 'activities must be an array' });
-    return { valid: false, errors, warnings };
-  }
-
-  const doc = raw as unknown as ActivityDoc;
-  const idSet = new Set<string>();
-
-  for (let i = 0; i < doc.activities.length; i++) {
-    const a = doc.activities[i] as unknown as Record<string, unknown>;
-    if (!a.id || typeof a.id !== 'string') {
-      errors.push({ code: 'ACT-002', message: `Activity at index ${i} is missing a non-empty id` });
-      continue;
-    }
-    if (!a.name || typeof a.name !== 'string') {
-      errors.push({ code: 'ACT-003', message: `Activity "${a.id}" is missing a non-empty name` });
-    }
-    if (idSet.has(a.id)) {
-      errors.push({ code: 'ACT-004', message: `Duplicate activity id: "${a.id}"` });
-    } else {
-      idSet.add(a.id);
-    }
-    if ('goal' in a || 'predecessor' in a || 'tag' in a) {
-      errors.push({ code: 'ACT-010', message: `Use plural array form (goals/predecessors/tags) for activity "${a.id}"` });
-    }
-  }
-
-  if (errors.length > 0) return { valid: false, errors, warnings };
-
-  for (const a of doc.activities) {
-    for (const pred of (a.predecessors ?? [])) {
-      if (!idSet.has(pred)) {
-        errors.push({ code: 'ACT-005', message: `Activity "${a.id}" references unknown predecessor "${pred}"` });
-      }
-    }
-    if (Array.isArray(a.predecessors) && a.predecessors.includes(a.id)) {
-      errors.push({ code: 'ACT-007', message: `Activity "${a.id}" lists itself as a predecessor` });
-    }
-    if (a.duration === undefined) {
-      warnings.push({ code: 'ACT-011', message: `Activity "${a.id}" has no duration — excluded from CPM` });
-    }
-  }
-
-  return { valid: errors.length === 0, errors, warnings };
-}
-
-// ── CPM computation ───────────────────────────────────────────────────────────
-
-function computeCpm(activities: Activity[]): Map<string, CpmValues> {
-  const result = new Map<string, CpmValues>();
-  if (activities.length === 0) return result;
-
-  const successors = new Map<string, string[]>();
-  const predecessors = new Map<string, string[]>();
-  for (const a of activities) {
-    successors.set(a.id, []);
-    predecessors.set(a.id, (a.predecessors ?? []).filter(p => p !== a.id));
-  }
-  for (const a of activities) {
-    for (const pred of (predecessors.get(a.id) ?? [])) {
-      successors.get(pred)?.push(a.id);
-    }
-  }
-
-  const inDegree = new Map<string, number>();
-  for (const a of activities) inDegree.set(a.id, (predecessors.get(a.id) ?? []).length);
-  const queue: string[] = [];
-  for (const a of activities) { if ((inDegree.get(a.id) ?? 0) === 0) queue.push(a.id); }
-  const topoOrder: string[] = [];
-  while (queue.length > 0) {
-    const id = queue.shift()!;
-    topoOrder.push(id);
-    for (const succ of (successors.get(id) ?? [])) {
-      const newDeg = (inDegree.get(succ) ?? 1) - 1;
-      inDegree.set(succ, newDeg);
-      if (newDeg === 0) queue.push(succ);
-    }
-  }
-
-  const actById = new Map(activities.map(a => [a.id, a]));
-  const es = new Map<string, number>();
-  const ef = new Map<string, number>();
-  for (const id of topoOrder) {
-    const a = actById.get(id)!;
-    const dur = a.duration ?? 0;
-    const maxPredEf = Math.max(0, ...(predecessors.get(id) ?? []).map(p => ef.get(p) ?? 0));
-    es.set(id, maxPredEf);
-    ef.set(id, maxPredEf + dur);
-  }
-
-  const projectFinish = Math.max(0, ...[...ef.values()]);
-  const ls = new Map<string, number>();
-  const lf = new Map<string, number>();
-  for (const id of [...topoOrder].reverse()) {
-    const a = actById.get(id)!;
-    const dur = a.duration ?? 0;
-    const succs = successors.get(id) ?? [];
-    const minSuccLs = succs.length === 0 ? projectFinish : Math.min(...succs.map(s => ls.get(s) ?? projectFinish));
-    lf.set(id, minSuccLs);
-    ls.set(id, minSuccLs - dur);
-  }
-
-  for (const id of topoOrder) {
-    const esV = es.get(id) ?? 0;
-    const efV = ef.get(id) ?? 0;
-    const lsV = ls.get(id) ?? 0;
-    const lfV = lf.get(id) ?? 0;
-    const slack = lsV - esV;
-    result.set(id, { es: esV, ef: efV, ls: lsV, lf: lfV, slack, isCritical: slack <= 0 });
-  }
-  return result;
-}
-
-// ── Layout ────────────────────────────────────────────────────────────────────
-
-const NODE_W = 200;
-const NODE_H = 80;
-const H_GAP = 80;
-const V_GAP = 24;
-
-interface LayoutNode { id: string; x: number; y: number; data: Activity; cpm?: CpmValues; }
-interface LayoutEdge { sourceId: string; targetId: string; isCritical: boolean; }
-interface Layout { nodes: LayoutNode[]; edges: LayoutEdge[]; width: number; height: number; }
-
-function layoutActivities(doc: ActivityDoc): Layout {
-  const activities = doc.activities;
-  if (activities.length === 0) return { nodes: [], edges: [], width: 0, height: 0 };
-
-  const cpm = computeCpm(activities);
-
-  const successors = new Map<string, string[]>();
-  const inDegree = new Map<string, number>();
-  for (const a of activities) { successors.set(a.id, []); inDegree.set(a.id, 0); }
-  for (const a of activities) {
-    for (const pred of (a.predecessors ?? [])) {
-      successors.get(pred)?.push(a.id);
-      inDegree.set(a.id, (inDegree.get(a.id) ?? 0) + 1);
-    }
-  }
-
-  const column = new Map<string, number>();
-  const queue: string[] = [];
-  for (const a of activities) { if ((inDegree.get(a.id) ?? 0) === 0) queue.push(a.id); }
-  while (queue.length > 0) {
-    const id = queue.shift()!;
-    const col = column.get(id) ?? 0;
-    for (const succ of (successors.get(id) ?? [])) {
-      column.set(succ, Math.max(column.get(succ) ?? 0, col + 1));
-      const newDeg = (inDegree.get(succ) ?? 1) - 1;
-      inDegree.set(succ, newDeg);
-      if (newDeg === 0) queue.push(succ);
-    }
-  }
-
-  const cols = new Map<number, Activity[]>();
-  for (const a of activities) {
-    const col = column.get(a.id) ?? 0;
-    if (!cols.has(col)) cols.set(col, []);
-    cols.get(col)!.push(a);
-  }
-  for (const list of cols.values()) {
-    list.sort((a, b) => {
-      const sa = a.sort ?? Number.MAX_SAFE_INTEGER;
-      const sb = b.sort ?? Number.MAX_SAFE_INTEGER;
-      return sa !== sb ? sa - sb : a.id.localeCompare(b.id);
-    });
-  }
-
-  const nodes: LayoutNode[] = [];
-  const nodeMap = new Map<string, LayoutNode>();
-  const colCount = Math.max(0, ...[...cols.keys()]) + 1;
-  let maxH = 0;
-
-  for (let c = 0; c < colCount; c++) {
-    const list = cols.get(c) ?? [];
-    const x = c * (NODE_W + H_GAP);
-    let y = 0;
-    for (const a of list) {
-      const node: LayoutNode = { id: a.id, x, y, data: a, cpm: cpm.get(a.id) };
-      nodes.push(node);
-      nodeMap.set(a.id, node);
-      y += NODE_H + V_GAP;
-    }
-    maxH = Math.max(maxH, y - V_GAP + NODE_H);
-  }
-
-  const edges: LayoutEdge[] = [];
-  for (const a of activities) {
-    for (const predId of (a.predecessors ?? [])) {
-      if (nodeMap.has(predId)) {
-        const predCpm = cpm.get(predId);
-        const succCpm = cpm.get(a.id);
-        const isCritical = (predCpm?.isCritical ?? false) && (succCpm?.isCritical ?? false);
-        edges.push({ sourceId: predId, targetId: a.id, isCritical });
-      }
-    }
-  }
-
-  const totalW = colCount * (NODE_W + H_GAP) - H_GAP;
-  return { nodes, edges, width: totalW, height: maxH };
-}
-
-// ── SVG renderer ──────────────────────────────────────────────────────────────
+// ── Shared helpers ───────────────────────────────────────────────────────────
 
 function escXml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
@@ -271,40 +24,55 @@ function truncate(s: string, maxLen: number): string {
   return s.length > maxLen ? s.slice(0, maxLen - 1) + '…' : s;
 }
 
-function buildSvg(doc: ActivityDoc): string {
-  const { nodes, edges, width, height } = layoutActivities(doc);
-  if (nodes.length === 0) return '<svg xmlns="http://www.w3.org/2000/svg" width="200" height="60"><text x="10" y="40" font-family="system-ui,sans-serif" font-size="13">No activities</text></svg>';
+// ── Network (PSND) SVG renderer ──────────────────────────────────────────────
+//
+// Consumes layoutActivities + computeCpm from @transitrix/diagrams. Studio
+// supplies the SVG presentation layer only.
 
-  const PAD = 24;
-  const W = width + PAD * 2;
-  const H = height + PAD * 2;
-  const nodeMap = new Map(nodes.map(n => [n.id, n]));
+const N_NODE_W = 200;
+const N_NODE_H = 80;
+const N_PAD = 24;
 
-  const edgeSvg = edges.map(e => {
-    const s = nodeMap.get(e.sourceId)!;
-    const t = nodeMap.get(e.targetId)!;
-    const sx = s.x + PAD + NODE_W;
-    const sy = s.y + PAD + NODE_H / 2;
-    const tx = t.x + PAD;
-    const ty = t.y + PAD + NODE_H / 2;
+function networkSvg(doc: ActivityDoc): string {
+  const layout: ActivitiesLayout = layoutActivities(doc);
+  if (layout.nodes.length === 0) {
+    return '<svg xmlns="http://www.w3.org/2000/svg" width="200" height="60"><text x="10" y="40" font-family="system-ui,sans-serif" font-size="13">No activities</text></svg>';
+  }
+
+  const cpm = computeCpm(doc.activities ?? []);
+  const W = layout.bounds.width + N_PAD * 2;
+  const H = layout.bounds.height + N_PAD * 2;
+  const ox = -layout.bounds.x + N_PAD;
+  const oy = -layout.bounds.y + N_PAD;
+
+  const nodeMap = new Map(layout.nodes.map(n => [n.id, n]));
+  const edgeSvg = layout.edges.map(e => {
+    const s = nodeMap.get(e.sourceId);
+    const t = nodeMap.get(e.targetId);
+    if (!s || !t) return '';
+    const sx = s.x + ox + s.width;
+    const sy = s.y + oy + s.height / 2;
+    const tx = t.x + ox;
+    const ty = t.y + oy + t.height / 2;
     const mx = (sx + tx) / 2;
     const cls = e.isCritical ? 'diagram-edge critical-edge' : 'diagram-edge';
     return `<path d="M${sx},${sy} C${mx},${sy} ${mx},${ty} ${tx},${ty}" class="${cls}" marker-end="url(#${e.isCritical ? 'arrow-crit' : 'arrow'})"/>`;
   }).join('\n');
 
-  const nodeSvg = nodes.map(n => {
-    const x = n.x + PAD;
-    const y = n.y + PAD;
-    const isCritical = n.cpm?.isCritical ?? false;
-    const cls = isCritical ? 'diagram-node act-node critical-node' : 'diagram-node act-node';
+  const nodeSvg = layout.nodes.map(n => {
+    const x = n.x + ox;
+    const y = n.y + oy;
+    const isCritical = cpm.get(n.id)?.isCritical ?? false;
+    const isMilestone = (n.data.duration ?? -1) === 0;
+    const cls = `diagram-node act-node ${isCritical ? 'critical-node' : ''} ${isMilestone ? 'milestone-node' : ''}`.trim();
     const idLabel = escXml(n.id);
     const nameLabel = escXml(truncate(n.data.name, 24));
     const durLabel = n.data.duration !== undefined ? `${n.data.duration}d` : '—';
     return [
-      `<rect class="${cls}" x="${x}" y="${y}" width="${NODE_W}" height="${NODE_H}" rx="6"/>`,
+      `<rect class="${cls}" x="${x}" y="${y}" width="${N_NODE_W}" height="${N_NODE_H}" rx="6"/>`,
       `<text class="text-id" x="${x + 8}" y="${y + 18}" font-size="10" font-family="system-ui,sans-serif" font-weight="600">${idLabel}</text>`,
-      `<text class="text-primary" x="${x + NODE_W / 2}" y="${y + 46}" text-anchor="middle" font-size="12" font-weight="600" font-family="system-ui,sans-serif">${nameLabel}</text>`,
-      `<text class="text-secondary" x="${x + NODE_W - 8}" y="${y + NODE_H - 10}" text-anchor="end" font-size="11" font-family="system-ui,sans-serif">${durLabel}</text>`,
+      `<text class="text-primary" x="${x + N_NODE_W / 2}" y="${y + N_NODE_H / 2 + 4}" text-anchor="middle" dominant-baseline="central" font-size="12" font-weight="600" font-family="system-ui,sans-serif">${nameLabel}</text>`,
+      `<text class="text-secondary" x="${x + N_NODE_W - 8}" y="${y + N_NODE_H - 10}" text-anchor="end" font-size="11" font-family="system-ui,sans-serif">${durLabel}</text>`,
     ].join('\n');
   }).join('\n');
 
@@ -321,6 +89,203 @@ ${edgeSvg}
 ${nodeSvg}
 </svg>`;
 }
+
+// ── Gantt SVG renderer ───────────────────────────────────────────────────────
+
+const G_DAY_W = 24;       // px per calendar day on the timeline axis
+const G_ROW_H = 28;
+const G_LABEL_COL_W = 220;
+const G_HEADER_H = 36;
+const G_PAD = 24;
+const G_BAR_INSET_Y = 4;  // top/bottom inset of bars inside the row band
+
+function parseISO(s: string): Date {
+  const [y, m, d] = s.split('-').map((p) => Number.parseInt(p, 10));
+  return new Date(Date.UTC(y, m - 1, d));
+}
+
+function daysBetween(startISO: string, endISO: string): number {
+  const ms = parseISO(endISO).getTime() - parseISO(startISO).getTime();
+  return Math.round(ms / 86_400_000);
+}
+
+function ganttSvg(layout: GanttLayout): string {
+  // Sort bars by start date then id for stable display order.
+  const bars = [...layout.bars].sort((a, b) => {
+    if (a.startDate !== b.startDate) return a.startDate < b.startDate ? -1 : 1;
+    return a.id.localeCompare(b.id);
+  });
+
+  const totalDays = daysBetween(layout.timelineStart, layout.timelineEnd) + 1;
+  const timelineWidth = totalDays * G_DAY_W;
+  const W = G_LABEL_COL_W + timelineWidth + G_PAD * 2;
+  const H = G_HEADER_H + bars.length * G_ROW_H + G_PAD * 2;
+
+  const ox = G_PAD;
+  const oy = G_PAD;
+
+  // Date header strip: month labels above, day ticks below.
+  const headerParts: string[] = [];
+  headerParts.push(
+    `<rect class="diagram-node gantt-header" x="${ox}" y="${oy}" width="${G_LABEL_COL_W + timelineWidth}" height="${G_HEADER_H}"/>`,
+  );
+  headerParts.push(
+    `<text class="text-secondary" x="${ox + 12}" y="${oy + G_HEADER_H / 2}" dominant-baseline="central" font-size="11" font-weight="600" font-family="system-ui,sans-serif">Activity</text>`,
+  );
+  // Month band: walk days, group by yyyy-mm.
+  const months: Array<{ label: string; startCol: number; endCol: number }> = [];
+  for (let i = 0; i < totalDays; i++) {
+    const d = parseISO(layout.timelineStart);
+    d.setUTCDate(d.getUTCDate() + i);
+    const label = `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`;
+    const last = months[months.length - 1];
+    if (last && last.label === label) last.endCol = i;
+    else months.push({ label, startCol: i, endCol: i });
+  }
+  for (const m of months) {
+    const x = ox + G_LABEL_COL_W + m.startCol * G_DAY_W;
+    const w = (m.endCol - m.startCol + 1) * G_DAY_W;
+    headerParts.push(
+      `<text class="text-secondary" x="${x + w / 2}" y="${oy + 14}" text-anchor="middle" dominant-baseline="central" font-size="10" font-family="system-ui,sans-serif">${escXml(m.label)}</text>`,
+    );
+  }
+  // Day grid: thin vertical lines every 7 days.
+  for (let i = 0; i <= totalDays; i += 7) {
+    const x = ox + G_LABEL_COL_W + i * G_DAY_W;
+    headerParts.push(
+      `<line class="gantt-grid" x1="${x}" y1="${oy + G_HEADER_H}" x2="${x}" y2="${oy + G_HEADER_H + bars.length * G_ROW_H}"/>`,
+    );
+  }
+
+  // Rows
+  const rowParts: string[] = [];
+  const yByBarId = new Map<string, number>();
+  for (let r = 0; r < bars.length; r++) {
+    const bar = bars[r];
+    const rowY = oy + G_HEADER_H + r * G_ROW_H;
+    yByBarId.set(bar.id, rowY + G_ROW_H / 2);
+
+    // Alternating row band for readability.
+    if (r % 2 === 1) {
+      rowParts.push(
+        `<rect class="gantt-row-alt" x="${ox}" y="${rowY}" width="${G_LABEL_COL_W + timelineWidth}" height="${G_ROW_H}"/>`,
+      );
+    }
+    // Label column
+    rowParts.push(
+      `<text class="text-id" x="${ox + 8}" y="${rowY + G_ROW_H / 2}" dominant-baseline="central" font-size="10" font-family="system-ui,sans-serif" font-weight="600">${escXml(bar.id)}</text>`,
+    );
+    rowParts.push(
+      `<text class="text-primary" x="${ox + 56}" y="${rowY + G_ROW_H / 2}" dominant-baseline="central" font-size="11" font-family="system-ui,sans-serif">${escXml(truncate(bar.name, 22))}</text>`,
+    );
+
+    // Bar geometry
+    const startOffset = daysBetween(layout.timelineStart, bar.startDate);
+    const endOffset = daysBetween(layout.timelineStart, bar.endDate);
+    const barX = ox + G_LABEL_COL_W + startOffset * G_DAY_W;
+    const barY = rowY + G_BAR_INSET_Y;
+    const barH = G_ROW_H - G_BAR_INSET_Y * 2;
+
+    if (bar.kind === 'milestone') {
+      // Diamond marker
+      const cx = barX + G_DAY_W / 2;
+      const cy = rowY + G_ROW_H / 2;
+      const s = barH / 2;
+      const cls = `gantt-milestone ${bar.isCritical ? 'critical-bar' : ''}`.trim();
+      rowParts.push(
+        `<polygon class="${cls}" points="${cx},${cy - s} ${cx + s},${cy} ${cx},${cy + s} ${cx - s},${cy}"/>`,
+      );
+    } else {
+      const widthDays = endOffset - startOffset + 1;
+      const barWidth = widthDays * G_DAY_W;
+      const cls = bar.kind === 'phase'
+        ? 'gantt-phase'
+        : `gantt-bar ${bar.isCritical ? 'critical-bar' : ''}`.trim();
+      rowParts.push(
+        `<rect class="${cls}" x="${barX}" y="${barY}" width="${barWidth}" height="${barH}" rx="3"/>`,
+      );
+    }
+  }
+
+  // Link lines
+  const linkParts: string[] = [];
+  for (const link of layout.links) {
+    const sourceBar = bars.find(b => b.id === link.sourceId);
+    const targetBar = bars.find(b => b.id === link.targetId);
+    if (!sourceBar || !targetBar) continue;
+    const sourceEndOffset = daysBetween(layout.timelineStart, sourceBar.endDate);
+    const targetStartOffset = daysBetween(layout.timelineStart, targetBar.startDate);
+    const sx = ox + G_LABEL_COL_W + (sourceEndOffset + 1) * G_DAY_W;
+    const sy = yByBarId.get(link.sourceId) ?? 0;
+    const tx = ox + G_LABEL_COL_W + targetStartOffset * G_DAY_W;
+    const ty = yByBarId.get(link.targetId) ?? 0;
+    const cls = link.isCritical ? 'diagram-edge critical-edge' : 'diagram-edge';
+    // Right-angle elbow.
+    linkParts.push(
+      `<path d="M${sx},${sy} L${sx + 6},${sy} L${sx + 6},${ty} L${tx},${ty}" class="${cls}" fill="none"/>`,
+    );
+  }
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">
+${headerParts.join('\n')}
+${rowParts.join('\n')}
+${linkParts.join('\n')}
+</svg>`;
+}
+
+// ── Stacked canvas content (network + gantt) ─────────────────────────────────
+
+function buildCanvasContent(doc: ActivityDoc): string {
+  const network = networkSvg(doc);
+  const gantt: GanttResult = computeGanttLayout(doc);
+
+  const networkSection = `<section class="diagram-section">
+  <h3 class="section-heading">Network view — Project Schedule Network Diagram (PSND)</h3>
+  ${network}
+</section>`;
+
+  let ganttSection: string;
+  if (isGanttUnavailable(gantt)) {
+    ganttSection = `<section class="diagram-section">
+  <h3 class="section-heading">Gantt view</h3>
+  <div class="section-notice">${escXml(gantt.reason)}</div>
+</section>`;
+  } else {
+    const modeLabel = gantt.mode === 'computed'
+      ? `computed mode (project ${gantt.timelineStart} → ${gantt.timelineEnd})`
+      : `pinned mode (${gantt.timelineStart} → ${gantt.timelineEnd})`;
+    ganttSection = `<section class="diagram-section">
+  <h3 class="section-heading">Gantt view — ${escXml(modeLabel)}</h3>
+  ${ganttSvg(gantt)}
+</section>`;
+  }
+
+  return networkSection + ganttSection;
+}
+
+// ── Extra CSS injected into the diagram frame ───────────────────────────────
+
+const ACTIVITIES_STYLES = `
+  .diagram-section { margin: 16px 0; }
+  .section-heading { font-size: 13px; font-weight: 600; color: var(--ts-text-muted, #64748b); margin: 0 16px 8px; letter-spacing: 0.02em; }
+  .section-notice { margin: 0 16px; padding: 10px 14px; border-left: 3px solid var(--ts-text-muted, #94a3b8); background: var(--ts-bg-subtle, #f8fafc); color: var(--ts-text-muted, #64748b); font-size: 12px; }
+
+  .act-node { fill: var(--ts-bg-surface, #f8fafc); stroke: var(--ts-border, #94a3b8); stroke-width: 1.5; }
+  .critical-node { fill: #fff7ed; stroke: var(--ts-brand-orange, #ff4d00); stroke-width: 2.5; }
+  .milestone-node { fill: #ecfeff; stroke: var(--ts-text-muted, #64748b); stroke-dasharray: 4 2; }
+  .critical-edge { stroke: var(--ts-brand-orange, #ff4d00); stroke-width: 2; }
+  .arrow-fill-critical { fill: var(--ts-brand-orange, #ff4d00); }
+  .text-id { fill: var(--ts-text-muted, #64748b); }
+
+  .gantt-header { fill: var(--ts-bg-subtle, #f1f5f9); stroke: var(--ts-border, #cbd5e1); stroke-width: 1; }
+  .gantt-grid { stroke: var(--ts-border, #cbd5e1); stroke-width: 1; opacity: 0.5; }
+  .gantt-row-alt { fill: var(--ts-bg-subtle, #f8fafc); opacity: 0.5; }
+  .gantt-bar { fill: var(--ts-bg-surface, #dbeafe); stroke: var(--ts-border, #60a5fa); stroke-width: 1; }
+  .gantt-bar.critical-bar { fill: #fff7ed; stroke: var(--ts-brand-orange, #ff4d00); stroke-width: 1.5; }
+  .gantt-phase { fill: var(--ts-text-muted, #475569); opacity: 0.85; }
+  .gantt-milestone { fill: var(--ts-text, #0f172a); }
+  .gantt-milestone.critical-bar { fill: var(--ts-brand-orange, #ff4d00); }
+`;
 
 // ── ActivitiesPreview webview class ───────────────────────────────────────────
 
@@ -362,7 +327,7 @@ export class ActivitiesPreview {
   }
 
   private buildHtml(yamlText: string, filename: string): string {
-    let svgContent = '';
+    let bodyContent = '';
     let errorMsg = '';
     let warnings: string[] = [];
 
@@ -373,19 +338,31 @@ export class ActivitiesPreview {
       if (!v.valid) {
         errorMsg = v.errors.map(e => `${e.code}: ${e.message}`).join('\n');
       } else {
-        svgContent = buildSvg(parsed as ActivityDoc);
+        bodyContent = buildCanvasContent(parsed as ActivityDoc);
+        // Save-as-SVG exports only the network view today; the Gantt is a
+        // companion section in the webview. (Reconsider when the Gantt becomes
+        // a primary view.)
+        this.lastSvg = networkSvg(parsed as ActivityDoc);
       }
     } catch (e) {
       errorMsg = (e as Error).message ?? 'Parse error';
     }
 
-    this.lastSvg = svgContent;
+    if (!bodyContent) this.lastSvg = '';
 
     const themeId = vscode.workspace
       .getConfiguration('transitrix')
       .get<ThemeId>('theme', 'transitrix');
 
-    return buildDiagramFrame({ filename, notation: 'Activities (PSND)', svgContent, errorMsg, warnings, themeId, extraStyles: ACTIVITIES_STYLES });
+    return buildDiagramFrame({
+      filename,
+      notation: 'Activities (PSND + Gantt)',
+      bodyContent,
+      errorMsg,
+      warnings,
+      themeId,
+      extraStyles: ACTIVITIES_STYLES,
+    });
   }
 
   async saveAsSvg(): Promise<void> {
@@ -408,11 +385,3 @@ export class ActivitiesPreview {
     vscode.window.showInformationMessage(`Saved: ${path.basename(target.fsPath)}`);
   }
 }
-
-const ACTIVITIES_STYLES = `
-  .act-node { fill: var(--ts-bg-surface, #f8fafc); stroke: var(--ts-border, #94a3b8); stroke-width: 1.5; }
-  .critical-node { fill: #fff7ed; stroke: var(--ts-brand-orange, #ff4d00); stroke-width: 2.5; }
-  .critical-edge { stroke: var(--ts-brand-orange, #ff4d00); stroke-width: 2; }
-  .arrow-fill-critical { fill: var(--ts-brand-orange, #ff4d00); }
-  .text-id { fill: var(--ts-text-muted, #64748b); }
-`;

--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -207,8 +207,13 @@ function ganttSvg(layout: GanttLayout): string {
     }
   }
 
-  // Link lines
+  // Link lines — Finish-to-Start elbow with the vertical anchored at the
+  // midpoint of the inter-bar gap (looks balanced regardless of gap width).
+  // A 4px gap on each side stops the line from fusing with the bar edges,
+  // and the arrowhead lives in that gap so it doesn't overlap the target.
   const linkParts: string[] = [];
+  const LINK_GAP = 4;
+  const LINK_MIN_STUB = 6;
   for (const link of layout.links) {
     const sourceBar = bars.find(b => b.id === link.sourceId);
     const targetBar = bars.find(b => b.id === link.targetId);
@@ -220,13 +225,39 @@ function ganttSvg(layout: GanttLayout): string {
     const tx = ox + G_LABEL_COL_W + targetStartOffset * G_DAY_W;
     const ty = yByBarId.get(link.targetId) ?? 0;
     const cls = link.isCritical ? 'diagram-edge critical-edge' : 'diagram-edge';
-    // Right-angle elbow.
+    const marker = link.isCritical ? 'gantt-arrow-crit' : 'gantt-arrow';
+
+    const sxStart = sx + LINK_GAP;
+    const txEnd = tx - LINK_GAP;
+    let d: string;
+    if (txEnd - sxStart >= LINK_MIN_STUB * 2) {
+      // Forward link with comfortable gap: midpoint vertical.
+      const midX = (sxStart + txEnd) / 2;
+      d = `M${sxStart},${sy} L${midX},${sy} L${midX},${ty} L${txEnd},${ty}`;
+    } else if (txEnd > sxStart) {
+      // Tight gap: keep the stub but distribute it.
+      const stubX = sxStart + Math.max(0, (txEnd - sxStart) / 2);
+      d = `M${sxStart},${sy} L${stubX},${sy} L${stubX},${ty} L${txEnd},${ty}`;
+    } else {
+      // Backward/overlap (target starts at or before source ends): route
+      // below both rows so the link doesn't cross the source bar.
+      const hookY = Math.max(sy, ty) + G_ROW_H / 2 + 6;
+      d = `M${sxStart},${sy} L${sxStart + LINK_MIN_STUB},${sy} L${sxStart + LINK_MIN_STUB},${hookY} L${txEnd - LINK_MIN_STUB},${hookY} L${txEnd - LINK_MIN_STUB},${ty} L${txEnd},${ty}`;
+    }
     linkParts.push(
-      `<path d="M${sx},${sy} L${sx + 6},${sy} L${sx + 6},${ty} L${tx},${ty}" class="${cls}" fill="none"/>`,
+      `<path d="${d}" class="${cls}" fill="none" marker-end="url(#${marker})"/>`,
     );
   }
 
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">
+<defs>
+  <marker id="gantt-arrow" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto" markerUnits="userSpaceOnUse">
+    <path d="M0,0 L0,6 L6,3 z" class="arrow-fill"/>
+  </marker>
+  <marker id="gantt-arrow-crit" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto" markerUnits="userSpaceOnUse">
+    <path d="M0,0 L0,6 L6,3 z" class="arrow-fill-critical"/>
+  </marker>
+</defs>
 ${headerParts.join('\n')}
 ${rowParts.join('\n')}
 ${linkParts.join('\n')}

--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -270,34 +270,80 @@ function buildCanvasContent(doc: ActivityDoc): string {
   const network = networkSvg(doc);
   const gantt: GanttResult = computeGanttLayout(doc);
 
-  const networkSection = `<section class="diagram-section">
-  <h3 class="section-heading">Network view — Project Schedule Network Diagram (PSND)</h3>
-  ${network}
-</section>`;
-
-  let ganttSection: string;
+  let ganttHeading: string;
+  let ganttBody: string;
   if (isGanttUnavailable(gantt)) {
-    ganttSection = `<section class="diagram-section">
-  <h3 class="section-heading">Gantt view</h3>
-  <div class="section-notice">${escXml(gantt.reason)}</div>
-</section>`;
+    ganttHeading = 'Gantt view — unavailable';
+    ganttBody = `<div class="section-notice">${escXml(gantt.reason)}</div>`;
   } else {
     const modeLabel = gantt.mode === 'computed'
       ? `computed mode (project ${gantt.timelineStart} → ${gantt.timelineEnd})`
       : `pinned mode (${gantt.timelineStart} → ${gantt.timelineEnd})`;
-    ganttSection = `<section class="diagram-section">
-  <h3 class="section-heading">Gantt view — ${escXml(modeLabel)}</h3>
-  ${ganttSvg(gantt)}
-</section>`;
+    ganttHeading = `Gantt view — ${modeLabel}`;
+    ganttBody = ganttSvg(gantt);
   }
 
-  return networkSection + ganttSection;
+  // Pure-CSS tab switcher: hidden radio inputs at the top, labels styled as
+  // tabs, panels shown via `:checked ~ section[data-view=…]`. Works under the
+  // webview's `enableScripts: false` + script-less CSP because no JS is
+  // involved — the browser handles `:checked` natively.
+  return `<input type="radio" id="view-network" name="view-tabs" class="view-radio" checked>
+<input type="radio" id="view-gantt" name="view-tabs" class="view-radio">
+<nav class="view-tabs" role="tablist">
+  <label for="view-network" class="view-tab" data-tab="network">Network</label>
+  <label for="view-gantt" class="view-tab" data-tab="gantt">Gantt</label>
+</nav>
+<section class="diagram-section" data-view="network">
+  <h3 class="section-heading">Network view — Project Schedule Network Diagram (PSND)</h3>
+  ${network}
+</section>
+<section class="diagram-section" data-view="gantt">
+  <h3 class="section-heading">${escXml(ganttHeading)}</h3>
+  ${ganttBody}
+</section>`;
 }
 
 // ── Extra CSS injected into the diagram frame ───────────────────────────────
 
 const ACTIVITIES_STYLES = `
-  .diagram-section { margin: 16px 0; }
+  /* ── View switcher (CSS-only, no JS) ────────────────────────────────── */
+  /* Move the radios fully off-screen rather than just hiding via opacity —
+     keeps them keyboard-focusable while not taking layout space, and stops
+     the webview default styles from showing a 13px input box. */
+  .view-radio { position: absolute; left: -9999px; width: 1px; height: 1px; }
+  .view-tabs { display: flex; gap: 4px; padding: 12px 16px 0; border-bottom: 1px solid var(--ts-border, #cbd5e1); margin-bottom: 8px; }
+  .view-tab {
+    padding: 6px 14px;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--ts-text-muted, #64748b);
+    background: transparent;
+    border: 1px solid transparent;
+    border-bottom: none;
+    border-radius: 6px 6px 0 0;
+    cursor: pointer;
+    user-select: none;
+    margin-bottom: -1px;
+  }
+  .view-tab:hover { color: var(--ts-text, #0f172a); background: var(--ts-bg-subtle, #f1f5f9); }
+  /* Default state: both panels hidden until a radio activates one. */
+  .diagram-section[data-view] { display: none; }
+  /* Network tab/panel active. */
+  .view-radio#view-network:checked ~ .view-tabs .view-tab[data-tab="network"] {
+    color: var(--ts-text, #0f172a);
+    background: var(--ts-bg-surface, #ffffff);
+    border-color: var(--ts-border, #cbd5e1);
+  }
+  .view-radio#view-network:checked ~ section[data-view="network"] { display: block; }
+  /* Gantt tab/panel active. */
+  .view-radio#view-gantt:checked ~ .view-tabs .view-tab[data-tab="gantt"] {
+    color: var(--ts-text, #0f172a);
+    background: var(--ts-bg-surface, #ffffff);
+    border-color: var(--ts-border, #cbd5e1);
+  }
+  .view-radio#view-gantt:checked ~ section[data-view="gantt"] { display: block; }
+
+  .diagram-section { margin: 8px 0 16px; }
   .section-heading { font-size: 13px; font-weight: 600; color: var(--ts-text-muted, #64748b); margin: 0 16px 8px; letter-spacing: 0.02em; }
   .section-notice { margin: 0 16px; padding: 10px 14px; border-left: 3px solid var(--ts-text-muted, #94a3b8); background: var(--ts-bg-subtle, #f8fafc); color: var(--ts-text-muted, #64748b); font-size: 12px; }
 

--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -283,22 +283,34 @@ function ganttSvg(layout: GanttLayout): string {
     }
 
     if (forward.length > 0) {
-      const deepestTy = Math.max(...forward.map(t => t.ty));
-      // Fix the back-step y to the inter-row band immediately below source.
-      // This keeps it in safe empty space regardless of how far below the
-      // deepest target sits, and it never lands on an intermediate row.
       const midY = sy + G_ROW_H / 2;
       const stubX = sx + STUB_OUT;
       const backX = sx - BACK_OFFSET;
 
-      const trunkCritical = forward.some(t => t.link.isCritical);
-      const trunkCls = trunkCritical ? 'diagram-edge critical-edge' : 'diagram-edge';
+      // Top of the trunk (right stub + short vertical at stubX + back-step at
+      // midY). All outgoing routes traverse this segment, so it's coloured by
+      // "any outgoing critical" — orange if at least one successor is on the
+      // critical path, gray otherwise.
+      const anyCritical = forward.some(t => t.link.isCritical);
+      const topCls = anyCritical ? 'diagram-edge critical-edge' : 'diagram-edge';
+      const topD = `M${sx},${sy} L${stubX},${sy} L${stubX},${midY} L${backX},${midY}`;
+      linkParts.push(`<path d="${topD}" class="${topCls}" fill="none"/>`);
 
-      // Trunk: source right edge → right stub → down to midY → back left →
-      // down to the deepest target row. No arrow on the trunk itself.
-      const trunkD =
-        `M${sx},${sy} L${stubX},${sy} L${stubX},${midY} L${backX},${midY} L${backX},${deepestTy}`;
-      linkParts.push(`<path d="${trunkD}" class="${trunkCls}" fill="none"/>`);
+      // Long vertical at x = backX, split at each target's row. Each segment
+      // is coloured by whether any route still served by it (= targets at or
+      // below the segment's bottom) is on the critical path. This way the
+      // orange line stops at the deepest critical target's row — the part of
+      // the trunk that purely carries non-critical routes shows in gray.
+      const sortedForward = [...forward].sort((a, b) => a.ty - b.ty);
+      let segTop = midY;
+      for (let i = 0; i < sortedForward.length; i++) {
+        const segBottom = sortedForward[i].ty;
+        const segCritical = sortedForward.slice(i).some(t => t.link.isCritical);
+        const segCls = segCritical ? 'diagram-edge critical-edge' : 'diagram-edge';
+        const segD = `M${backX},${segTop} L${backX},${segBottom}`;
+        linkParts.push(`<path d="${segD}" class="${segCls}" fill="none"/>`);
+        segTop = segBottom;
+      }
 
       // Branches: short horizontals at each target's row, from the trunk's
       // x = backX into the target's left edge. The arrowhead lives a few px

--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -93,11 +93,11 @@ ${nodeSvg}
 // ── Gantt SVG renderer ───────────────────────────────────────────────────────
 
 const G_DAY_W = 24;       // px per calendar day on the timeline axis
-const G_ROW_H = 28;
+const G_ROW_H = 40;       // row height — taller than the bar so links have inter-row breathing room
 const G_LABEL_COL_W = 220;
 const G_HEADER_H = 36;
 const G_PAD = 24;
-const G_BAR_INSET_Y = 4;  // top/bottom inset of bars inside the row band
+const G_BAR_INSET_Y = 8;  // top/bottom inset of bars inside the row band (sets inter-row gap = 2*INSET = 16px)
 
 function parseISO(s: string): Date {
   const [y, m, d] = s.split('-').map((p) => Number.parseInt(p, 10));
@@ -209,22 +209,36 @@ function ganttSvg(layout: GanttLayout): string {
 
   // Link lines — Finish-to-Start.
   //
-  // Routing rule: the vertical sits at the source bar's right edge (x = sx),
-  // which is also the column-grid boundary. Successor bars start at that
-  // same boundary in computed mode, so the vertical runs along their LEFT
-  // EDGE rather than crossing their interior. This is the MS Project /
-  // Primavera convention — links travel along column rails, not through bar
-  // bodies.
+  // Routing strategy:
   //
-  // - Comfortable gap (tx well past sx): midpoint elbow inside the gap.
-  // - Adjacent (tx == sx, no weekend between source.end+1 and target.start):
-  //   vertical at the column boundary; short horizontal stub into target.
-  // - True overlap (tx < sx, possible in pinned mode where a successor's
-  //   pinned start_date precedes its predecessor's end_date): detour BELOW
-  //   both rows so the link doesn't run through either bar.
+  // - **Comfortable gap** (tx well past sx, e.g., weekend separates the two
+  //   dates): single midpoint elbow inside the gap. The vertical sits between
+  //   source-end and target-start, naturally clear of both bars.
+  //
+  // - **Adjacent / near-adjacent** (tx == sx or near it — the convergent
+  //   case where successors begin in the source's end column): a Z-shape
+  //   that takes the long vertical OUT of the source-end column so it
+  //   doesn't visually graze successor left edges. Routing:
+  //   1. Exit source right edge, step RIGHT by a small stub.
+  //   2. Drop DOWN to the y-midpoint between the source and target rows
+  //      (lands in the inter-row band where no bar is drawn).
+  //   3. Step LEFT past source's right edge (the "back" step) into the
+  //      column UNDER source's bar — safe because we're below source row.
+  //   4. Drop the rest of the way DOWN to the target row.
+  //   5. Sweep RIGHT into target's left edge.
+  //   Result: the long vertical sits to the left of the busy convergent
+  //   column, the short verticals are in the inter-row band, and the arrow
+  //   enters target from the left.
+  //
+  // - **True backward** (tx < sx — possible in pinned mode where a
+  //   successor's pinned start_date precedes its predecessor's end_date):
+  //   detour BELOW both rows so the link doesn't run inside either bar.
   const linkParts: string[] = [];
   const LINK_GAP = 4;
   const LINK_MIN_STUB = 6;
+  const STUB_OUT = 8;       // right-stub past source before turning down
+  const BACK_OFFSET = 8;    // back-step distance to the LEFT of sx for the long vertical
+  const ENTER_DEPTH = 4;    // how far inside target the arrow path lands (marker tip ~1px further)
   for (const link of layout.links) {
     const sourceBar = bars.find(b => b.id === link.sourceId);
     const targetBar = bars.find(b => b.id === link.targetId);
@@ -239,22 +253,21 @@ function ganttSvg(layout: GanttLayout): string {
     const marker = link.isCritical ? 'gantt-arrow-crit' : 'gantt-arrow';
 
     let d: string;
-    if (tx > sx + LINK_MIN_STUB * 2) {
-      // Comfortable gap — midpoint elbow inside the gap so the vertical sits
-      // visually between source-end and target-start, away from both bars.
+    if (tx > sx + STUB_OUT * 2) {
+      // Comfortable gap — single midpoint elbow inside the gap.
       const sxStart = sx + LINK_GAP;
       const txEnd = tx - LINK_GAP;
       const midX = (sxStart + txEnd) / 2;
       d = `M${sxStart},${sy} L${midX},${sy} L${midX},${ty} L${txEnd},${ty}`;
     } else if (tx >= sx) {
-      // Adjacent or near-adjacent — vertical at the column boundary x = sx.
-      // The final horizontal stub lands at min(sx + 6, tx + 6) so the arrow
-      // sits a few px inside the target bar's left edge zone (bars are ≥1 day
-      // = 24px wide, so the stub never reaches the right edge).
-      const finalX = Math.max(sx + LINK_MIN_STUB, tx + LINK_MIN_STUB - LINK_GAP);
-      d = `M${sx},${sy} L${sx},${ty} L${finalX},${ty}`;
+      // Adjacent or near-adjacent — Z-shape going around source's right edge.
+      const stubX = sx + STUB_OUT;
+      const backX = sx - BACK_OFFSET;
+      const midY = (sy + ty) / 2;
+      const enterX = tx + ENTER_DEPTH;
+      d = `M${sx},${sy} L${stubX},${sy} L${stubX},${midY} L${backX},${midY} L${backX},${ty} L${enterX},${ty}`;
     } else {
-      // True backward (tx < sx, pinned-mode overlap): detour below both rows.
+      // True backward (tx < sx) — detour below both rows.
       const hookY = Math.max(sy, ty) + G_ROW_H / 2 + 6;
       const sxOut = sx + LINK_GAP;
       const txIn = tx + LINK_MIN_STUB;

--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -209,73 +209,118 @@ function ganttSvg(layout: GanttLayout): string {
 
   // Link lines — Finish-to-Start.
   //
-  // Routing strategy:
+  // Routing strategy is **trunk + branches per source**:
   //
-  // - **Comfortable gap** (tx well past sx, e.g., weekend separates the two
-  //   dates): single midpoint elbow inside the gap. The vertical sits between
-  //   source-end and target-start, naturally clear of both bars.
+  // - Outgoing links from the same source share ONE trunk (the Z-shape that
+  //   exits source's right edge, drops to the inter-row band immediately
+  //   below source, steps back to the LEFT of the source-end column, and
+  //   descends to the deepest target). Each link contributes a horizontal
+  //   BRANCH off the trunk at its target's row, ending with an arrowhead
+  //   inside the target bar's left edge.
   //
-  // - **Adjacent / near-adjacent** (tx == sx or near it — the convergent
-  //   case where successors begin in the source's end column): a Z-shape
-  //   that takes the long vertical OUT of the source-end column so it
-  //   doesn't visually graze successor left edges. Routing:
-  //   1. Exit source right edge, step RIGHT by a small stub.
-  //   2. Drop DOWN to the y-midpoint between the source and target rows
-  //      (lands in the inter-row band where no bar is drawn).
-  //   3. Step LEFT past source's right edge (the "back" step) into the
-  //      column UNDER source's bar — safe because we're below source row.
-  //   4. Drop the rest of the way DOWN to the target row.
-  //   5. Sweep RIGHT into target's left edge.
-  //   Result: the long vertical sits to the left of the busy convergent
-  //   column, the short verticals are in the inter-row band, and the arrow
-  //   enters target from the left.
+  // This solves three problems with per-link routing:
   //
-  // - **True backward** (tx < sx — possible in pinned mode where a
-  //   successor's pinned start_date precedes its predecessor's end_date):
-  //   detour BELOW both rows so the link doesn't run inside either bar.
+  // 1. **Layering**: per-link rendering drew identical right-stubs and
+  //    short verticals four times (once per outgoing link from A-002 in
+  //    platform-launch), with the last-drawn gray covering the orange
+  //    critical link's overlapping segments. The trunk is drawn once.
+  //
+  // 2. **midY landing on a bar row**: per-link midY = (sy + ty)/2 lands on
+  //    an intermediate row's CENTER when target is an even number of rows
+  //    below source (e.g., A-002 → A-005 lands midY on A-003's bar row,
+  //    pulling the back-step horizontal through A-003's bar). The trunk's
+  //    midY is fixed to the inter-row band immediately below source, so the
+  //    back-step is always in safe empty space.
+  //
+  // 3. **Visual consistency**: the trunk colour is critical (orange) if
+  //    ANY outgoing link from this source is on the critical path, so the
+  //    critical-path lineage is visible from source down to the critical
+  //    target. Branches are coloured per link, so non-critical successors
+  //    show in gray with their own arrows.
+  //
+  // Backward links (tx < sx — pinned-mode overlap where target.start_date
+  // precedes source.end_date, or targets sorted above source in the row
+  // order) use the existing detour-below routing.
   const linkParts: string[] = [];
   const LINK_GAP = 4;
   const LINK_MIN_STUB = 6;
   const STUB_OUT = 8;       // right-stub past source before turning down
   const BACK_OFFSET = 8;    // back-step distance to the LEFT of sx for the long vertical
   const ENTER_DEPTH = 4;    // how far inside target the arrow path lands (marker tip ~1px further)
-  for (const link of layout.links) {
-    const sourceBar = bars.find(b => b.id === link.sourceId);
-    const targetBar = bars.find(b => b.id === link.targetId);
-    if (!sourceBar || !targetBar) continue;
-    const sourceEndOffset = daysBetween(layout.timelineStart, sourceBar.endDate);
-    const targetStartOffset = daysBetween(layout.timelineStart, targetBar.startDate);
-    const sx = ox + G_LABEL_COL_W + (sourceEndOffset + 1) * G_DAY_W;
-    const sy = yByBarId.get(link.sourceId) ?? 0;
-    const tx = ox + G_LABEL_COL_W + targetStartOffset * G_DAY_W;
-    const ty = yByBarId.get(link.targetId) ?? 0;
-    const cls = link.isCritical ? 'diagram-edge critical-edge' : 'diagram-edge';
-    const marker = link.isCritical ? 'gantt-arrow-crit' : 'gantt-arrow';
 
-    let d: string;
-    if (tx > sx + STUB_OUT * 2) {
-      // Comfortable gap — single midpoint elbow inside the gap.
-      const sxStart = sx + LINK_GAP;
-      const txEnd = tx - LINK_GAP;
-      const midX = (sxStart + txEnd) / 2;
-      d = `M${sxStart},${sy} L${midX},${sy} L${midX},${ty} L${txEnd},${ty}`;
-    } else if (tx >= sx) {
-      // Adjacent or near-adjacent — Z-shape going around source's right edge.
+  // Group links by source so all outgoing links share one trunk.
+  const linksBySource = new Map<string, typeof layout.links>();
+  for (const link of layout.links) {
+    let list = linksBySource.get(link.sourceId);
+    if (!list) {
+      list = [];
+      linksBySource.set(link.sourceId, list);
+    }
+    list.push(link);
+  }
+
+  for (const [sourceId, outgoing] of linksBySource) {
+    const sourceBar = bars.find(b => b.id === sourceId);
+    if (!sourceBar) continue;
+    const sourceEndOffset = daysBetween(layout.timelineStart, sourceBar.endDate);
+    const sx = ox + G_LABEL_COL_W + (sourceEndOffset + 1) * G_DAY_W;
+    const sy = yByBarId.get(sourceId) ?? 0;
+
+    type Target = { link: typeof outgoing[number]; tx: number; ty: number };
+    const forward: Target[] = [];
+    const backward: Target[] = [];
+    for (const link of outgoing) {
+      const targetBar = bars.find(b => b.id === link.targetId);
+      if (!targetBar) continue;
+      const targetStartOffset = daysBetween(layout.timelineStart, targetBar.startDate);
+      const tx = ox + G_LABEL_COL_W + targetStartOffset * G_DAY_W;
+      const ty = yByBarId.get(link.targetId) ?? 0;
+      // "Forward" here means below source on the timeline (ty > sy). Pinned
+      // mode can place a successor above its predecessor or to the left of
+      // its end date — both go through the backward branch.
+      if (ty > sy && tx >= sx) forward.push({ link, tx, ty });
+      else backward.push({ link, tx, ty });
+    }
+
+    if (forward.length > 0) {
+      const deepestTy = Math.max(...forward.map(t => t.ty));
+      // Fix the back-step y to the inter-row band immediately below source.
+      // This keeps it in safe empty space regardless of how far below the
+      // deepest target sits, and it never lands on an intermediate row.
+      const midY = sy + G_ROW_H / 2;
       const stubX = sx + STUB_OUT;
       const backX = sx - BACK_OFFSET;
-      const midY = (sy + ty) / 2;
-      const enterX = tx + ENTER_DEPTH;
-      d = `M${sx},${sy} L${stubX},${sy} L${stubX},${midY} L${backX},${midY} L${backX},${ty} L${enterX},${ty}`;
-    } else {
-      // True backward (tx < sx) — detour below both rows.
-      const hookY = Math.max(sy, ty) + G_ROW_H / 2 + 6;
-      const sxOut = sx + LINK_GAP;
-      const txIn = tx + LINK_MIN_STUB;
-      d = `M${sxOut},${sy} L${sxOut},${hookY} L${txIn},${hookY} L${txIn},${ty}`;
+
+      const trunkCritical = forward.some(t => t.link.isCritical);
+      const trunkCls = trunkCritical ? 'diagram-edge critical-edge' : 'diagram-edge';
+
+      // Trunk: source right edge → right stub → down to midY → back left →
+      // down to the deepest target row. No arrow on the trunk itself.
+      const trunkD =
+        `M${sx},${sy} L${stubX},${sy} L${stubX},${midY} L${backX},${midY} L${backX},${deepestTy}`;
+      linkParts.push(`<path d="${trunkD}" class="${trunkCls}" fill="none"/>`);
+
+      // Branches: short horizontals at each target's row, from the trunk's
+      // x = backX into the target's left edge. The arrowhead lives a few px
+      // inside the target bar.
+      for (const t of forward) {
+        const cls = t.link.isCritical ? 'diagram-edge critical-edge' : 'diagram-edge';
+        const marker = t.link.isCritical ? 'gantt-arrow-crit' : 'gantt-arrow';
+        const enterX = t.tx + ENTER_DEPTH;
+        const branchD = `M${backX},${t.ty} L${enterX},${t.ty}`;
+        linkParts.push(`<path d="${branchD}" class="${cls}" fill="none" marker-end="url(#${marker})"/>`);
+      }
     }
-    linkParts.push(
-      `<path d="${d}" class="${cls}" fill="none" marker-end="url(#${marker})"/>`,
-    );
+
+    for (const t of backward) {
+      const cls = t.link.isCritical ? 'diagram-edge critical-edge' : 'diagram-edge';
+      const marker = t.link.isCritical ? 'gantt-arrow-crit' : 'gantt-arrow';
+      const hookY = Math.max(sy, t.ty) + G_ROW_H / 2 + 6;
+      const sxOut = sx + LINK_GAP;
+      const txIn = t.tx + LINK_MIN_STUB;
+      const d = `M${sxOut},${sy} L${sxOut},${hookY} L${txIn},${hookY} L${txIn},${t.ty}`;
+      linkParts.push(`<path d="${d}" class="${cls}" fill="none" marker-end="url(#${marker})"/>`);
+    }
   }
 
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">

--- a/packages/diagrams/src/activities/__tests__/gantt.test.ts
+++ b/packages/diagrams/src/activities/__tests__/gantt.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect } from 'vitest';
+import { computeGanttLayout, isGanttUnavailable } from '../gantt.js';
+import type { ActivityDoc, GanttLayout } from '../types.js';
+
+function assertRenders(result: ReturnType<typeof computeGanttLayout>): GanttLayout {
+  if (isGanttUnavailable(result)) {
+    throw new Error(`Expected Gantt to render but got unavailable: ${result.reason}`);
+  }
+  return result;
+}
+
+describe('computeGanttLayout — mode detection', () => {
+  it('returns unavailable when neither project.start_date nor pinned dates exist', () => {
+    const doc: ActivityDoc = {
+      notation: 'activities',
+      activities: [
+        { id: 'A', name: 'A', duration: 3 },
+        { id: 'B', name: 'B', duration: 2, predecessors: ['A'] },
+      ],
+    };
+    const r = computeGanttLayout(doc);
+    expect(isGanttUnavailable(r)).toBe(true);
+  });
+
+  it('selects computed mode when project.start_date + every leaf has duration', () => {
+    const doc: ActivityDoc = {
+      notation: 'activities',
+      project: { start_date: '2026-06-01' },
+      activities: [
+        { id: 'A', name: 'A', duration: 3 },
+        { id: 'B', name: 'B', duration: 2, predecessors: ['A'] },
+      ],
+    };
+    const r = assertRenders(computeGanttLayout(doc));
+    expect(r.mode).toBe('computed');
+  });
+
+  it('selects pinned mode when every leaf has start_date + end_date', () => {
+    const doc: ActivityDoc = {
+      notation: 'activities',
+      activities: [
+        { id: 'A', name: 'A', start_date: '2026-06-01', end_date: '2026-06-03' },
+        { id: 'B', name: 'B', start_date: '2026-06-04', end_date: '2026-06-06' },
+      ],
+    };
+    const r = assertRenders(computeGanttLayout(doc));
+    expect(r.mode).toBe('pinned');
+  });
+
+  it('unavailable when only some leaves have pinned dates and no project.start_date', () => {
+    const doc: ActivityDoc = {
+      notation: 'activities',
+      activities: [
+        { id: 'A', name: 'A', start_date: '2026-06-01', end_date: '2026-06-03' },
+        { id: 'B', name: 'B', duration: 3 }, // no pinned dates, no project.start_date
+      ],
+    };
+    const r = computeGanttLayout(doc);
+    expect(isGanttUnavailable(r)).toBe(true);
+  });
+
+  it('unavailable when the document has no activities', () => {
+    const r = computeGanttLayout({ notation: 'activities', activities: [] });
+    expect(isGanttUnavailable(r)).toBe(true);
+  });
+});
+
+describe('computeGanttLayout — computed mode (CPM + calendar projection)', () => {
+  const doc: ActivityDoc = {
+    notation: 'activities',
+    project: { start_date: '2026-06-01' }, // Monday
+    activities: [
+      { id: 'A', name: 'A', duration: 3 },
+      { id: 'B', name: 'B', duration: 2, predecessors: ['A'] },
+    ],
+  };
+
+  it('places the first bar at project.start_date and spans its duration', () => {
+    const r = assertRenders(computeGanttLayout(doc));
+    const a = r.bars.find(b => b.id === 'A')!;
+    expect(a.startDate).toBe('2026-06-01');
+    // 7-day default calendar: day 0 = start_date, last day = 2026-06-03 (start + 2)
+    expect(a.endDate).toBe('2026-06-03');
+  });
+
+  it('places successor bars after their predecessor finishes', () => {
+    const r = assertRenders(computeGanttLayout(doc));
+    const b = r.bars.find(b => b.id === 'B')!;
+    // B has ES = EF(A) = 3 working days, so it starts at 2026-06-04
+    expect(b.startDate).toBe('2026-06-04');
+    expect(b.endDate).toBe('2026-06-05');
+  });
+
+  it('marks critical-path bars on a linear chain', () => {
+    const r = assertRenders(computeGanttLayout(doc));
+    const a = r.bars.find(b => b.id === 'A')!;
+    const bbar = r.bars.find(b => b.id === 'B')!;
+    expect(a.isCritical).toBe(true);
+    expect(bbar.isCritical).toBe(true);
+  });
+
+  it('emits predecessor → successor links with critical flag carried over', () => {
+    const r = assertRenders(computeGanttLayout(doc));
+    expect(r.links).toHaveLength(1);
+    expect(r.links[0]).toMatchObject({ sourceId: 'A', targetId: 'B', isCritical: true });
+  });
+
+  it('timeline bounds span min(start) to max(end)', () => {
+    const r = assertRenders(computeGanttLayout(doc));
+    expect(r.timelineStart).toBe('2026-06-01');
+    expect(r.timelineEnd).toBe('2026-06-05');
+  });
+});
+
+describe('computeGanttLayout — calendar (working_days, holidays)', () => {
+  it('skips weekend days when working_days excludes them', () => {
+    // 2026-06-01 is a Monday. Duration 7 days, only Mon–Fri working.
+    // Day 0 = Mon 06-01, days 1..4 = Tue-Fri, day 5 = next Mon 06-08, day 6 = Tue 06-09.
+    const doc: ActivityDoc = {
+      notation: 'activities',
+      project: {
+        start_date: '2026-06-01',
+        calendar: { working_days: ['mon', 'tue', 'wed', 'thu', 'fri'] },
+      },
+      activities: [{ id: 'A', name: 'A', duration: 7 }],
+    };
+    const r = assertRenders(computeGanttLayout(doc));
+    const a = r.bars.find(b => b.id === 'A')!;
+    expect(a.startDate).toBe('2026-06-01');
+    expect(a.endDate).toBe('2026-06-09');
+  });
+
+  it('skips dates listed under holidays', () => {
+    // 7-day week, but 2026-06-02 is a holiday → 3-day activity ends on 2026-06-04.
+    const doc: ActivityDoc = {
+      notation: 'activities',
+      project: {
+        start_date: '2026-06-01',
+        calendar: { holidays: ['2026-06-02'] },
+      },
+      activities: [{ id: 'A', name: 'A', duration: 3 }],
+    };
+    const r = assertRenders(computeGanttLayout(doc));
+    const a = r.bars.find(b => b.id === 'A')!;
+    expect(a.startDate).toBe('2026-06-01');
+    expect(a.endDate).toBe('2026-06-04');
+  });
+});
+
+describe('computeGanttLayout — milestones', () => {
+  it('renders zero-duration leaves as milestones with start == end', () => {
+    const doc: ActivityDoc = {
+      notation: 'activities',
+      project: { start_date: '2026-06-01' },
+      activities: [
+        { id: 'A', name: 'A', duration: 3 },
+        { id: 'M', name: 'Launch', duration: 0, predecessors: ['A'] },
+      ],
+    };
+    const r = assertRenders(computeGanttLayout(doc));
+    const m = r.bars.find(b => b.id === 'M')!;
+    expect(m.kind).toBe('milestone');
+    expect(m.startDate).toBe(m.endDate);
+    // M lives at the working day immediately after A finishes (ES = 3).
+    expect(m.startDate).toBe('2026-06-04');
+  });
+
+  it('pinned mode treats start==end activities as milestones', () => {
+    const doc: ActivityDoc = {
+      notation: 'activities',
+      activities: [
+        { id: 'M', name: 'Launch', duration: 0, start_date: '2026-06-15', end_date: '2026-06-15' },
+      ],
+    };
+    const r = assertRenders(computeGanttLayout(doc));
+    const m = r.bars.find(b => b.id === 'M')!;
+    expect(m.kind).toBe('milestone');
+  });
+});
+
+describe('computeGanttLayout — phases (parent activities)', () => {
+  it('rolls up phase span from children', () => {
+    const doc: ActivityDoc = {
+      notation: 'activities',
+      project: { start_date: '2026-06-01' },
+      activities: [
+        { id: 'PHASE-1', name: 'Design' },
+        { id: 'A', name: 'A', duration: 3, parent: 'PHASE-1' },
+        { id: 'B', name: 'B', duration: 5, parent: 'PHASE-1', predecessors: ['A'] },
+      ],
+    };
+    const r = assertRenders(computeGanttLayout(doc));
+    const phase = r.bars.find(b => b.id === 'PHASE-1')!;
+    expect(phase.kind).toBe('phase');
+    expect(phase.startDate).toBe('2026-06-01'); // earliest child = A start
+    expect(phase.endDate).toBe('2026-06-08');   // latest child = B end (ES=3 + 5 days)
+  });
+
+  it('marks the phase critical if any child is on the critical path', () => {
+    const doc: ActivityDoc = {
+      notation: 'activities',
+      project: { start_date: '2026-06-01' },
+      activities: [
+        { id: 'PHASE-1', name: 'Design' },
+        { id: 'A', name: 'A', duration: 3, parent: 'PHASE-1' },
+      ],
+    };
+    const r = assertRenders(computeGanttLayout(doc));
+    const phase = r.bars.find(b => b.id === 'PHASE-1')!;
+    expect(phase.isCritical).toBe(true);
+  });
+});
+
+describe('computeGanttLayout — pinned mode', () => {
+  it('places bars at pinned dates without computing CPM', () => {
+    const doc: ActivityDoc = {
+      notation: 'activities',
+      activities: [
+        { id: 'A', name: 'A', start_date: '2026-08-01', end_date: '2026-08-10' },
+        { id: 'B', name: 'B', start_date: '2026-08-12', end_date: '2026-08-20', predecessors: ['A'] },
+      ],
+    };
+    const r = assertRenders(computeGanttLayout(doc));
+    expect(r.mode).toBe('pinned');
+    expect(r.bars.find(b => b.id === 'A')?.startDate).toBe('2026-08-01');
+    expect(r.bars.find(b => b.id === 'A')?.endDate).toBe('2026-08-10');
+    expect(r.bars.find(b => b.id === 'B')?.startDate).toBe('2026-08-12');
+    // Pinned mode does not compute CPM → critical flag is false.
+    expect(r.bars.find(b => b.id === 'A')?.isCritical).toBe(false);
+  });
+
+  it('still emits links between pinned leaves', () => {
+    const doc: ActivityDoc = {
+      notation: 'activities',
+      activities: [
+        { id: 'A', name: 'A', start_date: '2026-08-01', end_date: '2026-08-10' },
+        { id: 'B', name: 'B', start_date: '2026-08-12', end_date: '2026-08-20', predecessors: ['A'] },
+      ],
+    };
+    const r = assertRenders(computeGanttLayout(doc));
+    expect(r.links).toHaveLength(1);
+    expect(r.links[0].sourceId).toBe('A');
+    expect(r.links[0].targetId).toBe('B');
+  });
+});

--- a/packages/diagrams/src/activities/__tests__/validate.test.ts
+++ b/packages/diagrams/src/activities/__tests__/validate.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import yaml from 'js-yaml';
 import { validateActivities } from '../validate.js';
+
+const EXAMPLES_DIR = path.resolve(process.cwd(), '..', '..', 'examples', 'activities');
 
 const minimalValid = {
   notation: 'activities',
@@ -244,4 +249,155 @@ describe('validateActivities', () => {
     expect(r.valid).toBe(true);
     expect(r.errors).toHaveLength(0);
   });
+
+  // ── Project block + calendar (ACT-014, ACT-015) ───────────────────────────
+
+  it('ACT-014 — rejects unknown weekday in working_days', () => {
+    const r = validateActivities({
+      ...minimalValid,
+      project: { start_date: '2026-06-01', calendar: { working_days: ['mon', 'funday'] } },
+    });
+    expect(r.valid).toBe(false);
+    expect(r.errors.some(e => e.code === 'ACT-014' && /funday/.test(e.message))).toBe(true);
+  });
+
+  it('ACT-014 — rejects duplicate weekday entries', () => {
+    const r = validateActivities({
+      ...minimalValid,
+      project: { calendar: { working_days: ['mon', 'tue', 'mon'] } },
+    });
+    expect(r.valid).toBe(false);
+    expect(r.errors.some(e => e.code === 'ACT-014' && /duplicate/i.test(e.message))).toBe(true);
+  });
+
+  it('ACT-014 — accepts mixed-case weekday names', () => {
+    const r = validateActivities({
+      ...minimalValid,
+      project: { start_date: '2026-06-01', calendar: { working_days: ['MON', 'Tue', 'wed', 'thu', 'fri'] } },
+    });
+    expect(r.errors.some(e => e.code === 'ACT-014')).toBe(false);
+  });
+
+  it('ACT-015 — rejects non-ISO holiday date', () => {
+    const r = validateActivities({
+      ...minimalValid,
+      project: { start_date: '2026-06-01', calendar: { holidays: ['2026-07-04', 'July 4 2026'] } },
+    });
+    expect(r.valid).toBe(false);
+    expect(r.errors.some(e => e.code === 'ACT-015' && /July 4 2026/.test(e.message))).toBe(true);
+  });
+
+  it('ACT-015 — accepts an array of ISO dates', () => {
+    const r = validateActivities({
+      ...minimalValid,
+      project: { start_date: '2026-06-01', calendar: { holidays: ['2026-07-04', '2026-12-25'] } },
+    });
+    expect(r.errors.some(e => e.code === 'ACT-015')).toBe(false);
+  });
+
+  // ── Milestone date equality (ACT-016) ─────────────────────────────────────
+
+  it('ACT-016 — rejects milestone with mismatched start/end dates', () => {
+    const r = validateActivities({
+      notation: 'activities',
+      activities: [
+        { id: 'M-1', name: 'Launch', duration: 0, start_date: '2026-06-01', end_date: '2026-06-02' },
+      ],
+    });
+    expect(r.valid).toBe(false);
+    expect(r.errors.some(e => e.code === 'ACT-016')).toBe(true);
+  });
+
+  it('ACT-016 — accepts milestone with equal start/end dates', () => {
+    const r = validateActivities({
+      notation: 'activities',
+      activities: [
+        { id: 'M-1', name: 'Launch', duration: 0, start_date: '2026-06-01', end_date: '2026-06-01' },
+      ],
+    });
+    expect(r.errors.some(e => e.code === 'ACT-016')).toBe(false);
+  });
+
+  // ── Phase warnings (ACT-017, ACT-018) ─────────────────────────────────────
+
+  it('ACT-017 — warns when a referenced-as-parent activity carries its own duration', () => {
+    const r = validateActivities({
+      notation: 'activities',
+      activities: [
+        { id: 'PHASE-1', name: 'Design', duration: 5 },
+        { id: 'A-1', name: 'Child', duration: 3, parent: 'PHASE-1' },
+      ],
+    });
+    expect(r.valid).toBe(true);
+    expect(r.warnings.some(w => w.code === 'ACT-017' && /PHASE-1/.test(w.message))).toBe(true);
+  });
+
+  it('ACT-017 — no warning when phase omits duration/dates and rolls up from children', () => {
+    const r = validateActivities({
+      notation: 'activities',
+      activities: [
+        { id: 'PHASE-1', name: 'Design' },
+        { id: 'A-1', name: 'Child', duration: 3, parent: 'PHASE-1' },
+      ],
+    });
+    expect(r.warnings.some(w => w.code === 'ACT-017')).toBe(false);
+  });
+
+  it('ACT-018 — warns when an activity with no duration is not referenced as parent', () => {
+    const r = validateActivities({
+      notation: 'activities',
+      activities: [
+        { id: 'A-1', name: 'Has duration', duration: 3 },
+        { id: 'P-EMPTY', name: 'Looks like phase but no children' },
+      ],
+    });
+    expect(r.warnings.some(w => w.code === 'ACT-018' && /P-EMPTY/.test(w.message))).toBe(true);
+  });
+
+  it('ACT-018 — no warning when the no-duration activity has at least one child', () => {
+    const r = validateActivities({
+      notation: 'activities',
+      activities: [
+        { id: 'PHASE-1', name: 'Phase' },
+        { id: 'A-1', name: 'Child', duration: 3, parent: 'PHASE-1' },
+      ],
+    });
+    expect(r.warnings.some(w => w.code === 'ACT-018')).toBe(false);
+  });
+
+  // ── Gantt-renderability notice (ACT-019) ──────────────────────────────────
+
+  it('ACT-019 — warns when neither project.start_date nor pinned dates exist', () => {
+    const r = validateActivities(minimalValid);
+    expect(r.warnings.some(w => w.code === 'ACT-019')).toBe(true);
+  });
+
+  it('ACT-019 — no warning when project.start_date is set', () => {
+    const r = validateActivities({ ...minimalValid, project: { start_date: '2026-06-01' } });
+    expect(r.warnings.some(w => w.code === 'ACT-019')).toBe(false);
+  });
+
+  it('ACT-019 — no warning when every activity has pinned dates', () => {
+    const r = validateActivities({
+      notation: 'activities',
+      activities: [
+        { id: 'A-1', name: 'A', duration: 3, start_date: '2026-06-01', end_date: '2026-06-04' },
+      ],
+    });
+    expect(r.warnings.some(w => w.code === 'ACT-019')).toBe(false);
+  });
+});
+
+describe('activities examples (regression)', () => {
+  const files = fs.readdirSync(EXAMPLES_DIR).filter(f => f.endsWith('.yaml'));
+  expect(files.length).toBeGreaterThan(0);
+  for (const file of files) {
+    it(`validates examples/activities/${file}`, () => {
+      const text = fs.readFileSync(path.join(EXAMPLES_DIR, file), 'utf8');
+      const parsed = yaml.load(text);
+      const r = validateActivities(parsed);
+      expect(r.errors).toEqual([]);
+      expect(r.valid).toBe(true);
+    });
+  }
 });

--- a/packages/diagrams/src/activities/gantt.ts
+++ b/packages/diagrams/src/activities/gantt.ts
@@ -1,0 +1,276 @@
+import type {
+  Activity,
+  ActivityDoc,
+  GanttBar,
+  GanttLayout,
+  GanttLink,
+  GanttResult,
+  ProjectCalendar,
+  Weekday,
+} from './types.js';
+import { computeCpm } from './cpm.js';
+
+// ── Calendar helpers (UTC midnight to avoid timezone shifts) ─────────────────
+
+const DEFAULT_WORKING_DAYS: Weekday[] = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
+const WEEKDAY_BY_INDEX: Weekday[] = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'];
+
+interface ResolvedCalendar {
+  workingDays: Set<Weekday>;
+  holidays: Set<string>;
+}
+
+function resolveCalendar(cal: ProjectCalendar | undefined): ResolvedCalendar {
+  const wdRaw = Array.isArray(cal?.working_days) && cal!.working_days.length > 0
+    ? cal!.working_days
+    : DEFAULT_WORKING_DAYS;
+  const workingDays = new Set<Weekday>();
+  for (const d of wdRaw) {
+    if (typeof d === 'string') workingDays.add(d.toLowerCase() as Weekday);
+  }
+  const holidays = new Set<string>();
+  for (const h of cal?.holidays ?? []) {
+    if (typeof h === 'string') holidays.add(h);
+  }
+  return { workingDays, holidays };
+}
+
+function parseISO(s: string): Date {
+  const [y, m, d] = s.split('-').map((p) => Number.parseInt(p, 10));
+  return new Date(Date.UTC(y, m - 1, d));
+}
+
+function formatISO(d: Date): string {
+  const yyyy = d.getUTCFullYear().toString().padStart(4, '0');
+  const mm = (d.getUTCMonth() + 1).toString().padStart(2, '0');
+  const dd = d.getUTCDate().toString().padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+function addUtcDays(d: Date, n: number): Date {
+  const r = new Date(d.getTime());
+  r.setUTCDate(r.getUTCDate() + n);
+  return r;
+}
+
+function isWorkingDay(d: Date, cal: ResolvedCalendar): boolean {
+  if (cal.holidays.has(formatISO(d))) return false;
+  return cal.workingDays.has(WEEKDAY_BY_INDEX[d.getUTCDay()]);
+}
+
+/**
+ * Date of the n-th (0-indexed) working day at or after `startDate`.
+ *
+ * If `startDate` itself is a working day, that's index 0. Walks forward day
+ * by day, counting only working days. The loop is bounded by a sanity cap to
+ * avoid hangs if the calendar ever has zero working days (which the validator
+ * should already have flagged via ACT-014, but defending here too).
+ */
+function nthWorkingDay(startDate: string, n: number, cal: ResolvedCalendar): string {
+  if (n < 0) return startDate;
+  let cur = parseISO(startDate);
+  let count = 0;
+  const sanityLimit = Math.max(10, n) * 10 + 365;
+  for (let i = 0; i < sanityLimit; i++) {
+    if (isWorkingDay(cur, cal)) {
+      if (count === n) return formatISO(cur);
+      count++;
+    }
+    cur = addUtcDays(cur, 1);
+  }
+  return formatISO(cur);
+}
+
+// ── Mode detection + leaf classification ─────────────────────────────────────
+
+interface ActivityRoles {
+  childCount: Map<string, number>;
+  leaves: Activity[];
+  phases: Activity[];
+}
+
+function classifyActivities(activities: Activity[]): ActivityRoles {
+  const childCount = new Map<string, number>();
+  for (const a of activities) {
+    if (typeof a.parent === 'string' && a.parent.length > 0) {
+      childCount.set(a.parent, (childCount.get(a.parent) ?? 0) + 1);
+    }
+  }
+  const leaves: Activity[] = [];
+  const phases: Activity[] = [];
+  for (const a of activities) {
+    if ((childCount.get(a.id) ?? 0) > 0) phases.push(a);
+    else leaves.push(a);
+  }
+  return { childCount, leaves, phases };
+}
+
+function detectMode(doc: ActivityDoc, leaves: Activity[]): 'computed' | 'pinned' | null {
+  if (leaves.length === 0) return null;
+  const allPinned = leaves.every(
+    (a) => typeof a.start_date === 'string' && typeof a.end_date === 'string',
+  );
+  if (allPinned) return 'pinned';
+  const hasProjectStart =
+    typeof doc.project?.start_date === 'string' && doc.project.start_date.length > 0;
+  const allHaveDuration = leaves.every(
+    (a) => typeof a.duration === 'number' && Number.isFinite(a.duration) && a.duration >= 0,
+  );
+  if (hasProjectStart && allHaveDuration) return 'computed';
+  return null;
+}
+
+// ── Main entry ───────────────────────────────────────────────────────────────
+
+export function computeGanttLayout(doc: ActivityDoc): GanttResult {
+  const activities = doc.activities ?? [];
+  if (activities.length === 0) {
+    return { unavailable: true, reason: 'Document has no activities to render on a Gantt timeline.' };
+  }
+
+  const { leaves, phases } = classifyActivities(activities);
+  const mode = detectMode(doc, leaves);
+  if (mode === null) {
+    const reason = leaves.length === 0
+      ? 'All activities are parent (phase) activities — no leaf activities to place on the timeline.'
+      : 'Gantt view unavailable: provide either project.start_date plus durations on every leaf activity (computed mode), or per-activity start_date and end_date on every leaf (pinned mode).';
+    return { unavailable: true, reason };
+  }
+
+  const bars: GanttBar[] = [];
+  const barById = new Map<string, GanttBar>();
+
+  if (mode === 'pinned') {
+    for (const a of leaves) {
+      const startDate = a.start_date as string;
+      const endDate = a.end_date as string;
+      const isMilestone = a.duration === 0 || startDate === endDate;
+      const bar: GanttBar = {
+        id: a.id,
+        name: a.name,
+        kind: isMilestone ? 'milestone' : 'leaf',
+        startDate,
+        endDate,
+        isCritical: false, // pinned mode does not compute CPM
+        parent: typeof a.parent === 'string' ? a.parent : undefined,
+        data: a,
+      };
+      bars.push(bar);
+      barById.set(a.id, bar);
+    }
+  } else {
+    // computed: project.start_date + CPM ES + working-day calendar
+    const cpm = computeCpm(activities);
+    const projectStart = (doc.project!.start_date as string);
+    const calendar = resolveCalendar(doc.project?.calendar);
+    for (const a of leaves) {
+      const c = cpm.get(a.id);
+      const es = c?.es ?? 0;
+      const dur = a.duration ?? 0;
+      const startDate = nthWorkingDay(projectStart, es, calendar);
+      const endDate = dur === 0
+        ? startDate
+        : nthWorkingDay(projectStart, es + dur - 1, calendar);
+      const bar: GanttBar = {
+        id: a.id,
+        name: a.name,
+        kind: dur === 0 ? 'milestone' : 'leaf',
+        startDate,
+        endDate,
+        isCritical: c?.isCritical ?? false,
+        parent: typeof a.parent === 'string' ? a.parent : undefined,
+        data: a,
+      };
+      bars.push(bar);
+      barById.set(a.id, bar);
+    }
+  }
+
+  // Phase rollup — earliest child start to latest child end across all
+  // descendants. Walk depth-first so nested phases inherit grandchildren too.
+  if (phases.length > 0) {
+    const childrenOf = new Map<string, Activity[]>();
+    for (const a of activities) {
+      if (typeof a.parent === 'string' && a.parent.length > 0) {
+        if (!childrenOf.has(a.parent)) childrenOf.set(a.parent, []);
+        childrenOf.get(a.parent)!.push(a);
+      }
+    }
+
+    const phaseSpan = new Map<string, { startDate: string; endDate: string; isCritical: boolean }>();
+    function spanOf(activityId: string): { startDate: string; endDate: string; isCritical: boolean } | null {
+      const cached = phaseSpan.get(activityId);
+      if (cached) return cached;
+      const leaf = barById.get(activityId);
+      if (leaf) return { startDate: leaf.startDate, endDate: leaf.endDate, isCritical: leaf.isCritical };
+      const children = childrenOf.get(activityId) ?? [];
+      if (children.length === 0) return null;
+      let minStart: string | null = null;
+      let maxEnd: string | null = null;
+      let anyCritical = false;
+      for (const child of children) {
+        const s = spanOf(child.id);
+        if (!s) continue;
+        if (minStart === null || s.startDate < minStart) minStart = s.startDate;
+        if (maxEnd === null || s.endDate > maxEnd) maxEnd = s.endDate;
+        if (s.isCritical) anyCritical = true;
+      }
+      if (minStart === null || maxEnd === null) return null;
+      const span = { startDate: minStart, endDate: maxEnd, isCritical: anyCritical };
+      phaseSpan.set(activityId, span);
+      return span;
+    }
+
+    for (const p of phases) {
+      const span = spanOf(p.id);
+      if (!span) continue;
+      const bar: GanttBar = {
+        id: p.id,
+        name: p.name,
+        kind: 'phase',
+        startDate: span.startDate,
+        endDate: span.endDate,
+        isCritical: span.isCritical,
+        parent: typeof p.parent === 'string' ? p.parent : undefined,
+        data: p,
+      };
+      bars.push(bar);
+      barById.set(p.id, bar);
+    }
+  }
+
+  // Predecessor link lines. Only between leaves (phases derive their dates).
+  const links: GanttLink[] = [];
+  for (const a of leaves) {
+    for (const predId of a.predecessors ?? []) {
+      const sourceBar = barById.get(predId);
+      const targetBar = barById.get(a.id);
+      if (!sourceBar || !targetBar) continue;
+      links.push({
+        sourceId: predId,
+        targetId: a.id,
+        isCritical: sourceBar.isCritical && targetBar.isCritical,
+      });
+    }
+  }
+
+  // Timeline bounds — pure min/max over the bar set.
+  let timelineStart = bars[0].startDate;
+  let timelineEnd = bars[0].endDate;
+  for (const b of bars) {
+    if (b.startDate < timelineStart) timelineStart = b.startDate;
+    if (b.endDate > timelineEnd) timelineEnd = b.endDate;
+  }
+
+  return {
+    mode,
+    timelineStart,
+    timelineEnd,
+    bars,
+    links,
+  };
+}
+
+export function isGanttUnavailable(result: GanttResult): result is { unavailable: true; reason: string } {
+  return (result as { unavailable?: boolean }).unavailable === true;
+}

--- a/packages/diagrams/src/activities/index.ts
+++ b/packages/diagrams/src/activities/index.ts
@@ -9,8 +9,19 @@ export type {
   LayoutNode,
   LayoutEdge,
   ActivitiesLayout,
+  Weekday,
+  ProjectCalendar,
+  ProjectBlock,
+  GanttMode,
+  GanttBarKind,
+  GanttBar,
+  GanttLink,
+  GanttLayout,
+  GanttUnavailable,
+  GanttResult,
 } from './types.js';
 
 export { validateActivities } from './validate.js';
 export { computeCpm } from './cpm.js';
 export { layoutActivities } from './layout.js';
+export { computeGanttLayout, isGanttUnavailable } from './gantt.js';

--- a/packages/diagrams/src/activities/types.ts
+++ b/packages/diagrams/src/activities/types.ts
@@ -1,3 +1,16 @@
+// Activities historically exposed PREFIXED validation type names. Keep them
+// as aliases of the shared shape (`../validation-types.ts`) so external
+// consumers keep working.
+import type {
+  ValidationError as SharedValidationError,
+  ValidationWarning as SharedValidationWarning,
+  ValidationResult as SharedValidationResult,
+} from '../validation-types.js';
+
+export type ActivityValidationError = SharedValidationError;
+export type ActivityValidationWarning = SharedValidationWarning;
+export type ActivityValidationResult = SharedValidationResult;
+
 export interface Activity {
   id: string;
   name: string;
@@ -23,6 +36,19 @@ export interface Activity {
   delivers_changes?: string[];
 }
 
+export type Weekday = 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat' | 'sun';
+
+export interface ProjectCalendar {
+  working_days?: Weekday[];
+  hours_per_day?: number;
+  holidays?: string[];
+}
+
+export interface ProjectBlock {
+  start_date?: string;
+  calendar?: ProjectCalendar;
+}
+
 export interface ActivityDoc {
   notation: string;
   spec_version?: string;
@@ -31,21 +57,9 @@ export interface ActivityDoc {
   version?: string;
   date?: string;
   author?: string;
+  project?: ProjectBlock;
   activities: Activity[];
 }
-
-// Activities historically exposed PREFIXED validation type names. Keep them
-// as aliases of the shared shape (`../validation-types.ts`) so external
-// consumers keep working.
-import type {
-  ValidationError as SharedValidationError,
-  ValidationWarning as SharedValidationWarning,
-  ValidationResult as SharedValidationResult,
-} from '../validation-types.js';
-
-export type ActivityValidationError = SharedValidationError;
-export type ActivityValidationWarning = SharedValidationWarning;
-export type ActivityValidationResult = SharedValidationResult;
 
 export interface CpmValues {
   es: number;
@@ -79,3 +93,49 @@ export interface ActivitiesLayout {
   edges: LayoutEdge[];
   bounds: { x: number; y: number; width: number; height: number };
 }
+
+// ── Gantt view (spec §9) ─────────────────────────────────────────────────────
+
+export type GanttMode = 'computed' | 'pinned';
+
+export type GanttBarKind = 'leaf' | 'milestone' | 'phase';
+
+export interface GanttBar {
+  id: string;
+  name: string;
+  kind: GanttBarKind;
+  /** Inclusive start date as ISO 8601 yyyy-mm-dd. */
+  startDate: string;
+  /** Inclusive end date as ISO 8601 yyyy-mm-dd. For milestones equals startDate. */
+  endDate: string;
+  /** True if the activity is on the critical path (only when CPM applies — computed mode). */
+  isCritical: boolean;
+  /** Optional parent activity id (for phase grouping). */
+  parent?: string;
+  /** Activity record. */
+  data: Activity;
+}
+
+export interface GanttLink {
+  sourceId: string;
+  targetId: string;
+  isCritical: boolean;
+}
+
+export interface GanttLayout {
+  /** Render mode that produced this layout. */
+  mode: GanttMode;
+  /** Inclusive timeline bounds as ISO 8601 yyyy-mm-dd. */
+  timelineStart: string;
+  timelineEnd: string;
+  bars: GanttBar[];
+  links: GanttLink[];
+}
+
+export interface GanttUnavailable {
+  unavailable: true;
+  /** Human-readable explanation of what is missing. */
+  reason: string;
+}
+
+export type GanttResult = GanttLayout | GanttUnavailable;

--- a/packages/diagrams/src/activities/validate.ts
+++ b/packages/diagrams/src/activities/validate.ts
@@ -7,6 +7,7 @@ import type {
 } from './types.js';
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const VALID_WEEKDAYS = new Set(['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']);
 
 export function validateActivities(input: unknown): ActivityValidationResult {
   const errors: ActivityValidationError[] = [];
@@ -31,6 +32,58 @@ export function validateActivities(input: unknown): ActivityValidationResult {
   if (!Array.isArray(raw.activities)) {
     errors.push({ code: 'SCHEMA_INVALID', message: 'activities must be an array', path: 'activities' });
     return { valid: false, errors, warnings };
+  }
+
+  // ACT-014 / ACT-015: project.calendar validation (run before per-activity loop;
+  // surfaces clearly even when activities also have issues).
+  if (raw.project && typeof raw.project === 'object') {
+    const project = raw.project as Record<string, unknown>;
+    const cal = project.calendar;
+    if (cal && typeof cal === 'object') {
+      const calendar = cal as Record<string, unknown>;
+      if (calendar.working_days !== undefined) {
+        if (!Array.isArray(calendar.working_days)) {
+          errors.push({ code: 'ACT-014', message: 'project.calendar.working_days must be an array of weekday names', path: 'project.calendar.working_days' });
+        } else {
+          const seen = new Set<string>();
+          for (let i = 0; i < calendar.working_days.length; i++) {
+            const raw = calendar.working_days[i];
+            const day = typeof raw === 'string' ? raw.toLowerCase() : '';
+            if (!VALID_WEEKDAYS.has(day)) {
+              errors.push({
+                code: 'ACT-014',
+                message: `project.calendar.working_days[${i}] "${String(raw)}" must be one of: mon, tue, wed, thu, fri, sat, sun`,
+                path: `project.calendar.working_days[${i}]`,
+              });
+            } else if (seen.has(day)) {
+              errors.push({
+                code: 'ACT-014',
+                message: `project.calendar.working_days has duplicate entry "${day}"`,
+                path: `project.calendar.working_days[${i}]`,
+              });
+            } else {
+              seen.add(day);
+            }
+          }
+        }
+      }
+      if (calendar.holidays !== undefined) {
+        if (!Array.isArray(calendar.holidays)) {
+          errors.push({ code: 'ACT-015', message: 'project.calendar.holidays must be an array of ISO 8601 dates', path: 'project.calendar.holidays' });
+        } else {
+          for (let i = 0; i < calendar.holidays.length; i++) {
+            const h = calendar.holidays[i];
+            if (typeof h !== 'string' || !DATE_RE.test(h)) {
+              errors.push({
+                code: 'ACT-015',
+                message: `project.calendar.holidays[${i}] "${String(h)}" must be an ISO 8601 date (YYYY-MM-DD)`,
+                path: `project.calendar.holidays[${i}]`,
+              });
+            }
+          }
+        }
+      }
+    }
   }
 
   const doc = raw as unknown as ActivityDoc;
@@ -175,6 +228,79 @@ export function validateActivities(input: unknown): ActivityValidationResult {
         path: `activities[${i}]`,
       });
     }
+  }
+
+  // ACT-016: milestone (duration=0) with both pinned dates MUST have start == end.
+  for (let i = 0; i < doc.activities.length; i++) {
+    const a = doc.activities[i];
+    if (a.duration === 0 && a.start_date && a.end_date && a.start_date !== a.end_date) {
+      errors.push({
+        code: 'ACT-016',
+        message: `Milestone "${a.id}" has duration 0 but start_date "${a.start_date}" ≠ end_date "${a.end_date}"`,
+        path: `activities[${i}]`,
+      });
+    }
+  }
+
+  if (errors.length > 0) return { valid: false, errors, warnings };
+
+  // ACT-017 / ACT-018: phase warnings. A "phase" is an activity that is referenced
+  // by another activity's `parent` field. ACT-017 warns when a phase carries its
+  // own duration/dates (those roll up from children). ACT-018 warns when an
+  // activity that looks like a phase (no duration, no pinned dates) has no
+  // children — possibly an unused placeholder.
+  const childCount = new Map<string, number>();
+  for (const a of doc.activities) {
+    if (typeof a.parent === 'string' && a.parent.length > 0) {
+      childCount.set(a.parent, (childCount.get(a.parent) ?? 0) + 1);
+    }
+  }
+  for (let i = 0; i < doc.activities.length; i++) {
+    const a = doc.activities[i];
+    const isReferencedAsParent = (childCount.get(a.id) ?? 0) > 0;
+    if (isReferencedAsParent) {
+      const carriesOwnTiming =
+        (a.duration !== undefined && a.duration !== null) ||
+        typeof a.start_date === 'string' ||
+        typeof a.end_date === 'string';
+      if (carriesOwnTiming) {
+        warnings.push({
+          code: 'ACT-017',
+          message: `Phase "${a.id}" carries its own duration/dates — those should roll up from children, not be authored directly`,
+          path: `activities[${i}]`,
+        });
+      }
+    } else {
+      // Not referenced as parent. ACT-018 only fires when the activity LOOKS
+      // like a phase: no duration declared and no pinned dates. A leaf without
+      // duration is already covered by ACT-011 — the same activity may surface
+      // both warnings, which is correct (separate concerns: CPM-unfit vs
+      // empty-phase).
+      const looksLikePhase =
+        (a.duration === undefined || a.duration === null) &&
+        !a.start_date &&
+        !a.end_date;
+      if (looksLikePhase) {
+        warnings.push({
+          code: 'ACT-018',
+          message: `Activity "${a.id}" has no duration and no children — may be an empty phase`,
+          path: `activities[${i}]`,
+        });
+      }
+    }
+  }
+
+  // ACT-019: Gantt view will not render when neither project.start_date nor
+  // any per-activity pinned date pair is present. Network view is unaffected.
+  const hasProjectStart = typeof doc.project?.start_date === 'string' && doc.project.start_date.length > 0;
+  const hasPinnedActivity = doc.activities.some(
+    (a) => typeof a.start_date === 'string' && typeof a.end_date === 'string',
+  );
+  if (!hasProjectStart && !hasPinnedActivity) {
+    warnings.push({
+      code: 'ACT-019',
+      message: 'Gantt view will not render: project.start_date is absent and no activity has both start_date and end_date pinned. Network view is unaffected.',
+    });
   }
 
   return { valid: errors.length === 0, errors, warnings };


### PR DESCRIPTION
## Summary

Closes hub task **#20** — Gantt view for `*.activities.transitrix.yaml`.

Implements the timeline projection alongside the existing PSND/AoN network view, per the canonical spec [`notations/07-activities.md` v0.3 §9](https://github.com/transitrix/methodology/blob/main/notations/07-activities.md) (Gantt render contract). The two views are projections of one schedule — the network is always renderable from `activities[]` + `predecessors[]`; the Gantt renders when the schedule is **computable** (durations + DAG + `project.start_date`) or **pinned** (per-activity `start_date` and `end_date` on every leaf).

## Acceptance criteria (from hub issue #20)

- [x] A file with durations + dependencies + a project start renders as a **computed Gantt** (timeline derived from CPM offsets, not hand-placed).
- [x] The same file with explicit per-task dates renders as a **pinned Gantt**.
- [x] A file with only activities + dependencies still renders as the network view; the Gantt view **degrades gracefully** with a non-blocking notice (not an error).
- [x] **Milestones** (zero-duration activities) render as diamonds. **Phases** (parent activities) render as summary bars spanning earliest child start → latest child end.

## Module — `@transitrix/diagrams`

### `types.ts`
Adds `ProjectBlock` / `ProjectCalendar` / `Weekday` to `ActivityDoc`, plus the Gantt layout types: `GanttBar`, `GanttLink`, `GanttLayout`, `GanttResult`, `GanttUnavailable`, `GanttMode`, `GanttBarKind`.

### `validate.ts`
Adds the spec-defined rules that were missing:

| Rule | Severity | What it checks |
|---|---|---|
| ACT-014 | error | `project.calendar.working_days` from the seven weekday names (case-insensitive), unique |
| ACT-015 | error | `project.calendar.holidays` entries are `YYYY-MM-DD` |
| ACT-016 | error | milestone (`duration: 0`) with both pinned dates must have `start_date == end_date` |
| ACT-017 | warn | activity referenced as `parent` by ≥1 child carries its own duration/dates |
| ACT-018 | warn | activity with no duration and no pinned dates is not referenced as parent — likely an empty phase |
| ACT-019 | warn | Gantt view will not render — neither `project.start_date` nor any pinned date pair |

### `gantt.ts` (new)
- `computeGanttLayout(doc): GanttResult` — returns a `GanttLayout` or `{ unavailable: true, reason }`.
- **Mode detection** — pinned first (every leaf has both dates), then computed (project.start_date + every leaf has duration), else unavailable.
- **Computed mode** uses CPM `ES[a]` projected onto a working-day calendar. Defaults: 7-day week, no holidays. `working_days` and `holidays` from `project.calendar` are respected.
- **Phase rollup** — earliest descendant start → latest descendant end. Critical flag bubbles up if any descendant is critical.
- **Milestones** — zero-duration leaves render with `kind: 'milestone'` and `startDate == endDate`.
- **Links** — predecessor → successor lines between leaves; `isCritical` set only when both endpoints are critical.

## Studio preview — `extension/src/activities-preview.ts`

Refactor + extension:

- **Drops the inlined types / validate / layout / CPM copies** (~260 lines of duplicated logic) and imports from `@transitrix/diagrams`, matching the process-blueprint pattern per the standing rule.
- Keeps the network SVG renderer (Studio's presentation layer) and adds a Gantt SVG renderer:
  - Date-header band with month labels and weekly grid lines.
  - Alternating row stripes for readability.
  - Bars sized per calendar day; phase bars styled distinctly; milestones as diamonds.
  - Predecessor link elbows; critical-path highlight on bars, milestones, and links.
- Webview now stacks both views via `bodyContent`: PSND network on top, Gantt below.
- When the Gantt cannot render, that section shows a **non-blocking notice** explaining what is missing (matches spec §9.3 renderer-MUST item).
- Save-as-SVG currently exports the network view only; the Gantt is a companion section in the panel.

## Example fixture

`examples/activities/platform-launch.activities.transitrix.yaml` — adds a `project:` block (`start_date: 2026-06-01`, Mon–Fri calendar with one holiday `2026-07-04`) so the existing 9-activity example renders the Gantt view out of the box. Network content unchanged.

## Tests

- **9 new validate tests** covering ACT-014..ACT-019 (positive and negative cases).
- **1 example conformance test** that loads every YAML under `examples/activities/` and asserts `valid: true` (matches the capability-map / process-map / scenarios pattern).
- **18 new Gantt layout tests**: mode detection (computed / pinned / unavailable), calendar projection (default + working_days + holidays), milestones (computed and pinned), phase rollup, links carrying the critical flag, timeline bounds.
- **diagrams: 336 / 336** passing (was 303; +33).
- **core: 247 / 247** passing.
- `tsc --noEmit` clean across root / `packages/diagrams` / `extension`.

## Test plan

- [x] `npx vitest run` in `packages/diagrams` — 336 passing.
- [x] `tsc --noEmit` in `packages/diagrams` — clean.
- [x] `tsc --noEmit` in `extension` — clean.
- [x] Conformance: `examples/activities/platform-launch…` validates clean.
- [ ] Manual: open the example, confirm the preview shows network view on top and Gantt view below with a date header and critical-path bars in orange.
- [ ] Manual: remove the `project:` block from the example, confirm the Gantt section shows the "view unavailable" notice and the network still renders.
- [ ] Manual: pin `start_date` / `end_date` on every activity (drop `project:` and `predecessors:` if needed), confirm the Gantt renders in pinned mode.
- [ ] Manual: set `duration: 0` on the last activity, confirm it renders as a diamond marker.
- [ ] Manual: add a parent activity (`parent: A-001` on a few children), confirm the parent renders as a phase bar.

## Out of scope (follow-ups)

- **Hours-per-day duration unit** (spec §5.4 / §9.2) — current implementation assumes days; `hours_per_day` field is accepted in the document but unused by the renderer. Tracked for v0.6.
- **Mixed mode** (some leaves pinned, others computed) — spec §9.1 MAY case; strict modes cover the acceptance criteria.
- **Interactive zoom / today line** (spec §9.3 SHOULD items) — needs webview scripting; the current static SVG path is intentional (matches `enableScripts: false` across all static previews).

🤖 Generated with [Claude Code](https://claude.com/claude-code)