### PR TITLE
Previews: Save .svg toolbar button on every vector notation (1.0.0 export)

### DIFF
--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -493,7 +493,7 @@ export class ActivitiesPreview {
         'activitiesPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true },
+        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveActivitiesAsSvg'] },
       );
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
     }
@@ -554,6 +554,7 @@ export class ActivitiesPreview {
       warnings,
       themeId,
       extraStyles: ACTIVITIES_STYLES,
+      saveSvgCommand: 'transitrixStudio.saveActivitiesAsSvg',
     });
   }
 

--- a/extension/src/blocks-preview.ts
+++ b/extension/src/blocks-preview.ts
@@ -87,7 +87,7 @@ export class BlocksPreview {
       'blocksPreview',
       `Blocks: ${path.basename(doc.fileName)}`,
       vscode.ViewColumn.Beside,
-      { enableScripts: false, retainContextWhenHidden: true },
+      { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveBlocksAsSvg'] },
     );
     this.currentUri = doc.uri.toString();
     this.panel.onDidDispose(() => {
@@ -140,6 +140,7 @@ export class BlocksPreview {
           notation: 'blocks',
           svgContent,
           extraStyles: BLOCKS_STYLES,
+          saveSvgCommand: 'transitrixStudio.saveBlocksAsSvg',
         });
       }
     } catch (err: unknown) {

--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -51,6 +51,14 @@ export interface DiagramFrameOpts {
   version?: string;
   /** Date string for the metadata strip (e.g. "2026-05-13"). */
   date?: string;
+  /**
+   * Command ID for the "Save as SVG" toolbar button (e.g.
+   * "transitrixStudio.saveGoalsAsSvg"). When provided, the toolbar shows a
+   * "Save .svg" pill next to the Title toggle, wired as a `command:` URI.
+   * The preview's webview must opt into command URIs via `enableCommandUris`.
+   * Omit on previews that don't render a vector diagram (HTML catalogues).
+   */
+  saveSvgCommand?: string;
 }
 
 function escXml(s: string): string {
@@ -118,7 +126,9 @@ const TITLE_TOGGLE_CSS = `
 .title-toggle-cb { position: absolute; left: -9999px; width: 1px; height: 1px; opacity: 0; }
 #toolbar { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
 .toolbar-label { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.title-toggle {
+.toolbar-actions { display: flex; gap: 4px; align-items: center; flex-shrink: 0; }
+.title-toggle,
+.toolbar-btn {
   cursor: pointer;
   user-select: none;
   font-size: 11px;
@@ -126,7 +136,9 @@ const TITLE_TOGGLE_CSS = `
   border-radius: 4px;
   color: var(--ts-text-muted, #64748b);
   white-space: nowrap;
+  text-decoration: none;
 }
+.toolbar-btn:hover { color: var(--ts-text, #0f172a); background: var(--ts-bg-elevated, #f1f5f9); }
 .title-toggle::before { content: "\\2611\\00a0"; font-size: 12px; }
 .title-toggle:hover { color: var(--ts-text, #0f172a); background: var(--ts-bg-elevated, #f1f5f9); }
 .title-toggle-cb:focus-visible ~ #toolbar .title-toggle { outline: 1px dashed var(--ts-text-muted, #64748b); outline-offset: 2px; }
@@ -186,6 +198,7 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
     errorMsg = '', warnings = [],
     themeId = 'transitrix', extraStyles = '', fixPrompt = '',
     title, subtitle, version, date,
+    saveSvgCommand,
   } = opts;
 
   const canvasContent = bodyContent ?? svgContent;
@@ -224,11 +237,21 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
   // hide. Skip the widget on error-only renders so users don't see a button
   // that does nothing.
   const showToggle = Boolean(title) || Boolean(canvasContent);
+  // Save .svg button — only render when both (a) a vector diagram is on screen
+  // and (b) the preview supplied a command id (HTML catalogues never do).
+  const showSaveSvg = Boolean(canvasContent) && Boolean(saveSvgCommand);
   const toggleInput = showToggle
     ? `<input type="checkbox" id="ts-title-toggle" class="title-toggle-cb" checked>`
     : '';
-  const toolbarRight = showToggle
-    ? `<label for="ts-title-toggle" class="title-toggle" title="Show or hide the diagram title">Title</label>`
+  const actionParts: string[] = [];
+  if (showToggle) {
+    actionParts.push(`<label for="ts-title-toggle" class="title-toggle" title="Show or hide the diagram title">Title</label>`);
+  }
+  if (showSaveSvg) {
+    actionParts.push(`<a href="command:${escXml(saveSvgCommand!)}" class="toolbar-btn" title="Save the current diagram as an .svg file">Save .svg</a>`);
+  }
+  const toolbarRight = actionParts.length > 0
+    ? `<div class="toolbar-actions">${actionParts.join('')}</div>`
     : '';
 
   return `<!DOCTYPE html>

--- a/extension/src/fgca-preview.ts
+++ b/extension/src/fgca-preview.ts
@@ -365,7 +365,7 @@ export class FGCAPreview {
         'fgcaPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true },
+        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveFGCAAsSvg'] },
       );
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
     }
@@ -406,7 +406,7 @@ export class FGCAPreview {
       .getConfiguration('transitrix')
       .get<ThemeId>('theme', 'transitrix');
 
-    return buildDiagramFrame({ filename, notation: 'FGCA', svgContent, errorMsg, warnings, themeId });
+    return buildDiagramFrame({ filename, notation: 'FGCA', svgContent, errorMsg, warnings, themeId, saveSvgCommand: 'transitrixStudio.saveFGCAAsSvg' });
   }
 
   async saveAsSvg(): Promise<void> {
@@ -452,7 +452,7 @@ export class FGAPreview {
         'fgaPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true },
+        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveFGAAsSvg'] },
       );
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
     }
@@ -494,7 +494,7 @@ export class FGAPreview {
       .getConfiguration('transitrix')
       .get<ThemeId>('theme', 'transitrix');
 
-    return buildDiagramFrame({ filename, notation: 'FGA', svgContent, errorMsg, warnings, themeId });
+    return buildDiagramFrame({ filename, notation: 'FGA', svgContent, errorMsg, warnings, themeId, saveSvgCommand: 'transitrixStudio.saveFGAAsSvg' });
   }
 
   async saveAsSvg(): Promise<void> {

--- a/extension/src/goals-preview.ts
+++ b/extension/src/goals-preview.ts
@@ -227,7 +227,7 @@ export class GoalsPreview {
         'goalsPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true },
+        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveGoalsAsSvg'] },
       );
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
     }
@@ -270,7 +270,7 @@ export class GoalsPreview {
       .getConfiguration('transitrix')
       .get<ThemeId>('theme', 'transitrix');
 
-    return buildDiagramFrame({ filename, notation: 'Goal tree', svgContent, errorMsg, warnings, themeId });
+    return buildDiagramFrame({ filename, notation: 'Goal tree', svgContent, errorMsg, warnings, themeId, saveSvgCommand: 'transitrixStudio.saveGoalsAsSvg' });
   }
 
   async saveAsSvg(): Promise<void> {

--- a/extension/src/process-blueprint-preview.ts
+++ b/extension/src/process-blueprint-preview.ts
@@ -119,7 +119,7 @@ export class ProcessBlueprintPreview {
         'processBlueprintPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true },
+        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveProcessBlueprintAsSvg'] },
       );
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
     }
@@ -162,7 +162,7 @@ export class ProcessBlueprintPreview {
       .getConfiguration('transitrix')
       .get<ThemeId>('theme', 'transitrix');
 
-    return buildDiagramFrame({ filename, notation: 'Process Blueprint', svgContent, errorMsg, warnings, themeId });
+    return buildDiagramFrame({ filename, notation: 'Process Blueprint', svgContent, errorMsg, warnings, themeId, saveSvgCommand: 'transitrixStudio.saveProcessBlueprintAsSvg' });
   }
 
   async saveAsSvg(): Promise<void> {


### PR DESCRIPTION
**Re-opened after stack rebase — predecessor #20 (now #34) was auto-closed by branch deletion.**

## Summary

Per orchestrator decision on the three-buttons hand-test request: ship **Save .svg** for 1.0.0, defer PNG (Copy + Save) to 1.1.0 in `@transitrix/diagrams` shared lib.

Each vector preview's toolbar shows a "Save .svg" pill next to the Title toggle. Click triggers the existing per-notation save command via `command:` URI — no script enablement.

- `DiagramFrameOpts.saveSvgCommand?: string`; provided → toolbar shows the button. Omitted (HTML catalogues) → no button.
- `#toolbar` right edge hosts a `.toolbar-actions` flex container grouping the Title toggle and the Save button.
- Button gates on `canvasContent && saveSvgCommand` — nothing visible in error-only renders.
- Each SVG preview's `createWebviewPanel` options gain `enableCommandUris: ['transitrixStudio.saveXxxAsSvg']` (least-privilege).

6 notations gain the button: goals, fgca, fga, activities, blocks, process-blueprint.