### PR TITLE
feat(diagrams): add the issues notation module

### DIFF
--- a/packages/diagrams/src/index.ts
+++ b/packages/diagrams/src/index.ts
@@ -3,6 +3,7 @@ export * from "./applications/index";
 export * from "./capability-map/index";
 export * from "./fgca/index";
 export * from "./goals/index";
+export * from "./issues/index";
 export * from "./process-blueprint/index";
 export * from "./process-map/index";
 export * from "./products/index";

--- a/packages/diagrams/src/issues/__tests__/layout.test.ts
+++ b/packages/diagrams/src/issues/__tests__/layout.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { layoutIssues } from '../layout.js';
+import type { Issue, IssuesFile } from '../types.js';
+
+function build(issues: Issue[]): IssuesFile {
+  return {
+    notation: 'issues',
+    issues_catalogue: {
+      id: 'ISSUES-CAT-1',
+      name: 'Test',
+      updated_at: '2026-05-25',
+      issues,
+    },
+  };
+}
+
+describe('layoutIssues', () => {
+  it('lays out one row per issue', () => {
+    const layout = layoutIssues(build([
+      { issue_id: 'ISSUE-1', name: 'A', status: 'open' },
+      { issue_id: 'ISSUE-2', name: 'B', status: 'open' },
+    ]));
+    expect(layout.rows).toHaveLength(2);
+  });
+
+  it('indents sub-issues by nesting depth', () => {
+    const layout = layoutIssues(build([
+      { issue_id: 'ISSUE-1', name: 'Root', status: 'open' },
+      { issue_id: 'ISSUE-2', name: 'Child', status: 'open', parent: 'ISSUE-1' },
+      { issue_id: 'ISSUE-3', name: 'Grandchild', status: 'open', parent: 'ISSUE-2' },
+    ]));
+    const byId = new Map(layout.rows.map((r) => [r.issue_id, r]));
+    expect(byId.get('ISSUE-1')!.depth).toBe(0);
+    expect(byId.get('ISSUE-2')!.depth).toBe(1);
+    expect(byId.get('ISSUE-3')!.depth).toBe(2);
+    expect(byId.get('ISSUE-2')!.x).toBeGreaterThan(byId.get('ISSUE-1')!.x);
+  });
+
+  it('renders pre-order: a child row follows its parent', () => {
+    const layout = layoutIssues(build([
+      { issue_id: 'ISSUE-1', name: 'Root', status: 'open' },
+      { issue_id: 'ISSUE-2', name: 'Child', status: 'open', parent: 'ISSUE-1' },
+    ]));
+    expect(layout.rows[0].issue_id).toBe('ISSUE-1');
+    expect(layout.rows[1].issue_id).toBe('ISSUE-2');
+    expect(layout.rows[0].hasChildren).toBe(true);
+    expect(layout.rows[1].hasChildren).toBe(false);
+  });
+
+  it('places a broken-parent issue at the root', () => {
+    const layout = layoutIssues(build([
+      { issue_id: 'ISSUE-1', name: 'Orphan', status: 'open', parent: 'ISSUE-99' },
+    ]));
+    expect(layout.rows[0].depth).toBe(0);
+  });
+
+  it('does not stack-overflow or drop nodes on a parent cycle', () => {
+    const layout = layoutIssues(build([
+      { issue_id: 'ISSUE-1', name: 'A', status: 'open', parent: 'ISSUE-2' },
+      { issue_id: 'ISSUE-2', name: 'B', status: 'open', parent: 'ISSUE-1' },
+    ]));
+    expect(layout.rows).toHaveLength(2);
+  });
+
+  it('returns empty bounds for an empty register', () => {
+    const layout = layoutIssues(build([]));
+    expect(layout.rows).toHaveLength(0);
+    expect(layout.bounds).toEqual({ x: 0, y: 0, width: 0, height: 0 });
+  });
+});

--- a/packages/diagrams/src/issues/__tests__/validate.test.ts
+++ b/packages/diagrams/src/issues/__tests__/validate.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { validateIssues } from '../validate.js';
+
+const VALID = {
+  notation: 'issues',
+  issues_catalogue: {
+    id: 'ISSUES-CAT-1',
+    name: 'Test Register',
+    updated_at: '2026-05-25',
+    issues: [
+      { issue_id: 'ISSUE-1', name: 'Root issue', status: 'open' },
+      { issue_id: 'ISSUE-2', name: 'Sub issue', status: 'in_progress', parent: 'ISSUE-1' },
+    ],
+  },
+};
+
+function withIssues(issues: unknown[]): unknown {
+  return { ...VALID, issues_catalogue: { ...VALID.issues_catalogue, issues } };
+}
+
+describe('validateIssues', () => {
+  it('passes on valid input', () => {
+    const r = validateIssues(VALID);
+    expect(r.valid).toBe(true);
+    expect(r.errors).toHaveLength(0);
+  });
+
+  it('ISS-000: rejects a non-object', () => {
+    expect(validateIssues(null).valid).toBe(false);
+    expect(validateIssues('x').errors[0].code).toBe('ISS-000');
+  });
+
+  it('ISS-000: rejects a wrong notation header', () => {
+    const r = validateIssues({ ...VALID, notation: 'goals' });
+    expect(r.errors.some(e => e.code === 'ISS-000')).toBe(true);
+  });
+
+  it('ISS-000: rejects a missing issues_catalogue', () => {
+    const r = validateIssues({ notation: 'issues' });
+    expect(r.errors.some(e => e.code === 'ISS-000')).toBe(true);
+  });
+
+  it('ISS-001: detects a duplicate issue_id', () => {
+    const r = validateIssues(withIssues([
+      { issue_id: 'ISSUE-1', name: 'A', status: 'open' },
+      { issue_id: 'ISSUE-1', name: 'B', status: 'open' },
+    ]));
+    expect(r.errors.some(e => e.code === 'ISS-001')).toBe(true);
+  });
+
+  it('ISS-002: detects a status outside the vocabulary', () => {
+    const r = validateIssues(withIssues([{ issue_id: 'ISSUE-1', name: 'A', status: 'wip' }]));
+    expect(r.errors.some(e => e.code === 'ISS-002')).toBe(true);
+  });
+
+  it('ISS-003: detects a missing or empty name', () => {
+    const r = validateIssues(withIssues([{ issue_id: 'ISSUE-1', name: '', status: 'open' }]));
+    expect(r.errors.some(e => e.code === 'ISS-003')).toBe(true);
+  });
+
+  it('ISS-004: warns on a broken parent reference and stays valid', () => {
+    const r = validateIssues(withIssues([
+      { issue_id: 'ISSUE-1', name: 'Orphan', status: 'open', parent: 'ISSUE-99' },
+    ]));
+    expect(r.valid).toBe(true);
+    expect(r.warnings.some(w => w.code === 'ISS-004')).toBe(true);
+  });
+
+  it('ISS-005: detects a parent cycle', () => {
+    const r = validateIssues(withIssues([
+      { issue_id: 'ISSUE-1', name: 'A', status: 'open', parent: 'ISSUE-2' },
+      { issue_id: 'ISSUE-2', name: 'B', status: 'open', parent: 'ISSUE-1' },
+    ]));
+    expect(r.errors.some(e => e.code === 'ISS-005')).toBe(true);
+  });
+
+  it('ISS-006: rejects a relates_to entry that is not an ACTIVITY-/GOAL- id', () => {
+    const r = validateIssues(withIssues([
+      { issue_id: 'ISSUE-1', name: 'A', status: 'open', relates_to: ['PRODUCT-1'] },
+    ]));
+    expect(r.errors.some(e => e.code === 'ISS-006')).toBe(true);
+  });
+
+  it('accepts valid ACTIVITY-/GOAL- relates_to ids', () => {
+    const r = validateIssues(withIssues([
+      { issue_id: 'ISSUE-1', name: 'A', status: 'open', relates_to: ['ACTIVITY-5', 'GOAL-CUST-1'] },
+    ]));
+    expect(r.valid).toBe(true);
+  });
+
+  it('tolerates a null element in issues[] without throwing', () => {
+    const r = validateIssues(withIssues([null]));
+    expect(r.valid).toBe(false);
+    expect(r.errors.some(e => e.code === 'ISS-003')).toBe(true);
+  });
+});

--- a/packages/diagrams/src/issues/index.ts
+++ b/packages/diagrams/src/issues/index.ts
@@ -1,0 +1,19 @@
+export type {
+  IssueStatus,
+  Issue,
+  IssuesCatalogue,
+  IssuesFile,
+  IssuesLayoutOptions,
+  LaidOutIssue,
+  IssuesLayoutBounds,
+  IssuesLayout,
+} from './types.js';
+
+export { validateIssues } from './validate.js';
+export type {
+  ValidationError as IssuesValidationError,
+  ValidationWarning as IssuesValidationWarning,
+  ValidationResult as IssuesValidationResult,
+} from './validate.js';
+
+export { layoutIssues } from './layout.js';

--- a/packages/diagrams/src/issues/layout.ts
+++ b/packages/diagrams/src/issues/layout.ts
@@ -1,0 +1,94 @@
+import type {
+  Issue,
+  IssuesFile,
+  IssuesLayout,
+  IssuesLayoutOptions,
+  LaidOutIssue,
+} from './types.js';
+
+const DEFAULTS = {
+  rowHeight: 44,
+  rowGap: 10,
+  indentWidth: 32,
+  nodeWidth: 460,
+  paddingX: 0,
+  paddingY: 0,
+};
+
+/**
+ * Lays an Issues document out as a nested outline: one row per issue, in
+ * pre-order, with x indented by nesting depth and y stacked top-to-bottom.
+ *
+ * Robust to malformed input — a broken `parent` reference is treated as a
+ * root, and a `parent` cycle cannot stack-overflow or drop nodes (a
+ * `placed` guard ensures every issue is laid out exactly once).
+ */
+export function layoutIssues(file: IssuesFile, options: IssuesLayoutOptions = {}): IssuesLayout {
+  const o = { ...DEFAULTS, ...options };
+  const issues: Issue[] = file?.issues_catalogue?.issues ?? [];
+
+  const byId = new Map<string, Issue>();
+  for (const it of issues) {
+    if (it && typeof it.issue_id === 'string') byId.set(it.issue_id, it);
+  }
+
+  const childrenOf = new Map<string, string[]>();
+  const roots: string[] = [];
+  for (const it of issues) {
+    if (!it || typeof it.issue_id !== 'string') continue;
+    const parent = it.parent;
+    if (typeof parent === 'string' && byId.has(parent) && parent !== it.issue_id) {
+      const arr = childrenOf.get(parent) ?? [];
+      arr.push(it.issue_id);
+      childrenOf.set(parent, arr);
+    } else {
+      roots.push(it.issue_id);
+    }
+  }
+
+  const rows: LaidOutIssue[] = [];
+  const placed = new Set<string>();
+  let y = o.paddingY;
+
+  function place(id: string, depth: number): void {
+    if (placed.has(id)) return; // cycle / duplicate guard
+    const issue = byId.get(id);
+    if (!issue) return;
+    placed.add(id);
+
+    const kids = childrenOf.get(id) ?? [];
+    rows.push({
+      issue_id: id,
+      depth,
+      x: o.paddingX + depth * o.indentWidth,
+      y,
+      width: o.nodeWidth,
+      height: o.rowHeight,
+      data: issue,
+      hasChildren: kids.length > 0,
+    });
+    y += o.rowHeight + o.rowGap;
+
+    for (const childId of kids) place(childId, depth + 1);
+  }
+
+  for (const rootId of roots) place(rootId, 0);
+  // Any issue not reached above (e.g. trapped inside a parent cycle) is
+  // still laid out, at the root level, so nothing silently disappears.
+  for (const it of issues) {
+    if (it && typeof it.issue_id === 'string' && !placed.has(it.issue_id)) {
+      place(it.issue_id, 0);
+    }
+  }
+
+  if (rows.length === 0) {
+    return { rows: [], bounds: { x: 0, y: 0, width: 0, height: 0 } };
+  }
+
+  const minX = Math.min(...rows.map((r) => r.x));
+  const minY = Math.min(...rows.map((r) => r.y));
+  const maxX = Math.max(...rows.map((r) => r.x + r.width));
+  const maxY = Math.max(...rows.map((r) => r.y + r.height));
+
+  return { rows, bounds: { x: minX, y: minY, width: maxX - minX, height: maxY - minY } };
+}

--- a/packages/diagrams/src/issues/types.ts
+++ b/packages/diagrams/src/issues/types.ts
@@ -1,0 +1,73 @@
+/**
+ * Issues notation — a text-native register of issues (problems, defects,
+ * open questions) with parent/child nesting. See methodology spec
+ * `notations/12-issues.md`.
+ */
+
+export type IssueStatus = 'open' | 'in_progress' | 'blocked' | 'resolved' | 'closed';
+
+export interface Issue {
+  issue_id: string;
+  name: string;
+  status: IssueStatus;
+  /** issue_id of the parent issue — the nesting mechanism. */
+  parent?: string;
+  description?: string;
+  /** Typed IDs of ACTIVITY / GOAL elements this issue concerns. */
+  relates_to?: string[];
+  /** ROLE element ID of the role accountable for the issue. */
+  owner_role?: string;
+}
+
+export interface IssuesCatalogue {
+  id: string;
+  name: string;
+  description?: string;
+  version?: string;
+  updated_at: string;
+  issues: Issue[];
+}
+
+export interface IssuesFile {
+  notation: string;
+  spec_version?: string;
+  issues_catalogue: IssuesCatalogue;
+}
+
+export interface IssuesLayoutOptions {
+  rowHeight?: number;
+  rowGap?: number;
+  indentWidth?: number;
+  nodeWidth?: number;
+  paddingX?: number;
+  paddingY?: number;
+}
+
+export interface LaidOutIssue {
+  issue_id: string;
+  /** 0 for a root issue, +1 per nesting level. */
+  depth: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  data: Issue;
+  hasChildren: boolean;
+}
+
+export interface IssuesLayoutBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface IssuesLayout {
+  rows: LaidOutIssue[];
+  bounds: IssuesLayoutBounds;
+}
+
+// Validation result shape is shared across every notation module — see
+// `../validation-types.ts`. Re-exported here so consumers of this module
+// have a single import surface.
+export type { ValidationError, ValidationWarning, ValidationResult } from '../validation-types.js';

--- a/packages/diagrams/src/issues/validate.ts
+++ b/packages/diagrams/src/issues/validate.ts
@@ -1,0 +1,161 @@
+import type { IssueStatus, ValidationError, ValidationWarning, ValidationResult } from './types.js';
+
+export type { ValidationError, ValidationWarning, ValidationResult };
+
+/**
+ * Validates an Issues document against `notations/12-issues.md`.
+ *
+ * Error codes:
+ *  - ISS-000  structural / header problem (not an object, wrong notation,
+ *             missing issues_catalogue, missing catalogue fields)
+ *  - ISS-001  duplicate issue_id
+ *  - ISS-002  status outside the vocabulary
+ *  - ISS-003  issue_id or name missing or empty
+ *  - ISS-004  parent references a missing issue (warning)
+ *  - ISS-005  cycle in the parent chain
+ *  - ISS-006  relates_to entry is not an ACTIVITY- / GOAL- id
+ */
+
+const STATUS_VALUES: IssueStatus[] = ['open', 'in_progress', 'blocked', 'resolved', 'closed'];
+const RELATES_TO_RE = /^(ACTIVITY|GOAL)(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
+
+function isNonEmptyString(v: unknown): v is string {
+  return typeof v === 'string' && v.trim().length > 0;
+}
+
+export function validateIssues(input: unknown): ValidationResult {
+  const errors: ValidationError[] = [];
+  const warnings: ValidationWarning[] = [];
+
+  if (!input || typeof input !== 'object') {
+    return { valid: false, errors: [{ code: 'ISS-000', message: 'Input must be an object' }], warnings };
+  }
+
+  const raw = input as Record<string, unknown>;
+
+  if ('notation' in raw && raw['notation'] !== 'issues') {
+    errors.push({ code: 'ISS-000', message: `notation must be "issues", got "${String(raw['notation'])}"` });
+  }
+
+  const catRaw = raw['issues_catalogue'];
+  if (!catRaw || typeof catRaw !== 'object') {
+    errors.push({ code: 'ISS-000', message: 'Missing required root key: issues_catalogue' });
+    return { valid: false, errors, warnings };
+  }
+  const cat = catRaw as Record<string, unknown>;
+
+  if (!isNonEmptyString(cat['id'])) {
+    errors.push({ code: 'ISS-000', message: 'issues_catalogue.id is required', path: 'issues_catalogue.id' });
+  }
+  if (!isNonEmptyString(cat['name'])) {
+    errors.push({ code: 'ISS-000', message: 'issues_catalogue.name is required', path: 'issues_catalogue.name' });
+  }
+  if (!isNonEmptyString(cat['updated_at'])) {
+    errors.push({ code: 'ISS-000', message: 'issues_catalogue.updated_at is required', path: 'issues_catalogue.updated_at' });
+  }
+
+  const issuesRaw = cat['issues'];
+  if (!Array.isArray(issuesRaw)) {
+    errors.push({ code: 'ISS-000', message: 'issues_catalogue.issues must be an array', path: 'issues_catalogue.issues' });
+    return { valid: false, errors, warnings };
+  }
+
+  const idSet = new Set<string>();
+
+  for (let i = 0; i < issuesRaw.length; i++) {
+    const it = issuesRaw[i] as unknown;
+    const path = `issues_catalogue.issues[${i}]`;
+
+    if (!it || typeof it !== 'object') {
+      errors.push({ code: 'ISS-003', message: `${path} must be an object`, path });
+      continue;
+    }
+    const issue = it as Record<string, unknown>;
+
+    const idOk = isNonEmptyString(issue['issue_id']);
+    if (!idOk) {
+      errors.push({ code: 'ISS-003', message: `${path}.issue_id is missing or empty`, path });
+    }
+    if (!isNonEmptyString(issue['name'])) {
+      errors.push({ code: 'ISS-003', message: `${path}.name is missing or empty`, path });
+    }
+
+    if (idOk) {
+      const id = (issue['issue_id'] as string).trim();
+      if (idSet.has(id)) {
+        errors.push({ code: 'ISS-001', message: `Duplicate issue_id: "${id}"`, path });
+      } else {
+        idSet.add(id);
+      }
+    }
+
+    const status = issue['status'];
+    if (!STATUS_VALUES.includes(status as IssueStatus)) {
+      errors.push({
+        code: 'ISS-002',
+        message: `${path}.status "${String(status)}" must be one of: ${STATUS_VALUES.join(', ')}`,
+        path,
+      });
+    }
+
+    const relates = issue['relates_to'];
+    if (relates !== undefined) {
+      if (!Array.isArray(relates)) {
+        errors.push({ code: 'ISS-006', message: `${path}.relates_to must be an array`, path });
+      } else {
+        for (let j = 0; j < relates.length; j++) {
+          const ref = relates[j];
+          if (typeof ref !== 'string' || !RELATES_TO_RE.test(ref)) {
+            errors.push({
+              code: 'ISS-006',
+              message: `${path}.relates_to[${j}] "${String(ref)}" must be an ACTIVITY- or GOAL- id`,
+              path,
+            });
+          }
+        }
+      }
+    }
+  }
+
+  // parent reference + cycle checks — run once all ids are collected.
+  const parentOf = new Map<string, string>();
+  for (let i = 0; i < issuesRaw.length; i++) {
+    const it = issuesRaw[i] as unknown;
+    if (!it || typeof it !== 'object') continue;
+    const issue = it as Record<string, unknown>;
+    const parent = issue['parent'];
+    const path = `issues_catalogue.issues[${i}]`;
+    if (parent === undefined) continue;
+    if (typeof parent !== 'string' || !idSet.has(parent.trim())) {
+      warnings.push({
+        code: 'ISS-004',
+        message: `${path}.parent "${String(parent)}" does not resolve to a known issue — rendered at the root`,
+        path,
+      });
+      continue;
+    }
+    if (isNonEmptyString(issue['issue_id'])) {
+      parentOf.set((issue['issue_id'] as string).trim(), parent.trim());
+    }
+  }
+
+  let cycleNode: string | undefined;
+  for (const start of parentOf.keys()) {
+    if (cycleNode) break;
+    const seen = new Set<string>();
+    let cur: string | undefined = start;
+    while (cur !== undefined) {
+      if (seen.has(cur)) {
+        cycleNode = cur;
+        break;
+      }
+      seen.add(cur);
+      cur = parentOf.get(cur);
+    }
+  }
+  if (cycleNode) {
+    errors.push({ code: 'ISS-005', message: `Cycle detected in the parent chain involving issue "${cycleNode}"` });
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}


### PR DESCRIPTION
Adds the `issues` notation to `@transitrix/diagrams` — validation and layout for a text-native issue register with parent/child nesting (problems, defects, open questions). It complements the `activities` notation rather than replacing anything.

Implements the notation specified in transitrix/methodology#17.

## Contents

- `src/issues/types.ts` — `Issue`, `IssuesCatalogue`, `IssuesFile`, and the layout types.
- `src/issues/validate.ts` — `validateIssues` with codes `ISS-000…006`: duplicate `issue_id`, status outside the vocabulary, missing/empty fields, broken parent (warning), parent cycle, malformed `relates_to`.
- `src/issues/layout.ts` — `layoutIssues`, a nested-outline layout (one row per issue, indented by depth); cycle-safe and tolerant of broken parent references.
- `src/issues/__tests__/` — 18 unit tests covering validation and layout.
- `src/index.ts` — exports the new module.

## Verification

- `tsc -p .` — clean.
- `vitest run src/issues` — 18/18 passing.

## Scope

Per the library-first convention, this PR is the `@transitrix/diagrams` half. The VS Code extension preview for `*.issues.transitrix.yaml` (a nested-tree webview), its activation event, and the language contribution follow in a separate PR that consumes this module.

Do not merge without review — gating is intentional.