### PR TITLE
Previews: longer horizontal section near bezier endpoints (round 2)

### DIFF
--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -66,7 +66,7 @@ function networkSvg(doc: ActivityDoc, heading?: string, filename?: string, date?
   // a stub→curve joint is tangent-continuous but shows a curvature jump
   // (0 → non-zero) the eye reads as a kink. Marker refX = markerWidth anchors
   // the tip at the path endpoint, on the node's edge rather than inside it.
-  const EDGE_MIN_HANDLE = 48;
+  const EDGE_MIN_HANDLE = 64;
   const edgeSvg = orderedEdges.map(e => {
     const s = nodeMap.get(e.sourceId);
     const t = nodeMap.get(e.targetId);
@@ -81,7 +81,7 @@ function networkSvg(doc: ActivityDoc, heading?: string, filename?: string, date?
     // regardless, so perpendicular entry/exit is guaranteed. When handle >
     // dx/2 the control points cross over: intentional, it produces the
     // graceful "lazy S" for vertically stacked nodes.
-    const handle = Math.max(EDGE_MIN_HANDLE, Math.abs(dx) * 0.5, Math.abs(dy) * 0.6);
+    const handle = Math.max(EDGE_MIN_HANDLE, Math.abs(dx) * 0.5, Math.abs(dy) * 0.8);
     const cls = e.isCritical ? 'diagram-edge critical-edge' : 'diagram-edge';
     const marker = `url(#${e.isCritical ? 'arrow-crit' : 'arrow'})`;
     return `<path d="M${sx},${sy} C${sx + handle},${sy} ${tx - handle},${ty} ${tx},${ty}" class="${cls}" marker-end="${marker}"/>`;

--- a/extension/src/fgca-preview.ts
+++ b/extension/src/fgca-preview.ts
@@ -299,11 +299,11 @@ function buildSvg(doc: FGCADoc, hideChanges = false, heading?: string, filename?
   // the curve stays visibly horizontal long enough at each endpoint for the
   // marker-end arrowhead to sit flush against the line and read as
   // perpendicular to the node's vertical edge.
-  const EDGE_MIN_HANDLE = 48;
+  const EDGE_MIN_HANDLE = 64;
   const edgeSvg = edges.map(e => {
     const dx = e.tx - e.sx;
     const dy = e.ty - e.sy;
-    const handle = Math.max(EDGE_MIN_HANDLE, Math.abs(dx) * 0.5, Math.abs(dy) * 0.6);
+    const handle = Math.max(EDGE_MIN_HANDLE, Math.abs(dx) * 0.5, Math.abs(dy) * 0.8);
     return `<path d="M${e.sx},${e.sy} C${e.sx + handle},${e.sy} ${e.tx - handle},${e.ty} ${e.tx},${e.ty}" class="diagram-edge" marker-end="url(#arrow)"/>`;
   }).join('\n');
 

--- a/extension/src/goals-preview.ts
+++ b/extension/src/goals-preview.ts
@@ -44,7 +44,7 @@ function layoutToSvg(layout: GoalTreeLayout, treeName: string, filename?: string
   // marker-end arrow reads as perpendicular to the node's vertical edge.
   // Handle length grows with both spans so the curve stays visibly
   // horizontal long enough for the arrowhead to sit flush against the line.
-  const EDGE_MIN_HANDLE = 48;
+  const EDGE_MIN_HANDLE = 64;
   function edgePath(e: LaidOutEdge): string {
     const s = nodeMap.get(e.source);
     const t = nodeMap.get(e.target);
@@ -55,7 +55,7 @@ function layoutToSvg(layout: GoalTreeLayout, treeName: string, filename?: string
     const ty = t.y + oy + t.height / 2;
     const dx = tx - sx;
     const dy = ty - sy;
-    const handle = Math.max(EDGE_MIN_HANDLE, Math.abs(dx) * 0.5, Math.abs(dy) * 0.6);
+    const handle = Math.max(EDGE_MIN_HANDLE, Math.abs(dx) * 0.5, Math.abs(dy) * 0.8);
     return `M${sx},${sy} C${sx + handle},${sy} ${tx - handle},${ty} ${tx},${ty}`;
   }
 


### PR DESCRIPTION
Hand-test still wanted more — additional bump on top of #46:

- `EDGE_MIN_HANDLE`: 48 → 64
- `|dy|` multiplier: 0.6 → 0.8
- `|dx|` multiplier: 0.5 (unchanged)

For `dy=160` case: handle was 96 → now 128. Arrowhead sits flush against a clearly horizontal tail.

Same change in activities-preview (Network), goals-preview, fgca-preview (FGCA + FGA).