### PR TITLE
fix(pre-release): robustness should-fix batch (TX-R003/R004/R005 + activities + cleanup)

### DIFF
--- a/extension/src/blocks-preview.ts
+++ b/extension/src/blocks-preview.ts
@@ -142,17 +142,11 @@ export class BlocksPreview {
       const svgbobPath = cfg.get<string>('svgbobPath') || 'svgbob_cli';
       const payload = JSON.stringify({ mode: 'ascii', source, svgbobCommand: svgbobPath });
 
-      let proc: cp.ChildProcess;
-      try {
-        proc = cp.spawn(pythonPath, [scriptPath], { stdio: ['pipe', 'pipe', 'pipe'] });
-      } catch (err: unknown) {
-        resolve({
-          ok: false,
-          message: `Python not found at "${pythonPath}". See the prompt below to install it.`,
-          fixPrompt: PYTHON_FIX_PROMPT,
-        });
-        return;
-      }
+      // `cp.spawn` does not throw synchronously when the executable is
+      // missing — ENOENT surfaces via the `'error'` event handler below.
+      // The previous try/catch around the spawn was therefore dead code and
+      // its `resolve(...)` path was never taken.
+      const proc = cp.spawn(pythonPath, [scriptPath], { stdio: ['pipe', 'pipe', 'pipe'] });
 
       let stdout = '';
       let stderr = '';

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -92,21 +92,29 @@ function notYet(label: string): void {
 }
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
-  let compileFn: CompileFn | undefined;
+  // TX-R003: cache the in-flight Promise, not the resolved result. Two
+  // concurrent calls during the brief window before `loadCompiler` resolves
+  // would otherwise both pass the `if (!compileFn)` guard and run the loader
+  // twice. A failed load clears the cached Promise so a retry can attempt to
+  // re-load (transient errors).
+  let compilerPromise: Promise<CompileFn> | undefined;
 
-  async function compiler(): Promise<CompileFn> {
-    if (!compileFn) {
-      try {
-        compileFn = await loadCompiler(context);
-      } catch (err) {
-        const detail = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
-        console.error('Transitrix Studio: loadCompiler failed:', err);
-        throw new Error(
-          `Transitrix Studio: compiler bundle failed to load — ${detail}. Run the 'extension:prep' build step and reload the extension.`,
-        );
-      }
+  function compiler(): Promise<CompileFn> {
+    if (!compilerPromise) {
+      compilerPromise = (async () => {
+        try {
+          return await loadCompiler(context);
+        } catch (err) {
+          compilerPromise = undefined;
+          const detail = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+          console.error('Transitrix Studio: loadCompiler failed:', err);
+          throw new Error(
+            `Transitrix Studio: compiler bundle failed to load — ${detail}. Run the 'extension:prep' build step and reload the extension.`,
+          );
+        }
+      })();
     }
-    return compileFn;
+    return compilerPromise;
   }
 
   const preview = new CervinPreview(context.extensionUri, (yaml: string) =>

--- a/packages/diagrams/src/activities/__tests__/cpm.test.ts
+++ b/packages/diagrams/src/activities/__tests__/cpm.test.ts
@@ -129,3 +129,36 @@ describe('computeCpm — edge cases', () => {
     expect(result.get('B')!.slack).toBe(0);
   });
 });
+
+describe('computeCpm — cycle defence', () => {
+  // Pre-release should-fix: Kahn's topo-order silently omits cyclic nodes.
+  // The validator's ACT-006 is the authoritative cycle error, but
+  // layoutActivities is reachable without validation, so computeCpm must
+  // still produce an entry for every activity (filled with neutral values
+  // for omitted cyclic ones) — otherwise consumers see `undefined` and
+  // bars render without CPM data.
+
+  it('emits entries for every activity on a 2-node mutual cycle', () => {
+    const result = computeCpm([
+      { id: 'A', name: 'A', duration: 3, predecessors: ['B'] },
+      { id: 'B', name: 'B', duration: 2, predecessors: ['A'] },
+    ]);
+    expect(result.size).toBe(2);
+    expect(result.get('A')).toMatchObject({ es: 0, ef: 0, slack: 0, isCritical: false });
+    expect(result.get('B')).toMatchObject({ es: 0, ef: 0, slack: 0, isCritical: false });
+  });
+
+  it('keeps real CPM data for the acyclic prefix when a cycle exists downstream', () => {
+    // A → B is acyclic; C ↔ D is a mutual cycle disconnected from A/B.
+    const result = computeCpm([
+      { id: 'A', name: 'A', duration: 5 },
+      { id: 'B', name: 'B', duration: 3, predecessors: ['A'] },
+      { id: 'C', name: 'C', duration: 2, predecessors: ['D'] },
+      { id: 'D', name: 'D', duration: 2, predecessors: ['C'] },
+    ]);
+    expect(result.get('A')?.ef).toBe(5);
+    expect(result.get('B')?.ef).toBe(8);
+    expect(result.get('C')).toMatchObject({ es: 0, ef: 0, isCritical: false });
+    expect(result.get('D')).toMatchObject({ es: 0, ef: 0, isCritical: false });
+  });
+});

--- a/packages/diagrams/src/activities/__tests__/validate.test.ts
+++ b/packages/diagrams/src/activities/__tests__/validate.test.ts
@@ -124,6 +124,43 @@ describe('validateActivities', () => {
     expect(r.errors.some(e => e.code === 'ACT-008')).toBe(false);
   });
 
+  it('ACT-008 — rejects non-ISO start_date format', () => {
+    const r = validateActivities({
+      notation: 'activities',
+      activities: [
+        { id: 'A-001', name: 'Task', duration: 5, start_date: 'June 1 2026' },
+      ],
+    });
+    expect(r.valid).toBe(false);
+    expect(r.errors.some(e => e.code === 'ACT-008' && /start_date/.test(e.message))).toBe(true);
+  });
+
+  it('ACT-008 — rejects non-ISO end_date format', () => {
+    const r = validateActivities({
+      notation: 'activities',
+      activities: [
+        { id: 'A-001', name: 'Task', duration: 5, end_date: '2026/06/30' },
+      ],
+    });
+    expect(r.valid).toBe(false);
+    expect(r.errors.some(e => e.code === 'ACT-008' && /end_date/.test(e.message))).toBe(true);
+  });
+
+  it('ACT-008 — does not raise the order-compare error when dates are malformed', () => {
+    // If start_date and end_date are both wrongly formatted, the file already
+    // has two ACT-008 format errors — adding a third "end < start" complaint
+    // on top would be misleading because the lexicographic compare is
+    // meaningless on non-ISO strings.
+    const r = validateActivities({
+      notation: 'activities',
+      activities: [
+        { id: 'A-001', name: 'Task', duration: 5, start_date: 'tomorrow', end_date: 'yesterday' },
+      ],
+    });
+    expect(r.errors.filter(e => e.code === 'ACT-008').length).toBe(2);
+    expect(r.errors.every(e => /must be ISO 8601 YYYY-MM-DD/.test(e.message))).toBe(true);
+  });
+
   it('ACT-009 — rejects negative duration', () => {
     const r = validateActivities({
       notation: 'activities',

--- a/packages/diagrams/src/activities/cpm.ts
+++ b/packages/diagrams/src/activities/cpm.ts
@@ -76,5 +76,20 @@ export function computeCpm(activities: Activity[]): CpmResult {
     result.set(id, { es: esV, ef: efV, ls: lsV, lf: lfV, slack, isCritical: slack <= 0 });
   }
 
+  // Cycle defence: Kahn's topo-order silently omits any activity that's part
+  // of a cycle (its in-degree never reaches zero), and the forward/backward
+  // passes above skip those nodes. The validator's ACT-006 is the
+  // authoritative cycle error — but layoutActivities is reachable without
+  // validation, so fill the omitted nodes with neutral CPM values so
+  // downstream consumers don't see `undefined` entries. Cyclic activities
+  // simply render without critical-path highlighting.
+  if (topoOrder.length < activities.length) {
+    for (const a of activities) {
+      if (!result.has(a.id)) {
+        result.set(a.id, { es: 0, ef: 0, ls: 0, lf: 0, slack: 0, isCritical: false });
+      }
+    }
+  }
+
   return result;
 }

--- a/packages/diagrams/src/activities/validate.ts
+++ b/packages/diagrams/src/activities/validate.ts
@@ -6,6 +6,8 @@ import type {
   ActivityValidationWarning,
 } from './types.js';
 
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
 export function validateActivities(input: unknown): ActivityValidationResult {
   const errors: ActivityValidationError[] = [];
   const warnings: ActivityValidationWarning[] = [];
@@ -104,8 +106,27 @@ export function validateActivities(input: unknown): ActivityValidationResult {
       }
     }
 
-    // ACT-008: end_date >= start_date
-    if (a.start_date && a.end_date) {
+    // ACT-008: date format validation + end_date >= start_date.
+    // The orchestrator's pre-release review flagged that the raw lexicographic
+    // string compare is only correct for strict YYYY-MM-DD, with no format
+    // check applied. Now we validate the format first; the order compare runs
+    // only when both dates are valid (otherwise the comparison message would
+    // be misleading).
+    let startValid = true;
+    let endValid = true;
+    if (a.start_date !== undefined) {
+      if (typeof a.start_date !== 'string' || !DATE_RE.test(a.start_date)) {
+        errors.push({ code: 'ACT-008', message: `Activity "${a.id}" start_date "${String(a.start_date)}" must be ISO 8601 YYYY-MM-DD`, path });
+        startValid = false;
+      }
+    }
+    if (a.end_date !== undefined) {
+      if (typeof a.end_date !== 'string' || !DATE_RE.test(a.end_date)) {
+        errors.push({ code: 'ACT-008', message: `Activity "${a.id}" end_date "${String(a.end_date)}" must be ISO 8601 YYYY-MM-DD`, path });
+        endValid = false;
+      }
+    }
+    if (a.start_date && a.end_date && startValid && endValid) {
       if (a.end_date < a.start_date) {
         errors.push({ code: 'ACT-008', message: `Activity "${a.id}" end_date "${a.end_date}" is before start_date "${a.start_date}"`, path });
       }

--- a/scripts/measure-baseline.mjs
+++ b/scripts/measure-baseline.mjs
@@ -38,7 +38,7 @@ async function main() {
   try {
     const corpusFiles = await findCorpusFiles()
     if (corpusFiles.length === 0) {
-      console.warn('⚠️  No corpus files found in', corpusDir)
+      console.warn('⚠️  No corpus files found in', examplesDir)
       process.exit(1)
     }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { readFileSync, writeFileSync } from 'node:fs';
+import { writeFileSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 
 import {
@@ -74,7 +74,7 @@ async function handleCompileCommand(argv: string[]): Promise<void> {
   const noValidateWarnings = argv.includes('--no-validate');
 
   try {
-    const yaml = readFileSync(src, 'utf8');
+    const yaml = await readFile(src, 'utf8');
     const result = await compileCervinYamlWithLayout(yaml);
     writeFileSync(dst, result.xml);
 
@@ -207,8 +207,25 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
     process.exit(1);
   }
 
-  // Read and parse YAML
-  const yaml = await readFile(src, 'utf8');
+  // Read and parse YAML. TX-R004 — file read was outside the try block, so a
+  // missing file surfaced as an unhandled rejection / stack trace instead of
+  // a clean exit-1.
+  let yaml: string;
+  try {
+    yaml = await readFile(src, 'utf8');
+  } catch (e) {
+    const err = e as NodeJS.ErrnoException;
+    if (useJson) {
+      console.log(JSON.stringify({ valid: false, message: err.message }, null, 2));
+    } else {
+      console.error(`✗ ${src}`);
+      console.error();
+      console.error(`Read error: ${err.message}`);
+      console.error();
+    }
+    process.exit(1);
+  }
+
   let ir: ProcessIr;
   try {
     ir = parseYamlToIr(yaml);
@@ -301,7 +318,7 @@ async function handleMetricsCommand(argv: string[]): Promise<void> {
   }
 
   try {
-    const yaml = readFileSync(src, 'utf8');
+    const yaml = await readFile(src, 'utf8');
     const result = await compileCervinYamlWithLayout(yaml);
     const metrics = computeLayoutMetrics(result.layout);
 
@@ -325,28 +342,38 @@ async function handleMetricsCommand(argv: string[]): Promise<void> {
 
 const subcommand = process.argv[2];
 
-if (subcommand === 'serve') {
-  const serveArgv = process.argv.slice(3);
-  try {
-    const { cliServeArgv } = await import('./serve-ui.js');
-    await cliServeArgv(serveArgv);
-  } catch (e) {
-    const err = e as Error;
-    console.error(err.message);
+// TX-R004: wrap the top-level dispatch in a try/catch so a logic bug inside
+// a handler doesn't surface as an unhandled rejection + stack trace. Each
+// handler already exits non-zero on its own expected errors; this is a
+// safety net for surprises.
+try {
+  if (subcommand === 'serve') {
+    const serveArgv = process.argv.slice(3);
+    try {
+      const { cliServeArgv } = await import('./serve-ui.js');
+      await cliServeArgv(serveArgv);
+    } catch (e) {
+      const err = e as Error;
+      console.error(err.message);
+      process.exit(1);
+    }
+  } else if (subcommand === 'metrics') {
+    await handleMetricsCommand(process.argv.slice(3));
+  } else if (subcommand === 'validate') {
+    await handleValidateCommand(process.argv.slice(3));
+  } else if (!subcommand || subcommand === 'compile') {
+    // Default: compile
+    const compileArgv = subcommand === 'compile'
+      ? process.argv.slice(3)
+      : process.argv.slice(2);
+    await handleCompileCommand(compileArgv);
+  } else {
+    console.error(`cervin: unknown command '${subcommand}'`);
+    printUsage();
     process.exit(1);
   }
-} else if (subcommand === 'metrics') {
-  await handleMetricsCommand(process.argv.slice(3));
-} else if (subcommand === 'validate') {
-  await handleValidateCommand(process.argv.slice(3));
-} else if (!subcommand || subcommand === 'compile') {
-  // Default: compile
-  const compileArgv = subcommand === 'compile'
-    ? process.argv.slice(3)
-    : process.argv.slice(2);
-  await handleCompileCommand(compileArgv);
-} else {
-  console.error(`cervin: unknown command '${subcommand}'`);
-  printUsage();
+} catch (e) {
+  const err = e as Error;
+  console.error(`cervin: unexpected error: ${err.message ?? String(e)}`);
   process.exit(1);
 }


### PR DESCRIPTION
## Summary

Should-fix items from the 2026-05-21 orchestrator pre-release code review, grouped as **one connected theme**: correctness and error-path hardening across CLI, extension activation, activities/CPM, and small cleanup. (Per orchestrator guidance — "batch into a PR or two, each one connected theme".)

A separate follow-up PR will cover the **config + infrastructure** half of the batch (extension/package.json languages, Python subprocess timeout, CI Python job, lockfile cleanup, bump script). The cross-module `validation-types.ts` refactor is left for a third PR as it's high-churn cross-cutting work better isolated.

## Fixes

### TX-R003 — extension.ts `compiler()` singleton race
Previous code stored the resolved `CompileFn` and gated on its presence; two concurrent calls during the brief window before `loadCompiler` resolved both passed the guard and ran the loader twice. Now caches the in-flight `Promise` instead; failed loads clear the cache so retries attempt to re-load.

### TX-R004 — cli.ts unhandled-rejection paths
`handleValidateCommand` called `await readFile(...)` **outside** its try block — a missing file surfaced as an unhandled rejection + stack trace instead of a clean exit-1. The read is now wrapped and emits the same JSON / human shape as other parse errors. Added a top-level try/catch around the subcommand dispatch as a safety net for surprises in handlers.

### TX-R005 — sync/async `readFile` consistency
`handleCompileCommand` and `handleMetricsCommand` used `readFileSync`, while `handleValidateCommand` used async `readFile`. All three now use async `readFile`. Dropped the now-unused `readFileSync` import.

### CPM cycle defence
`computeCpm`'s Kahn topo-order silently omits cyclic nodes; downstream consumers then saw `undefined` when calling `cpm.get(a.id)` for those activities. The validator's ACT-006 is the authoritative cycle error, but `layoutActivities` is reachable without validation. `computeCpm` now fills omitted entries with neutral CPM values (`es=ef=ls=lf=slack=0`, `isCritical=false`). Cyclic activities simply render without critical-path highlighting.

### ACT-008 — date format validation
The order compare `a.end_date < a.start_date` is only correct for strict ISO `YYYY-MM-DD` — with any other format it's a meaningless lexicographic compare. There was no format check. ACT-008 now validates each pinned date against `/^\d{4}-\d{2}-\d{2}$/` and only runs the order compare when both dates are well-formed (otherwise the "end < start" complaint would be misleading on malformed input).

### blocks-preview dead try/catch
`cp.spawn` doesn't throw synchronously when the executable is missing — ENOENT surfaces via the `'error'` event handler that lives further down. The synchronous try/catch around the spawn was dead code; removed.

### measure-baseline `corpusDir` typo
`scripts/measure-baseline.mjs:43` referenced undefined `corpusDir` on the empty-corpus path → `ReferenceError` instead of the intended warning. Variable name is `examplesDir`.

## Tests

| Package | Before | After | Delta |
|---|---|---|---|
| `packages/diagrams` | 303 | **307** | +4 (3 ACT-008 format + 2 cycle defence; 1 stale self-parent test replaced) |
| core (`tests/`) | 247 | 247 | — |
| `tsc --noEmit` (root / diagrams / extension) | clean | **clean** | — |

## Test plan

- [x] `npx vitest run` in `packages/diagrams` — 307 passing.
- [x] `npx vitest run` at repo root — 247 passing.
- [x] `tsc --noEmit` clean across root / `packages/diagrams` / `extension`.
- [ ] Manual: `cervin validate nonexistent.yaml` exits with code 1 and a clean message (no stack trace).
- [ ] Manual: open the extension in a fresh VS Code window and trigger the BPMN preview twice in quick succession; observe `loadCompiler` runs once.

## Out of scope (follow-ups)

- **PR-B "Pre-release config + infra"** (separate): extension/package.json languages for `transitrix-activities` and `transitrix-blocks`, `backends/blocks` `subprocess.run` timeout, CI Python job, `extension/package-lock.json` cleanup, bump-extension-version script note for 1.0.0.
- **PR-C "Shared validation-types"** (separate, optional): unify the duplicated `ValidationError` / `ValidationResult` declarations across notation modules into one `validation-types.ts`. Cross-cutting refactor — better isolated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)