### PR TITLE
Previews: arrow tips on block edge + smoother bezier (drops the visible stubs)

### DIFF
--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -55,12 +55,18 @@ function networkSvg(doc: ActivityDoc, heading?: string, filename?: string, date?
   const orderedEdges = [...layout.edges].sort(
     (a, b) => Number(Boolean(a.isCritical)) - Number(Boolean(b.isCritical)),
   );
-  // Pure cubic bezier. Tangent at both endpoints is mathematically horizontal
-  // (control points at (mx, sy) and (mx, ty) — same Y as the respective
-  // endpoint), so the marker-end arrow auto-orients horizontal and reads as
-  // perpendicular to the target's vertical edge. Marker refX = markerWidth
-  // anchors the tip at the path endpoint, so the arrow lands ON the bar's
-  // left edge rather than poking inside it.
+  // Edge path = a single cubic Bézier with horizontal control handles. Each
+  // control point shares its endpoint's Y, so the tangent is horizontal at
+  // both ends — the curve meets the vertical node edge at a true right angle
+  // and the marker-end arrow (orient="auto") reads as perpendicular. The
+  // handle length grows with both the horizontal and the vertical span so the
+  // curve stays visibly horizontal long enough for the arrowhead to sit flush:
+  // short handles leave the curve horizontal only at the exact endpoint, so a
+  // rigid arrowhead visibly mismatches the curve behind it. No straight stubs —
+  // a stub→curve joint is tangent-continuous but shows a curvature jump
+  // (0 → non-zero) the eye reads as a kink. Marker refX = markerWidth anchors
+  // the tip at the path endpoint, on the node's edge rather than inside it.
+  const EDGE_MIN_HANDLE = 32;
   const edgeSvg = orderedEdges.map(e => {
     const s = nodeMap.get(e.sourceId);
     const t = nodeMap.get(e.targetId);
@@ -69,10 +75,16 @@ function networkSvg(doc: ActivityDoc, heading?: string, filename?: string, date?
     const sy = s.y + oy + s.height / 2;
     const tx = t.x + ox;
     const ty = t.y + oy + t.height / 2;
-    const mx = (sx + tx) / 2;
+    const dx = tx - sx;
+    const dy = ty - sy;
+    // Handle length is a magnitude only — the tangent stays horizontal
+    // regardless, so perpendicular entry/exit is guaranteed. When handle >
+    // dx/2 the control points cross over: intentional, it produces the
+    // graceful "lazy S" for vertically stacked nodes.
+    const handle = Math.max(EDGE_MIN_HANDLE, Math.abs(dx) * 0.5, Math.abs(dy) * 0.4);
     const cls = e.isCritical ? 'diagram-edge critical-edge' : 'diagram-edge';
     const marker = `url(#${e.isCritical ? 'arrow-crit' : 'arrow'})`;
-    return `<path d="M${sx},${sy} C${mx},${sy} ${mx},${ty} ${tx},${ty}" class="${cls}" marker-end="${marker}"/>`;
+    return `<path d="M${sx},${sy} C${sx + handle},${sy} ${tx - handle},${ty} ${tx},${ty}" class="${cls}" marker-end="${marker}"/>`;
   }).join('\n');
 
   const nodeSvg = layout.nodes.map(n => {

--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -55,11 +55,12 @@ function networkSvg(doc: ActivityDoc, heading?: string, filename?: string, date?
   const orderedEdges = [...layout.edges].sort(
     (a, b) => Number(Boolean(a.isCritical)) - Number(Boolean(b.isCritical)),
   );
-  // Edge path = short horizontal stub out of source → smooth cubic to a stub
-  // before the target → short horizontal stub into the target. The arrow
-  // marker lands on the trailing horizontal segment, so it always reads as
-  // perpendicular to the node's vertical edge — no tilted arrowheads.
-  const EDGE_STUB = 8;
+  // Pure cubic bezier. Tangent at both endpoints is mathematically horizontal
+  // (control points at (mx, sy) and (mx, ty) — same Y as the respective
+  // endpoint), so the marker-end arrow auto-orients horizontal and reads as
+  // perpendicular to the target's vertical edge. Marker refX = markerWidth
+  // anchors the tip at the path endpoint, so the arrow lands ON the bar's
+  // left edge rather than poking inside it.
   const edgeSvg = orderedEdges.map(e => {
     const s = nodeMap.get(e.sourceId);
     const t = nodeMap.get(e.targetId);
@@ -68,19 +69,10 @@ function networkSvg(doc: ActivityDoc, heading?: string, filename?: string, date?
     const sy = s.y + oy + s.height / 2;
     const tx = t.x + ox;
     const ty = t.y + oy + t.height / 2;
+    const mx = (sx + tx) / 2;
     const cls = e.isCritical ? 'diagram-edge critical-edge' : 'diagram-edge';
     const marker = `url(#${e.isCritical ? 'arrow-crit' : 'arrow'})`;
-    let d: string;
-    if (tx - sx > 2 * EDGE_STUB) {
-      const exitX = sx + EDGE_STUB;
-      const enterX = tx - EDGE_STUB;
-      const mx = (exitX + enterX) / 2;
-      d = `M${sx},${sy} L${exitX},${sy} C${mx},${sy} ${mx},${ty} ${enterX},${ty} L${tx},${ty}`;
-    } else {
-      const mx = (sx + tx) / 2;
-      d = `M${sx},${sy} C${mx},${sy} ${mx},${ty} ${tx},${ty}`;
-    }
-    return `<path d="${d}" class="${cls}" marker-end="${marker}"/>`;
+    return `<path d="M${sx},${sy} C${mx},${sy} ${mx},${ty} ${tx},${ty}" class="${cls}" marker-end="${marker}"/>`;
   }).join('\n');
 
   const nodeSvg = layout.nodes.map(n => {
@@ -103,10 +95,10 @@ function networkSvg(doc: ActivityDoc, heading?: string, filename?: string, date?
   const titleSvg = showTitle ? titleBlockSvg(heading!, filename!, date!, N_PAD, N_PAD) : '';
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">
 <defs>
-  <marker id="arrow" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+  <marker id="arrow" markerWidth="8" markerHeight="8" refX="8" refY="3" orient="auto">
     <path d="M0,0 L0,6 L8,3 z" class="arrow-fill"/>
   </marker>
-  <marker id="arrow-crit" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+  <marker id="arrow-crit" markerWidth="8" markerHeight="8" refX="8" refY="3" orient="auto">
     <path d="M0,0 L0,6 L8,3 z" class="arrow-fill-critical"/>
   </marker>
 </defs>
@@ -281,7 +273,7 @@ function ganttSvg(layout: GanttLayout, heading?: string, filename?: string, date
   const LINK_MIN_STUB = 6;
   const STUB_OUT = 8;       // right-stub past source before turning down
   const BACK_OFFSET = 8;    // back-step distance to the LEFT of sx for the long vertical
-  const ENTER_DEPTH = 4;    // how far inside target the arrow path lands (marker tip ~1px further)
+  const ENTER_DEPTH = 0;    // path ends exactly at target.left so marker tip lands on the bar's edge, not inside it
 
   // Group links by source so all outgoing links share one trunk.
   const linksBySource = new Map<string, typeof layout.links>();
@@ -395,10 +387,10 @@ function ganttSvg(layout: GanttLayout, heading?: string, filename?: string, date
   const titleSvg = showTitle ? titleBlockSvg(heading!, filename!, date!, G_PAD, G_PAD) : '';
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">
 <defs>
-  <marker id="gantt-arrow" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto" markerUnits="userSpaceOnUse">
+  <marker id="gantt-arrow" markerWidth="6" markerHeight="6" refX="6" refY="3" orient="auto" markerUnits="userSpaceOnUse">
     <path d="M0,0 L0,6 L6,3 z" class="arrow-fill"/>
   </marker>
-  <marker id="gantt-arrow-crit" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto" markerUnits="userSpaceOnUse">
+  <marker id="gantt-arrow-crit" markerWidth="6" markerHeight="6" refX="6" refY="3" orient="auto" markerUnits="userSpaceOnUse">
     <path d="M0,0 L0,6 L6,3 z" class="arrow-fill-critical"/>
   </marker>
 </defs>
@@ -492,6 +484,16 @@ const ACTIVITIES_DIAGRAM_CSS = `
 
 /** Webview-only chrome (tab switcher, section notice). Not exported. */
 const ACTIVITIES_WEBVIEW_CSS = `
+  /* ── Fill the webview viewport ──────────────────────────────────────── */
+  /* The base shell leaves #canvas at content height with overflow:auto, so a
+     diagram shorter or narrower than the panel strands the canvas's own
+     scrollbar mid-panel with empty space below it. Make <body> a full-height
+     flex column and let #canvas grow into a single scroll region — the same
+     pattern the blocks preview already uses. */
+  html, body { height: 100%; }
+  body { display: flex; flex-direction: column; }
+  #canvas { flex: 1; min-height: 0; overflow: auto; }
+
   /* ── View switcher (CSS-only, no JS) ────────────────────────────────── */
   /* Move the radios fully off-screen rather than just hiding via opacity —
      keeps them keyboard-focusable while not taking layout space, and stops

--- a/extension/src/fgca-preview.ts
+++ b/extension/src/fgca-preview.ts
@@ -295,22 +295,13 @@ function buildSvg(doc: FGCADoc, hideChanges = false, heading?: string, filename?
     ].join('\n');
   }).join('\n');
 
-  // Horizontal stubs at both ends pin the arrow marker on a strictly
-  // horizontal segment so the arrowhead reads as perpendicular to the
-  // node's vertical edge, regardless of the cubic curve's slope.
-  const EDGE_STUB = 8;
+  // Pure cubic bezier. Tangent stays horizontal at both endpoints via the
+  // (mx, sy)/(mx, ty) control points, so the marker-end arrow reads as
+  // perpendicular to the node's vertical edge. Marker refX = markerWidth
+  // pins the tip at the path endpoint.
   const edgeSvg = edges.map(e => {
-    let d: string;
-    if (e.tx - e.sx > 2 * EDGE_STUB) {
-      const exitX = e.sx + EDGE_STUB;
-      const enterX = e.tx - EDGE_STUB;
-      const mx = (exitX + enterX) / 2;
-      d = `M${e.sx},${e.sy} L${exitX},${e.sy} C${mx},${e.sy} ${mx},${e.ty} ${enterX},${e.ty} L${e.tx},${e.ty}`;
-    } else {
-      const mx = (e.sx + e.tx) / 2;
-      d = `M${e.sx},${e.sy} C${mx},${e.sy} ${mx},${e.ty} ${e.tx},${e.ty}`;
-    }
-    return `<path d="${d}" class="diagram-edge" marker-end="url(#arrow)"/>`;
+    const mx = (e.sx + e.tx) / 2;
+    return `<path d="M${e.sx},${e.sy} C${mx},${e.sy} ${mx},${e.ty} ${e.tx},${e.ty}" class="diagram-edge" marker-end="url(#arrow)"/>`;
   }).join('\n');
 
   const nodeSvg = nodes.map(n => {
@@ -343,7 +334,7 @@ function buildSvg(doc: FGCADoc, hideChanges = false, heading?: string, filename?
   // group so the title block can sit above without rewriting every node/edge.
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${totalH}" viewBox="0 0 ${width} ${totalH}">
 <defs>
-  <marker id="arrow" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+  <marker id="arrow" markerWidth="8" markerHeight="8" refX="8" refY="3" orient="auto">
     <path d="M0,0 L0,6 L8,3 z" class="arrow-fill"/>
   </marker>
 </defs>

--- a/extension/src/goals-preview.ts
+++ b/extension/src/goals-preview.ts
@@ -39,10 +39,11 @@ function layoutToSvg(layout: GoalTreeLayout, treeName: string, filename?: string
 
   const nodeMap = new Map(layout.nodes.map(n => [n.id, n]));
 
-  // Horizontal stubs at both ends keep the arrow marker on a strictly
-  // horizontal segment, so it reads as perpendicular to the node's
-  // vertical edge regardless of the curve's overall shape.
-  const EDGE_STUB = 8;
+  // Pure cubic bezier. Control points at (mx, sy) and (mx, ty) keep the
+  // tangent horizontal at both endpoints, so the marker-end arrow reads as
+  // perpendicular to the node's vertical edge. Marker refX = markerWidth
+  // pins the tip at the path endpoint so the arrow stops at the node's
+  // left edge instead of poking inside.
   function edgePath(e: LaidOutEdge): string {
     const s = nodeMap.get(e.source);
     const t = nodeMap.get(e.target);
@@ -51,12 +52,6 @@ function layoutToSvg(layout: GoalTreeLayout, treeName: string, filename?: string
     const sy = s.y + oy + s.height / 2;
     const tx = t.x + ox;
     const ty = t.y + oy + t.height / 2;
-    if (tx - sx > 2 * EDGE_STUB) {
-      const exitX = sx + EDGE_STUB;
-      const enterX = tx - EDGE_STUB;
-      const mx = (exitX + enterX) / 2;
-      return `M${sx},${sy} L${exitX},${sy} C${mx},${sy} ${mx},${ty} ${enterX},${ty} L${tx},${ty}`;
-    }
     const mx = (sx + tx) / 2;
     return `M${sx},${sy} C${mx},${sy} ${mx},${ty} ${tx},${ty}`;
   }
@@ -81,7 +76,7 @@ function layoutToSvg(layout: GoalTreeLayout, treeName: string, filename?: string
   const titleSvg = showTitle ? titleBlockSvg(heading, filename!, date!, pad, pad) : '';
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">
 <defs>
-  <marker id="arrow" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+  <marker id="arrow" markerWidth="8" markerHeight="8" refX="8" refY="3" orient="auto">
     <path d="M0,0 L0,6 L8,3 z" class="arrow-fill"/>
   </marker>
 </defs>


### PR DESCRIPTION
**Re-opened after stack rebase — predecessor #27 (now #43) was auto-closed by branch deletion.**

## Summary

Two commits closing two hand-test issues that surfaced after #43 (edges-over-nodes):

### 1. Arrow tips poked inside rectangles

`refX=6` of `markerWidth=8` left the tip 2 marker units past the path endpoint (~3-4 px after `strokeWidth` scaling). With edges painted on top, the overhang became fully visible.

**Fix:** `refX=6 → refX=8` on every marker definition. Tip coincides with path endpoint. Gantt markers (`markerWidth=6`) bump to `refX=6`. `ENTER_DEPTH` in Gantt L-elbow + Z-trunk branches goes `4 → 0`.

### 2. Exit stubs were too visible / bezier replaced by handle-scaled curve

**Fix (commit 1):** drop both stubs from #41 and render `M sx,sy C mx,sy mx,ty tx,ty`. Tangent stays mathematically horizontal at endpoints so marker auto-orientation reads as perpendicular.

**Fix (commit 2 — bezier handles):** the midpoint formula left the curve flat only at the exact endpoint, so a rigid arrowhead mismatched a visibly curved line behind it. `handle = max(32, |dx|*0.5, |dy|*0.4)` grows with both spans so the curve stays horizontal long enough for the arrowhead to sit flush, and produces a graceful "lazy S" for vertically stacked nodes.

### 3. Activities preview was split mid-canvas

Bundled here per orchestrator's plan addendum on issue #30. Three CSS rules at the top of `ACTIVITIES_WEBVIEW_CSS`:

```css
html, body { height: 100%; }
body { display: flex; flex-direction: column; }
#canvas { flex: 1; min-height: 0; overflow: auto; }
```

Activities-only — base-shell de-duplication is filed as #35 for post-1.0.0.