### PR TITLE
TX-R009: CSS-only show/hide diagram title toggle

### DIFF
--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -94,6 +94,42 @@ const FRAME_HEADER_CSS = `
 `;
 
 /**
+ * CSS-only title show/hide toggle (TX-R009).
+ *
+ * Static previews run with enableScripts: false, so this follows the same
+ * trick as the activities Network/Gantt switcher (PR #9):
+ *   1. A hidden checkbox sits at the top of <body> before any sibling that
+ *      should react. It's positioned off-screen rather than display:none so
+ *      keyboard focus still reaches it.
+ *   2. A <label for="…"> lives inside #toolbar styled as a button.
+ *   3. `:checked` propagates via the sibling combinator to hide either
+ *      .frame-header (catalogue previews) or .diagram-caption (SVG previews).
+ *
+ * Default is "title shown" (checkbox checked). Clicking unchecks → title
+ * hidden.
+ */
+const TITLE_TOGGLE_CSS = `
+.title-toggle-cb { position: absolute; left: -9999px; width: 1px; height: 1px; opacity: 0; }
+#toolbar { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.toolbar-label { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.title-toggle {
+  cursor: pointer;
+  user-select: none;
+  font-size: 11px;
+  padding: 1px 8px;
+  border-radius: 4px;
+  color: var(--ts-text-muted, #64748b);
+  white-space: nowrap;
+}
+.title-toggle::before { content: "\\2611\\00a0"; font-size: 12px; }
+.title-toggle:hover { color: var(--ts-text, #0f172a); background: var(--ts-bg-elevated, #f1f5f9); }
+.title-toggle-cb:focus-visible ~ #toolbar .title-toggle { outline: 1px dashed var(--ts-text-muted, #64748b); outline-offset: 2px; }
+.title-toggle-cb:not(:checked) ~ #toolbar .title-toggle::before { content: "\\2610\\00a0"; }
+.title-toggle-cb:not(:checked) ~ .frame-header { display: none; }
+.title-toggle-cb:not(:checked) ~ #canvas .diagram-caption { display: none; }
+`;
+
+/**
  * Shared styling for catalogue-style HTML previews (applications, products,
  * process-map, scenarios, capability-map). Covers the bits that every
  * catalogue notation duplicates verbatim — badges, maturity dots, empty
@@ -170,6 +206,17 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
     ? `<div class="diagram-caption">${escXml(notation)} — ${escXml(filename)}</div>`
     : '';
 
+  // The toggle only makes sense when there's actually a title-ish element to
+  // hide. Skip the widget on error-only renders so users don't see a button
+  // that does nothing.
+  const showToggle = Boolean(title) || Boolean(canvasContent);
+  const toggleInput = showToggle
+    ? `<input type="checkbox" id="ts-title-toggle" class="title-toggle-cb" checked>`
+    : '';
+  const toolbarRight = showToggle
+    ? `<label for="ts-title-toggle" class="title-toggle" title="Show or hide the diagram title">Title</label>`
+    : '';
+
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -179,11 +226,13 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
 ${generateWebviewCss(themeId)}
 ${FIX_PROMPT_CSS}
 ${FRAME_HEADER_CSS}
+${TITLE_TOGGLE_CSS}
 ${extraStyles}
   </style>
 </head>
 <body data-theme="${escXml(themeId)}">
-  <div id="toolbar">${escXml(notation)}: ${escXml(filename)}</div>
+  ${toggleInput}
+  <div id="toolbar"><span class="toolbar-label">${escXml(notation)}: ${escXml(filename)}</span>${toolbarRight}</div>
   ${errBlock}${fixPromptBlock}${warnBlock}
   ${headerBlock}
   <div id="canvas">


### PR DESCRIPTION
## Summary

Adds a small "Title" button to the toolbar of every notation preview. Click toggles the visibility of the main title block — `.frame-header` for catalogue previews driven by YAML frontmatter, or `.diagram-caption` for SVG-only previews.

Phase 1 item 2 from strategy hub #30.

## Constraint

Static previews run with `enableScripts: false`. The implementation reuses the CSS-only pattern from the activities Network/Gantt switcher (PR #9):

- Hidden checkbox at the top of `<body>`, positioned off-screen but keyboard-focusable
- Visible `<label>` inside `#toolbar`, styled as a pill button with a ☑/☐ glyph via `::before` content swap
- `:checked` state propagates through the sibling combinator to hide `.frame-header` / `.diagram-caption`

Default is "title shown" — checkbox is `checked`. Click to hide.

## Stacked on TX-R008

This branch is built on top of `feat/tx-r008-preview-visual-consistency` (PR #13). The diagram-frame.ts module already has `CATALOGUE_STYLES` and the typography contract introduced there; the title toggle is a separate concern but lives in the same file. After PR #13 merges, this PR's diff against main should be the toggle commit only.

If review order matters: merge PR #13 first.

## Other touches

- `#toolbar` becomes a flex row to host both the notation+filename label (now in a `.toolbar-label` span) and the toggle on the right
- Toggle is omitted on error-only renders so users don't see a button that does nothing

## Test plan

- [x] `npm run compile:extension` — clean
- [x] `npm test` — 341 pass
- [x] `npm run extension:prep` — bundle builds (272.3kb, +1.4kb for the toggle CSS+HTML)
- [ ] Hand-test: open each notation preview, confirm the title hides/shows and the toolbar reflects ☑/☐ state — Valerii's pass before 1.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)