### PR TITLE
Shell: lift full-height flex chain into shellCss() (closes strategy #35)

### DIFF
--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -500,16 +500,6 @@ const ACTIVITIES_DIAGRAM_CSS = `
 
 /** Webview-only chrome (tab switcher, section notice). Not exported. */
 const ACTIVITIES_WEBVIEW_CSS = `
-  /* ── Fill the webview viewport ──────────────────────────────────────── */
-  /* The base shell leaves #canvas at content height with overflow:auto, so a
-     diagram shorter or narrower than the panel strands the canvas's own
-     scrollbar mid-panel with empty space below it. Make <body> a full-height
-     flex column and let #canvas grow into a single scroll region — the same
-     pattern the blocks preview already uses. */
-  html, body { height: 100%; }
-  body { display: flex; flex-direction: column; }
-  #canvas { flex: 1; min-height: 0; overflow: auto; }
-
   /* ── View switcher (CSS-only, no JS) ────────────────────────────────── */
   /* Move the radios fully off-screen rather than just hiding via opacity —
      keeps them keyboard-focusable while not taking layout space, and stops

--- a/extension/src/blocks-preview.ts
+++ b/extension/src/blocks-preview.ts
@@ -9,9 +9,6 @@ function escHtml(s: string): string {
 }
 
 const BLOCKS_STYLES = `
-html { height: 100%; }
-body { height: 100%; display: flex; flex-direction: column; }
-#canvas { flex: 1; min-height: 0; overflow: auto; }
 .blocks-svg-wrap { display: inline-flex; flex-direction: column; gap: 24px; padding: 8px 16px; min-width: 100%; }
 .blocks-svg-wrap svg { display: block; }
 `;

--- a/packages/diagrams/src/theme/themes.ts
+++ b/packages/diagrams/src/theme/themes.ts
@@ -98,15 +98,23 @@ function diagramVars(variant: 'light' | 'dark' | 'hc'): string {
 function shellCss(): string {
   const cv = CSS_VAR;
   const t = TYPOGRAPHY;
+  // Full-height flex chain lifted from blocks-preview / activities-preview
+  // into the shared shell (per strategy hub #35). Body is a flex column
+  // sized to the iframe; #canvas takes the remaining height with its own
+  // scroll region. Without this, #canvas was content-height and any
+  // overflow-x scrollbar landed mid-panel with empty space below it — the
+  // "two-page" split flagged on goals, activities, and others.
+  //
   // html bg + min-height are set per-theme in generateWebviewCss (literal
   // hex / VS Code var) so they don't depend on `--ts-bg` resolving on html —
   // CSS custom properties only cascade DOWN, and `--ts-bg` is defined on the
   // body[data-theme] selector, so html itself can't read it. Without that
   // explicit html bg, the iframe's underlying VS Code editor background
   // showed through any uncovered area below short diagrams.
-  return `body{background:var(${cv.bg});color:var(${cv.text});min-height:100vh;}
-#toolbar{position:sticky;top:0;z-index:10;padding:6px 12px;border-bottom:1px solid var(${cv.border});font-family:${t.fontFamily};font-size:${t.sizes.secondary}px;color:var(${cv.textMuted});background:var(${cv.bg});}
-#canvas{padding:16px;overflow:auto;}
+  return `html,body{height:100%;}
+body{background:var(${cv.bg});color:var(${cv.text});display:flex;flex-direction:column;}
+#toolbar{position:sticky;top:0;z-index:10;padding:6px 12px;border-bottom:1px solid var(${cv.border});font-family:${t.fontFamily};font-size:${t.sizes.secondary}px;color:var(${cv.textMuted});background:var(${cv.bg});flex-shrink:0;}
+#canvas{flex:1;min-height:0;padding:16px;overflow:auto;}
 svg{display:block;}`;
 }
 


### PR DESCRIPTION
Per orchestrator's decision on strategy hub #30: pull #35 forward into 1.0.0 — every preview now fills the panel from one place in the shared shell CSS.

## Summary

Same "two-page" canvas-fill bug previously fixed locally for activities (PR #44) and shipped from day one in blocks-preview is now lifted into `shellCss()`. All vector + catalogue previews benefit; the local copies in activities-preview and blocks-preview are removed.

## Changes

- **`packages/diagrams/src/theme/themes.ts` → `shellCss()`:**
  - `html, body { height: 100% }`
  - `body { display: flex; flex-direction: column }` (keeps bg + color)
  - `#toolbar { flex-shrink: 0 }` so it doesn't collapse in the flex column
  - `#canvas { flex: 1; min-height: 0; padding: 16px; overflow: auto }`

- **`extension/src/activities-preview.ts`** — remove the local 3-line flex block from `ACTIVITIES_WEBVIEW_CSS`.

- **`extension/src/blocks-preview.ts`** — remove the local 3-line flex block from `BLOCKS_STYLES`.

## Hand-test priority

Catalogue HTML previews (applications / products / process-map / scenarios / capability-map) — the orchestrator flagged these as the real blast-radius concern. Confirm:
- Body fills the panel; no dead strip below the table.
- `#toolbar` still stickies at top.
- Table scrolls when content exceeds canvas height.

## Closes

Strategy hub issue #35 — "Lift the full-height flex layout into the shared shell CSS".

## Test plan

- [x] `npm run compile` + `npm run compile:extension` — clean
- [x] `npm test` — 341 pass
- [x] `npm run extension:prep` — bundle 286.0 kb (-2 kb from removing local copies)
- [ ] Hand-test all 11 previews: confirm canvas fills panel, single scroll region, no two-page split