### PR TITLE
docs(extension): refresh notation list to 1.0.0+ state (Issues + native blocks)

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -13,7 +13,8 @@ Live **preview** for Transitrix diagram formats inside VS Code:
 - **Scenarios** — `.scenarios.transitrix.yaml` (scenario planning: factors, references across the model)
 - **Applications catalogue** — `.applications.transitrix.yaml` (applications, integrations, platforms, data stores)
 - **Products catalogue** — `.products.transitrix.yaml` (digital products, services, platforms, bundles)
-- **Nested blocks** — `.blocks.transitrix.txt` (ASCII block diagrams via Svgbob; requires Python 3 + `svgbob_cli`)
+- **Nested blocks** — `.blocks.transitrix.yaml` (recursive `block` tree rendered as nested containers; native TypeScript renderer — no external binaries)
+- **Issues register** — `.issues.transitrix.yaml` (nested issue tree with colour-coded status badges: open / in_progress / blocked / resolved / closed)
 
 Every vector preview toolbar provides:
 - **Title** — toggle the diagram caption on/off


### PR DESCRIPTION
## Summary

Two stale entries in `extension/README.md` — the file that renders as the Marketplace listing Overview — brought up to the post-1.0.0 state:

- **Nested blocks** — was described as ASCII via Svgbob with Python + `svgbob_cli` prerequisites. After #54 the notation is structured YAML and renders natively in TypeScript with no external binaries.
- **Issues register** — was missing entirely. #53 (diagrams module) + #58 (extension preview) added the support; the listing should advertise it.

Surfaced by strategy/transitrix-studio#39. Pairs with a `vsce publish` from main to push the corrected 13-notation Overview to the Marketplace.

## Out of scope (mentioned as follow-ups in the strategy comment)

The root `README.md` is more deeply stale than this PR addresses — it still references v0.4.0 markers (`.cervin.yaml` extension, `cervin` CLI binary), lists only three formats in the support table, mentions `backends/blocks/  — Python nested-block backend` in the repo-layout diagram (deleted in #54), and references VSIX `0.4.0`. Not touched here because the strategy task scopes specifically the Marketplace listing Overview (= this file) and the GitHub About blurb (manual UI fix). Happy to open a separate small PR for the root README refresh — say the word.

## Test plan

- [x] `git diff` shows exactly the two-line README change above; nothing else touched.
- [ ] Build the extension (`npm run package-extension`) and visually inspect the generated `.vsix`'s shipped README before `vsce publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
