### PR TITLE
docs(changelog): 1.1.0 release notes

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Transitrix Studio — changelog
 
+## 1.1.0 — 2026-05-26
+
+Closes the 1.0.0 "Nested blocks needs Python + svgbob" known limitation with a native TS renderer, and adds the **Issues register** notation. The blocks notation moves to a structured-YAML schema with a new file extension — breaking for the small `.blocks.transitrix.txt` corpus that existed before 1.1.0.
+
+### Breaking
+
+- **`.blocks.transitrix.txt` is no longer recognised.** Nested blocks moved to `.blocks.transitrix.yaml` with a structured YAML schema (`nested_blocks:` root, recursive `block` tree carrying `id`, `name`, optional `children`).
+  - **Migration:** rewrite the diagram in the new form. The spec is canonical at [transitrix/methodology — `08-blocks.md`](https://github.com/transitrix/methodology/blob/main/notations/08-blocks.md); the worked example ships at [`examples/blocks/architecture.blocks.transitrix.yaml`](./examples/blocks/architecture.blocks.transitrix.yaml).
+- **Settings removed:** `transitrix.pythonPath` and `transitrix.svgbobPath`. They configured the now-deleted Python + svgbob backend and are no longer read.
+- **`cervin serve` API:** the `/api/blocks/compile` endpoint is gone — the dev UI's "Nested blocks (Svgbob)" tab and its server route both depended on the Python backend.
+
+### Added
+
+- **Issues register** — `.issues.transitrix.yaml` — new vector notation: nested issue tree (parent → child via the `parent:` field) with colour-coded status badges (`open` / `in_progress` / `blocked` / `resolved` / `closed`). Validation codes `ISS-001 … 006`. Save-as-SVG works like every other vector preview.
+- `npm run sync-examples` — developer tooling that mirrors `notations/examples/` from a local `transitrix/methodology` checkout into Studio's `examples/`. Dry-run by default; `--apply` copies added / changed files, `--apply --delete-stale` is strict mirror.
+
+### Changed
+
+- **Nested blocks** — structured YAML schema replaces the ASCII art form. Renders natively in TypeScript via `@transitrix/diagrams/blocks` — no external binaries. Validation codes `BL-001 … 009`.
+- `extension/README.md` and root `README.md` refreshed for the post-1.0 notation set: Issues bullet added, Nested blocks bullet rewritten without svgbob, repo-layout diagram drops the deleted Python-backend folder, CLI port corrected from `3000` to `8765`, install command bumped to 1.1.0.
+- Removed the duplicate `examples/bpmn/order-processing.bpmn.yaml` (byte-identical to `order-fulfillment.bpmn.yaml`; the methodology repo's `NOTATIONS_VALIDATION.md` §2.4 had flagged it).
+
+### Removed
+
+- `backends/blocks/` — Python + svgbob backend (`blocks_stdio.py`, `diagram_generator.py`, README, Makefile, tests, requirements.txt).
+- `src/blocks-backend.ts` — Node-side wrapper around the Python backend.
+- `tests/blocks-backend.test.ts` and the corresponding `handleBlocksCompile` test block in `tests/serve-ui.test.ts`.
+- `.github/workflows/python-backend.yml` — the only Python CI job; nothing Python-dependent remains in the codebase.
+- Pre-release review items closed by removal: TX-R001 `svgbobCommand` external-process surface; the `should-fix` missing-timeout on the `svgbob` subprocess; the dead `try/catch` nit in the old `blocks-preview.ts`; the CI-gap should-fix where the Python backend was untested.
+
 ## 1.0.0 — 2026-05-24
 
 First marketplace release. The full Transitrix notation set previews in VS Code with a unified visual contract, in-SVG title blocks, a per-preview toolbar, and `.svg` export.


### PR DESCRIPTION
## Summary

Adds the `1.1.0 — 2026-05-26` entry to `extension/CHANGELOG.md` ahead of the actual `node scripts/bump-extension-version.mjs minor` + `vsce publish`. Drafted as a separate PR so the user-visible release-notes text can be reviewed before going to the Marketplace.

The section follows the existing 1.0.0 format (Added / Changed / Removed) with a leading **Breaking** subsection placed first so it lands on anyone scanning the changelog. That's the only structural addition versus the 1.0.0 template — no "Known limitations" subsection because nothing on the 1.0.0 list survives into 1.1.0 unaddressed.

### What the entry covers

- **Breaking**: `.blocks.transitrix.txt` → `.blocks.transitrix.yaml` extension change with migration pointer; removed `transitrix.pythonPath` / `transitrix.svgbobPath` settings; removed `/api/blocks/compile` endpoint in `cervin serve`.
- **Added**: Issues register notation (`.issues.transitrix.yaml`); `npm run sync-examples` tooling.
- **Changed**: Nested blocks renderer rewritten (native TS, no external binaries); both READMEs refreshed; duplicate BPMN example deleted.
- **Removed**: `backends/blocks/`, `src/blocks-backend.ts`, related tests, the Python CI workflow; the four pre-release review items closed by the blocks redesign (TX-R001 / missing-timeout / dead try-catch / Python-CI-gap).

### Release flow after this lands

Once you sign off:

```powershell
cd C:\GitHub\transitrix-studio
git checkout main; git pull
node scripts/bump-extension-version.mjs minor       # 1.0.0 → 1.1.0
npm run compile; npm run compile:extension; npm test
npm run extension:prep
cd extension; vsce package                          # produces transitrix-studio-1.1.0.vsix
cd ..; git add -A; git commit -m "chore(release): 1.1.0"
git tag v1.1.0; git push; git push --tags
cd extension; vsce publish                          # or upload via Marketplace UI
gh release create v1.1.0 -R transitrix/transitrix-studio extension/transitrix-studio-1.1.0.vsix --notes-from-tag
```

(I can run the bump + build steps once you merge this and give the go-ahead, but `vsce publish` is your call — it touches the Marketplace.)

## Test plan

- [x] CHANGELOG diff: 30 lines added above the existing 1.0.0 section; nothing else touched.
- [ ] Visual review of the text: terminology consistent with the codebase, no typos, the migration pointer link resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
