### PR TITLE
Previews: show document version in vector title block (per #30 addendum)

### DIFF
--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -34,7 +34,7 @@ const N_NODE_W = 200;
 const N_NODE_H = 80;
 const N_PAD = 24;
 
-function networkSvg(doc: ActivityDoc, heading?: string, filename?: string, date?: string): string {
+function networkSvg(doc: ActivityDoc, heading?: string, filename?: string, date?: string, version?: string): string {
   const layout: ActivitiesLayout = layoutActivities(doc);
   if (layout.nodes.length === 0) {
     return '<svg xmlns="http://www.w3.org/2000/svg" width="200" height="60"><text class="text-primary" x="10" y="40">No activities</text></svg>';
@@ -104,7 +104,7 @@ function networkSvg(doc: ActivityDoc, heading?: string, filename?: string, date?
     ].join('\n');
   }).join('\n');
 
-  const titleSvg = showTitle ? titleBlockSvg(heading!, filename!, date!, N_PAD, N_PAD) : '';
+  const titleSvg = showTitle ? titleBlockSvg(heading!, filename!, date!, N_PAD, N_PAD, version) : '';
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">
 <defs>
   <marker id="arrow" markerWidth="8" markerHeight="8" refX="8" refY="3" orient="auto">
@@ -139,7 +139,7 @@ function daysBetween(startISO: string, endISO: string): number {
   return Math.round(ms / 86_400_000);
 }
 
-function ganttSvg(layout: GanttLayout, heading?: string, filename?: string, date?: string): string {
+function ganttSvg(layout: GanttLayout, heading?: string, filename?: string, date?: string, version?: string): string {
   // Sort bars by start date then id for stable display order.
   const bars = [...layout.bars].sort((a, b) => {
     if (a.startDate !== b.startDate) return a.startDate < b.startDate ? -1 : 1;
@@ -396,7 +396,7 @@ function ganttSvg(layout: GanttLayout, heading?: string, filename?: string, date
     }
   }
 
-  const titleSvg = showTitle ? titleBlockSvg(heading!, filename!, date!, G_PAD, G_PAD) : '';
+  const titleSvg = showTitle ? titleBlockSvg(heading!, filename!, date!, G_PAD, G_PAD, version) : '';
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">
 <defs>
   <marker id="gantt-arrow" markerWidth="6" markerHeight="6" refX="6" refY="3" orient="auto" markerUnits="userSpaceOnUse">
@@ -426,10 +426,14 @@ interface ActivityViews {
   ganttSvg: string;
 }
 
-function buildActivityViews(doc: ActivityDoc, filename: string, date: string): ActivityViews {
+function buildActivityViews(doc: ActivityDoc, filename: string, date: string, version?: string): ActivityViews {
   const networkHeading = 'Network view — Project Schedule Network Diagram (PSND)';
-  const networkSvgStr = networkSvg(doc, networkHeading, filename, date);
+  const networkSvgStr = networkSvg(doc, networkHeading, filename, date, version);
   const gantt: GanttResult = computeGanttLayout(doc);
+
+  // Mirror titleBlockSvg's date line: `v{version} · {date}` when version is set.
+  const trimmedVersion = version?.trim();
+  const dateLine = trimmedVersion ? `v${trimmedVersion} · ${date}` : date;
 
   if (isGanttUnavailable(gantt)) {
     // No SVG to embed the title into — fall back to an HTML title block plus
@@ -437,7 +441,7 @@ function buildActivityViews(doc: ActivityDoc, filename: string, date: string): A
     const ganttBody = `<div class="diagram-title-block diagram-title-block-html">
   <div class="text-header">Gantt view — unavailable</div>
   <div class="text-secondary">${escXml(filename)}</div>
-  <div class="text-secondary">${escXml(date)}</div>
+  <div class="text-secondary">${escXml(dateLine)}</div>
 </div>
 <div class="section-notice">${escXml(gantt.reason)}</div>`;
     return { networkSvg: networkSvgStr, ganttBody, ganttSvg: '' };
@@ -447,7 +451,7 @@ function buildActivityViews(doc: ActivityDoc, filename: string, date: string): A
     ? `computed mode (project ${gantt.timelineStart} → ${gantt.timelineEnd})`
     : `pinned mode (${gantt.timelineStart} → ${gantt.timelineEnd})`;
   const ganttHeading = `Gantt view — ${modeLabel}`;
-  const ganttSvgStr = ganttSvg(gantt, ganttHeading, filename, date);
+  const ganttSvgStr = ganttSvg(gantt, ganttHeading, filename, date, version);
   return { networkSvg: networkSvgStr, ganttBody: ganttSvgStr, ganttSvg: ganttSvgStr };
 }
 
@@ -597,16 +601,22 @@ export class ActivitiesPreview {
     let bodyContent = '';
     let errorMsg = '';
     let warnings: string[] = [];
-    const today = todayIso();
 
     try {
       const parsed = yaml.load(yamlText) as unknown;
+      // Document version/date for the title block. `version` is optional;
+      // `date` falls back to today when the document has no date field —
+      // a frozen version paired with a floating render date would be
+      // incoherent, so the doc's own date wins when present.
+      const raw = (parsed && typeof parsed === 'object' ? parsed : {}) as Record<string, unknown>;
+      const docVersion = typeof raw['version'] === 'string' ? raw['version'] : undefined;
+      const docDate = typeof raw['date'] === 'string' ? raw['date'] : todayIso();
       const v = validateActivities(parsed);
       warnings = v.warnings.map(w => `${w.code}: ${w.message}`);
       if (!v.valid) {
         errorMsg = v.errors.map(e => `${e.code}: ${e.message}`).join('\n');
       } else {
-        const views = buildActivityViews(parsed as ActivityDoc, filename, today);
+        const views = buildActivityViews(parsed as ActivityDoc, filename, docDate, docVersion);
         bodyContent = buildCanvasContent(views);
         this.lastNetworkSvg = views.networkSvg;
         this.lastGanttSvg = views.ganttSvg;

--- a/extension/src/fgca-preview.ts
+++ b/extension/src/fgca-preview.ts
@@ -279,7 +279,7 @@ function escXml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
 
-function buildSvg(doc: FGCADoc, hideChanges = false, heading?: string, filename?: string, date?: string): string {
+function buildSvg(doc: FGCADoc, hideChanges = false, heading?: string, filename?: string, date?: string, version?: string): string {
   const { nodes, edges, width, height } = layoutFGCA(doc, hideChanges);
   const showTitle = heading != null && filename != null && date != null;
   const titleH = showTitle ? TITLE_BLOCK_H : 0;
@@ -332,7 +332,7 @@ function buildSvg(doc: FGCADoc, hideChanges = false, heading?: string, filename?
   }).join('\n');
 
   const totalH = height + titleH;
-  const titleSvg = showTitle ? titleBlockSvg(heading!, filename!, date!, PAD, PAD) : '';
+  const titleSvg = showTitle ? titleBlockSvg(heading!, filename!, date!, PAD, PAD, version) : '';
   // The layoutFGCA coordinates are absolute; wrap the diagram in a translate
   // group so the title block can sit above without rewriting every node/edge.
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${totalH}" viewBox="0 0 ${width} ${totalH}">
@@ -396,12 +396,15 @@ export class FGCAPreview {
 
     try {
       const parsed = yaml.load(yamlText) as unknown;
+      const meta = (parsed && typeof parsed === 'object' ? parsed : {}) as { version?: unknown; date?: unknown };
+      const docVersion = typeof meta.version === 'string' ? meta.version : undefined;
+      const docDate = typeof meta.date === 'string' ? meta.date : todayIso();
       const v = validateFGCA(parsed);
       warnings = v.warnings.map(w => `${w.code}: ${w.message}`);
       if (!v.valid) {
         errorMsg = v.errors.map(e => `${e.code}: ${e.message}`).join('\n');
       } else {
-        svgContent = buildSvg(parsed as FGCADoc, false, 'FGCA — Factor → Goal → Change → Activity', filename, todayIso());
+        svgContent = buildSvg(parsed as FGCADoc, false, 'FGCA — Factor → Goal → Change → Activity', filename, docDate, docVersion);
       }
     } catch (e) {
       errorMsg = (e as Error).message ?? 'Parse error';
@@ -483,13 +486,16 @@ export class FGAPreview {
 
     try {
       const parsed = yaml.load(yamlText) as unknown;
+      const meta = (parsed && typeof parsed === 'object' ? parsed : {}) as { version?: unknown; date?: unknown };
+      const docVersion = typeof meta.version === 'string' ? meta.version : undefined;
+      const docDate = typeof meta.date === 'string' ? meta.date : todayIso();
       const v = validateFGA(parsed);
       warnings = v.warnings.map(w => `${w.code}: ${w.message}`);
       if (!v.valid) {
         errorMsg = v.errors.map(e => `${e.code}: ${e.message}`).join('\n');
       } else {
         const flat = fgaToFlat(parsed as FGADoc);
-        svgContent = buildSvg(flat, true, 'FGA — Factor → Goal → Activity', filename, todayIso());
+        svgContent = buildSvg(flat, true, 'FGA — Factor → Goal → Activity', filename, docDate, docVersion);
       }
     } catch (e) {
       errorMsg = (e as Error).message ?? 'Parse error';

--- a/extension/src/goals-preview.ts
+++ b/extension/src/goals-preview.ts
@@ -28,7 +28,7 @@ function escXml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
 
-function layoutToSvg(layout: GoalTreeLayout, treeName: string, filename?: string, date?: string): string {
+function layoutToSvg(layout: GoalTreeLayout, treeName: string, filename?: string, date?: string, version?: string): string {
   const pad = 24;
   const showTitle = filename != null && date != null;
   const titleH = showTitle ? TITLE_BLOCK_H : 0;
@@ -76,7 +76,7 @@ function layoutToSvg(layout: GoalTreeLayout, treeName: string, filename?: string
   }).join('\n');
 
   const heading = treeName ? `Goal tree — ${treeName}` : 'Goal tree';
-  const titleSvg = showTitle ? titleBlockSvg(heading, filename!, date!, pad, pad) : '';
+  const titleSvg = showTitle ? titleBlockSvg(heading, filename!, date!, pad, pad, version) : '';
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">
 <defs>
   <marker id="arrow" markerWidth="8" markerHeight="8" refX="8" refY="3" orient="auto">
@@ -141,14 +141,17 @@ export class GoalsPreview {
         errorMsg = v.errors.map(e => `${e.code}: ${e.message}`).join('\n');
       } else {
         const tree = parsed as GoalTree;
-        const treeName = (parsed as { title?: unknown }).title;
+        const meta = parsed as { title?: unknown; version?: unknown; date?: unknown };
+        const treeName = typeof meta.title === 'string' ? meta.title : '';
+        const docVersion = typeof meta.version === 'string' ? meta.version : undefined;
+        const docDate = typeof meta.date === 'string' ? meta.date : todayIso();
         const layout = layoutGoalTree(tree, {
           nodeWidth: NODE_W,
           nodeHeight: NODE_H,
           rankSep: RANK_SEP,
           nodeSep: NODE_SEP,
         });
-        svgContent = layoutToSvg(layout, typeof treeName === 'string' ? treeName : '', filename, todayIso());
+        svgContent = layoutToSvg(layout, treeName, filename, docDate, docVersion);
       }
     } catch (e) {
       errorMsg = (e as Error).message ?? 'Parse error';

--- a/extension/src/process-blueprint-preview.ts
+++ b/extension/src/process-blueprint-preview.ts
@@ -19,7 +19,7 @@ function truncate(text: string, maxChars: number): string {
   return text.slice(0, Math.max(0, maxChars - 1)) + '…';
 }
 
-function layoutToSvg(layout: ProcessBlueprintLayout, filename?: string, date?: string): string {
+function layoutToSvg(layout: ProcessBlueprintLayout, filename?: string, date?: string, version?: string): string {
   const pad = 24;
   const showTitle = filename != null && date != null;
   const titleH = showTitle ? TITLE_BLOCK_H : 0;
@@ -92,7 +92,7 @@ function layoutToSvg(layout: ProcessBlueprintLayout, filename?: string, date?: s
     }
   }
 
-  const titleSvg = showTitle ? titleBlockSvg('Process Blueprint', filename!, date!, pad, pad) : '';
+  const titleSvg = showTitle ? titleBlockSvg('Process Blueprint', filename!, date!, pad, pad, version) : '';
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">
 ${titleSvg}
 ${parts.join('\n')}
@@ -149,8 +149,13 @@ export class ProcessBlueprintPreview {
         errorMsg = v.errors.map(e => `${e.code}: ${e.message}`).join('\n');
       } else {
         const file = parsed as ProcessBlueprintFile;
+        // Process Blueprint nests version/date under process_blueprint:, not
+        // top-level. Per orchestrator instruction, read the nested path.
+        const pb = (file as unknown as { process_blueprint?: { version?: unknown; date?: unknown } }).process_blueprint ?? {};
+        const docVersion = typeof pb.version === 'string' ? pb.version : undefined;
+        const docDate = typeof pb.date === 'string' ? pb.date : todayIso();
         const layout = layoutProcessBlueprint(file);
-        svgContent = layoutToSvg(layout, filename, todayIso());
+        svgContent = layoutToSvg(layout, filename, docDate, docVersion);
       }
     } catch (e) {
       errorMsg = (e as Error).message ?? 'Parse error';

--- a/extension/src/svg-title-block.ts
+++ b/extension/src/svg-title-block.ts
@@ -3,7 +3,9 @@
 // Every vector preview embeds a 3-line caption at the top of its SVG:
 //   line 1 — diagram heading (e.g. "Goal tree", "FGCA", "Block diagram")
 //   line 2 — source filename
-//   line 3 — today's date
+//   line 3 — `v{version} · {date}` when a document `version` is present,
+//            otherwise just the date. Format matches `frame-meta` in the
+//            catalogue HTML previews (`v` prefix, ` · ` separator).
 //
 // The block is class="diagram-title-block" so the Title toggle in #toolbar
 // (see TITLE_TOGGLE_CSS in diagram-frame.ts) can hide it via CSS. Renderers
@@ -18,22 +20,33 @@ function escXml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
 
-/** Build the title <g> for embedding at (x, top) inside an SVG. */
+/**
+ * Build the title <g> for embedding at (x, top) inside an SVG.
+ *
+ * `version` is the document's `version` field (front-matter). When set, line 3
+ * renders as `v{version} · {date}`; otherwise just `{date}`. `spec_version`
+ * (the notation/methodology version) deliberately does NOT appear — it stays
+ * front-matter metadata, never painted on the diagram.
+ */
 export function titleBlockSvg(
   heading: string,
   filename: string,
   date: string,
   x: number,
   top: number,
+  version?: string,
 ): string {
+  const trimmedVersion = version?.trim();
+  const dateLine = trimmedVersion ? `v${trimmedVersion} · ${date}` : date;
   return `<g class="diagram-title-block">
   <text class="text-header" x="${x}" y="${top + 14}">${escXml(heading)}</text>
   <text class="text-secondary" x="${x}" y="${top + 30}">${escXml(filename)}</text>
-  <text class="text-secondary" x="${x}" y="${top + 46}">${escXml(date)}</text>
+  <text class="text-secondary" x="${x}" y="${top + 46}">${escXml(dateLine)}</text>
 </g>`;
 }
 
-/** Today's date in YYYY-MM-DD. Used as the third title-block line. */
+/** Today's date in YYYY-MM-DD. Used as the third title-block line's fallback
+ *  when the source document has no `date` field. */
 export function todayIso(): string {
   return new Date().toISOString().slice(0, 10);
 }


### PR DESCRIPTION
Per orchestrator's plan addendum on strategy issue #30.

## Summary

Vector previews' title block line 3 now renders `v{version} · {date}` when the document has a `version` field — matching the `.frame-meta` format catalogue HTML previews already use. `spec_version` does **not** appear (front-matter metadata, never painted).

## Changes

- `svg-title-block.ts` — `titleBlockSvg(…, version?)`. 3 lines stay, `TITLE_BLOCK_H` stays 60. Version folds into the date line; no 4th line.
- Vector previews read the document's `version` and `date` from parsed YAML and thread them through:
  - **activities** / **goals** / **fgca** (both FGCA & FGA) — top-level fields
  - **process-blueprint** — nested under `process_blueprint:` per its schema
  - **blocks** (no front-matter) and **bpmn** (separate viewer) untouched
- `date` is the document's `date`; `todayIso()` is the fallback when the doc has no `date`. Reason: `v0.1 · <today>` is incoherent — the version is frozen, the date must not float per render.
- Activities Gantt-unavailable HTML fallback mirrors the same date-line format.

## Test plan

- [x] `npm run compile:extension` — clean
- [x] `npm test` — 341 pass
- [x] `npm run extension:prep` — bundle 288.2 kb
- [ ] Hand-test: open an activities / goals / fgca / process-blueprint example with a `version` field, confirm line 3 reads `v… · YYYY-MM-DD`
- [ ] Hand-test: open an example without `version`, confirm line 3 reads just the date