### PR TITLE
Previews: horizontal stubs at edge endpoints so arrows stay perpendicular

### DIFF
--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -55,6 +55,11 @@ function networkSvg(doc: ActivityDoc, heading?: string, filename?: string, date?
   const orderedEdges = [...layout.edges].sort(
     (a, b) => Number(Boolean(a.isCritical)) - Number(Boolean(b.isCritical)),
   );
+  // Edge path = short horizontal stub out of source → smooth cubic to a stub
+  // before the target → short horizontal stub into the target. The arrow
+  // marker lands on the trailing horizontal segment, so it always reads as
+  // perpendicular to the node's vertical edge — no tilted arrowheads.
+  const EDGE_STUB = 8;
   const edgeSvg = orderedEdges.map(e => {
     const s = nodeMap.get(e.sourceId);
     const t = nodeMap.get(e.targetId);
@@ -63,9 +68,19 @@ function networkSvg(doc: ActivityDoc, heading?: string, filename?: string, date?
     const sy = s.y + oy + s.height / 2;
     const tx = t.x + ox;
     const ty = t.y + oy + t.height / 2;
-    const mx = (sx + tx) / 2;
     const cls = e.isCritical ? 'diagram-edge critical-edge' : 'diagram-edge';
-    return `<path d="M${sx},${sy} C${mx},${sy} ${mx},${ty} ${tx},${ty}" class="${cls}" marker-end="url(#${e.isCritical ? 'arrow-crit' : 'arrow'})"/>`;
+    const marker = `url(#${e.isCritical ? 'arrow-crit' : 'arrow'})`;
+    let d: string;
+    if (tx - sx > 2 * EDGE_STUB) {
+      const exitX = sx + EDGE_STUB;
+      const enterX = tx - EDGE_STUB;
+      const mx = (exitX + enterX) / 2;
+      d = `M${sx},${sy} L${exitX},${sy} C${mx},${sy} ${mx},${ty} ${enterX},${ty} L${tx},${ty}`;
+    } else {
+      const mx = (sx + tx) / 2;
+      d = `M${sx},${sy} C${mx},${sy} ${mx},${ty} ${tx},${ty}`;
+    }
+    return `<path d="${d}" class="${cls}" marker-end="${marker}"/>`;
   }).join('\n');
 
   const nodeSvg = layout.nodes.map(n => {

--- a/extension/src/fgca-preview.ts
+++ b/extension/src/fgca-preview.ts
@@ -295,9 +295,22 @@ function buildSvg(doc: FGCADoc, hideChanges = false, heading?: string, filename?
     ].join('\n');
   }).join('\n');
 
+  // Horizontal stubs at both ends pin the arrow marker on a strictly
+  // horizontal segment so the arrowhead reads as perpendicular to the
+  // node's vertical edge, regardless of the cubic curve's slope.
+  const EDGE_STUB = 8;
   const edgeSvg = edges.map(e => {
-    const mx = (e.sx + e.tx) / 2;
-    return `<path d="M${e.sx},${e.sy} C${mx},${e.sy} ${mx},${e.ty} ${e.tx},${e.ty}" class="diagram-edge" marker-end="url(#arrow)"/>`;
+    let d: string;
+    if (e.tx - e.sx > 2 * EDGE_STUB) {
+      const exitX = e.sx + EDGE_STUB;
+      const enterX = e.tx - EDGE_STUB;
+      const mx = (exitX + enterX) / 2;
+      d = `M${e.sx},${e.sy} L${exitX},${e.sy} C${mx},${e.sy} ${mx},${e.ty} ${enterX},${e.ty} L${e.tx},${e.ty}`;
+    } else {
+      const mx = (e.sx + e.tx) / 2;
+      d = `M${e.sx},${e.sy} C${mx},${e.sy} ${mx},${e.ty} ${e.tx},${e.ty}`;
+    }
+    return `<path d="${d}" class="diagram-edge" marker-end="url(#arrow)"/>`;
   }).join('\n');
 
   const nodeSvg = nodes.map(n => {

--- a/extension/src/goals-preview.ts
+++ b/extension/src/goals-preview.ts
@@ -164,6 +164,10 @@ function layoutToSvg(layout: GoalTreeLayout, treeName: string, filename?: string
 
   const nodeMap = new Map(layout.nodes.map(n => [n.id, n]));
 
+  // Horizontal stubs at both ends keep the arrow marker on a strictly
+  // horizontal segment, so it reads as perpendicular to the node's
+  // vertical edge regardless of the curve's overall shape.
+  const EDGE_STUB = 8;
   function edgePath(e: LaidOutEdge): string {
     const s = nodeMap.get(e.source);
     const t = nodeMap.get(e.target);
@@ -172,6 +176,12 @@ function layoutToSvg(layout: GoalTreeLayout, treeName: string, filename?: string
     const sy = s.y + oy + s.height / 2;
     const tx = t.x + ox;
     const ty = t.y + oy + t.height / 2;
+    if (tx - sx > 2 * EDGE_STUB) {
+      const exitX = sx + EDGE_STUB;
+      const enterX = tx - EDGE_STUB;
+      const mx = (exitX + enterX) / 2;
+      return `M${sx},${sy} L${exitX},${sy} C${mx},${sy} ${mx},${ty} ${enterX},${ty} L${tx},${ty}`;
+    }
     const mx = (sx + tx) / 2;
     return `M${sx},${sy} C${mx},${sy} ${mx},${ty} ${tx},${ty}`;
   }


### PR DESCRIPTION
**Re-opened after stack rebase — predecessor #15 (now #40) was auto-closed by branch deletion.**

## Summary

Adds 8 px horizontal stubs at both ends of each bezier edge in Network / Goals / FGCA / FGA so the arrow marker is anchored on a strictly horizontal segment (perpendicular to the node's vertical edge).

```
M sx,sy  L sx+8,sy  C ... ... ...  L tx-8,ty  L tx,ty
```

Falls back to plain bezier when target sits within 16 px of source (stub windows would collide).

**Note:** PR #28 later refines this by dropping the visible stubs and using a handle-scaled bezier instead. Both PRs land sequentially — net result on main is the refined version.