### PR TITLE
FGA preview: accept canonical FLAT schema (same as FGCA)

### DIFF
--- a/extension/src/fgca-preview.ts
+++ b/extension/src/fgca-preview.ts
@@ -32,13 +32,6 @@ interface FGCADoc {
   activities: ActivityItem[];
 }
 
-// Canonical FGA nested types (spec v0.1)
-interface FGAActivityItem { id: string; name: string; owner?: string; status?: string; due_date?: string; }
-interface FGAGoalItem    { id: string; name: string; activities: FGAActivityItem[]; }
-interface FGAFactorItem  { id: string; name: string; type: 'external' | 'internal'; goals: FGAGoalItem[]; }
-interface FGARoot        { id: string; name: string; description?: string; period?: string; factors: FGAFactorItem[]; }
-interface FGADoc         { notation: string; fga: FGARoot; }
-
 interface ValidationError { code: string; message: string; }
 interface ValidationResult { valid: boolean; errors: ValidationError[]; warnings: Array<{ code: string; message: string }>; }
 
@@ -95,6 +88,16 @@ function validateFGCA(input: unknown): ValidationResult {
   return { valid: errors.length === 0, errors, warnings };
 }
 
+/**
+ * FGA shares the FLAT shape of FGCA — top-level `factors[]` + `goals[]` +
+ * `activities[]` with `goal_id` references — minus the `changes[]` column.
+ * The example file's own description puts it plainly: "Factor–Goal–Activity
+ * view (Changes column hidden)". A previously-shipped NESTED variant
+ * (`fga.factors[].goals[].activities[]`) didn't match any example or
+ * methodology spec and broke `examples/fga/strategy-2026.fga.transitrix.yaml`
+ * on open with "fga root key is required". Validation now mirrors validateFGCA
+ * exactly, just with `changes` optional/empty.
+ */
 function validateFGA(input: unknown): ValidationResult {
   const errors: ValidationError[] = [];
   const warnings: Array<{ code: string; message: string }> = [];
@@ -114,73 +117,28 @@ function validateFGA(input: unknown): ValidationResult {
     return { valid: false, errors, warnings };
   }
 
-  if (!raw.fga || typeof raw.fga !== 'object') {
-    errors.push({ code: 'MISSING_ROOT', message: 'fga root key is required' });
-    return { valid: false, errors, warnings };
-  }
+  if (!Array.isArray(raw.factors)) errors.push({ code: 'SCHEMA_INVALID', message: 'factors must be an array' });
+  if (!Array.isArray(raw.goals)) errors.push({ code: 'SCHEMA_INVALID', message: 'goals must be an array' });
+  if (!Array.isArray(raw.activities)) errors.push({ code: 'SCHEMA_INVALID', message: 'activities must be an array' });
+  if (errors.length > 0) return { valid: false, errors, warnings };
 
-  const fga = raw.fga as Record<string, unknown>;
-  if (!Array.isArray(fga.factors)) {
-    errors.push({ code: 'SCHEMA_INVALID', message: 'fga.factors must be an array' });
-    return { valid: false, errors, warnings };
-  }
+  const factorIds = new Set((raw.factors as Array<{ id: number | string }>).map(f => f.id));
+  const goalIds = new Set((raw.goals as Array<{ id: number | string }>).map(g => g.id));
 
-  for (const factor of fga.factors as Array<Record<string, unknown>>) {
-    if (!factor.id || !factor.name) {
-      errors.push({ code: 'SCHEMA_INVALID', message: `Factor missing required id or name` });
-    }
-    if (!factor.type) {
-      warnings.push({ code: 'MISSING_FIELD', message: `Factor "${factor.id}" missing type (expected "external" or "internal")` });
-    }
-    if (!Array.isArray(factor.goals)) {
-      errors.push({ code: 'SCHEMA_INVALID', message: `Factor "${factor.id}" goals must be an array` });
-      continue;
-    }
-    for (const goal of factor.goals as Array<Record<string, unknown>>) {
-      if (!goal.id || !goal.name) {
-        errors.push({ code: 'SCHEMA_INVALID', message: `Goal missing required id or name under factor "${factor.id}"` });
+  for (const g of raw.goals as Array<{ id: number | string; factor?: Array<{ id: number | string }> }>) {
+    for (const f of (g.factor ?? [])) {
+      if (!factorIds.has(f.id)) {
+        warnings.push({ code: 'BROKEN_REF', message: `Goal ${g.id} references missing factor ${f.id}` });
       }
-      if (!Array.isArray(goal.activities)) {
-        errors.push({ code: 'SCHEMA_INVALID', message: `Goal "${goal.id}" activities must be an array` });
-        continue;
-      }
-      for (const act of goal.activities as Array<Record<string, unknown>>) {
-        if (!act.id || !act.name) {
-          errors.push({ code: 'SCHEMA_INVALID', message: `Activity missing required id or name under goal "${goal.id}"` });
-        }
-      }
+    }
+  }
+  for (const a of raw.activities as Array<{ id: number | string; goal_id?: number | string | null }>) {
+    if (a.goal_id != null && !goalIds.has(a.goal_id)) {
+      warnings.push({ code: 'BROKEN_REF', message: `Activity ${a.id} references missing goal ${a.goal_id}` });
     }
   }
 
   return { valid: errors.length === 0, errors, warnings };
-}
-
-// Convert canonical nested FGA → flat FGCADoc for the existing layout engine
-function fgaToFlat(doc: FGADoc): FGCADoc {
-  const factors: FactorItem[] = [];
-  const goals: GoalItem[] = [];
-  const activities: ActivityItem[] = [];
-
-  const goalSeen = new Set<string>();
-
-  for (const factor of doc.fga.factors) {
-    factors.push({ id: factor.id, name: factor.name });
-    for (const goal of factor.goals) {
-      if (!goalSeen.has(goal.id)) {
-        goals.push({ id: goal.id, name: goal.name, factor: [{ id: factor.id }] });
-        goalSeen.add(goal.id);
-      } else {
-        // Goal appears under multiple factors — add factor reference
-        const existing = goals.find(g => g.id === goal.id);
-        if (existing) existing.factor = [...(existing.factor ?? []), { id: factor.id }];
-      }
-      for (const act of goal.activities) {
-        activities.push({ id: act.id, name: act.name, goal_id: goal.id });
-      }
-    }
-  }
-
-  return { notation: 'fga', factors, goals, activities };
 }
 
 // ── Inline layout ─────────────────────────────────────────────────────────────
@@ -494,8 +452,8 @@ export class FGAPreview {
       if (!v.valid) {
         errorMsg = v.errors.map(e => `${e.code}: ${e.message}`).join('\n');
       } else {
-        const flat = fgaToFlat(parsed as FGADoc);
-        svgContent = buildSvg(flat, true, 'FGA — Factor → Goal → Activity', filename, docDate, docVersion);
+        // FGA shares FGCA's FLAT shape; just hide the (absent) Changes column.
+        svgContent = buildSvg(parsed as FGCADoc, true, 'FGA — Factor → Goal → Activity', filename, docDate, docVersion);
       }
     } catch (e) {
       errorMsg = (e as Error).message ?? 'Parse error';

--- a/extension/src/fgca-preview.ts
+++ b/extension/src/fgca-preview.ts
@@ -97,6 +97,12 @@ function validateFGCA(input: unknown): ValidationResult {
  * methodology spec and broke `examples/fga/strategy-2026.fga.transitrix.yaml`
  * on open with "fga root key is required". Validation now mirrors validateFGCA
  * exactly, just with `changes` optional/empty.
+ *
+ * NOTE: this is a **provisional 1.0.0 shape**, not the canonical decision.
+ * The family-wide flat-vs-nested-root choice for FGCA / FGA / Goals /
+ * Activities is filed for methodology-level resolution in strategy hub
+ * issue #37 — post-1.0.0. If that lands on nested-root, all four notations
+ * migrate together; FGA is not specially burdened.
  */
 function validateFGA(input: unknown): ValidationResult {
   const errors: ValidationError[] = [];


### PR DESCRIPTION
## Summary

Hand-test: `examples/fga/strategy-2026.fga.transitrix.yaml` threw `MISSING_ROOT: fga root key is required`. The example uses the FLAT schema (top-level `factors[]` + `goals[]` + `activities[]` with `goal_id`), same as FGCA but without `changes[]`. Its own description: *"Factor–Goal–Activity view (Changes column hidden)"*.

The preview shipped a NESTED-schema validator + `fgaToFlat` converter. No example or methodology spec used that shape.

## Fix

`validateFGA` now mirrors `validateFGCA` (FLAT shape, `changes` absent). Drops the FGA*Item / FGARoot / FGADoc nested types and the `fgaToFlat` conversion — parsed YAML flows straight into `buildSvg` with `hideChanges=true`.

Same class of fix as the goals canonical-schema PR earlier in the stack.

## Test plan

- [x] `npm run compile:extension` — clean
- [x] `npm test` — 341 pass
- [x] `npm run extension:prep` — bundle 286.9 kb
- [ ] Open `examples/fga/strategy-2026.fga.transitrix.yaml` — should render with factors / goals / activities columns (no Changes column), title `FGA — Factor → Goal → Activity`