### PR TITLE
Activities network: centre node name vertically

### DIFF
--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -74,7 +74,7 @@ function networkSvg(doc: ActivityDoc, heading?: string, filename?: string, date?
     return [
       `<rect class="${cls}" x="${x}" y="${y}" width="${N_NODE_W}" height="${N_NODE_H}" rx="6"/>`,
       `<text class="text-id" x="${x + 8}" y="${y + 18}">${idLabel}</text>`,
-      `<text class="text-primary" x="${x + N_NODE_W / 2}" y="${y + N_NODE_H / 2 + 4}" text-anchor="middle" dominant-baseline="central">${nameLabel}</text>`,
+      `<text class="text-primary" x="${x + N_NODE_W / 2}" y="${y + N_NODE_H / 2}" text-anchor="middle" dominant-baseline="central">${nameLabel}</text>`,
       `<text class="text-secondary" x="${x + N_NODE_W - 8}" y="${y + N_NODE_H - 10}" text-anchor="end">${durLabel}</text>`,
     ].join('\n');
   }).join('\n');


### PR DESCRIPTION
**Re-opened after stack rebase — predecessor #19 (now #33) was auto-closed by branch deletion.**

## Summary

Hand-test: activity name in each network node sat visibly low — closer to the duration row at the bottom than to the id chip at the top.

Cause: text placed at `y = node.y + N_NODE_H / 2 + 4` with `dominant-baseline="central"`. The `+4` offset pushed the text centre 4 px below the rectangle's geometric centre (legacy empirical correction from the inline-font-attributes era, no longer needed after TX-R008 typography came in via CSS classes).

Drops the `+4` so the text centre lands on the rectangle centre. One-liner.