### PR TITLE
Previews: longer horizontal section near bezier endpoints

### DIFF
--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -66,7 +66,7 @@ function networkSvg(doc: ActivityDoc, heading?: string, filename?: string, date?
   // a stub→curve joint is tangent-continuous but shows a curvature jump
   // (0 → non-zero) the eye reads as a kink. Marker refX = markerWidth anchors
   // the tip at the path endpoint, on the node's edge rather than inside it.
-  const EDGE_MIN_HANDLE = 32;
+  const EDGE_MIN_HANDLE = 48;
   const edgeSvg = orderedEdges.map(e => {
     const s = nodeMap.get(e.sourceId);
     const t = nodeMap.get(e.targetId);
@@ -81,7 +81,7 @@ function networkSvg(doc: ActivityDoc, heading?: string, filename?: string, date?
     // regardless, so perpendicular entry/exit is guaranteed. When handle >
     // dx/2 the control points cross over: intentional, it produces the
     // graceful "lazy S" for vertically stacked nodes.
-    const handle = Math.max(EDGE_MIN_HANDLE, Math.abs(dx) * 0.5, Math.abs(dy) * 0.4);
+    const handle = Math.max(EDGE_MIN_HANDLE, Math.abs(dx) * 0.5, Math.abs(dy) * 0.6);
     const cls = e.isCritical ? 'diagram-edge critical-edge' : 'diagram-edge';
     const marker = `url(#${e.isCritical ? 'arrow-crit' : 'arrow'})`;
     return `<path d="M${sx},${sy} C${sx + handle},${sy} ${tx - handle},${ty} ${tx},${ty}" class="${cls}" marker-end="${marker}"/>`;

--- a/extension/src/fgca-preview.ts
+++ b/extension/src/fgca-preview.ts
@@ -295,13 +295,16 @@ function buildSvg(doc: FGCADoc, hideChanges = false, heading?: string, filename?
     ].join('\n');
   }).join('\n');
 
-  // Pure cubic bezier. Tangent stays horizontal at both endpoints via the
-  // (mx, sy)/(mx, ty) control points, so the marker-end arrow reads as
-  // perpendicular to the node's vertical edge. Marker refX = markerWidth
-  // pins the tip at the path endpoint.
+  // Cubic bezier with horizontal control handles that grow with both spans —
+  // the curve stays visibly horizontal long enough at each endpoint for the
+  // marker-end arrowhead to sit flush against the line and read as
+  // perpendicular to the node's vertical edge.
+  const EDGE_MIN_HANDLE = 48;
   const edgeSvg = edges.map(e => {
-    const mx = (e.sx + e.tx) / 2;
-    return `<path d="M${e.sx},${e.sy} C${mx},${e.sy} ${mx},${e.ty} ${e.tx},${e.ty}" class="diagram-edge" marker-end="url(#arrow)"/>`;
+    const dx = e.tx - e.sx;
+    const dy = e.ty - e.sy;
+    const handle = Math.max(EDGE_MIN_HANDLE, Math.abs(dx) * 0.5, Math.abs(dy) * 0.6);
+    return `<path d="M${e.sx},${e.sy} C${e.sx + handle},${e.sy} ${e.tx - handle},${e.ty} ${e.tx},${e.ty}" class="diagram-edge" marker-end="url(#arrow)"/>`;
   }).join('\n');
 
   const nodeSvg = nodes.map(n => {

--- a/extension/src/goals-preview.ts
+++ b/extension/src/goals-preview.ts
@@ -39,11 +39,12 @@ function layoutToSvg(layout: GoalTreeLayout, treeName: string, filename?: string
 
   const nodeMap = new Map(layout.nodes.map(n => [n.id, n]));
 
-  // Pure cubic bezier. Control points at (mx, sy) and (mx, ty) keep the
-  // tangent horizontal at both endpoints, so the marker-end arrow reads as
-  // perpendicular to the node's vertical edge. Marker refX = markerWidth
-  // pins the tip at the path endpoint so the arrow stops at the node's
-  // left edge instead of poking inside.
+  // Cubic bezier with horizontal control handles. Each control point shares
+  // its endpoint's Y, so the tangent is horizontal at both ends and the
+  // marker-end arrow reads as perpendicular to the node's vertical edge.
+  // Handle length grows with both spans so the curve stays visibly
+  // horizontal long enough for the arrowhead to sit flush against the line.
+  const EDGE_MIN_HANDLE = 48;
   function edgePath(e: LaidOutEdge): string {
     const s = nodeMap.get(e.source);
     const t = nodeMap.get(e.target);
@@ -52,8 +53,10 @@ function layoutToSvg(layout: GoalTreeLayout, treeName: string, filename?: string
     const sy = s.y + oy + s.height / 2;
     const tx = t.x + ox;
     const ty = t.y + oy + t.height / 2;
-    const mx = (sx + tx) / 2;
-    return `M${sx},${sy} C${mx},${sy} ${mx},${ty} ${tx},${ty}`;
+    const dx = tx - sx;
+    const dy = ty - sy;
+    const handle = Math.max(EDGE_MIN_HANDLE, Math.abs(dx) * 0.5, Math.abs(dy) * 0.6);
+    return `M${sx},${sy} C${sx + handle},${sy} ${tx - handle},${ty} ${tx},${ty}`;
   }
 
   const edgeSvg = layout.edges.map(e =>


### PR DESCRIPTION
## Summary

Hand-test on `platform-launch.activities`: the gray edges from the off-screen source to A-004 / A-005 still curved away too quickly near the target. Arrowhead sat slightly mis-aligned with the visibly curved line behind it.

## Fix

Bumps the bezier handle formula:

- `EDGE_MIN_HANDLE`: 32 → 48
- `|dy|` multiplier: 0.4 → 0.6 (the vertically-stacked-nodes case from the screenshot)
- `|dx|` multiplier: 0.5 (unchanged)

For a `dy=160, dx=120` edge: handle was 64 → now 96 (50% longer flat section).

Same formula now in **activities-preview** (Network), **goals-preview**, **fgca-preview** (FGCA + FGA) — every bezier-routed notation reads the same. Gantt's L-elbow / Z-trunk routing untouched.

## Test plan

- [x] `npm run compile:extension` — clean
- [x] `npm test` — 341 pass
- [ ] Hand-test: open `platform-launch.activities` Network — confirm gray arrows to A-004 / A-005 enter horizontally with the arrowhead sitting flush against the line
- [ ] Confirm: horizontal edges (same-row source/target) stay near-straight (`|dx|` multiplier unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)