### PR TITLE
feat(extension): preview viewer for the issues notation (re-open of #56)

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -58,7 +58,8 @@
     "workspaceContains:**/*.process-map.transitrix.yaml",
     "workspaceContains:**/*.scenarios.transitrix.yaml",
     "workspaceContains:**/*.capability-map.transitrix.yaml",
-    "workspaceContains:**/*.process-blueprint.transitrix.yaml"
+    "workspaceContains:**/*.process-blueprint.transitrix.yaml",
+    "workspaceContains:**/*.issues.transitrix.yaml"
   ],
   "contributes": {
     "configuration": {
@@ -195,6 +196,17 @@
         ],
         "extensions": [
           ".process-blueprint.transitrix.yaml"
+        ],
+        "configuration": "./language-configuration.json"
+      },
+      {
+        "id": "transitrix-issues",
+        "aliases": [
+          "Transitrix Issues",
+          "Issues Register"
+        ],
+        "extensions": [
+          ".issues.transitrix.yaml"
         ],
         "configuration": "./language-configuration.json"
       },
@@ -347,6 +359,18 @@
         "title": "Transitrix: Save process blueprint as SVG",
         "category": "Transitrix",
         "icon": "$(save)"
+      },
+      {
+        "command": "transitrixStudio.previewIssues",
+        "title": "Transitrix: Preview issues register",
+        "category": "Transitrix",
+        "icon": "$(list-tree)"
+      },
+      {
+        "command": "transitrixStudio.saveIssuesAsSvg",
+        "title": "Transitrix: Save issues register as SVG",
+        "category": "Transitrix",
+        "icon": "$(save)"
       }
     ],
     "menus": {
@@ -469,6 +493,21 @@
         {
           "when": "activeWebviewPanelId == processBlueprintPreview",
           "command": "transitrixStudio.saveProcessBlueprintAsSvg",
+          "group": "navigation@-9"
+        },
+        {
+          "when": "resourceFilename =~ /\\.issues\\.transitrix\\.yaml$/",
+          "command": "transitrixStudio.previewIssues",
+          "group": "navigation@-10"
+        },
+        {
+          "when": "resourceFilename =~ /\\.issues\\.transitrix\\.yaml$/",
+          "command": "transitrixStudio.saveIssuesAsSvg",
+          "group": "navigation@-9"
+        },
+        {
+          "when": "activeWebviewPanelId == issuesPreview",
+          "command": "transitrixStudio.saveIssuesAsSvg",
           "group": "navigation@-9"
         }
       ]

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -14,6 +14,7 @@ import { ProcessMapPreview } from './process-map-preview.js';
 import { ScenariosPreview } from './scenarios-preview.js';
 import { CapabilityMapPreview } from './capability-map-preview.js';
 import { ProcessBlueprintPreview } from './process-blueprint-preview.js';
+import { IssuesPreview } from './issues-preview.js';
 import type { LayoutMetrics, ValidationReport } from './types.js';
 import {
   documentMatchesCervinSource,
@@ -63,6 +64,10 @@ function isCapabilityMapFile(doc: vscode.TextDocument): boolean {
 
 function isProcessBlueprintFile(doc: vscode.TextDocument): boolean {
   return doc.fileName.endsWith('.process-blueprint.transitrix.yaml');
+}
+
+function isIssuesFile(doc: vscode.TextDocument): boolean {
+  return doc.fileName.endsWith('.issues.transitrix.yaml');
 }
 
 async function loadCompiler(ext: vscode.ExtensionContext): Promise<CompileFn> {
@@ -131,6 +136,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   const scenariosPreview = new ScenariosPreview();
   const capabilityMapPreview = new CapabilityMapPreview();
   const processBlueprintPreview = new ProcessBlueprintPreview();
+  const issuesPreview = new IssuesPreview();
 
   context.subscriptions.push(
     vscode.commands.registerCommand('cervin.openPreview', async () => {
@@ -253,6 +259,17 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     vscode.commands.registerCommand('transitrixStudio.saveProcessBlueprintAsSvg', async () => {
       await processBlueprintPreview.saveAsSvg();
     }),
+    vscode.commands.registerCommand('transitrixStudio.previewIssues', async () => {
+      const doc = vscode.window.activeTextEditor?.document;
+      if (!doc || !isIssuesFile(doc)) {
+        vscode.window.showWarningMessage('Open a *.issues.transitrix.yaml file first.');
+        return;
+      }
+      await issuesPreview.showOrReveal(doc);
+    }),
+    vscode.commands.registerCommand('transitrixStudio.saveIssuesAsSvg', async () => {
+      await issuesPreview.saveAsSvg();
+    }),
     vscode.workspace.onDidSaveTextDocument((doc) => {
       if (isGoalsFile(doc)) { void goalsPreview.refreshSaved(doc); return; }
       if (isFGCAFile(doc)) { void fgcaPreview.refreshSaved(doc); return; }
@@ -265,6 +282,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       if (isScenariosFile(doc)) { void scenariosPreview.refreshSaved(doc); return; }
       if (isCapabilityMapFile(doc)) { void capabilityMapPreview.refreshSaved(doc); return; }
       if (isProcessBlueprintFile(doc)) { void processBlueprintPreview.refreshSaved(doc); return; }
+      if (isIssuesFile(doc)) { void issuesPreview.refreshSaved(doc); return; }
       if (!documentMatchesCervinSource(doc)) return;
       void preview.refreshSaved(doc);
     }),
@@ -279,7 +297,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       if (isProcessMapFile(doc)) { await processMapPreview.showOrReveal(doc); return; }
       if (isScenariosFile(doc)) { await scenariosPreview.showOrReveal(doc); return; }
       if (isCapabilityMapFile(doc)) { await capabilityMapPreview.showOrReveal(doc); return; }
-      if (isProcessBlueprintFile(doc)) { await processBlueprintPreview.showOrReveal(doc); }
+      if (isProcessBlueprintFile(doc)) { await processBlueprintPreview.showOrReveal(doc); return; }
+      if (isIssuesFile(doc)) { await issuesPreview.showOrReveal(doc); }
     }),
   );
 }

--- a/extension/src/issues-preview.ts
+++ b/extension/src/issues-preview.ts
@@ -1,0 +1,230 @@
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+import yaml from 'js-yaml';
+import { buildDiagramFrame, prepareSvgForExport, type ThemeId } from './diagram-frame.js';
+import { TITLE_BLOCK_H, titleBlockSvg, todayIso } from './svg-title-block.js';
+import {
+  validateIssues,
+  layoutIssues,
+  type IssuesFile,
+  type IssuesLayout,
+  type IssueStatus,
+} from '../../packages/diagrams/src/issues/index.js';
+
+function escXml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+function truncate(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  return text.slice(0, Math.max(0, maxChars - 1)) + '…';
+}
+
+/**
+ * Map the methodology spec's status vocabulary (§5.3) onto Studio's
+ * existing four-palette status colour set:
+ *
+ *   open         → info     (neutral blue — registered, not yet worked)
+ *   in_progress  → warning  (yellow — work in motion)
+ *   blocked      → error    (red — cannot progress)
+ *   resolved     → success  (green — fixed)
+ *   closed       → neutral  (muted — no longer tracked)
+ *
+ * Returns `[bgVar, fgVar]` so the caller can reference the CSS variable
+ * names defined in `packages/diagrams/src/theme/themes.ts`.
+ */
+function statusPalette(s: IssueStatus | undefined): [bg: string, fg: string, label: string] {
+  switch (s) {
+    case 'open':
+      return ['var(--ts-status-info-bg)', 'var(--ts-status-info-fg)', 'open'];
+    case 'in_progress':
+      return ['var(--ts-status-warning-bg)', 'var(--ts-status-warning-fg)', 'in progress'];
+    case 'blocked':
+      return ['var(--ts-status-error-bg)', 'var(--ts-status-error-fg)', 'blocked'];
+    case 'resolved':
+      return ['var(--ts-status-success-bg)', 'var(--ts-status-success-fg)', 'resolved'];
+    case 'closed':
+      return ['var(--ts-divider)', 'var(--ts-text-secondary)', 'closed'];
+    default:
+      // Validation surfaces a bad status as ISS-002, so we won't usually
+      // reach here — but the layout module is robust to garbage, so the
+      // renderer should be too.
+      return ['var(--ts-divider)', 'var(--ts-text-secondary)', String(s ?? '?')];
+  }
+}
+
+const STATUS_BADGE_WIDTH = 96;
+const STATUS_BADGE_HEIGHT = 22;
+const STATUS_BADGE_PAD = 10;
+
+function layoutToSvg(
+  layout: IssuesLayout,
+  filename?: string,
+  date?: string,
+  version?: string,
+): string {
+  const pad = 24;
+  const showTitle = filename != null && date != null;
+  const titleH = showTitle ? TITLE_BLOCK_H : 0;
+  const w = layout.bounds.width + pad * 2;
+  const h = layout.bounds.height + pad * 2 + titleH;
+  const ox = pad;
+  const oy = pad + titleH;
+
+  const parts: string[] = [];
+
+  for (const row of layout.rows) {
+    const x = row.x + ox;
+    const y = row.y + oy;
+
+    parts.push(
+      `<rect class="diagram-node level-0" x="${x}" y="${y}" width="${row.width}" height="${row.height}" rx="6"/>`,
+    );
+
+    // Name label, left-aligned with internal padding. The badge sits on
+    // the right; reserve its column so the name does not overlap when the
+    // status label is long.
+    const nameMaxChars = Math.max(
+      8,
+      Math.floor((row.width - STATUS_BADGE_WIDTH - STATUS_BADGE_PAD * 3) / 7),
+    );
+    parts.push(
+      `<text class="text-primary" x="${x + STATUS_BADGE_PAD}" y="${y + row.height / 2}" dominant-baseline="central">${escXml(truncate(row.data.name, nameMaxChars))}</text>`,
+    );
+
+    // Status badge on the right.
+    const [bg, fg, label] = statusPalette(row.data.status);
+    const badgeX = x + row.width - STATUS_BADGE_WIDTH - STATUS_BADGE_PAD;
+    const badgeY = y + (row.height - STATUS_BADGE_HEIGHT) / 2;
+    parts.push(
+      `<rect x="${badgeX}" y="${badgeY}" width="${STATUS_BADGE_WIDTH}" height="${STATUS_BADGE_HEIGHT}" rx="4" fill="${bg}"/>`,
+    );
+    parts.push(
+      `<text x="${badgeX + STATUS_BADGE_WIDTH / 2}" y="${badgeY + STATUS_BADGE_HEIGHT / 2}" text-anchor="middle" dominant-baseline="central" font-size="11" font-weight="600" fill="${fg}">${escXml(label)}</text>`,
+    );
+
+    // Secondary line under the name when there is room: owner role +
+    // relates_to count. Drawn only when the node height permits — today
+    // the default 44 px row stays single-line; this is for future tuning.
+    // (Skipped in v1: keeps the surface area small.)
+  }
+
+  const titleSvg = showTitle ? titleBlockSvg('Issues Register', filename!, date!, pad, pad, version) : '';
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">
+${titleSvg}
+${parts.join('\n')}
+</svg>`;
+}
+
+export class IssuesPreview {
+  readonly panelTitle = 'Issues Preview';
+  private panel: vscode.WebviewPanel | undefined;
+  private trackedUri: string | undefined;
+  private lastSvg = '';
+
+  isShowingDocument(uri: vscode.Uri): boolean {
+    return this.panel != null && this.trackedUri === uri.toString();
+  }
+
+  async showOrReveal(doc: vscode.TextDocument): Promise<void> {
+    this.trackedUri = doc.uri.toString();
+    if (this.panel) {
+      this.panel.title = `${this.panelTitle} — ${path.basename(doc.fileName)}`;
+      this.panel.reveal(vscode.ViewColumn.Beside, true);
+    } else {
+      this.panel = vscode.window.createWebviewPanel(
+        'issuesPreview',
+        `${this.panelTitle} — ${path.basename(doc.fileName)}`,
+        { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
+        {
+          enableScripts: false,
+          retainContextWhenHidden: true,
+          enableCommandUris: ['transitrixStudio.saveIssuesAsSvg'],
+        },
+      );
+      this.panel.onDidDispose(() => {
+        this.panel = undefined;
+        this.trackedUri = undefined;
+      });
+    }
+    await this.pushDocument(doc);
+  }
+
+  async refreshSaved(doc: vscode.TextDocument): Promise<void> {
+    if (!this.isShowingDocument(doc.uri)) return;
+    await this.pushDocument(doc);
+  }
+
+  private async pushDocument(doc: vscode.TextDocument): Promise<void> {
+    if (!this.panel) return;
+    this.panel.webview.html = this.buildHtml(doc.getText(), path.basename(doc.fileName));
+  }
+
+  private buildHtml(yamlText: string, filename: string): string {
+    let svgContent = '';
+    let errorMsg = '';
+    let warnings: string[] = [];
+
+    try {
+      const parsed = yaml.load(yamlText) as unknown;
+      const v = validateIssues(parsed);
+      warnings = v.warnings.map((w) => `${w.code}: ${w.message}`);
+      if (!v.valid) {
+        errorMsg = v.errors.map((e) => `${e.code}: ${e.message}`).join('\n');
+      } else {
+        const file = parsed as IssuesFile;
+        const cat = (file as unknown as { issues_catalogue?: { version?: unknown; updated_at?: unknown } })
+          .issues_catalogue ?? {};
+        const docVersion = typeof cat.version === 'string' ? cat.version : undefined;
+        const docDate = typeof cat.updated_at === 'string' ? cat.updated_at : todayIso();
+        const layout = layoutIssues(file);
+        svgContent = layoutToSvg(layout, filename, docDate, docVersion);
+      }
+    } catch (e) {
+      errorMsg = (e as Error).message ?? 'Parse error';
+    }
+
+    this.lastSvg = svgContent;
+
+    const themeId = vscode.workspace
+      .getConfiguration('transitrix')
+      .get<ThemeId>('theme', 'transitrix');
+
+    return buildDiagramFrame({
+      filename,
+      notation: 'Issues Register',
+      svgContent,
+      errorMsg,
+      warnings,
+      themeId,
+      saveSvgCommand: 'transitrixStudio.saveIssuesAsSvg',
+    });
+  }
+
+  async saveAsSvg(): Promise<void> {
+    if (!this.lastSvg) {
+      vscode.window.showWarningMessage(
+        'No diagram rendered yet. Open a *.issues.transitrix.yaml file first.',
+      );
+      return;
+    }
+    const sourceUri = this.trackedUri ? vscode.Uri.parse(this.trackedUri) : undefined;
+    const stem = sourceUri
+      ? path.basename(sourceUri.fsPath).replace(/\.issues\.transitrix\.yaml$/, '')
+      : 'diagram';
+    const defaultUri = sourceUri
+      ? vscode.Uri.file(path.join(path.dirname(sourceUri.fsPath), `${stem}.svg`))
+      : vscode.Uri.file(`${stem}.svg`);
+    const target = await vscode.window.showSaveDialog({
+      defaultUri,
+      filters: { 'SVG Image': ['svg'] },
+    });
+    if (!target) return;
+    const themeId = vscode.workspace
+      .getConfiguration('transitrix')
+      .get<ThemeId>('theme', 'transitrix');
+    const svg = prepareSvgForExport(this.lastSvg, themeId);
+    await vscode.workspace.fs.writeFile(target, Buffer.from(svg, 'utf-8'));
+    vscode.window.showInformationMessage(`Saved: ${path.basename(target.fsPath)}`);
+  }
+}


### PR DESCRIPTION
## Summary

Re-opens transitrix-studio#56. The original PR was based on `feat/issues-diagrams-module` (the data-layer branch that became #53), and was auto-closed by GitHub when its base branch got deleted on #53's `--delete-branch` merge — not as a review decision. Same commit, rebased onto current `main` (which now contains the diagrams module via squash commit `85603e9`). The earlier preview commit replays cleanly; `87d9b31` (the diagrams-module commit on the original stack) is detected as already-applied and dropped automatically.

The PR adds the VS Code extension preview surface for `*.issues.transitrix.yaml` files, consuming the `@transitrix/diagrams` `issues` module directly — no duplicate validation or layout logic in the extension.

- **`extension/src/issues-preview.ts`** — modelled on `process-blueprint-preview.ts`. Parses the YAML, runs `validateIssues` (`ISS-001…006`), lays out with `layoutIssues` (the nested-outline algorithm in `@transitrix/diagrams/issues`), and emits an SVG: one row per issue, indented by depth, colour-coded status badge per the methodology spec §5.3 vocabulary. `enableScripts: false` retained; Save-as-SVG routes through `prepareSvgForExport`.
- **`extension/src/extension.ts`** — `isIssuesFile` predicate, `IssuesPreview` instance, `transitrixStudio.previewIssues` + `transitrixStudio.saveIssuesAsSvg` commands, and the matching `onDidSave` / `onDidOpen` branches.
- **`extension/package.json`** — `workspaceContains:**/*.issues.transitrix.yaml` activation event; `transitrix-issues` language contribution; two commands; three `editor/title` menu entries (preview, save, save-from-webview).

## Status badge palette

Methodology spec §8 mandates colour-coded badges but doesn't fix exact colours. Mapped to Studio's existing four-palette set already in use by `capability-map` and `scenarios` previews:

| Status | Palette |
|---|---|
| `open` | info (light blue) |
| `in_progress` | warning (yellow) |
| `blocked` | error (red) |
| `resolved` | success (green) |
| `closed` | neutral (`--ts-divider` + `--ts-text-secondary` — muted, archived) |

`closed` falls back to neutral because the four-palette set has no archived slot.

## Verification

- `npm run compile` clean.
- `npm run compile:extension` clean.
- `npm test` — **391 tests pass** (228 core + 163 diagrams including the 18 issues-module tests that landed via #53 + the rest of the family).
- No new tests added in this PR — the diagrams module already carries unit coverage, and the extension layer is glue (consistent with how the other notation previews are tested).

## Test plan

- [ ] Hand-test in VS Code: open the issues example file from a local checkout of `transitrix/methodology` (`notations/examples/issues/platform-launch.issues.transitrix.yaml`), confirm preview opens beside the editor, nested indentation renders, status badges colour-code correctly, Save-as-SVG produces a self-contained file that opens in a browser.

## Notes on the reopen

- Original PR #56 closed automatically when `feat/issues-diagrams-module` (its base) was deleted by GitHub's `--delete-branch` merge of #53.
- The commit content is identical to the original #56 — only the base reference changed.
- Strategy issue #50 was closed on the original PR's opening; I'll add a comment there pointing at this new PR so the trail is recoverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
