### PR TITLE
Previews: render edges over nodes so arrow tips aren't clipped

### DIFF
--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -111,8 +111,8 @@ function networkSvg(doc: ActivityDoc, heading?: string, filename?: string, date?
   </marker>
 </defs>
 ${titleSvg}
-${edgeSvg}
 ${nodeSvg}
+${edgeSvg}
 </svg>`;
 }
 

--- a/extension/src/fgca-preview.ts
+++ b/extension/src/fgca-preview.ts
@@ -350,8 +350,8 @@ function buildSvg(doc: FGCADoc, hideChanges = false, heading?: string, filename?
 ${titleSvg}
 <g transform="translate(0, ${titleH})">
 ${headerSvg}
-${edgeSvg}
 ${nodeSvg}
+${edgeSvg}
 </g>
 </svg>`;
 }

--- a/extension/src/goals-preview.ts
+++ b/extension/src/goals-preview.ts
@@ -86,8 +86,8 @@ function layoutToSvg(layout: GoalTreeLayout, treeName: string, filename?: string
   </marker>
 </defs>
 ${titleSvg}
-${edgeSvg}
 ${nodeSvg}
+${edgeSvg}
 </svg>`;
 }
 


### PR DESCRIPTION
**Re-opened after stack rebase — predecessor #26 (now #42) was auto-closed by branch deletion.**

## Summary

Hand-test: arrow tips entering nodes looked blunt — the node rectangle painted over the tip because edges came first in SVG sibling order. Truncated tip also blended into the same-colour node border (`--ts-node-stroke` = `--ts-edge-stroke`), so the arrow lost its character.

**Fix:** reverse SVG sibling order in three previews — edges paint last.
- `networkSvg` (activities)
- `layoutToSvg` (goals)
- `buildSvg` (fgca, both FGCA and FGA)

Edge bodies cross node interiors only along the `ENTER_DEPTH` stub — minor visible overlap that "roots" the arrow in its target. Arrow tip + marker triangle now sit on top of the target rect with full visibility.

Gantt already renders links after rows by construction. Process Blueprint has no marker-end arrows. Blocks comes from svgbob.