### PR TITLE
Previews: CSS-only discrete zoom control (50/75/100/150/200%)

### DIFF
--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -111,8 +111,8 @@ function networkSvg(doc: ActivityDoc, heading?: string, filename?: string, date?
   </marker>
 </defs>
 ${titleSvg}
-${edgeSvg}
 ${nodeSvg}
+${edgeSvg}
 </svg>`;
 }
 

--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -493,7 +493,7 @@ export class ActivitiesPreview {
         'activitiesPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true },
+        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveActivitiesAsSvg'] },
       );
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
     }
@@ -554,6 +554,7 @@ export class ActivitiesPreview {
       warnings,
       themeId,
       extraStyles: ACTIVITIES_STYLES,
+      saveSvgCommand: 'transitrixStudio.saveActivitiesAsSvg',
     });
   }
 

--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -302,7 +302,29 @@ function ganttSvg(layout: GanttLayout, heading?: string, filename?: string, date
       else backward.push({ link, tx, ty });
     }
 
-    if (forward.length > 0) {
+    // Forward routes: when *every* outgoing target has enough horizontal room
+    // for its own elbow, skip the trunk and emit per-target right-down-right
+    // L-elbows. The trunk+branches design exists to gather multiple outgoing
+    // routes safely and to keep the back-step vertical clear of intermediate
+    // bars — both concerns vanish when each target sits far enough past the
+    // source's end column to host its own vertical with STUB_OUT clearance
+    // from both edges. Hand-test feedback: the back-step LEFT of source read
+    // as a pointless kink even when the source had multiple outgoing links,
+    // as long as all of them had room.
+    if (forward.length > 0 && forward.every(t => (t.tx - sx) >= 2 * STUB_OUT)) {
+      for (const t of forward) {
+        const cls = t.link.isCritical ? 'diagram-edge critical-edge' : 'diagram-edge';
+        const marker = t.link.isCritical ? 'gantt-arrow-crit' : 'gantt-arrow';
+        const enterX = t.tx + ENTER_DEPTH;
+        // Vertical at the midpoint between source.end and target.start, clamped
+        // to STUB_OUT away from either bar edge (the all-have-room check above
+        // already guarantees the clamp window is non-empty).
+        const midX = (sx + t.tx) / 2;
+        const vx = Math.max(sx + STUB_OUT, Math.min(t.tx - STUB_OUT, midX));
+        const d = `M${sx},${sy} L${vx},${sy} L${vx},${t.ty} L${enterX},${t.ty}`;
+        pushLinkPath(`<path d="${d}" class="${cls}" fill="none" marker-end="url(#${marker})"/>`, t.link.isCritical);
+      }
+    } else if (forward.length > 0) {
       const midY = sy + G_ROW_H / 2;
       const stubX = sx + STUB_OUT;
       const backX = sx - BACK_OFFSET;

--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -374,29 +374,43 @@ ${[...linkPartsGray, ...linkPartsCrit].join('\n')}
 
 // ── Stacked canvas content (network + gantt) ─────────────────────────────────
 
-function buildCanvasContent(doc: ActivityDoc, filename: string, date: string): string {
+interface ActivityViews {
+  /** Network (PSND) SVG. Always present when activities validated. */
+  networkSvg: string;
+  /** Body content of the Gantt section: either the Gantt SVG or the
+   *  "unavailable" notice block. Always non-empty. */
+  ganttBody: string;
+  /** Gantt SVG string when computed mode/pinned mode produced one; empty
+   *  string when Gantt is unavailable. Used by Save-as-SVG. */
+  ganttSvg: string;
+}
+
+function buildActivityViews(doc: ActivityDoc, filename: string, date: string): ActivityViews {
   const networkHeading = 'Network view — Project Schedule Network Diagram (PSND)';
-  const network = networkSvg(doc, networkHeading, filename, date);
+  const networkSvgStr = networkSvg(doc, networkHeading, filename, date);
   const gantt: GanttResult = computeGanttLayout(doc);
 
-  let ganttBody: string;
   if (isGanttUnavailable(gantt)) {
     // No SVG to embed the title into — fall back to an HTML title block plus
     // the notice so the unavailable path still shows the same paragraph.
-    ganttBody = `<div class="diagram-title-block diagram-title-block-html">
+    const ganttBody = `<div class="diagram-title-block diagram-title-block-html">
   <div class="text-header">Gantt view — unavailable</div>
   <div class="text-secondary">${escXml(filename)}</div>
   <div class="text-secondary">${escXml(date)}</div>
 </div>
 <div class="section-notice">${escXml(gantt.reason)}</div>`;
-  } else {
-    const modeLabel = gantt.mode === 'computed'
-      ? `computed mode (project ${gantt.timelineStart} → ${gantt.timelineEnd})`
-      : `pinned mode (${gantt.timelineStart} → ${gantt.timelineEnd})`;
-    const ganttHeading = `Gantt view — ${modeLabel}`;
-    ganttBody = ganttSvg(gantt, ganttHeading, filename, date);
+    return { networkSvg: networkSvgStr, ganttBody, ganttSvg: '' };
   }
 
+  const modeLabel = gantt.mode === 'computed'
+    ? `computed mode (project ${gantt.timelineStart} → ${gantt.timelineEnd})`
+    : `pinned mode (${gantt.timelineStart} → ${gantt.timelineEnd})`;
+  const ganttHeading = `Gantt view — ${modeLabel}`;
+  const ganttSvgStr = ganttSvg(gantt, ganttHeading, filename, date);
+  return { networkSvg: networkSvgStr, ganttBody: ganttSvgStr, ganttSvg: ganttSvgStr };
+}
+
+function buildCanvasContent(views: ActivityViews): string {
   // Pure-CSS tab switcher: hidden radio inputs at the top, labels styled as
   // tabs, panels shown via `:checked ~ section[data-view=…]`. Works under the
   // webview's `enableScripts: false` + script-less CSP because no JS is
@@ -408,10 +422,10 @@ function buildCanvasContent(doc: ActivityDoc, filename: string, date: string): s
   <label for="view-gantt" class="view-tab" data-tab="gantt">Gantt</label>
 </nav>
 <section class="diagram-section" data-view="network">
-  ${network}
+  ${views.networkSvg}
 </section>
 <section class="diagram-section" data-view="gantt">
-  ${ganttBody}
+  ${views.ganttBody}
 </section>`;
 }
 
@@ -490,7 +504,12 @@ export class ActivitiesPreview {
   readonly panelTitle = 'Activities Preview';
   private panel: vscode.WebviewPanel | undefined;
   private trackedUri: string | undefined;
-  private lastSvg = '';
+  // Saved separately so Save .svg can offer whichever view the user wants —
+  // the webview's CSS-only Network/Gantt switcher doesn't surface its state
+  // back to the extension, so the only way to honour "save current view" is
+  // to ask the user when both views are available.
+  private lastNetworkSvg = '';
+  private lastGanttSvg = '';
 
   isShowingDocument(uri: vscode.Uri): boolean {
     return this.panel != null && this.trackedUri === uri.toString();
@@ -536,24 +555,19 @@ export class ActivitiesPreview {
       if (!v.valid) {
         errorMsg = v.errors.map(e => `${e.code}: ${e.message}`).join('\n');
       } else {
-        bodyContent = buildCanvasContent(parsed as ActivityDoc, filename, today);
-        // Save-as-SVG exports only the network view today; the Gantt is a
-        // companion section in the webview. (Reconsider when the Gantt becomes
-        // a primary view.) The exported SVG keeps the title block — it lives
-        // in the SVG, so opening the file outside VS Code shows the same
-        // heading + filename + date the user saw in the preview.
-        this.lastSvg = networkSvg(
-          parsed as ActivityDoc,
-          'Network view — Project Schedule Network Diagram (PSND)',
-          filename,
-          today,
-        );
+        const views = buildActivityViews(parsed as ActivityDoc, filename, today);
+        bodyContent = buildCanvasContent(views);
+        this.lastNetworkSvg = views.networkSvg;
+        this.lastGanttSvg = views.ganttSvg;
       }
     } catch (e) {
       errorMsg = (e as Error).message ?? 'Parse error';
     }
 
-    if (!bodyContent) this.lastSvg = '';
+    if (!bodyContent) {
+      this.lastNetworkSvg = '';
+      this.lastGanttSvg = '';
+    }
 
     const themeId = vscode.workspace
       .getConfiguration('transitrix')
@@ -572,21 +586,44 @@ export class ActivitiesPreview {
   }
 
   async saveAsSvg(): Promise<void> {
-    if (!this.lastSvg) {
+    const hasNetwork = Boolean(this.lastNetworkSvg);
+    const hasGantt = Boolean(this.lastGanttSvg);
+    if (!hasNetwork && !hasGantt) {
       vscode.window.showWarningMessage('No diagram rendered yet. Open a *.activities.transitrix.yaml file first.');
       return;
     }
+
+    // Pick the view to save. CSS-only switcher state is invisible to the
+    // extension, so when both exist we ask explicitly. When only one is
+    // available (Gantt unavailable mode), skip the prompt.
+    let view: 'network' | 'gantt';
+    if (hasNetwork && hasGantt) {
+      const choice = await vscode.window.showQuickPick(
+        [
+          { label: 'Network view', description: 'Project Schedule Network Diagram (PSND)', view: 'network' as const },
+          { label: 'Gantt view',   description: 'Timeline',                                  view: 'gantt'   as const },
+        ],
+        { placeHolder: 'Which view do you want to save?' },
+      );
+      if (!choice) return;
+      view = choice.view;
+    } else {
+      view = hasNetwork ? 'network' : 'gantt';
+    }
+
+    const svgSource = view === 'network' ? this.lastNetworkSvg : this.lastGanttSvg;
     const sourceUri = this.trackedUri ? vscode.Uri.parse(this.trackedUri) : undefined;
     const stem = sourceUri
       ? path.basename(sourceUri.fsPath).replace(/\.activities\.transitrix\.yaml$/, '')
       : 'diagram';
+    const suffixed = `${stem}-${view}.svg`;
     const defaultUri = sourceUri
-      ? vscode.Uri.file(path.join(path.dirname(sourceUri.fsPath), `${stem}.svg`))
-      : vscode.Uri.file(`${stem}.svg`);
+      ? vscode.Uri.file(path.join(path.dirname(sourceUri.fsPath), suffixed))
+      : vscode.Uri.file(suffixed);
     const target = await vscode.window.showSaveDialog({ defaultUri, filters: { 'SVG Image': ['svg'] } });
     if (!target) return;
     const themeId = vscode.workspace.getConfiguration('transitrix').get<ThemeId>('theme', 'transitrix');
-    const svg = prepareSvgForExport(this.lastSvg, themeId, ACTIVITIES_DIAGRAM_CSS);
+    const svg = prepareSvgForExport(svgSource, themeId, ACTIVITIES_DIAGRAM_CSS);
     await vscode.workspace.fs.writeFile(target, Buffer.from(svg, 'utf-8'));
     vscode.window.showInformationMessage(`Saved: ${path.basename(target.fsPath)}`);
   }

--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -55,12 +55,18 @@ function networkSvg(doc: ActivityDoc, heading?: string, filename?: string, date?
   const orderedEdges = [...layout.edges].sort(
     (a, b) => Number(Boolean(a.isCritical)) - Number(Boolean(b.isCritical)),
   );
-  // Pure cubic bezier. Tangent at both endpoints is mathematically horizontal
-  // (control points at (mx, sy) and (mx, ty) — same Y as the respective
-  // endpoint), so the marker-end arrow auto-orients horizontal and reads as
-  // perpendicular to the target's vertical edge. Marker refX = markerWidth
-  // anchors the tip at the path endpoint, so the arrow lands ON the bar's
-  // left edge rather than poking inside it.
+  // Edge path = a single cubic Bézier with horizontal control handles. Each
+  // control point shares its endpoint's Y, so the tangent is horizontal at
+  // both ends — the curve meets the vertical node edge at a true right angle
+  // and the marker-end arrow (orient="auto") reads as perpendicular. The
+  // handle length grows with both the horizontal and the vertical span so the
+  // curve stays visibly horizontal long enough for the arrowhead to sit flush:
+  // short handles leave the curve horizontal only at the exact endpoint, so a
+  // rigid arrowhead visibly mismatches the curve behind it. No straight stubs —
+  // a stub→curve joint is tangent-continuous but shows a curvature jump
+  // (0 → non-zero) the eye reads as a kink. Marker refX = markerWidth anchors
+  // the tip at the path endpoint, on the node's edge rather than inside it.
+  const EDGE_MIN_HANDLE = 32;
   const edgeSvg = orderedEdges.map(e => {
     const s = nodeMap.get(e.sourceId);
     const t = nodeMap.get(e.targetId);
@@ -69,10 +75,16 @@ function networkSvg(doc: ActivityDoc, heading?: string, filename?: string, date?
     const sy = s.y + oy + s.height / 2;
     const tx = t.x + ox;
     const ty = t.y + oy + t.height / 2;
-    const mx = (sx + tx) / 2;
+    const dx = tx - sx;
+    const dy = ty - sy;
+    // Handle length is a magnitude only — the tangent stays horizontal
+    // regardless, so perpendicular entry/exit is guaranteed. When handle >
+    // dx/2 the control points cross over: intentional, it produces the
+    // graceful "lazy S" for vertically stacked nodes.
+    const handle = Math.max(EDGE_MIN_HANDLE, Math.abs(dx) * 0.5, Math.abs(dy) * 0.4);
     const cls = e.isCritical ? 'diagram-edge critical-edge' : 'diagram-edge';
     const marker = `url(#${e.isCritical ? 'arrow-crit' : 'arrow'})`;
-    return `<path d="M${sx},${sy} C${mx},${sy} ${mx},${ty} ${tx},${ty}" class="${cls}" marker-end="${marker}"/>`;
+    return `<path d="M${sx},${sy} C${sx + handle},${sy} ${tx - handle},${ty} ${tx},${ty}" class="${cls}" marker-end="${marker}"/>`;
   }).join('\n');
 
   const nodeSvg = layout.nodes.map(n => {

--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -74,7 +74,7 @@ function networkSvg(doc: ActivityDoc, heading?: string, filename?: string, date?
     return [
       `<rect class="${cls}" x="${x}" y="${y}" width="${N_NODE_W}" height="${N_NODE_H}" rx="6"/>`,
       `<text class="text-id" x="${x + 8}" y="${y + 18}">${idLabel}</text>`,
-      `<text class="text-primary" x="${x + N_NODE_W / 2}" y="${y + N_NODE_H / 2 + 4}" text-anchor="middle" dominant-baseline="central">${nameLabel}</text>`,
+      `<text class="text-primary" x="${x + N_NODE_W / 2}" y="${y + N_NODE_H / 2}" text-anchor="middle" dominant-baseline="central">${nameLabel}</text>`,
       `<text class="text-secondary" x="${x + N_NODE_W - 8}" y="${y + N_NODE_H - 10}" text-anchor="end">${durLabel}</text>`,
     ].join('\n');
   }).join('\n');

--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -49,7 +49,13 @@ function networkSvg(doc: ActivityDoc, heading?: string, filename?: string, date?
   const oy = -layout.bounds.y + N_PAD + titleH;
 
   const nodeMap = new Map(layout.nodes.map(n => [n.id, n]));
-  const edgeSvg = layout.edges.map(e => {
+  // SVG paints later siblings over earlier ones. Sort non-critical first so
+  // the bright orange critical-path edges land on top — a gray edge crossing
+  // an orange one shouldn't bury the critical signal.
+  const orderedEdges = [...layout.edges].sort(
+    (a, b) => Number(Boolean(a.isCritical)) - Number(Boolean(b.isCritical)),
+  );
+  const edgeSvg = orderedEdges.map(e => {
     const s = nodeMap.get(e.sourceId);
     const t = nodeMap.get(e.targetId);
     if (!s || !t) return '';
@@ -248,7 +254,14 @@ function ganttSvg(layout: GanttLayout, heading?: string, filename?: string, date
   // Backward links (tx < sx — pinned-mode overlap where target.start_date
   // precedes source.end_date, or targets sorted above source in the row
   // order) use the existing detour-below routing.
-  const linkParts: string[] = [];
+  // Two buckets so critical paths render on top of gray ones — SVG paints
+  // later siblings over earlier ones, and a gray edge crossing an orange one
+  // shouldn't bury the critical signal.
+  const linkPartsGray: string[] = [];
+  const linkPartsCrit: string[] = [];
+  function pushLinkPath(html: string, isCritical: boolean): void {
+    (isCritical ? linkPartsCrit : linkPartsGray).push(html);
+  }
   const LINK_GAP = 4;
   const LINK_MIN_STUB = 6;
   const STUB_OUT = 8;       // right-stub past source before turning down
@@ -301,7 +314,7 @@ function ganttSvg(layout: GanttLayout, heading?: string, filename?: string, date
       const anyCritical = forward.some(t => t.link.isCritical);
       const topCls = anyCritical ? 'diagram-edge critical-edge' : 'diagram-edge';
       const topD = `M${sx},${sy} L${stubX},${sy} L${stubX},${midY} L${backX},${midY}`;
-      linkParts.push(`<path d="${topD}" class="${topCls}" fill="none"/>`);
+      pushLinkPath(`<path d="${topD}" class="${topCls}" fill="none"/>`, anyCritical);
 
       // Long vertical at x = backX, split at each target's row. Each segment
       // is coloured by whether any route still served by it (= targets at or
@@ -315,7 +328,7 @@ function ganttSvg(layout: GanttLayout, heading?: string, filename?: string, date
         const segCritical = sortedForward.slice(i).some(t => t.link.isCritical);
         const segCls = segCritical ? 'diagram-edge critical-edge' : 'diagram-edge';
         const segD = `M${backX},${segTop} L${backX},${segBottom}`;
-        linkParts.push(`<path d="${segD}" class="${segCls}" fill="none"/>`);
+        pushLinkPath(`<path d="${segD}" class="${segCls}" fill="none"/>`, segCritical);
         segTop = segBottom;
       }
 
@@ -327,7 +340,7 @@ function ganttSvg(layout: GanttLayout, heading?: string, filename?: string, date
         const marker = t.link.isCritical ? 'gantt-arrow-crit' : 'gantt-arrow';
         const enterX = t.tx + ENTER_DEPTH;
         const branchD = `M${backX},${t.ty} L${enterX},${t.ty}`;
-        linkParts.push(`<path d="${branchD}" class="${cls}" fill="none" marker-end="url(#${marker})"/>`);
+        pushLinkPath(`<path d="${branchD}" class="${cls}" fill="none" marker-end="url(#${marker})"/>`, t.link.isCritical);
       }
     }
 
@@ -338,7 +351,7 @@ function ganttSvg(layout: GanttLayout, heading?: string, filename?: string, date
       const sxOut = sx + LINK_GAP;
       const txIn = t.tx + LINK_MIN_STUB;
       const d = `M${sxOut},${sy} L${sxOut},${hookY} L${txIn},${hookY} L${txIn},${t.ty}`;
-      linkParts.push(`<path d="${d}" class="${cls}" fill="none" marker-end="url(#${marker})"/>`);
+      pushLinkPath(`<path d="${d}" class="${cls}" fill="none" marker-end="url(#${marker})"/>`, t.link.isCritical);
     }
   }
 
@@ -355,7 +368,7 @@ function ganttSvg(layout: GanttLayout, heading?: string, filename?: string, date
 ${titleSvg}
 ${headerParts.join('\n')}
 ${rowParts.join('\n')}
-${linkParts.join('\n')}
+${[...linkPartsGray, ...linkPartsCrit].join('\n')}
 </svg>`;
 }
 

--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -55,11 +55,12 @@ function networkSvg(doc: ActivityDoc, heading?: string, filename?: string, date?
   const orderedEdges = [...layout.edges].sort(
     (a, b) => Number(Boolean(a.isCritical)) - Number(Boolean(b.isCritical)),
   );
-  // Edge path = short horizontal stub out of source → smooth cubic to a stub
-  // before the target → short horizontal stub into the target. The arrow
-  // marker lands on the trailing horizontal segment, so it always reads as
-  // perpendicular to the node's vertical edge — no tilted arrowheads.
-  const EDGE_STUB = 8;
+  // Pure cubic bezier. Tangent at both endpoints is mathematically horizontal
+  // (control points at (mx, sy) and (mx, ty) — same Y as the respective
+  // endpoint), so the marker-end arrow auto-orients horizontal and reads as
+  // perpendicular to the target's vertical edge. Marker refX = markerWidth
+  // anchors the tip at the path endpoint, so the arrow lands ON the bar's
+  // left edge rather than poking inside it.
   const edgeSvg = orderedEdges.map(e => {
     const s = nodeMap.get(e.sourceId);
     const t = nodeMap.get(e.targetId);
@@ -68,19 +69,10 @@ function networkSvg(doc: ActivityDoc, heading?: string, filename?: string, date?
     const sy = s.y + oy + s.height / 2;
     const tx = t.x + ox;
     const ty = t.y + oy + t.height / 2;
+    const mx = (sx + tx) / 2;
     const cls = e.isCritical ? 'diagram-edge critical-edge' : 'diagram-edge';
     const marker = `url(#${e.isCritical ? 'arrow-crit' : 'arrow'})`;
-    let d: string;
-    if (tx - sx > 2 * EDGE_STUB) {
-      const exitX = sx + EDGE_STUB;
-      const enterX = tx - EDGE_STUB;
-      const mx = (exitX + enterX) / 2;
-      d = `M${sx},${sy} L${exitX},${sy} C${mx},${sy} ${mx},${ty} ${enterX},${ty} L${tx},${ty}`;
-    } else {
-      const mx = (sx + tx) / 2;
-      d = `M${sx},${sy} C${mx},${sy} ${mx},${ty} ${tx},${ty}`;
-    }
-    return `<path d="${d}" class="${cls}" marker-end="${marker}"/>`;
+    return `<path d="M${sx},${sy} C${mx},${sy} ${mx},${ty} ${tx},${ty}" class="${cls}" marker-end="${marker}"/>`;
   }).join('\n');
 
   const nodeSvg = layout.nodes.map(n => {
@@ -103,10 +95,10 @@ function networkSvg(doc: ActivityDoc, heading?: string, filename?: string, date?
   const titleSvg = showTitle ? titleBlockSvg(heading!, filename!, date!, N_PAD, N_PAD) : '';
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">
 <defs>
-  <marker id="arrow" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+  <marker id="arrow" markerWidth="8" markerHeight="8" refX="8" refY="3" orient="auto">
     <path d="M0,0 L0,6 L8,3 z" class="arrow-fill"/>
   </marker>
-  <marker id="arrow-crit" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+  <marker id="arrow-crit" markerWidth="8" markerHeight="8" refX="8" refY="3" orient="auto">
     <path d="M0,0 L0,6 L8,3 z" class="arrow-fill-critical"/>
   </marker>
 </defs>
@@ -281,7 +273,7 @@ function ganttSvg(layout: GanttLayout, heading?: string, filename?: string, date
   const LINK_MIN_STUB = 6;
   const STUB_OUT = 8;       // right-stub past source before turning down
   const BACK_OFFSET = 8;    // back-step distance to the LEFT of sx for the long vertical
-  const ENTER_DEPTH = 4;    // how far inside target the arrow path lands (marker tip ~1px further)
+  const ENTER_DEPTH = 0;    // path ends exactly at target.left so marker tip lands on the bar's edge, not inside it
 
   // Group links by source so all outgoing links share one trunk.
   const linksBySource = new Map<string, typeof layout.links>();
@@ -395,10 +387,10 @@ function ganttSvg(layout: GanttLayout, heading?: string, filename?: string, date
   const titleSvg = showTitle ? titleBlockSvg(heading!, filename!, date!, G_PAD, G_PAD) : '';
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">
 <defs>
-  <marker id="gantt-arrow" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto" markerUnits="userSpaceOnUse">
+  <marker id="gantt-arrow" markerWidth="6" markerHeight="6" refX="6" refY="3" orient="auto" markerUnits="userSpaceOnUse">
     <path d="M0,0 L0,6 L6,3 z" class="arrow-fill"/>
   </marker>
-  <marker id="gantt-arrow-crit" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto" markerUnits="userSpaceOnUse">
+  <marker id="gantt-arrow-crit" markerWidth="6" markerHeight="6" refX="6" refY="3" orient="auto" markerUnits="userSpaceOnUse">
     <path d="M0,0 L0,6 L6,3 z" class="arrow-fill-critical"/>
   </marker>
 </defs>
@@ -492,6 +484,16 @@ const ACTIVITIES_DIAGRAM_CSS = `
 
 /** Webview-only chrome (tab switcher, section notice). Not exported. */
 const ACTIVITIES_WEBVIEW_CSS = `
+  /* ── Fill the webview viewport ──────────────────────────────────────── */
+  /* The base shell leaves #canvas at content height with overflow:auto, so a
+     diagram shorter or narrower than the panel strands the canvas's own
+     scrollbar mid-panel with empty space below it. Make <body> a full-height
+     flex column and let #canvas grow into a single scroll region — the same
+     pattern the blocks preview already uses. */
+  html, body { height: 100%; }
+  body { display: flex; flex-direction: column; }
+  #canvas { flex: 1; min-height: 0; overflow: auto; }
+
   /* ── View switcher (CSS-only, no JS) ────────────────────────────────── */
   /* Move the radios fully off-screen rather than just hiding via opacity —
      keeps them keyboard-focusable while not taking layout space, and stops

--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -2,6 +2,7 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, prepareSvgForExport, type ThemeId } from './diagram-frame.js';
+import { TITLE_BLOCK_H, titleBlockSvg, todayIso } from './svg-title-block.js';
 import {
   validateActivities,
   layoutActivities,
@@ -32,23 +33,6 @@ function truncate(s: string, maxLen: number): string {
 const N_NODE_W = 200;
 const N_NODE_H = 80;
 const N_PAD = 24;
-
-// Height reserved at the top of every diagram SVG for the 3-line title block
-// (heading, filename, date). The block is class="diagram-title-block" so the
-// Title toggle in #toolbar can hide it via the shared TITLE_TOGGLE_CSS.
-const TITLE_BLOCK_H = 60;
-
-function titleBlockSvg(heading: string, filename: string, date: string, x: number, top: number): string {
-  // Single paragraph, left-aligned: 13/700 heading then 11/400 muted file+date.
-  // Baseline offsets reflect typical ascent of the font sizes plus a small line
-  // gap so the three rows read as one block. Position uses the SVG's own
-  // padding so the text lines up with the diagram's left edge.
-  return `<g class="diagram-title-block">
-  <text class="text-header" x="${x}" y="${top + 14}">${escXml(heading)}</text>
-  <text class="text-secondary" x="${x}" y="${top + 30}">${escXml(filename)}</text>
-  <text class="text-secondary" x="${x}" y="${top + 46}">${escXml(date)}</text>
-</g>`;
-}
 
 function networkSvg(doc: ActivityDoc, heading?: string, filename?: string, date?: string): string {
   const layout: ActivitiesLayout = layoutActivities(doc);
@@ -460,10 +444,6 @@ const ACTIVITIES_STYLES = `
 
   .diagram-section { margin: 8px 0 16px; }
   .section-notice { margin: 0 16px; padding: 10px 14px; border-left: 3px solid var(--ts-text-muted, #94a3b8); background: var(--ts-bg-subtle, #f8fafc); color: var(--ts-text-muted, #64748b); font-size: 12px; }
-  /* HTML fallback for the Gantt-unavailable path — same 3-line block as the
-     SVG version. .text-header / .text-secondary come from the shared theme. */
-  .diagram-title-block-html { margin: 0 16px 12px; }
-  .diagram-title-block-html div { line-height: 16px; }
 
   .act-node { fill: var(--ts-bg-surface, #f8fafc); stroke: var(--ts-border, #94a3b8); stroke-width: 1.5; }
   .critical-node { fill: #fff7ed; stroke: var(--ts-brand-orange, #ff4d00); stroke-width: 2.5; }
@@ -524,7 +504,7 @@ export class ActivitiesPreview {
     let bodyContent = '';
     let errorMsg = '';
     let warnings: string[] = [];
-    const today = new Date().toISOString().slice(0, 10);
+    const today = todayIso();
 
     try {
       const parsed = yaml.load(yamlText) as unknown;

--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -33,17 +33,36 @@ const N_NODE_W = 200;
 const N_NODE_H = 80;
 const N_PAD = 24;
 
-function networkSvg(doc: ActivityDoc): string {
+// Height reserved at the top of every diagram SVG for the 3-line title block
+// (heading, filename, date). The block is class="diagram-title-block" so the
+// Title toggle in #toolbar can hide it via the shared TITLE_TOGGLE_CSS.
+const TITLE_BLOCK_H = 60;
+
+function titleBlockSvg(heading: string, filename: string, date: string, x: number, top: number): string {
+  // Single paragraph, left-aligned: 13/700 heading then 11/400 muted file+date.
+  // Baseline offsets reflect typical ascent of the font sizes plus a small line
+  // gap so the three rows read as one block. Position uses the SVG's own
+  // padding so the text lines up with the diagram's left edge.
+  return `<g class="diagram-title-block">
+  <text class="text-header" x="${x}" y="${top + 14}">${escXml(heading)}</text>
+  <text class="text-secondary" x="${x}" y="${top + 30}">${escXml(filename)}</text>
+  <text class="text-secondary" x="${x}" y="${top + 46}">${escXml(date)}</text>
+</g>`;
+}
+
+function networkSvg(doc: ActivityDoc, heading?: string, filename?: string, date?: string): string {
   const layout: ActivitiesLayout = layoutActivities(doc);
   if (layout.nodes.length === 0) {
     return '<svg xmlns="http://www.w3.org/2000/svg" width="200" height="60"><text class="text-primary" x="10" y="40">No activities</text></svg>';
   }
 
+  const showTitle = heading != null && filename != null && date != null;
+  const titleH = showTitle ? TITLE_BLOCK_H : 0;
   const cpm = computeCpm(doc.activities ?? []);
   const W = layout.bounds.width + N_PAD * 2;
-  const H = layout.bounds.height + N_PAD * 2;
+  const H = layout.bounds.height + N_PAD * 2 + titleH;
   const ox = -layout.bounds.x + N_PAD;
-  const oy = -layout.bounds.y + N_PAD;
+  const oy = -layout.bounds.y + N_PAD + titleH;
 
   const nodeMap = new Map(layout.nodes.map(n => [n.id, n]));
   const edgeSvg = layout.edges.map(e => {
@@ -76,6 +95,7 @@ function networkSvg(doc: ActivityDoc): string {
     ].join('\n');
   }).join('\n');
 
+  const titleSvg = showTitle ? titleBlockSvg(heading!, filename!, date!, N_PAD, N_PAD) : '';
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">
 <defs>
   <marker id="arrow" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
@@ -85,6 +105,7 @@ function networkSvg(doc: ActivityDoc): string {
     <path d="M0,0 L0,6 L8,3 z" class="arrow-fill-critical"/>
   </marker>
 </defs>
+${titleSvg}
 ${edgeSvg}
 ${nodeSvg}
 </svg>`;
@@ -109,20 +130,22 @@ function daysBetween(startISO: string, endISO: string): number {
   return Math.round(ms / 86_400_000);
 }
 
-function ganttSvg(layout: GanttLayout): string {
+function ganttSvg(layout: GanttLayout, heading?: string, filename?: string, date?: string): string {
   // Sort bars by start date then id for stable display order.
   const bars = [...layout.bars].sort((a, b) => {
     if (a.startDate !== b.startDate) return a.startDate < b.startDate ? -1 : 1;
     return a.id.localeCompare(b.id);
   });
 
+  const showTitle = heading != null && filename != null && date != null;
+  const titleH = showTitle ? TITLE_BLOCK_H : 0;
   const totalDays = daysBetween(layout.timelineStart, layout.timelineEnd) + 1;
   const timelineWidth = totalDays * G_DAY_W;
   const W = G_LABEL_COL_W + timelineWidth + G_PAD * 2;
-  const H = G_HEADER_H + bars.length * G_ROW_H + G_PAD * 2;
+  const H = G_HEADER_H + bars.length * G_ROW_H + G_PAD * 2 + titleH;
 
   const ox = G_PAD;
-  const oy = G_PAD;
+  const oy = G_PAD + titleH;
 
   // Date header strip: month labels above, day ticks below.
   const headerParts: string[] = [];
@@ -335,6 +358,7 @@ function ganttSvg(layout: GanttLayout): string {
     }
   }
 
+  const titleSvg = showTitle ? titleBlockSvg(heading!, filename!, date!, G_PAD, G_PAD) : '';
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">
 <defs>
   <marker id="gantt-arrow" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto" markerUnits="userSpaceOnUse">
@@ -344,6 +368,7 @@ function ganttSvg(layout: GanttLayout): string {
     <path d="M0,0 L0,6 L6,3 z" class="arrow-fill-critical"/>
   </marker>
 </defs>
+${titleSvg}
 ${headerParts.join('\n')}
 ${rowParts.join('\n')}
 ${linkParts.join('\n')}
@@ -352,21 +377,27 @@ ${linkParts.join('\n')}
 
 // ── Stacked canvas content (network + gantt) ─────────────────────────────────
 
-function buildCanvasContent(doc: ActivityDoc): string {
-  const network = networkSvg(doc);
+function buildCanvasContent(doc: ActivityDoc, filename: string, date: string): string {
+  const networkHeading = 'Network view — Project Schedule Network Diagram (PSND)';
+  const network = networkSvg(doc, networkHeading, filename, date);
   const gantt: GanttResult = computeGanttLayout(doc);
 
-  let ganttHeading: string;
   let ganttBody: string;
   if (isGanttUnavailable(gantt)) {
-    ganttHeading = 'Gantt view — unavailable';
-    ganttBody = `<div class="section-notice">${escXml(gantt.reason)}</div>`;
+    // No SVG to embed the title into — fall back to an HTML title block plus
+    // the notice so the unavailable path still shows the same paragraph.
+    ganttBody = `<div class="diagram-title-block diagram-title-block-html">
+  <div class="text-header">Gantt view — unavailable</div>
+  <div class="text-secondary">${escXml(filename)}</div>
+  <div class="text-secondary">${escXml(date)}</div>
+</div>
+<div class="section-notice">${escXml(gantt.reason)}</div>`;
   } else {
     const modeLabel = gantt.mode === 'computed'
       ? `computed mode (project ${gantt.timelineStart} → ${gantt.timelineEnd})`
       : `pinned mode (${gantt.timelineStart} → ${gantt.timelineEnd})`;
-    ganttHeading = `Gantt view — ${modeLabel}`;
-    ganttBody = ganttSvg(gantt);
+    const ganttHeading = `Gantt view — ${modeLabel}`;
+    ganttBody = ganttSvg(gantt, ganttHeading, filename, date);
   }
 
   // Pure-CSS tab switcher: hidden radio inputs at the top, labels styled as
@@ -380,11 +411,9 @@ function buildCanvasContent(doc: ActivityDoc): string {
   <label for="view-gantt" class="view-tab" data-tab="gantt">Gantt</label>
 </nav>
 <section class="diagram-section" data-view="network">
-  <h3 class="section-heading">Network view — Project Schedule Network Diagram (PSND)</h3>
   ${network}
 </section>
 <section class="diagram-section" data-view="gantt">
-  <h3 class="section-heading">${escXml(ganttHeading)}</h3>
   ${ganttBody}
 </section>`;
 }
@@ -430,8 +459,11 @@ const ACTIVITIES_STYLES = `
   .view-radio#view-gantt:checked ~ section[data-view="gantt"] { display: block; }
 
   .diagram-section { margin: 8px 0 16px; }
-  .section-heading { font-size: 13px; font-weight: 600; color: var(--ts-text-muted, #64748b); margin: 0 16px 8px; letter-spacing: 0.02em; }
   .section-notice { margin: 0 16px; padding: 10px 14px; border-left: 3px solid var(--ts-text-muted, #94a3b8); background: var(--ts-bg-subtle, #f8fafc); color: var(--ts-text-muted, #64748b); font-size: 12px; }
+  /* HTML fallback for the Gantt-unavailable path — same 3-line block as the
+     SVG version. .text-header / .text-secondary come from the shared theme. */
+  .diagram-title-block-html { margin: 0 16px 12px; }
+  .diagram-title-block-html div { line-height: 16px; }
 
   .act-node { fill: var(--ts-bg-surface, #f8fafc); stroke: var(--ts-border, #94a3b8); stroke-width: 1.5; }
   .critical-node { fill: #fff7ed; stroke: var(--ts-brand-orange, #ff4d00); stroke-width: 2.5; }
@@ -492,6 +524,7 @@ export class ActivitiesPreview {
     let bodyContent = '';
     let errorMsg = '';
     let warnings: string[] = [];
+    const today = new Date().toISOString().slice(0, 10);
 
     try {
       const parsed = yaml.load(yamlText) as unknown;
@@ -500,11 +533,18 @@ export class ActivitiesPreview {
       if (!v.valid) {
         errorMsg = v.errors.map(e => `${e.code}: ${e.message}`).join('\n');
       } else {
-        bodyContent = buildCanvasContent(parsed as ActivityDoc);
+        bodyContent = buildCanvasContent(parsed as ActivityDoc, filename, today);
         // Save-as-SVG exports only the network view today; the Gantt is a
         // companion section in the webview. (Reconsider when the Gantt becomes
-        // a primary view.)
-        this.lastSvg = networkSvg(parsed as ActivityDoc);
+        // a primary view.) The exported SVG keeps the title block — it lives
+        // in the SVG, so opening the file outside VS Code shows the same
+        // heading + filename + date the user saw in the preview.
+        this.lastSvg = networkSvg(
+          parsed as ActivityDoc,
+          'Network view — Project Schedule Network Diagram (PSND)',
+          filename,
+          today,
+        );
       }
     } catch (e) {
       errorMsg = (e as Error).message ?? 'Parse error';

--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -55,6 +55,11 @@ function networkSvg(doc: ActivityDoc, heading?: string, filename?: string, date?
   const orderedEdges = [...layout.edges].sort(
     (a, b) => Number(Boolean(a.isCritical)) - Number(Boolean(b.isCritical)),
   );
+  // Edge path = short horizontal stub out of source → smooth cubic to a stub
+  // before the target → short horizontal stub into the target. The arrow
+  // marker lands on the trailing horizontal segment, so it always reads as
+  // perpendicular to the node's vertical edge — no tilted arrowheads.
+  const EDGE_STUB = 8;
   const edgeSvg = orderedEdges.map(e => {
     const s = nodeMap.get(e.sourceId);
     const t = nodeMap.get(e.targetId);
@@ -63,9 +68,19 @@ function networkSvg(doc: ActivityDoc, heading?: string, filename?: string, date?
     const sy = s.y + oy + s.height / 2;
     const tx = t.x + ox;
     const ty = t.y + oy + t.height / 2;
-    const mx = (sx + tx) / 2;
     const cls = e.isCritical ? 'diagram-edge critical-edge' : 'diagram-edge';
-    return `<path d="M${sx},${sy} C${mx},${sy} ${mx},${ty} ${tx},${ty}" class="${cls}" marker-end="url(#${e.isCritical ? 'arrow-crit' : 'arrow'})"/>`;
+    const marker = `url(#${e.isCritical ? 'arrow-crit' : 'arrow'})`;
+    let d: string;
+    if (tx - sx > 2 * EDGE_STUB) {
+      const exitX = sx + EDGE_STUB;
+      const enterX = tx - EDGE_STUB;
+      const mx = (exitX + enterX) / 2;
+      d = `M${sx},${sy} L${exitX},${sy} C${mx},${sy} ${mx},${ty} ${enterX},${ty} L${tx},${ty}`;
+    } else {
+      const mx = (sx + tx) / 2;
+      d = `M${sx},${sy} C${mx},${sy} ${mx},${ty} ${tx},${ty}`;
+    }
+    return `<path d="${d}" class="${cls}" marker-end="${marker}"/>`;
   }).join('\n');
 
   const nodeSvg = layout.nodes.map(n => {

--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -36,7 +36,7 @@ const N_PAD = 24;
 function networkSvg(doc: ActivityDoc): string {
   const layout: ActivitiesLayout = layoutActivities(doc);
   if (layout.nodes.length === 0) {
-    return '<svg xmlns="http://www.w3.org/2000/svg" width="200" height="60"><text x="10" y="40" font-family="system-ui,sans-serif" font-size="13">No activities</text></svg>';
+    return '<svg xmlns="http://www.w3.org/2000/svg" width="200" height="60"><text class="text-primary" x="10" y="40">No activities</text></svg>';
   }
 
   const cpm = computeCpm(doc.activities ?? []);
@@ -70,9 +70,9 @@ function networkSvg(doc: ActivityDoc): string {
     const durLabel = n.data.duration !== undefined ? `${n.data.duration}d` : '—';
     return [
       `<rect class="${cls}" x="${x}" y="${y}" width="${N_NODE_W}" height="${N_NODE_H}" rx="6"/>`,
-      `<text class="text-id" x="${x + 8}" y="${y + 18}" font-size="10" font-family="system-ui,sans-serif" font-weight="600">${idLabel}</text>`,
-      `<text class="text-primary" x="${x + N_NODE_W / 2}" y="${y + N_NODE_H / 2 + 4}" text-anchor="middle" dominant-baseline="central" font-size="12" font-weight="600" font-family="system-ui,sans-serif">${nameLabel}</text>`,
-      `<text class="text-secondary" x="${x + N_NODE_W - 8}" y="${y + N_NODE_H - 10}" text-anchor="end" font-size="11" font-family="system-ui,sans-serif">${durLabel}</text>`,
+      `<text class="text-id" x="${x + 8}" y="${y + 18}">${idLabel}</text>`,
+      `<text class="text-primary" x="${x + N_NODE_W / 2}" y="${y + N_NODE_H / 2 + 4}" text-anchor="middle" dominant-baseline="central">${nameLabel}</text>`,
+      `<text class="text-secondary" x="${x + N_NODE_W - 8}" y="${y + N_NODE_H - 10}" text-anchor="end">${durLabel}</text>`,
     ].join('\n');
   }).join('\n');
 
@@ -130,7 +130,7 @@ function ganttSvg(layout: GanttLayout): string {
     `<rect class="diagram-node gantt-header" x="${ox}" y="${oy}" width="${G_LABEL_COL_W + timelineWidth}" height="${G_HEADER_H}"/>`,
   );
   headerParts.push(
-    `<text class="text-secondary" x="${ox + 12}" y="${oy + G_HEADER_H / 2}" dominant-baseline="central" font-size="11" font-weight="600" font-family="system-ui,sans-serif">Activity</text>`,
+    `<text class="text-secondary" x="${ox + 12}" y="${oy + G_HEADER_H / 2}" dominant-baseline="central">Activity</text>`,
   );
   // Month band: walk days, group by yyyy-mm.
   const months: Array<{ label: string; startCol: number; endCol: number }> = [];
@@ -146,7 +146,7 @@ function ganttSvg(layout: GanttLayout): string {
     const x = ox + G_LABEL_COL_W + m.startCol * G_DAY_W;
     const w = (m.endCol - m.startCol + 1) * G_DAY_W;
     headerParts.push(
-      `<text class="text-secondary" x="${x + w / 2}" y="${oy + 14}" text-anchor="middle" dominant-baseline="central" font-size="10" font-family="system-ui,sans-serif">${escXml(m.label)}</text>`,
+      `<text class="text-secondary" x="${x + w / 2}" y="${oy + 14}" text-anchor="middle" dominant-baseline="central">${escXml(m.label)}</text>`,
     );
   }
   // Day grid: thin vertical lines every 7 days.
@@ -173,10 +173,10 @@ function ganttSvg(layout: GanttLayout): string {
     }
     // Label column
     rowParts.push(
-      `<text class="text-id" x="${ox + 8}" y="${rowY + G_ROW_H / 2}" dominant-baseline="central" font-size="10" font-family="system-ui,sans-serif" font-weight="600">${escXml(bar.id)}</text>`,
+      `<text class="text-id" x="${ox + 8}" y="${rowY + G_ROW_H / 2}" dominant-baseline="central">${escXml(bar.id)}</text>`,
     );
     rowParts.push(
-      `<text class="text-primary" x="${ox + 56}" y="${rowY + G_ROW_H / 2}" dominant-baseline="central" font-size="11" font-family="system-ui,sans-serif">${escXml(truncate(bar.name, 22))}</text>`,
+      `<text class="text-secondary" x="${ox + 56}" y="${rowY + G_ROW_H / 2}" dominant-baseline="central">${escXml(truncate(bar.name, 22))}</text>`,
     );
 
     // Bar geometry
@@ -438,7 +438,6 @@ const ACTIVITIES_STYLES = `
   .milestone-node { fill: #ecfeff; stroke: var(--ts-text-muted, #64748b); stroke-dasharray: 4 2; }
   .critical-edge { stroke: var(--ts-brand-orange, #ff4d00); stroke-width: 2; }
   .arrow-fill-critical { fill: var(--ts-brand-orange, #ff4d00); }
-  .text-id { fill: var(--ts-text-muted, #64748b); }
 
   .gantt-header { fill: var(--ts-bg-subtle, #f1f5f9); stroke: var(--ts-border, #cbd5e1); stroke-width: 1; }
   .gantt-grid { stroke: var(--ts-border, #cbd5e1); stroke-width: 1; opacity: 0.5; }

--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -403,8 +403,31 @@ function buildCanvasContent(doc: ActivityDoc, filename: string, date: string): s
 }
 
 // ── Extra CSS injected into the diagram frame ───────────────────────────────
+//
+// Split into two pieces so the exported .svg file carries only the rules that
+// shape the diagram itself. Webview-shell rules (view switcher, section
+// notice) are useless — and confusing — when the SVG is opened in Chrome.
 
-const ACTIVITIES_STYLES = `
+/** Diagram-class CSS used both in the webview and in saved .svg exports. */
+const ACTIVITIES_DIAGRAM_CSS = `
+  .act-node { fill: var(--ts-bg-surface, #f8fafc); stroke: var(--ts-border, #94a3b8); stroke-width: 1.5; }
+  .critical-node { fill: #fff7ed; stroke: var(--ts-brand-orange, #ff4d00); stroke-width: 2.5; }
+  .milestone-node { fill: #ecfeff; stroke: var(--ts-text-muted, #64748b); stroke-dasharray: 4 2; }
+  .critical-edge { stroke: var(--ts-brand-orange, #ff4d00); stroke-width: 2; }
+  .arrow-fill-critical { fill: var(--ts-brand-orange, #ff4d00); }
+
+  .gantt-header { fill: var(--ts-bg-subtle, #f1f5f9); stroke: var(--ts-border, #cbd5e1); stroke-width: 1; }
+  .gantt-grid { stroke: var(--ts-border, #cbd5e1); stroke-width: 1; opacity: 0.5; }
+  .gantt-row-alt { fill: var(--ts-bg-subtle, #f8fafc); opacity: 0.5; }
+  .gantt-bar { fill: var(--ts-bg-surface, #dbeafe); stroke: var(--ts-border, #60a5fa); stroke-width: 1; }
+  .gantt-bar.critical-bar { fill: #fff7ed; stroke: var(--ts-brand-orange, #ff4d00); stroke-width: 1.5; }
+  .gantt-phase { fill: var(--ts-text-muted, #475569); opacity: 0.85; }
+  .gantt-milestone { fill: var(--ts-text, #0f172a); }
+  .gantt-milestone.critical-bar { fill: var(--ts-brand-orange, #ff4d00); }
+`;
+
+/** Webview-only chrome (tab switcher, section notice). Not exported. */
+const ACTIVITIES_WEBVIEW_CSS = `
   /* ── View switcher (CSS-only, no JS) ────────────────────────────────── */
   /* Move the radios fully off-screen rather than just hiding via opacity —
      keeps them keyboard-focusable while not taking layout space, and stops
@@ -444,22 +467,9 @@ const ACTIVITIES_STYLES = `
 
   .diagram-section { margin: 8px 0 16px; }
   .section-notice { margin: 0 16px; padding: 10px 14px; border-left: 3px solid var(--ts-text-muted, #94a3b8); background: var(--ts-bg-subtle, #f8fafc); color: var(--ts-text-muted, #64748b); font-size: 12px; }
-
-  .act-node { fill: var(--ts-bg-surface, #f8fafc); stroke: var(--ts-border, #94a3b8); stroke-width: 1.5; }
-  .critical-node { fill: #fff7ed; stroke: var(--ts-brand-orange, #ff4d00); stroke-width: 2.5; }
-  .milestone-node { fill: #ecfeff; stroke: var(--ts-text-muted, #64748b); stroke-dasharray: 4 2; }
-  .critical-edge { stroke: var(--ts-brand-orange, #ff4d00); stroke-width: 2; }
-  .arrow-fill-critical { fill: var(--ts-brand-orange, #ff4d00); }
-
-  .gantt-header { fill: var(--ts-bg-subtle, #f1f5f9); stroke: var(--ts-border, #cbd5e1); stroke-width: 1; }
-  .gantt-grid { stroke: var(--ts-border, #cbd5e1); stroke-width: 1; opacity: 0.5; }
-  .gantt-row-alt { fill: var(--ts-bg-subtle, #f8fafc); opacity: 0.5; }
-  .gantt-bar { fill: var(--ts-bg-surface, #dbeafe); stroke: var(--ts-border, #60a5fa); stroke-width: 1; }
-  .gantt-bar.critical-bar { fill: #fff7ed; stroke: var(--ts-brand-orange, #ff4d00); stroke-width: 1.5; }
-  .gantt-phase { fill: var(--ts-text-muted, #475569); opacity: 0.85; }
-  .gantt-milestone { fill: var(--ts-text, #0f172a); }
-  .gantt-milestone.critical-bar { fill: var(--ts-brand-orange, #ff4d00); }
 `;
+
+const ACTIVITIES_STYLES = ACTIVITIES_WEBVIEW_CSS + ACTIVITIES_DIAGRAM_CSS;
 
 // ── ActivitiesPreview webview class ───────────────────────────────────────────
 
@@ -562,7 +572,7 @@ export class ActivitiesPreview {
     const target = await vscode.window.showSaveDialog({ defaultUri, filters: { 'SVG Image': ['svg'] } });
     if (!target) return;
     const themeId = vscode.workspace.getConfiguration('transitrix').get<ThemeId>('theme', 'transitrix');
-    const svg = prepareSvgForExport(this.lastSvg, themeId);
+    const svg = prepareSvgForExport(this.lastSvg, themeId, ACTIVITIES_DIAGRAM_CSS);
     await vscode.workspace.fs.writeFile(target, Buffer.from(svg, 'utf-8'));
     vscode.window.showInformationMessage(`Saved: ${path.basename(target.fsPath)}`);
   }

--- a/extension/src/applications-preview.ts
+++ b/extension/src/applications-preview.ts
@@ -1,7 +1,7 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
-import { buildDiagramFrame, type ThemeId } from './diagram-frame.js';
+import { buildDiagramFrame, CATALOGUE_STYLES, type ThemeId } from './diagram-frame.js';
 
 // ── Inline types (mirror packages/diagrams/src/applications/types.ts) ─────────
 
@@ -308,15 +308,12 @@ export class ApplicationsPreview {
       subtitle,
       version,
       date,
-      extraStyles: APPLICATIONS_STYLES,
+      extraStyles: CATALOGUE_STYLES + APPLICATIONS_STYLES,
     });
   }
 }
 
 const APPLICATIONS_STYLES = `
-  #canvas {
-    padding: 0 20px 16px;
-  }
   .applications-table {
     width: 100%;
     border-collapse: collapse;
@@ -340,15 +337,9 @@ const APPLICATIONS_STYLES = `
     border-bottom: 1px solid var(--ts-divider, #cbd5e1);
     vertical-align: top;
   }
-  .applications-table tr:last-child td {
-    border-bottom: none;
-  }
-  .applications-table tr:hover td {
-    background: var(--ts-bg-elevated, #f1f5f9);
-  }
-  .app-name {
-    font-weight: 600;
-  }
+  .applications-table tr:last-child td { border-bottom: none; }
+  .applications-table tr:hover td { background: var(--ts-bg-elevated, #f1f5f9); }
+  .app-name { font-weight: 600; }
   .app-id {
     font-size: 11px;
     color: var(--ts-text-muted, #64748b);
@@ -359,23 +350,6 @@ const APPLICATIONS_STYLES = `
     font-size: 12px;
     color: var(--ts-text-muted, #64748b);
     margin-top: 4px;
-  }
-  details {
-    margin-top: 6px;
-    font-size: 12px;
-  }
-  details summary {
-    cursor: pointer;
-    color: var(--ts-brand-primary, #004d67);
-    font-weight: 500;
-    user-select: none;
-  }
-  details ul {
-    margin: 4px 0 0 16px;
-    padding: 0;
-  }
-  details li {
-    margin-bottom: 3px;
   }
   .intg-dir {
     display: inline-block;
@@ -399,31 +373,6 @@ const APPLICATIONS_STYLES = `
     color: var(--ts-text-muted, #64748b);
     font-size: 11px;
   }
-  .badge {
-    display: inline-block;
-    padding: 2px 8px;
-    border-radius: 10px;
-    font-size: 11px;
-    font-weight: 600;
-    letter-spacing: 0.03em;
-    white-space: nowrap;
-  }
-  .badge-active {
-    background: var(--ts-status-success-bg, #d1fae5);
-    color: var(--ts-status-success-fg, #065f46);
-  }
-  .badge-draft {
-    background: var(--ts-status-info-bg, #e0f2fe);
-    color: var(--ts-status-info-fg, #0c4a6e);
-  }
-  .badge-deprecated {
-    background: var(--ts-status-warning-bg, #fef9c3);
-    color: var(--ts-status-warning-fg, #854d0e);
-  }
-  .badge-decommissioning {
-    background: var(--ts-status-error-bg, #fee2e2);
-    color: var(--ts-status-error-fg, #991b1b);
-  }
   .type-tag {
     display: inline-block;
     padding: 2px 8px;
@@ -433,30 +382,8 @@ const APPLICATIONS_STYLES = `
     color: var(--ts-text-muted, #64748b);
     white-space: nowrap;
   }
-  .vendor-internal {
-    font-style: italic;
-    color: var(--ts-text-muted, #64748b);
-  }
-  .vendor-external {
-    color: var(--ts-text, #0f172a);
-  }
-  .maturity-dots {
-    font-size: 14px;
-    letter-spacing: 1px;
-    color: var(--ts-brand-primary, #004d67);
-  }
-  .maturity-none {
-    color: var(--ts-text-muted, #64748b);
-  }
-  .cell-empty {
-    color: var(--ts-text-muted, #94a3b8);
-  }
-  .empty-catalogue {
-    text-align: center;
-    color: var(--ts-text-muted, #64748b);
-    padding: 32px;
-    font-style: italic;
-  }
+  .vendor-internal { font-style: italic; color: var(--ts-text-muted, #64748b); }
+  .vendor-external { color: var(--ts-text, #0f172a); }
   .col-name { min-width: 200px; }
   .col-type, .col-status, .col-maturity, .col-domain, .col-vendor, .col-owner { white-space: nowrap; }
 `;

--- a/extension/src/blocks-preview.ts
+++ b/extension/src/blocks-preview.ts
@@ -2,6 +2,11 @@ import * as cp from 'node:child_process';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import { buildDiagramFrame } from './diagram-frame.js';
+import { todayIso } from './svg-title-block.js';
+
+function escHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
 
 const BLOCKS_STYLES = `
 html { height: 100%; }
@@ -118,7 +123,18 @@ export class BlocksPreview {
       } else {
         const svgs = result.svgs ?? [];
         this.lastSvgs = svgs;
-        const svgContent = `<div class="blocks-svg-wrap">${svgs.join('\n')}</div>`;
+        const today = todayIso();
+        // The blocks backend emits one SVG per top-level block, joined in
+        // `.blocks-svg-wrap`. Embedding the title into each SVG would multiply
+        // captions, so it lives in an HTML header above the wrapper — the same
+        // class as the SVG variant, the Title toggle picks both up via
+        // TITLE_TOGGLE_CSS in diagram-frame.ts.
+        const titleHtml = `<div class="diagram-title-block diagram-title-block-html">
+  <div class="text-header">Block diagram</div>
+  <div class="text-secondary">${escHtml(filename)}</div>
+  <div class="text-secondary">${escHtml(today)}</div>
+</div>`;
+        const svgContent = `${titleHtml}<div class="blocks-svg-wrap">${svgs.join('\n')}</div>`;
         html = buildDiagramFrame({
           filename,
           notation: 'blocks',

--- a/extension/src/blocks-preview.ts
+++ b/extension/src/blocks-preview.ts
@@ -87,7 +87,7 @@ export class BlocksPreview {
       'blocksPreview',
       `Blocks: ${path.basename(doc.fileName)}`,
       vscode.ViewColumn.Beside,
-      { enableScripts: false, retainContextWhenHidden: true },
+      { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveBlocksAsSvg'] },
     );
     this.currentUri = doc.uri.toString();
     this.panel.onDidDispose(() => {
@@ -140,6 +140,7 @@ export class BlocksPreview {
           notation: 'blocks',
           svgContent,
           extraStyles: BLOCKS_STYLES,
+          saveSvgCommand: 'transitrixStudio.saveBlocksAsSvg',
         });
       }
     } catch (err: unknown) {

--- a/extension/src/capability-map-preview.ts
+++ b/extension/src/capability-map-preview.ts
@@ -1,7 +1,7 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
-import { buildDiagramFrame, type ThemeId } from './diagram-frame.js';
+import { buildDiagramFrame, CATALOGUE_STYLES, type ThemeId } from './diagram-frame.js';
 
 // ── Inline types (mirror packages/diagrams/src/capability-map/types.ts) ───────
 
@@ -289,15 +289,12 @@ export class CapabilityMapPreview {
       subtitle,
       version,
       date,
-      extraStyles: CAPABILITY_MAP_STYLES,
+      extraStyles: CATALOGUE_STYLES + CAPABILITY_MAP_STYLES,
     });
   }
 }
 
 const CAPABILITY_MAP_STYLES = `
-  #canvas {
-    padding: 0 20px 16px;
-  }
   .cap-axis {
     margin-bottom: 24px;
   }
@@ -360,11 +357,11 @@ const CAPABILITY_MAP_STYLES = `
     letter-spacing: 0.04em;
     color: #fff;
   }
-  .maturity-1 { background: #b91c1c; }
-  .maturity-2 { background: #d97706; }
-  .maturity-3 { background: #ca8a04; }
-  .maturity-4 { background: #65a30d; }
-  .maturity-5 { background: #15803d; }
+  .maturity-pill.maturity-1 { background: var(--ts-maturity-1, #b91c1c); }
+  .maturity-pill.maturity-2 { background: var(--ts-maturity-2, #d97706); }
+  .maturity-pill.maturity-3 { background: var(--ts-maturity-3, #ca8a04); }
+  .maturity-pill.maturity-4 { background: var(--ts-maturity-4, #65a30d); }
+  .maturity-pill.maturity-5 { background: var(--ts-maturity-5, #15803d); }
   .maturity-arrow {
     color: var(--ts-text-muted, #64748b);
     font-size: 13px;

--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -6,10 +6,16 @@ export type { ThemeId };
 /**
  * Injects a <style> block with all --ts-* CSS variable definitions into an SVG string,
  * making it self-contained for file export (no external stylesheet required).
+ *
+ * Pass `notationCss` for the per-notation class rules (e.g. activities-preview's
+ * `.act-node`, `.critical-edge`, `.gantt-bar`) that live in the preview's
+ * webview `extraStyles` but are not part of the shared theme. Without them the
+ * exported SVG falls through to browser defaults — typically black fills on
+ * dark stroke — and looks nothing like the in-VS-Code preview.
  */
-export function prepareSvgForExport(svg: string, themeId: ThemeId = 'transitrix'): string {
+export function prepareSvgForExport(svg: string, themeId: ThemeId = 'transitrix', notationCss = ''): string {
   const css = generateSvgEmbedCss(themeId);
-  return svg.replace(/(<svg\b[^>]*>)/, `$1<style>${css}</style>`);
+  return svg.replace(/(<svg\b[^>]*>)/, `$1<style>${css}${notationCss}</style>`);
 }
 
 export interface DiagramFrameOpts {

--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -127,6 +127,7 @@ const TITLE_TOGGLE_CSS = `
 .title-toggle-cb:not(:checked) ~ #toolbar .title-toggle::before { content: "\\2610\\00a0"; }
 .title-toggle-cb:not(:checked) ~ .frame-header { display: none; }
 .title-toggle-cb:not(:checked) ~ #canvas .diagram-caption { display: none; }
+.title-toggle-cb:not(:checked) ~ #canvas .diagram-title-block { display: none; }
 `;
 
 /**

--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -128,6 +128,13 @@ const TITLE_TOGGLE_CSS = `
 .title-toggle-cb:not(:checked) ~ .frame-header { display: none; }
 .title-toggle-cb:not(:checked) ~ #canvas .diagram-caption { display: none; }
 .title-toggle-cb:not(:checked) ~ #canvas .diagram-title-block { display: none; }
+
+/* HTML-rendered title block — used when a preview can't embed in SVG
+   (Gantt-unavailable notice, blocks preview's multi-SVG wrapper). Same class
+   as the SVG variant so the toggle catches both. Reuses .text-header /
+   .text-secondary from the shared theme so the typography matches. */
+.diagram-title-block-html { margin: 0 16px 12px; }
+.diagram-title-block-html div { line-height: 16px; }
 `;
 
 /**

--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -93,6 +93,42 @@ const FRAME_HEADER_CSS = `
 .frame-meta{font-size:11px;color:var(--ts-text-muted,#64748b);letter-spacing:0.04em;}
 `;
 
+/**
+ * Shared styling for catalogue-style HTML previews (applications, products,
+ * process-map, scenarios, capability-map). Covers the bits that every
+ * catalogue notation duplicates verbatim — badges, maturity dots, empty
+ * states, details/summary, table reset. Notation-specific table class names
+ * and entity-row classes stay local to each preview.
+ *
+ * Inject by prepending to the preview's own extraStyles:
+ *   extraStyles: CATALOGUE_STYLES + LOCAL_STYLES
+ */
+export const CATALOGUE_STYLES = `
+#canvas { padding: 0 20px 16px; }
+.badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  white-space: nowrap;
+}
+.badge-active        { background: var(--ts-status-success-bg, #d1fae5); color: var(--ts-status-success-fg, #065f46); }
+.badge-draft         { background: var(--ts-status-info-bg, #e0f2fe);    color: var(--ts-status-info-fg, #0c4a6e); }
+.badge-deprecated    { background: var(--ts-status-warning-bg, #fef9c3); color: var(--ts-status-warning-fg, #854d0e); }
+.badge-decommissioning { background: var(--ts-status-error-bg, #fee2e2); color: var(--ts-status-error-fg, #991b1b); }
+.badge-archived      { background: var(--ts-status-warning-bg, #fef9c3); color: var(--ts-status-warning-fg, #854d0e); }
+.maturity-dots { font-size: 14px; letter-spacing: 1px; color: var(--ts-brand-primary, #004d67); }
+.maturity-none { color: var(--ts-text-muted, #64748b); }
+.cell-empty { color: var(--ts-text-muted, #94a3b8); }
+.empty-catalogue { text-align: center; color: var(--ts-text-muted, #64748b); padding: 32px; font-style: italic; }
+details { margin-top: 6px; font-size: 12px; }
+details summary { cursor: pointer; color: var(--ts-brand-primary, #004d67); font-weight: 500; user-select: none; }
+details ul { margin: 4px 0 0 16px; padding: 0; }
+details li { margin-bottom: 3px; }
+`;
+
 export function buildDiagramFrame(opts: DiagramFrameOpts): string {
   const {
     filename, notation,

--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -94,6 +94,42 @@ const FRAME_HEADER_CSS = `
 `;
 
 /**
+ * CSS-only title show/hide toggle (TX-R009).
+ *
+ * Static previews run with enableScripts: false, so this follows the same
+ * trick as the activities Network/Gantt switcher (PR #9):
+ *   1. A hidden checkbox sits at the top of <body> before any sibling that
+ *      should react. It's positioned off-screen rather than display:none so
+ *      keyboard focus still reaches it.
+ *   2. A <label for="…"> lives inside #toolbar styled as a button.
+ *   3. `:checked` propagates via the sibling combinator to hide either
+ *      .frame-header (catalogue previews) or .diagram-caption (SVG previews).
+ *
+ * Default is "title shown" (checkbox checked). Clicking unchecks → title
+ * hidden.
+ */
+const TITLE_TOGGLE_CSS = `
+.title-toggle-cb { position: absolute; left: -9999px; width: 1px; height: 1px; opacity: 0; }
+#toolbar { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.toolbar-label { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.title-toggle {
+  cursor: pointer;
+  user-select: none;
+  font-size: 11px;
+  padding: 1px 8px;
+  border-radius: 4px;
+  color: var(--ts-text-muted, #64748b);
+  white-space: nowrap;
+}
+.title-toggle::before { content: "\\2611\\00a0"; font-size: 12px; }
+.title-toggle:hover { color: var(--ts-text, #0f172a); background: var(--ts-bg-elevated, #f1f5f9); }
+.title-toggle-cb:focus-visible ~ #toolbar .title-toggle { outline: 1px dashed var(--ts-text-muted, #64748b); outline-offset: 2px; }
+.title-toggle-cb:not(:checked) ~ #toolbar .title-toggle::before { content: "\\2610\\00a0"; }
+.title-toggle-cb:not(:checked) ~ .frame-header { display: none; }
+.title-toggle-cb:not(:checked) ~ #canvas .diagram-caption { display: none; }
+`;
+
+/**
  * Shared styling for catalogue-style HTML previews (applications, products,
  * process-map, scenarios, capability-map). Covers the bits that every
  * catalogue notation duplicates verbatim — badges, maturity dots, empty
@@ -170,6 +206,17 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
     ? `<div class="diagram-caption">${escXml(notation)} — ${escXml(filename)}</div>`
     : '';
 
+  // The toggle only makes sense when there's actually a title-ish element to
+  // hide. Skip the widget on error-only renders so users don't see a button
+  // that does nothing.
+  const showToggle = Boolean(title) || Boolean(canvasContent);
+  const toggleInput = showToggle
+    ? `<input type="checkbox" id="ts-title-toggle" class="title-toggle-cb" checked>`
+    : '';
+  const toolbarRight = showToggle
+    ? `<label for="ts-title-toggle" class="title-toggle" title="Show or hide the diagram title">Title</label>`
+    : '';
+
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -179,11 +226,13 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
 ${generateWebviewCss(themeId)}
 ${FIX_PROMPT_CSS}
 ${FRAME_HEADER_CSS}
+${TITLE_TOGGLE_CSS}
 ${extraStyles}
   </style>
 </head>
 <body data-theme="${escXml(themeId)}">
-  <div id="toolbar">${escXml(notation)}: ${escXml(filename)}</div>
+  ${toggleInput}
+  <div id="toolbar"><span class="toolbar-label">${escXml(notation)}: ${escXml(filename)}</span>${toolbarRight}</div>
   ${errBlock}${fixPromptBlock}${warnBlock}
   ${headerBlock}
   <div id="canvas">

--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -155,6 +155,56 @@ const TITLE_TOGGLE_CSS = `
 `;
 
 /**
+ * CSS-only discrete zoom control (orchestrator decision on issue #30):
+ * 50 / 75 / 100 (default) / 150 / 200 % through hidden radios + labels.
+ * Same pattern as TX-R009 title toggle and Network/Gantt switcher — no
+ * script enablement, the security backstop on previews stays intact.
+ *
+ * `zoom` (rather than transform: scale) is used because it grows the layout
+ * box too, so `#canvas`'s scrollbars reflect the scaled diagram size and
+ * the user can pan a zoomed-in view. `zoom` is non-standard but native in
+ * Chromium-based webviews (where Studio runs) and on the CSS Sizing L4
+ * standardisation path.
+ */
+const ZOOM_CONTROL_CSS = `
+.zoom-radio { position: absolute; left: -9999px; width: 1px; height: 1px; opacity: 0; }
+.zoom-control { display: inline-flex; gap: 0; border: 1px solid var(--ts-border, #cbd5e1); border-radius: 4px; overflow: hidden; }
+.zoom-label {
+  cursor: pointer;
+  user-select: none;
+  font-size: 11px;
+  padding: 1px 6px;
+  color: var(--ts-text-muted, #64748b);
+  background: transparent;
+  white-space: nowrap;
+  border-right: 1px solid var(--ts-border, #cbd5e1);
+}
+.zoom-control .zoom-label:last-child { border-right: none; }
+.zoom-label:hover { color: var(--ts-text, #0f172a); background: var(--ts-bg-elevated, #f1f5f9); }
+.zoom-radio#z-50:checked  ~ #toolbar .zoom-label[for="z-50"],
+.zoom-radio#z-75:checked  ~ #toolbar .zoom-label[for="z-75"],
+.zoom-radio#z-100:checked ~ #toolbar .zoom-label[for="z-100"],
+.zoom-radio#z-150:checked ~ #toolbar .zoom-label[for="z-150"],
+.zoom-radio#z-200:checked ~ #toolbar .zoom-label[for="z-200"] {
+  background: var(--ts-bg-elevated, #f1f5f9);
+  color: var(--ts-text, #0f172a);
+  font-weight: 600;
+}
+/* Apply zoom to every SVG and the blocks multi-SVG wrapper. We use the
+   non-standard but Chromium-native 'zoom' property rather than transform:
+   scale so the layout box grows and #canvas scrollbars span the scaled
+   diagram. */
+.zoom-radio#z-50:checked  ~ #canvas svg,
+.zoom-radio#z-50:checked  ~ #canvas .blocks-svg-wrap { zoom: 0.5; }
+.zoom-radio#z-75:checked  ~ #canvas svg,
+.zoom-radio#z-75:checked  ~ #canvas .blocks-svg-wrap { zoom: 0.75; }
+.zoom-radio#z-150:checked ~ #canvas svg,
+.zoom-radio#z-150:checked ~ #canvas .blocks-svg-wrap { zoom: 1.5; }
+.zoom-radio#z-200:checked ~ #canvas svg,
+.zoom-radio#z-200:checked ~ #canvas .blocks-svg-wrap { zoom: 2; }
+`;
+
+/**
  * Shared styling for catalogue-style HTML previews (applications, products,
  * process-map, scenarios, capability-map). Covers the bits that every
  * catalogue notation duplicates verbatim — badges, maturity dots, empty
@@ -239,12 +289,26 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
   // Save .svg button — only render when both (a) a vector diagram is on screen
   // and (b) the preview supplied a command id (HTML catalogues never do).
   const showSaveSvg = Boolean(canvasContent) && Boolean(saveSvgCommand);
+  // Zoom control gates on the same signal as Save .svg — the six vector
+  // previews opt in by passing a saveSvgCommand. HTML catalogues are out of
+  // scope per the orchestrator's call on issue #30.
+  const showZoom = Boolean(canvasContent) && Boolean(saveSvgCommand);
   const toggleInput = showToggle
     ? `<input type="checkbox" id="ts-title-toggle" class="title-toggle-cb" checked>`
+    : '';
+  const zoomInputs = showZoom
+    ? `<input type="radio" name="ts-zoom" id="z-50"  class="zoom-radio">
+  <input type="radio" name="ts-zoom" id="z-75"  class="zoom-radio">
+  <input type="radio" name="ts-zoom" id="z-100" class="zoom-radio" checked>
+  <input type="radio" name="ts-zoom" id="z-150" class="zoom-radio">
+  <input type="radio" name="ts-zoom" id="z-200" class="zoom-radio">`
     : '';
   const actionParts: string[] = [];
   if (showToggle) {
     actionParts.push(`<label for="ts-title-toggle" class="title-toggle" title="Show or hide the diagram title">Title</label>`);
+  }
+  if (showZoom) {
+    actionParts.push(`<div class="zoom-control" title="Zoom level"><label for="z-50" class="zoom-label">50%</label><label for="z-75" class="zoom-label">75%</label><label for="z-100" class="zoom-label">100%</label><label for="z-150" class="zoom-label">150%</label><label for="z-200" class="zoom-label">200%</label></div>`);
   }
   if (showSaveSvg) {
     actionParts.push(`<a href="command:${escXml(saveSvgCommand!)}" class="toolbar-btn" title="Save the current diagram as an .svg file">Save .svg</a>`);
@@ -263,11 +327,13 @@ ${generateWebviewCss(themeId)}
 ${FIX_PROMPT_CSS}
 ${FRAME_HEADER_CSS}
 ${TITLE_TOGGLE_CSS}
+${ZOOM_CONTROL_CSS}
 ${extraStyles}
   </style>
 </head>
 <body data-theme="${escXml(themeId)}">
   ${toggleInput}
+  ${zoomInputs}
   <div id="toolbar"><span class="toolbar-label">${escXml(notation)}: ${escXml(filename)}</span>${toolbarRight}</div>
   ${errBlock}${fixPromptBlock}${warnBlock}
   ${headerBlock}

--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -51,6 +51,14 @@ export interface DiagramFrameOpts {
   version?: string;
   /** Date string for the metadata strip (e.g. "2026-05-13"). */
   date?: string;
+  /**
+   * Command ID for the "Save as SVG" toolbar button (e.g.
+   * "transitrixStudio.saveGoalsAsSvg"). When provided, the toolbar shows a
+   * "Save .svg" pill next to the Title toggle, wired as a `command:` URI.
+   * The preview's webview must opt into command URIs via `enableCommandUris`.
+   * Omit on previews that don't render a vector diagram (HTML catalogues).
+   */
+  saveSvgCommand?: string;
 }
 
 function escXml(s: string): string {
@@ -118,7 +126,9 @@ const TITLE_TOGGLE_CSS = `
 .title-toggle-cb { position: absolute; left: -9999px; width: 1px; height: 1px; opacity: 0; }
 #toolbar { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
 .toolbar-label { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.title-toggle {
+.toolbar-actions { display: flex; gap: 4px; align-items: center; flex-shrink: 0; }
+.title-toggle,
+.toolbar-btn {
   cursor: pointer;
   user-select: none;
   font-size: 11px;
@@ -126,7 +136,9 @@ const TITLE_TOGGLE_CSS = `
   border-radius: 4px;
   color: var(--ts-text-muted, #64748b);
   white-space: nowrap;
+  text-decoration: none;
 }
+.toolbar-btn:hover { color: var(--ts-text, #0f172a); background: var(--ts-bg-elevated, #f1f5f9); }
 .title-toggle::before { content: "\\2611\\00a0"; font-size: 12px; }
 .title-toggle:hover { color: var(--ts-text, #0f172a); background: var(--ts-bg-elevated, #f1f5f9); }
 .title-toggle-cb:focus-visible ~ #toolbar .title-toggle { outline: 1px dashed var(--ts-text-muted, #64748b); outline-offset: 2px; }
@@ -186,6 +198,7 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
     errorMsg = '', warnings = [],
     themeId = 'transitrix', extraStyles = '', fixPrompt = '',
     title, subtitle, version, date,
+    saveSvgCommand,
   } = opts;
 
   const canvasContent = bodyContent ?? svgContent;
@@ -224,11 +237,21 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
   // hide. Skip the widget on error-only renders so users don't see a button
   // that does nothing.
   const showToggle = Boolean(title) || Boolean(canvasContent);
+  // Save .svg button — only render when both (a) a vector diagram is on screen
+  // and (b) the preview supplied a command id (HTML catalogues never do).
+  const showSaveSvg = Boolean(canvasContent) && Boolean(saveSvgCommand);
   const toggleInput = showToggle
     ? `<input type="checkbox" id="ts-title-toggle" class="title-toggle-cb" checked>`
     : '';
-  const toolbarRight = showToggle
-    ? `<label for="ts-title-toggle" class="title-toggle" title="Show or hide the diagram title">Title</label>`
+  const actionParts: string[] = [];
+  if (showToggle) {
+    actionParts.push(`<label for="ts-title-toggle" class="title-toggle" title="Show or hide the diagram title">Title</label>`);
+  }
+  if (showSaveSvg) {
+    actionParts.push(`<a href="command:${escXml(saveSvgCommand!)}" class="toolbar-btn" title="Save the current diagram as an .svg file">Save .svg</a>`);
+  }
+  const toolbarRight = actionParts.length > 0
+    ? `<div class="toolbar-actions">${actionParts.join('')}</div>`
     : '';
 
   return `<!DOCTYPE html>

--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -144,7 +144,6 @@ const TITLE_TOGGLE_CSS = `
 .title-toggle-cb:focus-visible ~ #toolbar .title-toggle { outline: 1px dashed var(--ts-text-muted, #64748b); outline-offset: 2px; }
 .title-toggle-cb:not(:checked) ~ #toolbar .title-toggle::before { content: "\\2610\\00a0"; }
 .title-toggle-cb:not(:checked) ~ .frame-header { display: none; }
-.title-toggle-cb:not(:checked) ~ #canvas .diagram-caption { display: none; }
 .title-toggle-cb:not(:checked) ~ #canvas .diagram-title-block { display: none; }
 
 /* HTML-rendered title block — used when a preview can't embed in SVG
@@ -229,9 +228,9 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
 </div>`
     : '';
 
-  const caption = canvasContent && !title
-    ? `<div class="diagram-caption">${escXml(notation)} — ${escXml(filename)}</div>`
-    : '';
+  // Bottom .diagram-caption is gone — every vector preview now embeds its own
+  // 3-line title block inside the SVG (PR #17/#18) and HTML catalogues use
+  // .frame-header. The figcaption was redundant with the title block above.
 
   // The toggle only makes sense when there's actually a title-ish element to
   // hide. Skip the widget on error-only renders so users don't see a button
@@ -274,7 +273,6 @@ ${extraStyles}
   ${headerBlock}
   <div id="canvas">
     ${canvasContent}
-    ${caption}
   </div>
 </body>
 </html>`;

--- a/extension/src/fgca-preview.ts
+++ b/extension/src/fgca-preview.ts
@@ -295,22 +295,13 @@ function buildSvg(doc: FGCADoc, hideChanges = false, heading?: string, filename?
     ].join('\n');
   }).join('\n');
 
-  // Horizontal stubs at both ends pin the arrow marker on a strictly
-  // horizontal segment so the arrowhead reads as perpendicular to the
-  // node's vertical edge, regardless of the cubic curve's slope.
-  const EDGE_STUB = 8;
+  // Pure cubic bezier. Tangent stays horizontal at both endpoints via the
+  // (mx, sy)/(mx, ty) control points, so the marker-end arrow reads as
+  // perpendicular to the node's vertical edge. Marker refX = markerWidth
+  // pins the tip at the path endpoint.
   const edgeSvg = edges.map(e => {
-    let d: string;
-    if (e.tx - e.sx > 2 * EDGE_STUB) {
-      const exitX = e.sx + EDGE_STUB;
-      const enterX = e.tx - EDGE_STUB;
-      const mx = (exitX + enterX) / 2;
-      d = `M${e.sx},${e.sy} L${exitX},${e.sy} C${mx},${e.sy} ${mx},${e.ty} ${enterX},${e.ty} L${e.tx},${e.ty}`;
-    } else {
-      const mx = (e.sx + e.tx) / 2;
-      d = `M${e.sx},${e.sy} C${mx},${e.sy} ${mx},${e.ty} ${e.tx},${e.ty}`;
-    }
-    return `<path d="${d}" class="diagram-edge" marker-end="url(#arrow)"/>`;
+    const mx = (e.sx + e.tx) / 2;
+    return `<path d="M${e.sx},${e.sy} C${mx},${e.sy} ${mx},${e.ty} ${e.tx},${e.ty}" class="diagram-edge" marker-end="url(#arrow)"/>`;
   }).join('\n');
 
   const nodeSvg = nodes.map(n => {
@@ -343,7 +334,7 @@ function buildSvg(doc: FGCADoc, hideChanges = false, heading?: string, filename?
   // group so the title block can sit above without rewriting every node/edge.
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${totalH}" viewBox="0 0 ${width} ${totalH}">
 <defs>
-  <marker id="arrow" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+  <marker id="arrow" markerWidth="8" markerHeight="8" refX="8" refY="3" orient="auto">
     <path d="M0,0 L0,6 L8,3 z" class="arrow-fill"/>
   </marker>
 </defs>

--- a/extension/src/fgca-preview.ts
+++ b/extension/src/fgca-preview.ts
@@ -2,6 +2,7 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, prepareSvgForExport, type ThemeId } from './diagram-frame.js';
+import { TITLE_BLOCK_H, titleBlockSvg, todayIso } from './svg-title-block.js';
 
 // ── Inline types ──────────────────────────────────────────────────────────────
 //
@@ -278,8 +279,10 @@ function escXml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
 
-function buildSvg(doc: FGCADoc, hideChanges = false): string {
+function buildSvg(doc: FGCADoc, hideChanges = false, heading?: string, filename?: string, date?: string): string {
   const { nodes, edges, width, height } = layoutFGCA(doc, hideChanges);
+  const showTitle = heading != null && filename != null && date != null;
+  const titleH = showTitle ? TITLE_BLOCK_H : 0;
   const cols = hideChanges
     ? (['factor', 'goal', 'activity'] as const)
     : (['factor', 'goal', 'change', 'activity'] as const);
@@ -321,15 +324,22 @@ function buildSvg(doc: FGCADoc, hideChanges = false): string {
     ].filter(Boolean).join('\n');
   }).join('\n');
 
-  return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
+  const totalH = height + titleH;
+  const titleSvg = showTitle ? titleBlockSvg(heading!, filename!, date!, PAD, PAD) : '';
+  // The layoutFGCA coordinates are absolute; wrap the diagram in a translate
+  // group so the title block can sit above without rewriting every node/edge.
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${totalH}" viewBox="0 0 ${width} ${totalH}">
 <defs>
   <marker id="arrow" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
     <path d="M0,0 L0,6 L8,3 z" class="arrow-fill"/>
   </marker>
 </defs>
+${titleSvg}
+<g transform="translate(0, ${titleH})">
 ${headerSvg}
 ${edgeSvg}
 ${nodeSvg}
+</g>
 </svg>`;
 }
 
@@ -384,7 +394,7 @@ export class FGCAPreview {
       if (!v.valid) {
         errorMsg = v.errors.map(e => `${e.code}: ${e.message}`).join('\n');
       } else {
-        svgContent = buildSvg(parsed as FGCADoc);
+        svgContent = buildSvg(parsed as FGCADoc, false, 'FGCA — Factor → Goal → Change → Activity', filename, todayIso());
       }
     } catch (e) {
       errorMsg = (e as Error).message ?? 'Parse error';
@@ -472,7 +482,7 @@ export class FGAPreview {
         errorMsg = v.errors.map(e => `${e.code}: ${e.message}`).join('\n');
       } else {
         const flat = fgaToFlat(parsed as FGADoc);
-        svgContent = buildSvg(flat, true);
+        svgContent = buildSvg(flat, true, 'FGA — Factor → Goal → Activity', filename, todayIso());
       }
     } catch (e) {
       errorMsg = (e as Error).message ?? 'Parse error';

--- a/extension/src/fgca-preview.ts
+++ b/extension/src/fgca-preview.ts
@@ -350,8 +350,8 @@ function buildSvg(doc: FGCADoc, hideChanges = false, heading?: string, filename?
 ${titleSvg}
 <g transform="translate(0, ${titleH})">
 ${headerSvg}
-${edgeSvg}
 ${nodeSvg}
+${edgeSvg}
 </g>
 </svg>`;
 }

--- a/extension/src/fgca-preview.ts
+++ b/extension/src/fgca-preview.ts
@@ -365,7 +365,7 @@ export class FGCAPreview {
         'fgcaPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true },
+        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveFGCAAsSvg'] },
       );
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
     }
@@ -406,7 +406,7 @@ export class FGCAPreview {
       .getConfiguration('transitrix')
       .get<ThemeId>('theme', 'transitrix');
 
-    return buildDiagramFrame({ filename, notation: 'FGCA', svgContent, errorMsg, warnings, themeId });
+    return buildDiagramFrame({ filename, notation: 'FGCA', svgContent, errorMsg, warnings, themeId, saveSvgCommand: 'transitrixStudio.saveFGCAAsSvg' });
   }
 
   async saveAsSvg(): Promise<void> {
@@ -452,7 +452,7 @@ export class FGAPreview {
         'fgaPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true },
+        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveFGAAsSvg'] },
       );
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
     }
@@ -494,7 +494,7 @@ export class FGAPreview {
       .getConfiguration('transitrix')
       .get<ThemeId>('theme', 'transitrix');
 
-    return buildDiagramFrame({ filename, notation: 'FGA', svgContent, errorMsg, warnings, themeId });
+    return buildDiagramFrame({ filename, notation: 'FGA', svgContent, errorMsg, warnings, themeId, saveSvgCommand: 'transitrixStudio.saveFGAAsSvg' });
   }
 
   async saveAsSvg(): Promise<void> {

--- a/extension/src/fgca-preview.ts
+++ b/extension/src/fgca-preview.ts
@@ -288,7 +288,7 @@ function buildSvg(doc: FGCADoc, hideChanges = false): string {
     const x = PAD + ci * COL_STRIDE;
     return [
       `<rect class="diagram-node layer-${col}" x="${x}" y="${PAD}" width="${NODE_W}" height="${HEADER_H}" rx="6"/>`,
-      `<text class="text-header" x="${x + NODE_W / 2}" y="${PAD + HEADER_H / 2}" text-anchor="middle" dominant-baseline="central" font-size="12" font-family="system-ui,sans-serif">${escXml(COL_LABELS[col])}</text>`,
+      `<text class="text-header" x="${x + NODE_W / 2}" y="${PAD + HEADER_H / 2}" text-anchor="middle" dominant-baseline="central">${escXml(COL_LABELS[col])}</text>`,
     ].join('\n');
   }).join('\n');
 
@@ -316,8 +316,8 @@ function buildSvg(doc: FGCADoc, hideChanges = false): string {
     const y2 = y1 + 18;
     return [
       `<rect class="diagram-node layer-${n.col}" x="${n.x}" y="${n.y}" width="${NODE_W}" height="${NODE_H}" rx="8"/>`,
-      `<text class="text-primary" x="${n.x + NODE_W / 2}" y="${y1}" text-anchor="middle" font-size="12" font-weight="600" font-family="system-ui,sans-serif">${escXml(line1)}</text>`,
-      twoLines ? `<text class="text-primary" x="${n.x + NODE_W / 2}" y="${y2}" text-anchor="middle" font-size="12" font-family="system-ui,sans-serif">${escXml(line2)}</text>` : '',
+      `<text class="text-primary" x="${n.x + NODE_W / 2}" y="${y1}" text-anchor="middle">${escXml(line1)}</text>`,
+      twoLines ? `<text class="text-secondary" x="${n.x + NODE_W / 2}" y="${y2}" text-anchor="middle">${escXml(line2)}</text>` : '',
     ].filter(Boolean).join('\n');
   }).join('\n');
 

--- a/extension/src/fgca-preview.ts
+++ b/extension/src/fgca-preview.ts
@@ -295,9 +295,22 @@ function buildSvg(doc: FGCADoc, hideChanges = false, heading?: string, filename?
     ].join('\n');
   }).join('\n');
 
+  // Horizontal stubs at both ends pin the arrow marker on a strictly
+  // horizontal segment so the arrowhead reads as perpendicular to the
+  // node's vertical edge, regardless of the cubic curve's slope.
+  const EDGE_STUB = 8;
   const edgeSvg = edges.map(e => {
-    const mx = (e.sx + e.tx) / 2;
-    return `<path d="M${e.sx},${e.sy} C${mx},${e.sy} ${mx},${e.ty} ${e.tx},${e.ty}" class="diagram-edge" marker-end="url(#arrow)"/>`;
+    let d: string;
+    if (e.tx - e.sx > 2 * EDGE_STUB) {
+      const exitX = e.sx + EDGE_STUB;
+      const enterX = e.tx - EDGE_STUB;
+      const mx = (exitX + enterX) / 2;
+      d = `M${e.sx},${e.sy} L${exitX},${e.sy} C${mx},${e.sy} ${mx},${e.ty} ${enterX},${e.ty} L${e.tx},${e.ty}`;
+    } else {
+      const mx = (e.sx + e.tx) / 2;
+      d = `M${e.sx},${e.sy} C${mx},${e.sy} ${mx},${e.ty} ${e.tx},${e.ty}`;
+    }
+    return `<path d="${d}" class="diagram-edge" marker-end="url(#arrow)"/>`;
   }).join('\n');
 
   const nodeSvg = nodes.map(n => {

--- a/extension/src/goals-preview.ts
+++ b/extension/src/goals-preview.ts
@@ -39,10 +39,11 @@ function layoutToSvg(layout: GoalTreeLayout, treeName: string, filename?: string
 
   const nodeMap = new Map(layout.nodes.map(n => [n.id, n]));
 
-  // Horizontal stubs at both ends keep the arrow marker on a strictly
-  // horizontal segment, so it reads as perpendicular to the node's
-  // vertical edge regardless of the curve's overall shape.
-  const EDGE_STUB = 8;
+  // Pure cubic bezier. Control points at (mx, sy) and (mx, ty) keep the
+  // tangent horizontal at both endpoints, so the marker-end arrow reads as
+  // perpendicular to the node's vertical edge. Marker refX = markerWidth
+  // pins the tip at the path endpoint so the arrow stops at the node's
+  // left edge instead of poking inside.
   function edgePath(e: LaidOutEdge): string {
     const s = nodeMap.get(e.source);
     const t = nodeMap.get(e.target);
@@ -51,12 +52,6 @@ function layoutToSvg(layout: GoalTreeLayout, treeName: string, filename?: string
     const sy = s.y + oy + s.height / 2;
     const tx = t.x + ox;
     const ty = t.y + oy + t.height / 2;
-    if (tx - sx > 2 * EDGE_STUB) {
-      const exitX = sx + EDGE_STUB;
-      const enterX = tx - EDGE_STUB;
-      const mx = (exitX + enterX) / 2;
-      return `M${sx},${sy} L${exitX},${sy} C${mx},${sy} ${mx},${ty} ${enterX},${ty} L${tx},${ty}`;
-    }
     const mx = (sx + tx) / 2;
     return `M${sx},${sy} C${mx},${sy} ${mx},${ty} ${tx},${ty}`;
   }
@@ -81,7 +76,7 @@ function layoutToSvg(layout: GoalTreeLayout, treeName: string, filename?: string
   const titleSvg = showTitle ? titleBlockSvg(heading, filename!, date!, pad, pad) : '';
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">
 <defs>
-  <marker id="arrow" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+  <marker id="arrow" markerWidth="8" markerHeight="8" refX="8" refY="3" orient="auto">
     <path d="M0,0 L0,6 L8,3 z" class="arrow-fill"/>
   </marker>
 </defs>

--- a/extension/src/goals-preview.ts
+++ b/extension/src/goals-preview.ts
@@ -164,6 +164,10 @@ function layoutToSvg(layout: GoalTreeLayout, treeName: string, filename?: string
 
   const nodeMap = new Map(layout.nodes.map(n => [n.id, n]));
 
+  // Horizontal stubs at both ends keep the arrow marker on a strictly
+  // horizontal segment, so it reads as perpendicular to the node's
+  // vertical edge regardless of the curve's overall shape.
+  const EDGE_STUB = 8;
   function edgePath(e: LaidOutEdge): string {
     const s = nodeMap.get(e.source);
     const t = nodeMap.get(e.target);
@@ -172,6 +176,12 @@ function layoutToSvg(layout: GoalTreeLayout, treeName: string, filename?: string
     const sy = s.y + oy + s.height / 2;
     const tx = t.x + ox;
     const ty = t.y + oy + t.height / 2;
+    if (tx - sx > 2 * EDGE_STUB) {
+      const exitX = sx + EDGE_STUB;
+      const enterX = tx - EDGE_STUB;
+      const mx = (exitX + enterX) / 2;
+      return `M${sx},${sy} L${exitX},${sy} C${mx},${sy} ${mx},${ty} ${enterX},${ty} L${tx},${ty}`;
+    }
     const mx = (sx + tx) / 2;
     return `M${sx},${sy} C${mx},${sy} ${mx},${ty} ${tx},${ty}`;
   }

--- a/extension/src/goals-preview.ts
+++ b/extension/src/goals-preview.ts
@@ -227,7 +227,7 @@ export class GoalsPreview {
         'goalsPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true },
+        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveGoalsAsSvg'] },
       );
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
     }
@@ -270,7 +270,7 @@ export class GoalsPreview {
       .getConfiguration('transitrix')
       .get<ThemeId>('theme', 'transitrix');
 
-    return buildDiagramFrame({ filename, notation: 'Goal tree', svgContent, errorMsg, warnings, themeId });
+    return buildDiagramFrame({ filename, notation: 'Goal tree', svgContent, errorMsg, warnings, themeId, saveSvgCommand: 'transitrixStudio.saveGoalsAsSvg' });
   }
 
   async saveAsSvg(): Promise<void> {

--- a/extension/src/goals-preview.ts
+++ b/extension/src/goals-preview.ts
@@ -184,7 +184,7 @@ function layoutToSvg(layout: GoalTreeLayout, treeName: string): string {
     const label = n.label.length > 36 ? n.label.slice(0, 34) + '…' : n.label;
     return `<g>
   <rect class="diagram-node level-${level}" x="${x}" y="${y}" width="${n.width}" height="${n.height}" rx="8"/>
-  <text class="text-primary" x="${x + n.width / 2}" y="${y + n.height / 2}" text-anchor="middle" dominant-baseline="central" font-size="12" font-weight="600" font-family="system-ui,sans-serif">${escXml(label)}</text>
+  <text class="text-primary" x="${x + n.width / 2}" y="${y + n.height / 2}" text-anchor="middle" dominant-baseline="central">${escXml(label)}</text>
 </g>`;
   }).join('\n');
 

--- a/extension/src/goals-preview.ts
+++ b/extension/src/goals-preview.ts
@@ -2,6 +2,7 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, prepareSvgForExport, type ThemeId } from './diagram-frame.js';
+import { TITLE_BLOCK_H, titleBlockSvg, todayIso } from './svg-title-block.js';
 
 // ── Canonical types (spec: notations/04-goals.md v0.2) ──────────────────────
 //
@@ -152,12 +153,14 @@ function escXml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
 
-function layoutToSvg(layout: GoalTreeLayout, treeName: string): string {
+function layoutToSvg(layout: GoalTreeLayout, treeName: string, filename?: string, date?: string): string {
   const pad = 24;
+  const showTitle = filename != null && date != null;
+  const titleH = showTitle ? TITLE_BLOCK_H : 0;
   const w = layout.bounds.width + pad * 2;
-  const h = layout.bounds.height + pad * 2;
+  const h = layout.bounds.height + pad * 2 + titleH;
   const ox = -layout.bounds.x + pad;
-  const oy = -layout.bounds.y + pad;
+  const oy = -layout.bounds.y + pad + titleH;
 
   const nodeMap = new Map(layout.nodes.map(n => [n.id, n]));
 
@@ -188,12 +191,15 @@ function layoutToSvg(layout: GoalTreeLayout, treeName: string): string {
 </g>`;
   }).join('\n');
 
+  const heading = treeName ? `Goal tree — ${treeName}` : 'Goal tree';
+  const titleSvg = showTitle ? titleBlockSvg(heading, filename!, date!, pad, pad) : '';
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">
 <defs>
   <marker id="arrow" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
     <path d="M0,0 L0,6 L8,3 z" class="arrow-fill"/>
   </marker>
 </defs>
+${titleSvg}
 ${edgeSvg}
 ${nodeSvg}
 </svg>`;
@@ -252,7 +258,7 @@ export class GoalsPreview {
       } else {
         const doc = parsed as GoalsTreeDoc;
         const layout = layoutGoalTree(doc);
-        svgContent = layoutToSvg(layout, doc.goals_tree.name ?? '');
+        svgContent = layoutToSvg(layout, doc.goals_tree.name ?? '', filename, todayIso());
       }
     } catch (e) {
       errorMsg = (e as Error).message ?? 'Parse error';

--- a/extension/src/goals-preview.ts
+++ b/extension/src/goals-preview.ts
@@ -3,151 +3,26 @@ import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, prepareSvgForExport, type ThemeId } from './diagram-frame.js';
 import { TITLE_BLOCK_H, titleBlockSvg, todayIso } from './svg-title-block.js';
+import {
+  validateGoalTree,
+  layoutGoalTree,
+  type GoalTree,
+  type GoalTreeLayout,
+  type LaidOutEdge,
+} from '../../packages/diagrams/src/goals/index.js';
 
-// ── Canonical types (spec: notations/04-goals.md v0.2) ──────────────────────
+// ── SVG renderer ─────────────────────────────────────────────────────────────
 //
-// goals_tree:
-//   id: "GT-..."
-//   name: "..."
-//   description?: "..."
-//   root:
-//     goal_id: "GOAL-..."
-//     children?:
-//       - goal_id: "GOAL-..."
-//         children?: [...]
-
-interface TreeNode { goal_id: string; children?: TreeNode[]; }
-interface GoalsTreeRoot { id: string; name: string; description?: string; root: TreeNode; }
-interface GoalsTreeDoc { goals_tree: GoalsTreeRoot; }
-
-// Internal flat representation used by the layout engine
-interface FlatGoal { id: string; label: string; depth: number; parentId: string | null; }
-
-interface LaidOutNode { id: string; x: number; y: number; width: number; height: number; depth: number; label: string; }
-interface LaidOutEdge { source: string; target: string; }
-interface GoalTreeLayout {
-  nodes: LaidOutNode[];
-  edges: LaidOutEdge[];
-  bounds: { x: number; y: number; width: number; height: number };
-}
-
-interface ValidationError { code: string; message: string; }
-interface ValidationResult { valid: boolean; errors: ValidationError[]; warnings: Array<{ code: string; message: string }> }
-
-// ── Validation ───────────────────────────────────────────────────────────────
-
-function validateGoalTree(input: unknown): ValidationResult {
-  const errors: ValidationError[] = [];
-  const warnings: Array<{ code: string; message: string }> = [];
-
-  if (!input || typeof input !== 'object') {
-    return { valid: false, errors: [{ code: 'SCHEMA_INVALID', message: 'Input must be an object' }], warnings };
-  }
-
-  const raw = input as Record<string, unknown>;
-
-  if (!raw.goals_tree || typeof raw.goals_tree !== 'object') {
-    errors.push({ code: 'MISSING_ROOT', message: 'goals_tree root key is required' });
-    return { valid: false, errors, warnings };
-  }
-
-  const tree = raw.goals_tree as Record<string, unknown>;
-
-  if (!tree.root || typeof tree.root !== 'object') {
-    errors.push({ code: 'MISSING_ROOT', message: 'goals_tree.root is required' });
-    return { valid: false, errors, warnings };
-  }
-
-  const root = tree.root as Record<string, unknown>;
-  if (!root.goal_id || typeof root.goal_id !== 'string') {
-    errors.push({ code: 'MISSING_GOAL_ID', message: 'goals_tree.root.goal_id must be a non-empty string' });
-  }
-
-  // Check for cycles via DFS
-  function checkCycles(node: TreeNode, seen: Set<string>): boolean {
-    if (seen.has(node.goal_id)) {
-      warnings.push({ code: 'CYCLE_DETECTED', message: `goal_id "${node.goal_id}" appears more than once in the tree` });
-      return false;
-    }
-    seen.add(node.goal_id);
-    for (const child of (node.children ?? [])) checkCycles(child, new Set(seen));
-    return true;
-  }
-
-  if (errors.length === 0) {
-    checkCycles(tree.root as unknown as TreeNode, new Set());
-  }
-
-  return { valid: errors.length === 0, errors, warnings };
-}
-
-// ── Flatten nested tree → internal flat list ─────────────────────────────────
-
-function flattenTree(node: TreeNode, depth: number, parentId: string | null, out: FlatGoal[]): void {
-  out.push({ id: node.goal_id, label: node.goal_id, depth, parentId });
-  for (const child of (node.children ?? [])) {
-    flattenTree(child, depth + 1, node.goal_id, out);
-  }
-}
-
-// ── Layout ───────────────────────────────────────────────────────────────────
+// Validation, layout, and the canonical FLAT shape (`goal_types[]` +
+// `goals[]` with numeric `parent_id`) all come from @transitrix/diagrams.
+// This file only owns the SVG presentation of the layout the package
+// produces — never re-defines the schema, since the example file and the
+// shared package were drifting apart.
 
 const NODE_W = 250;
 const NODE_H = 60;
 const RANK_SEP = 100;
 const NODE_SEP = 24;
-
-function layoutGoalTree(doc: GoalsTreeDoc): GoalTreeLayout {
-  const flat: FlatGoal[] = [];
-  flattenTree(doc.goals_tree.root, 0, null, flat);
-
-  const byId = new Map(flat.map(g => [g.id, g]));
-  const childrenOf = new Map<string | null, string[]>();
-  for (const g of flat) {
-    const key = g.parentId;
-    if (!childrenOf.has(key)) childrenOf.set(key, []);
-    childrenOf.get(key)!.push(g.id);
-  }
-
-  const nodes: LaidOutNode[] = [];
-  const edges: LaidOutEdge[] = [];
-  const colNextY = new Map<number, number>();
-
-  function placeNode(id: string): { top: number; bottom: number } {
-    const goal = byId.get(id);
-    if (!goal) return { top: 0, bottom: 0 };
-    const col = goal.depth;
-    const kids = childrenOf.get(id) ?? [];
-
-    if (kids.length === 0) {
-      const y = colNextY.get(col) ?? 0;
-      colNextY.set(col, y + NODE_H + NODE_SEP);
-      nodes.push({ id, x: col * (NODE_W + RANK_SEP), y, width: NODE_W, height: NODE_H, depth: col, label: goal.label });
-      return { top: y, bottom: y + NODE_H };
-    }
-
-    const spans = kids.map(c => placeNode(c));
-    for (const c of kids) edges.push({ source: id, target: c });
-    const spanTop = Math.min(...spans.map(s => s.top));
-    const spanBot = Math.max(...spans.map(s => s.bottom));
-    const idealY = spanTop + (spanBot - spanTop) / 2 - NODE_H / 2;
-    const finalY = Math.max(idealY, colNextY.get(col) ?? 0);
-    colNextY.set(col, finalY + NODE_H + NODE_SEP);
-    nodes.push({ id, x: col * (NODE_W + RANK_SEP), y: finalY, width: NODE_W, height: NODE_H, depth: col, label: goal.label });
-    return { top: Math.min(finalY, spanTop), bottom: Math.max(finalY + NODE_H, spanBot) };
-  }
-
-  placeNode(doc.goals_tree.root.goal_id);
-
-  if (nodes.length === 0) return { nodes: [], edges: [], bounds: { x: 0, y: 0, width: 0, height: 0 } };
-  const minX = Math.min(...nodes.map(n => n.x));
-  const minY = Math.min(...nodes.map(n => n.y));
-  const maxX = Math.max(...nodes.map(n => n.x + n.width));
-  const maxY = Math.max(...nodes.map(n => n.y + n.height));
-  return { nodes, edges, bounds: { x: minX, y: minY, width: maxX - minX, height: maxY - minY } };
-}
-
-// ── SVG renderer ─────────────────────────────────────────────────────────────
 
 function escXml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
@@ -193,8 +68,9 @@ function layoutToSvg(layout: GoalTreeLayout, treeName: string, filename?: string
   const nodeSvg = layout.nodes.map(n => {
     const x = n.x + ox;
     const y = n.y + oy;
-    const level = n.depth % 8;
-    const label = n.label.length > 36 ? n.label.slice(0, 34) + '…' : n.label;
+    const level = n.data.level % 8;
+    const labelText = n.data.name ?? String(n.id);
+    const label = labelText.length > 36 ? labelText.slice(0, 34) + '…' : labelText;
     return `<g>
   <rect class="diagram-node level-${level}" x="${x}" y="${y}" width="${n.width}" height="${n.height}" rx="8"/>
   <text class="text-primary" x="${x + n.width / 2}" y="${y + n.height / 2}" text-anchor="middle" dominant-baseline="central">${escXml(label)}</text>
@@ -266,9 +142,15 @@ export class GoalsPreview {
       if (!v.valid) {
         errorMsg = v.errors.map(e => `${e.code}: ${e.message}`).join('\n');
       } else {
-        const doc = parsed as GoalsTreeDoc;
-        const layout = layoutGoalTree(doc);
-        svgContent = layoutToSvg(layout, doc.goals_tree.name ?? '', filename, todayIso());
+        const tree = parsed as GoalTree;
+        const treeName = (parsed as { title?: unknown }).title;
+        const layout = layoutGoalTree(tree, {
+          nodeWidth: NODE_W,
+          nodeHeight: NODE_H,
+          rankSep: RANK_SEP,
+          nodeSep: NODE_SEP,
+        });
+        svgContent = layoutToSvg(layout, typeof treeName === 'string' ? treeName : '', filename, todayIso());
       }
     } catch (e) {
       errorMsg = (e as Error).message ?? 'Parse error';

--- a/extension/src/goals-preview.ts
+++ b/extension/src/goals-preview.ts
@@ -86,8 +86,8 @@ function layoutToSvg(layout: GoalTreeLayout, treeName: string, filename?: string
   </marker>
 </defs>
 ${titleSvg}
-${edgeSvg}
 ${nodeSvg}
+${edgeSvg}
 </svg>`;
 }
 

--- a/extension/src/process-blueprint-preview.ts
+++ b/extension/src/process-blueprint-preview.ts
@@ -36,7 +36,7 @@ function layoutToSvg(layout: ProcessBlueprintLayout): string {
       `<rect class="diagram-node level-1" x="${s.x + ox}" y="${s.y + oy}" width="${s.width}" height="${s.height}"/>`,
     );
     parts.push(
-      `<text class="text-primary" x="${s.x + ox + s.width / 2}" y="${s.y + oy + s.height / 2}" text-anchor="middle" dominant-baseline="central" font-size="13" font-weight="600" font-family="system-ui,sans-serif">${escXml(truncate(s.name, 28))}</text>`,
+      `<text class="text-header" x="${s.x + ox + s.width / 2}" y="${s.y + oy + s.height / 2}" text-anchor="middle" dominant-baseline="central">${escXml(truncate(s.name, 28))}</text>`,
     );
   }
 
@@ -45,7 +45,7 @@ function layoutToSvg(layout: ProcessBlueprintLayout): string {
       `<rect class="diagram-node level-2" x="${ox}" y="${l.y + oy}" width="${layout.legendColumnWidth}" height="${l.height}"/>`,
     );
     parts.push(
-      `<text class="text-secondary" x="${ox + 12}" y="${l.y + oy + l.height / 2}" dominant-baseline="central" font-size="12" font-weight="600" font-family="system-ui,sans-serif">${escXml(l.label)}</text>`,
+      `<text class="text-primary" x="${ox + 12}" y="${l.y + oy + l.height / 2}" dominant-baseline="central">${escXml(l.label)}</text>`,
     );
   }
 
@@ -54,7 +54,7 @@ function layoutToSvg(layout: ProcessBlueprintLayout): string {
       `<rect class="diagram-node level-3" x="${c.x + ox}" y="${c.y + oy}" width="${c.width}" height="${c.height}"/>`,
     );
     parts.push(
-      `<text class="text-primary" x="${c.x + ox + 10}" y="${c.y + oy + c.height / 2}" dominant-baseline="central" font-size="12" font-family="system-ui,sans-serif">${escXml(truncate(c.text, 32))}</text>`,
+      `<text class="text-secondary" x="${c.x + ox + 10}" y="${c.y + oy + c.height / 2}" dominant-baseline="central">${escXml(truncate(c.text, 32))}</text>`,
     );
   }
   for (const c of layout.resultCells) {
@@ -62,7 +62,7 @@ function layoutToSvg(layout: ProcessBlueprintLayout): string {
       `<rect class="diagram-node level-4" x="${c.x + ox}" y="${c.y + oy}" width="${c.width}" height="${c.height}"/>`,
     );
     parts.push(
-      `<text class="text-primary" x="${c.x + ox + 10}" y="${c.y + oy + c.height / 2}" dominant-baseline="central" font-size="12" font-family="system-ui,sans-serif">${escXml(truncate(c.text, 32))}</text>`,
+      `<text class="text-secondary" x="${c.x + ox + 10}" y="${c.y + oy + c.height / 2}" dominant-baseline="central">${escXml(truncate(c.text, 32))}</text>`,
     );
   }
 
@@ -84,7 +84,7 @@ function layoutToSvg(layout: ProcessBlueprintLayout): string {
       );
       const label = p.id ? `${p.name} · ${p.id}` : p.name;
       parts.push(
-        `<text class="text-primary" x="${p.x + ox + p.width / 2}" y="${p.y + oy + p.height / 2}" text-anchor="middle" dominant-baseline="central" font-size="11" font-weight="500" font-family="system-ui,sans-serif">${escXml(truncate(label, Math.floor(p.width / 8)))}</text>`,
+        `<text class="text-pill" x="${p.x + ox + p.width / 2}" y="${p.y + oy + p.height / 2}" text-anchor="middle" dominant-baseline="central">${escXml(truncate(label, Math.floor(p.width / 8)))}</text>`,
       );
     }
   }

--- a/extension/src/process-blueprint-preview.ts
+++ b/extension/src/process-blueprint-preview.ts
@@ -119,7 +119,7 @@ export class ProcessBlueprintPreview {
         'processBlueprintPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true },
+        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveProcessBlueprintAsSvg'] },
       );
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
     }
@@ -162,7 +162,7 @@ export class ProcessBlueprintPreview {
       .getConfiguration('transitrix')
       .get<ThemeId>('theme', 'transitrix');
 
-    return buildDiagramFrame({ filename, notation: 'Process Blueprint', svgContent, errorMsg, warnings, themeId });
+    return buildDiagramFrame({ filename, notation: 'Process Blueprint', svgContent, errorMsg, warnings, themeId, saveSvgCommand: 'transitrixStudio.saveProcessBlueprintAsSvg' });
   }
 
   async saveAsSvg(): Promise<void> {

--- a/extension/src/process-blueprint-preview.ts
+++ b/extension/src/process-blueprint-preview.ts
@@ -2,6 +2,7 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, prepareSvgForExport, type ThemeId } from './diagram-frame.js';
+import { TITLE_BLOCK_H, titleBlockSvg, todayIso } from './svg-title-block.js';
 import {
   validateProcessBlueprint,
   layoutProcessBlueprint,
@@ -18,12 +19,14 @@ function truncate(text: string, maxChars: number): string {
   return text.slice(0, Math.max(0, maxChars - 1)) + '…';
 }
 
-function layoutToSvg(layout: ProcessBlueprintLayout): string {
+function layoutToSvg(layout: ProcessBlueprintLayout, filename?: string, date?: string): string {
   const pad = 24;
+  const showTitle = filename != null && date != null;
+  const titleH = showTitle ? TITLE_BLOCK_H : 0;
   const w = layout.bounds.width + pad * 2;
-  const h = layout.bounds.height + pad * 2;
+  const h = layout.bounds.height + pad * 2 + titleH;
   const ox = pad;
-  const oy = pad;
+  const oy = pad + titleH;
 
   const parts: string[] = [];
 
@@ -89,7 +92,9 @@ function layoutToSvg(layout: ProcessBlueprintLayout): string {
     }
   }
 
+  const titleSvg = showTitle ? titleBlockSvg('Process Blueprint', filename!, date!, pad, pad) : '';
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">
+${titleSvg}
 ${parts.join('\n')}
 </svg>`;
 }
@@ -145,7 +150,7 @@ export class ProcessBlueprintPreview {
       } else {
         const file = parsed as ProcessBlueprintFile;
         const layout = layoutProcessBlueprint(file);
-        svgContent = layoutToSvg(layout);
+        svgContent = layoutToSvg(layout, filename, todayIso());
       }
     } catch (e) {
       errorMsg = (e as Error).message ?? 'Parse error';

--- a/extension/src/process-map-preview.ts
+++ b/extension/src/process-map-preview.ts
@@ -1,7 +1,7 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
-import { buildDiagramFrame, type ThemeId } from './diagram-frame.js';
+import { buildDiagramFrame, CATALOGUE_STYLES, type ThemeId } from './diagram-frame.js';
 
 // ── Inline types (mirror packages/diagrams/src/process-map/types.ts) ──────────
 
@@ -303,15 +303,12 @@ export class ProcessMapPreview {
       subtitle,
       version,
       date,
-      extraStyles: PROCESS_MAP_STYLES,
+      extraStyles: CATALOGUE_STYLES + PROCESS_MAP_STYLES,
     });
   }
 }
 
 const PROCESS_MAP_STYLES = `
-  #canvas {
-    padding: 0 20px 16px;
-  }
   .group-section {
     margin-bottom: 24px;
     border: 1px solid var(--ts-divider, #cbd5e1);
@@ -404,23 +401,6 @@ const PROCESS_MAP_STYLES = `
     color: var(--ts-text-muted, #64748b);
     margin-top: 4px;
   }
-  .badge {
-    display: inline-block;
-    padding: 2px 8px;
-    border-radius: 10px;
-    font-size: 11px;
-    font-weight: 600;
-    white-space: nowrap;
-  }
-  .badge-active     { background: var(--ts-status-success-bg, #d1fae5); color: var(--ts-status-success-fg, #065f46); }
-  .badge-draft      { background: var(--ts-status-info-bg, #e0f2fe);   color: var(--ts-status-info-fg, #0c4a6e); }
-  .badge-deprecated { background: var(--ts-status-warning-bg, #fef9c3); color: var(--ts-status-warning-fg, #854d0e); }
-  .maturity-dots {
-    font-size: 14px;
-    letter-spacing: 1px;
-    color: var(--ts-brand-primary, #004d67);
-  }
-  .maturity-none { color: var(--ts-text-muted, #64748b); }
   .cap-tag {
     display: inline-block;
     padding: 2px 6px;
@@ -434,19 +414,13 @@ const PROCESS_MAP_STYLES = `
     font-size: 12px;
     color: var(--ts-brand-primary, #004d67);
   }
-  .cell-empty { color: var(--ts-text-muted, #94a3b8); }
   .col-name      { min-width: 220px; }
   .col-status, .col-maturity, .col-owner, .col-capability, .col-bpmn { white-space: nowrap; }
-  .empty-group {
+  .empty-group, .empty-map {
     text-align: center;
     color: var(--ts-text-muted, #64748b);
-    padding: 18px;
     font-style: italic;
   }
-  .empty-map {
-    text-align: center;
-    color: var(--ts-text-muted, #64748b);
-    padding: 48px;
-    font-style: italic;
-  }
+  .empty-group { padding: 18px; }
+  .empty-map   { padding: 48px; }
 `;

--- a/extension/src/products-preview.ts
+++ b/extension/src/products-preview.ts
@@ -1,7 +1,7 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
-import { buildDiagramFrame, type ThemeId } from './diagram-frame.js';
+import { buildDiagramFrame, CATALOGUE_STYLES, type ThemeId } from './diagram-frame.js';
 
 // ── Inline types (mirror packages/diagrams/src/products/types.ts) ─────────────
 
@@ -264,15 +264,12 @@ export class ProductsPreview {
       subtitle,
       version,
       date,
-      extraStyles: PRODUCTS_STYLES,
+      extraStyles: CATALOGUE_STYLES + PRODUCTS_STYLES,
     });
   }
 }
 
 const PRODUCTS_STYLES = `
-  #canvas {
-    padding: 0 20px 16px;
-  }
   .products-table {
     width: 100%;
     border-collapse: collapse;
@@ -296,15 +293,9 @@ const PRODUCTS_STYLES = `
     border-bottom: 1px solid var(--ts-divider, #cbd5e1);
     vertical-align: top;
   }
-  .products-table tr:last-child td {
-    border-bottom: none;
-  }
-  .products-table tr:hover td {
-    background: var(--ts-bg-elevated, #f1f5f9);
-  }
-  .product-name {
-    font-weight: 600;
-  }
+  .products-table tr:last-child td { border-bottom: none; }
+  .products-table tr:hover td { background: var(--ts-bg-elevated, #f1f5f9); }
+  .product-name { font-weight: 600; }
   .product-id {
     font-size: 11px;
     color: var(--ts-text-muted, #64748b);
@@ -316,44 +307,6 @@ const PRODUCTS_STYLES = `
     color: var(--ts-text-muted, #64748b);
     margin-top: 4px;
   }
-  details {
-    margin-top: 6px;
-    font-size: 12px;
-  }
-  details summary {
-    cursor: pointer;
-    color: var(--ts-brand-primary, #004d67);
-    font-weight: 500;
-    user-select: none;
-  }
-  details ul {
-    margin: 4px 0 0 16px;
-    padding: 0;
-  }
-  details li {
-    margin-bottom: 2px;
-  }
-  .badge {
-    display: inline-block;
-    padding: 2px 8px;
-    border-radius: 10px;
-    font-size: 11px;
-    font-weight: 600;
-    letter-spacing: 0.03em;
-    white-space: nowrap;
-  }
-  .badge-active {
-    background: var(--ts-status-success-bg, #d1fae5);
-    color: var(--ts-status-success-fg, #065f46);
-  }
-  .badge-draft {
-    background: var(--ts-status-info-bg, #e0f2fe);
-    color: var(--ts-status-info-fg, #0c4a6e);
-  }
-  .badge-deprecated {
-    background: var(--ts-status-warning-bg, #fef9c3);
-    color: var(--ts-status-warning-fg, #854d0e);
-  }
   .type-tag {
     display: inline-block;
     padding: 2px 8px;
@@ -362,23 +315,6 @@ const PRODUCTS_STYLES = `
     font-size: 11px;
     color: var(--ts-text-muted, #64748b);
     white-space: nowrap;
-  }
-  .maturity-dots {
-    font-size: 14px;
-    letter-spacing: 1px;
-    color: var(--ts-brand-primary, #004d67);
-  }
-  .maturity-none {
-    color: var(--ts-text-muted, #64748b);
-  }
-  .cell-empty {
-    color: var(--ts-text-muted, #94a3b8);
-  }
-  .empty-catalogue {
-    text-align: center;
-    color: var(--ts-text-muted, #64748b);
-    padding: 32px;
-    font-style: italic;
   }
   .col-name { min-width: 200px; }
   .col-type, .col-status, .col-maturity, .col-domain, .col-owner { white-space: nowrap; }

--- a/extension/src/scenarios-preview.ts
+++ b/extension/src/scenarios-preview.ts
@@ -1,7 +1,7 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
-import { buildDiagramFrame, type ThemeId } from './diagram-frame.js';
+import { buildDiagramFrame, CATALOGUE_STYLES, type ThemeId } from './diagram-frame.js';
 
 // ── Inline types (mirror packages/diagrams/src/scenarios/types.ts) ────────────
 
@@ -299,15 +299,12 @@ export class ScenariosPreview {
       subtitle,
       version,
       date,
-      extraStyles: SCENARIOS_STYLES,
+      extraStyles: CATALOGUE_STYLES + SCENARIOS_STYLES,
     });
   }
 }
 
 const SCENARIOS_STYLES = `
-  #canvas {
-    padding: 0 20px 16px;
-  }
   .scn-header-section {
     margin-bottom: 16px;
   }
@@ -408,21 +405,12 @@ const SCENARIOS_STYLES = `
     font-size: 12px;
     border: 1px solid var(--ts-divider, #cbd5e1);
   }
-  .badge {
-    display: inline-block;
-    padding: 2px 8px;
-    border-radius: 10px;
-    font-size: 11px;
-    font-weight: 600;
-    white-space: nowrap;
-  }
-  .badge-active   { background: var(--ts-status-success-bg, #d1fae5); color: var(--ts-status-success-fg, #065f46); }
-  .badge-draft    { background: var(--ts-status-info-bg, #e0f2fe);    color: var(--ts-status-info-fg, #0c4a6e); }
-  .badge-archived { background: var(--ts-bg-elevated, #f1f5f9);       color: var(--ts-text-muted, #64748b); }
+  /* Scenarios uses "archived" as muted (dormant), not warning — overrides catalogue default. */
+  .badge-archived { background: var(--ts-bg-elevated, #f1f5f9); color: var(--ts-text-muted, #64748b); }
+  /* Relevance ladder — scenarios-specific. */
   .badge-high   { background: var(--ts-status-warning-bg, #fef9c3); color: var(--ts-status-warning-fg, #854d0e); }
   .badge-medium { background: var(--ts-status-info-bg, #e0f2fe);    color: var(--ts-status-info-fg, #0c4a6e); }
   .badge-low    { background: var(--ts-bg-elevated, #f1f5f9);       color: var(--ts-text-muted, #64748b); }
-  .cell-empty { color: var(--ts-text-muted, #94a3b8); }
   .empty-scenario {
     text-align: center;
     color: var(--ts-text-muted, #64748b);

--- a/extension/src/svg-title-block.ts
+++ b/extension/src/svg-title-block.ts
@@ -1,0 +1,39 @@
+// Shared SVG title block for static diagram previews.
+//
+// Every vector preview embeds a 3-line caption at the top of its SVG:
+//   line 1 — diagram heading (e.g. "Goal tree", "FGCA", "Block diagram")
+//   line 2 — source filename
+//   line 3 — today's date
+//
+// The block is class="diagram-title-block" so the Title toggle in #toolbar
+// (see TITLE_TOGGLE_CSS in diagram-frame.ts) can hide it via CSS. Renderers
+// reserve TITLE_BLOCK_H pixels at the top of their viewBox; when the toggle
+// hides the text, the empty space stays — acceptable trade-off for an
+// interactive preview, and the right behaviour for exported SVG files
+// (the title travels with the diagram outside VS Code).
+
+export const TITLE_BLOCK_H = 60;
+
+function escXml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+/** Build the title <g> for embedding at (x, top) inside an SVG. */
+export function titleBlockSvg(
+  heading: string,
+  filename: string,
+  date: string,
+  x: number,
+  top: number,
+): string {
+  return `<g class="diagram-title-block">
+  <text class="text-header" x="${x}" y="${top + 14}">${escXml(heading)}</text>
+  <text class="text-secondary" x="${x}" y="${top + 30}">${escXml(filename)}</text>
+  <text class="text-secondary" x="${x}" y="${top + 46}">${escXml(date)}</text>
+</g>`;
+}
+
+/** Today's date in YYYY-MM-DD. Used as the third title-block line. */
+export function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}

--- a/packages/diagrams/src/theme/index.ts
+++ b/packages/diagrams/src/theme/index.ts
@@ -1,4 +1,4 @@
 export type { AdaptiveTokens } from './tokens.js';
-export { BRAND, FUNCTIONAL, LAYER_COLORS, LEVEL_COLORS, STRUCTURAL, CSS_VAR, getBaseResetCss } from './tokens.js';
+export { BRAND, FUNCTIONAL, LAYER_COLORS, LEVEL_COLORS, MATURITY_COLORS, STRUCTURAL, TYPOGRAPHY, CSS_VAR, getBaseResetCss } from './tokens.js';
 export type { ThemeId } from './themes.js';
 export { generateWebviewCss, generateSvgEmbedCss } from './themes.js';

--- a/packages/diagrams/src/theme/themes.ts
+++ b/packages/diagrams/src/theme/themes.ts
@@ -1,7 +1,9 @@
 import {
   LAYER_COLORS,
   LEVEL_COLORS,
+  MATURITY_COLORS,
   STRUCTURAL,
+  TYPOGRAPHY,
   CSS_VAR,
   getBaseResetCss,
   type AdaptiveTokens,
@@ -72,6 +74,7 @@ function diagramVars(variant: 'light' | 'dark' | 'hc'): string {
   const lc = LAYER_COLORS;
   const sc = STRUCTURAL;
   const lv = LEVEL_COLORS[variant];
+  const mat = MATURITY_COLORS[variant];
   const levelVars = lv.map((c, i) => `--ts-level-${i}:${c}`).join(';') + ';';
   return [
     `${CSS_VAR.layerFactor}:${lc.factor[variant]}`,
@@ -83,26 +86,37 @@ function diagramVars(variant: 'light' | 'dark' | 'hc'): string {
     `${CSS_VAR.textPrimary}:${sc.textPrimary[variant]}`,
     `${CSS_VAR.textSecondary}:${sc.textSecondary[variant]}`,
     `${CSS_VAR.headerText}:${sc.headerText[variant]}`,
+    `${CSS_VAR.maturity1}:${mat[0]}`,
+    `${CSS_VAR.maturity2}:${mat[1]}`,
+    `${CSS_VAR.maturity3}:${mat[2]}`,
+    `${CSS_VAR.maturity4}:${mat[3]}`,
+    `${CSS_VAR.maturity5}:${mat[4]}`,
   ].join(';') + ';' + levelVars;
 }
 
 /** CSS for the webview shell (toolbar, canvas, caption). */
 function shellCss(): string {
   const cv = CSS_VAR;
+  const t = TYPOGRAPHY;
   return `html,body{background:var(${cv.bg});color:var(${cv.text});}
-#toolbar{position:sticky;top:0;z-index:10;padding:6px 12px;border-bottom:1px solid var(${cv.border});font-family:var(--vscode-font-family,system-ui,sans-serif);font-size:12px;color:var(${cv.textMuted});background:var(${cv.bg});}
+#toolbar{position:sticky;top:0;z-index:10;padding:6px 12px;border-bottom:1px solid var(${cv.border});font-family:${t.fontFamily};font-size:${t.sizes.secondary}px;color:var(${cv.textMuted});background:var(${cv.bg});}
 #canvas{padding:16px;overflow:auto;}
 svg{display:block;}
-.diagram-caption{margin-top:8px;font-family:var(--vscode-font-family,system-ui,sans-serif);font-size:11px;color:var(${cv.textMuted});text-align:center;}`;
+.diagram-caption{margin-top:8px;font-family:${t.fontFamily};font-size:${t.sizes.caption}px;font-weight:${t.weights.caption};color:var(${cv.textMuted});text-align:center;}`;
 }
 
 /** CSS for SVG diagram classes — all consume --ts-* variables. */
 function diagramClassCss(): string {
   const cv = CSS_VAR;
+  const t = TYPOGRAPHY;
   const levelCount = LEVEL_COLORS.light.length;
   const levelRules = Array.from({ length: levelCount }, (_, i) =>
     `.level-${i}{fill:var(--ts-level-${i});}`
   ).join('');
+  // Typography: every <text> in a preview SVG resolves font-family, size and
+  // weight from these classes instead of inline attributes. That is the
+  // contract every notation preview honours so the catalogue reads as one
+  // visual family.
   return `.diagram-node{stroke:var(${cv.nodeStroke});stroke-width:1;}
 .layer-factor{fill:var(${cv.layerFactor});}
 .layer-goal{fill:var(${cv.layerGoal});}
@@ -111,9 +125,16 @@ function diagramClassCss(): string {
 ${levelRules}
 .diagram-edge{stroke:var(${cv.edgeStroke});stroke-width:1.5;fill:none;}
 .arrow-fill{fill:var(${cv.edgeStroke});}
-.text-primary{fill:var(${cv.textPrimary});}
-.text-secondary{fill:var(${cv.textSecondary});}
-.text-header{fill:var(${cv.headerText});font-weight:700;}`;
+.text-header{fill:var(${cv.headerText});font-family:${t.fontFamily};font-size:${t.sizes.header}px;font-weight:${t.weights.header};}
+.text-primary{fill:var(${cv.textPrimary});font-family:${t.fontFamily};font-size:${t.sizes.primary}px;font-weight:${t.weights.primary};}
+.text-secondary{fill:var(${cv.textSecondary});font-family:${t.fontFamily};font-size:${t.sizes.secondary}px;font-weight:${t.weights.secondary};}
+.text-id{fill:var(${cv.textSecondary});font-family:${t.fontFamily};font-size:${t.sizes.id}px;font-weight:${t.weights.id};}
+.text-pill{fill:var(${cv.textPrimary});font-family:${t.fontFamily};font-size:${t.sizes.pill}px;font-weight:${t.weights.pill};}
+.maturity-1{fill:var(${cv.maturity1});}
+.maturity-2{fill:var(${cv.maturity2});}
+.maturity-3{fill:var(${cv.maturity3});}
+.maturity-4{fill:var(${cv.maturity4});}
+.maturity-5{fill:var(${cv.maturity5});}`;
 }
 
 /**

--- a/packages/diagrams/src/theme/themes.ts
+++ b/packages/diagrams/src/theme/themes.ts
@@ -98,12 +98,13 @@ function diagramVars(variant: 'light' | 'dark' | 'hc'): string {
 function shellCss(): string {
   const cv = CSS_VAR;
   const t = TYPOGRAPHY;
-  // min-height:100vh stretches the body to fill the webview iframe even when
-  // the diagram is shorter than the editor pane — otherwise the body ends
-  // where its content ends and the iframe's underlying VS Code editor
-  // background shows through as a dark split below the canvas.
-  return `html,body{background:var(${cv.bg});color:var(${cv.text});}
-body{min-height:100vh;}
+  // html bg + min-height are set per-theme in generateWebviewCss (literal
+  // hex / VS Code var) so they don't depend on `--ts-bg` resolving on html —
+  // CSS custom properties only cascade DOWN, and `--ts-bg` is defined on the
+  // body[data-theme] selector, so html itself can't read it. Without that
+  // explicit html bg, the iframe's underlying VS Code editor background
+  // showed through any uncovered area below short diagrams.
+  return `body{background:var(${cv.bg});color:var(${cv.text});min-height:100vh;}
 #toolbar{position:sticky;top:0;z-index:10;padding:6px 12px;border-bottom:1px solid var(${cv.border});font-family:${t.fontFamily};font-size:${t.sizes.secondary}px;color:var(${cv.textMuted});background:var(${cv.bg});}
 #canvas{padding:16px;overflow:auto;}
 svg{display:block;}`;
@@ -167,6 +168,7 @@ export function generateWebviewCss(themeId: ThemeId): string {
 
   if (themeId === 'transitrix') {
     return `${base}
+html{background:${TRANSITRIX_LIGHT.bg};min-height:100vh;}
 body[data-theme="transitrix"]{${adaptiveVars(TRANSITRIX_LIGHT)}${diagramVars('light')}}
 ${shell}
 ${classes}`;
@@ -174,6 +176,7 @@ ${classes}`;
 
   if (themeId === 'transitrix-dark') {
     return `${base}
+html{background:${TRANSITRIX_DARK.bg};min-height:100vh;}
 body[data-theme="transitrix-dark"]{${adaptiveVars(TRANSITRIX_DARK)}${diagramVars('dark')}}
 ${shell}
 ${classes}`;
@@ -183,6 +186,7 @@ ${classes}`;
   // layer/level/structural colors follow the VS Code theme body class.
   const cv = CSS_VAR;
   return `${base}
+html{background:var(--vscode-editor-background,${TRANSITRIX_LIGHT.bg});min-height:100vh;}
 body[data-theme="vscode-adaptive"]{
   ${cv.bg}:var(--vscode-editor-background);
   ${cv.bgSurface}:var(--vscode-sideBar-background,var(--vscode-editor-background));

--- a/packages/diagrams/src/theme/themes.ts
+++ b/packages/diagrams/src/theme/themes.ts
@@ -94,15 +94,19 @@ function diagramVars(variant: 'light' | 'dark' | 'hc'): string {
   ].join(';') + ';' + levelVars;
 }
 
-/** CSS for the webview shell (toolbar, canvas, caption). */
+/** CSS for the webview shell (toolbar, canvas). */
 function shellCss(): string {
   const cv = CSS_VAR;
   const t = TYPOGRAPHY;
+  // min-height:100vh stretches the body to fill the webview iframe even when
+  // the diagram is shorter than the editor pane — otherwise the body ends
+  // where its content ends and the iframe's underlying VS Code editor
+  // background shows through as a dark split below the canvas.
   return `html,body{background:var(${cv.bg});color:var(${cv.text});}
+body{min-height:100vh;}
 #toolbar{position:sticky;top:0;z-index:10;padding:6px 12px;border-bottom:1px solid var(${cv.border});font-family:${t.fontFamily};font-size:${t.sizes.secondary}px;color:var(${cv.textMuted});background:var(${cv.bg});}
 #canvas{padding:16px;overflow:auto;}
-svg{display:block;}
-.diagram-caption{margin-top:8px;font-family:${t.fontFamily};font-size:${t.sizes.caption}px;font-weight:${t.weights.caption};color:var(${cv.textMuted});text-align:center;}`;
+svg{display:block;}`;
 }
 
 /** CSS for SVG diagram classes — all consume --ts-* variables. */

--- a/packages/diagrams/src/theme/tokens.ts
+++ b/packages/diagrams/src/theme/tokens.ts
@@ -37,6 +37,43 @@ export const STRUCTURAL = {
   headerText:    { light: '#374151', dark: '#e5e7eb', hc: '#ffffff' },
 } as const;
 
+/**
+ * Maturity scale fill colors — Likert 1..5, danger→success.
+ * Used by Capability Map and any future maturity-based notation.
+ */
+export const MATURITY_COLORS = {
+  light: ['#b91c1c', '#d97706', '#ca8a04', '#65a30d', '#15803d'],
+  dark:  ['#7f1d1d', '#92400e', '#854d0e', '#3f6212', '#14532d'],
+  hc:    ['#f87171', '#fb923c', '#facc15', '#a3e635', '#4ade80'],
+} as const;
+
+/**
+ * Typography hierarchy. All previews resolve text styling from these roles
+ * — never from inline font-* attributes on individual <text> elements.
+ *
+ * fontFamily threads through the VS Code font setting so the preview reads
+ * as part of the editor; size + weight encode the visual hierarchy.
+ */
+export const TYPOGRAPHY = {
+  fontFamily: 'var(--vscode-font-family, system-ui, -apple-system, sans-serif)',
+  sizes: {
+    header:    13,  // stage/column headers, diagram captions
+    primary:   12,  // primary node/cell labels
+    secondary: 11,  // annotations, secondary lines, meta
+    id:        10,  // compact id/code chips
+    pill:      11,  // pill labels (process-blueprint aspects, badges)
+    caption:   11,  // figcaption under the canvas
+  },
+  weights: {
+    header:    700,
+    primary:   600,
+    secondary: 400,
+    id:        600,
+    pill:      500,
+    caption:   400,
+  },
+} as const;
+
 /** Adaptive shell tokens (background, text, border, status). */
 export interface AdaptiveTokens {
   bg:               string;
@@ -84,6 +121,11 @@ export const CSS_VAR = {
   textPrimary:      '--ts-text-primary',
   textSecondary:    '--ts-text-secondary',
   headerText:       '--ts-header-text',
+  maturity1:        '--ts-maturity-1',
+  maturity2:        '--ts-maturity-2',
+  maturity3:        '--ts-maturity-3',
+  maturity4:        '--ts-maturity-4',
+  maturity5:        '--ts-maturity-5',
 } as const;
 
 export function getBaseResetCss(): string {


### PR DESCRIPTION
## Summary

Per orchestrator decision on issue #30: ship a CSS-only discrete zoom in 1.0.0. **Option 2 from my proposal, declined option 1 (script enablement) on security grounds** — the `enableScripts: false` backstop on previews stays, the 2026-05-21 pre-release "Security — clean" verdict rests on it.

## Mechanics

Five hidden radio inputs at the top of `<body>` (next to the title-toggle checkbox) drive a segmented pill group of labels in `.toolbar-actions`. Same proven pattern as TX-R009 title toggle and the Network/Gantt switcher.

- Steps: **50 / 75 / 100 (default) / 150 / 200 %**
- Sibling combinator `:checked ~ #canvas svg` sets `zoom: …` on every SVG plus the blocks multi-SVG wrapper
- `zoom` (not `transform: scale`) so the layout box grows — #canvas's scrollbars span the scaled diagram and a 200% view can be panned. `zoom` is non-standard but native in Chromium webviews and on the CSS Sizing L4 standardisation path

## Visual

```
[Goals tree: strategy-2026.goals.transitrix.yaml]                [☑ Title] [50%|75%|100%|150%|200%] [Save .svg]
```

Active step gets a highlighted background via the same `:checked ~ #toolbar .zoom-label[for=…]` selector pattern.

## Gating

`showZoom = canvasContent && saveSvgCommand` — identical to the Save .svg button. The six vector previews (goals, fgca, fga, activities, blocks, process-blueprint) opt in; HTML catalogues (applications, products, process-map, scenarios, capability-map) don't, per the orchestrator's scope call.

## Test plan

- [x] `npm run compile:extension` — clean
- [x] `npm test` — 341 pass
- [x] `npm run extension:prep` — bundle 286.3 kb (+2.5 kb)
- [ ] Hand-test: click 50/75/150/200% on each of the six vector previews, confirm the diagram scales while toolbar/title chrome stays at native size
- [ ] Confirm at 200%: scrollbars expand and the diagram can be panned end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)