### PR TITLE
Previews: stretch body to viewport + drop redundant figcaption

### DIFF
--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -144,7 +144,6 @@ const TITLE_TOGGLE_CSS = `
 .title-toggle-cb:focus-visible ~ #toolbar .title-toggle { outline: 1px dashed var(--ts-text-muted, #64748b); outline-offset: 2px; }
 .title-toggle-cb:not(:checked) ~ #toolbar .title-toggle::before { content: "\\2610\\00a0"; }
 .title-toggle-cb:not(:checked) ~ .frame-header { display: none; }
-.title-toggle-cb:not(:checked) ~ #canvas .diagram-caption { display: none; }
 .title-toggle-cb:not(:checked) ~ #canvas .diagram-title-block { display: none; }
 
 /* HTML-rendered title block — used when a preview can't embed in SVG
@@ -229,9 +228,9 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
 </div>`
     : '';
 
-  const caption = canvasContent && !title
-    ? `<div class="diagram-caption">${escXml(notation)} — ${escXml(filename)}</div>`
-    : '';
+  // Bottom .diagram-caption is gone — every vector preview now embeds its own
+  // 3-line title block inside the SVG (PR #17/#18) and HTML catalogues use
+  // .frame-header. The figcaption was redundant with the title block above.
 
   // The toggle only makes sense when there's actually a title-ish element to
   // hide. Skip the widget on error-only renders so users don't see a button
@@ -274,7 +273,6 @@ ${extraStyles}
   ${headerBlock}
   <div id="canvas">
     ${canvasContent}
-    ${caption}
   </div>
 </body>
 </html>`;

--- a/packages/diagrams/src/theme/themes.ts
+++ b/packages/diagrams/src/theme/themes.ts
@@ -94,15 +94,19 @@ function diagramVars(variant: 'light' | 'dark' | 'hc'): string {
   ].join(';') + ';' + levelVars;
 }
 
-/** CSS for the webview shell (toolbar, canvas, caption). */
+/** CSS for the webview shell (toolbar, canvas). */
 function shellCss(): string {
   const cv = CSS_VAR;
   const t = TYPOGRAPHY;
+  // min-height:100vh stretches the body to fill the webview iframe even when
+  // the diagram is shorter than the editor pane — otherwise the body ends
+  // where its content ends and the iframe's underlying VS Code editor
+  // background shows through as a dark split below the canvas.
   return `html,body{background:var(${cv.bg});color:var(${cv.text});}
+body{min-height:100vh;}
 #toolbar{position:sticky;top:0;z-index:10;padding:6px 12px;border-bottom:1px solid var(${cv.border});font-family:${t.fontFamily};font-size:${t.sizes.secondary}px;color:var(${cv.textMuted});background:var(${cv.bg});}
 #canvas{padding:16px;overflow:auto;}
-svg{display:block;}
-.diagram-caption{margin-top:8px;font-family:${t.fontFamily};font-size:${t.sizes.caption}px;font-weight:${t.weights.caption};color:var(${cv.textMuted});text-align:center;}`;
+svg{display:block;}`;
 }
 
 /** CSS for SVG diagram classes — all consume --ts-* variables. */


### PR DESCRIPTION
**Re-opened after stack rebase — predecessor #16 (now #36) was auto-closed by branch deletion.**

## Summary

Two hand-test issues:

### 1. Viewport split into two

Webview body was sized to its content. With a short diagram, body ended mid-screen and the iframe's underlying VS Code editor background bled through as a dark strip below — looked like a split viewport. Fix: `body { min-height: 100vh; }` in `shellCss` so body always fills the iframe.

### 2. Redundant centred figcaption

The bottom `.diagram-caption` ("Activities (PSND + Gantt) — filename") duplicated the new in-SVG 3-line title block from PR #31/#32. Removes:
- `caption` rendering in `buildDiagramFrame`
- `.diagram-caption` CSS in `shellCss`
- Dead `.title-toggle-cb:not(:checked) ~ #canvas .diagram-caption` selector in `TITLE_TOGGLE_CSS`

HTML catalogues with YAML title still get `.frame-header` — unchanged. The figcaption-as-fallback path was only exercised by SVG previews, and those now embed their own title block.