### PR TITLE
Previews: widen gap between frame-header and catalogue body

### DIFF
--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -101,7 +101,7 @@ const FIX_PROMPT_CSS = `
 `;
 
 const FRAME_HEADER_CSS = `
-.frame-header{padding:16px 20px 0;}
+.frame-header{padding:16px 20px 20px;}
 .frame-title{font-size:18px;font-weight:700;color:var(--ts-text,#0f172a);margin-bottom:4px;}
 .frame-subtitle{font-size:13px;color:var(--ts-text-muted,#64748b);margin-bottom:4px;}
 .frame-meta{font-size:11px;color:var(--ts-text-muted,#64748b);letter-spacing:0.04em;}


### PR DESCRIPTION
Hand-test on northbay-retail.process-map: the title block (`.frame-header` with title/subtitle/meta) sat right against the table.

`.frame-header` had `padding: 16px 20px 0` (no bottom). `CATALOGUE_STYLES` overrides `#canvas` to `padding: 0 20px 16px` (no top). The actual gap between the meta line and the table's first row was **0 px**.

Bumps `.frame-header` bottom padding to **20 px**. Affects the five HTML catalogue previews (applications, products, process-map, scenarios, capability-map). SVG notations embed their title inside the SVG and don't touch this rule.