### PR TITLE
feat(diagrams): coerce native Date values to ISO YYYY-MM-DD at parse boundary

### DIFF
--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -14,6 +14,7 @@ import {
   type GanttLayout,
   type GanttResult,
 } from '../../packages/diagrams/src/activities/index.js';
+import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 
 // ── Shared helpers ───────────────────────────────────────────────────────────
 
@@ -593,7 +594,7 @@ export class ActivitiesPreview {
     let warnings: string[] = [];
 
     try {
-      const parsed = yaml.load(yamlText) as unknown;
+      const parsed = coerceDatesToIsoStrings(yaml.load(yamlText) as unknown);
       // Document version/date for the title block. `version` is optional;
       // `date` falls back to today when the document has no date field —
       // a frozen version paired with a floating render date would be

--- a/extension/src/applications-preview.ts
+++ b/extension/src/applications-preview.ts
@@ -2,6 +2,7 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, CATALOGUE_STYLES, type ThemeId } from './diagram-frame.js';
+import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 
 // ── Inline types (mirror packages/diagrams/src/applications/types.ts) ─────────
 
@@ -272,7 +273,7 @@ export class ApplicationsPreview {
     let date: string | undefined;
 
     try {
-      const parsed = yaml.load(yamlText) as unknown;
+      const parsed = coerceDatesToIsoStrings(yaml.load(yamlText) as unknown);
 
       if (parsed && typeof parsed === 'object') {
         const raw = parsed as Record<string, unknown>;

--- a/extension/src/blocks-preview.ts
+++ b/extension/src/blocks-preview.ts
@@ -11,6 +11,7 @@ import {
   type BlocksLayout,
   type LaidOutBlock,
 } from '../../packages/diagrams/src/blocks/index.js';
+import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 
 function escXml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
@@ -127,7 +128,7 @@ export class BlocksPreview {
     let warnings: string[] = [];
 
     try {
-      const parsed = yaml.load(yamlText) as unknown;
+      const parsed = coerceDatesToIsoStrings(yaml.load(yamlText) as unknown);
       const v = validateNestedBlocks(parsed);
       warnings = v.warnings.map((w) => `${w.code}: ${w.message}`);
       if (!v.valid) {

--- a/extension/src/capability-map-preview.ts
+++ b/extension/src/capability-map-preview.ts
@@ -2,6 +2,7 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, CATALOGUE_STYLES, type ThemeId } from './diagram-frame.js';
+import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 
 // ── Inline types (mirror packages/diagrams/src/capability-map/types.ts) ───────
 
@@ -251,7 +252,7 @@ export class CapabilityMapPreview {
     let date: string | undefined;
 
     try {
-      const parsed = yaml.load(yamlText) as unknown;
+      const parsed = coerceDatesToIsoStrings(yaml.load(yamlText) as unknown);
       if (parsed && typeof parsed === 'object') {
         const raw = parsed as Record<string, unknown>;
         if (typeof raw['title'] === 'string') title = raw['title'];

--- a/extension/src/fgca-preview.ts
+++ b/extension/src/fgca-preview.ts
@@ -4,6 +4,7 @@ import yaml from 'js-yaml';
 import { buildDiagramFrame, prepareSvgForExport, type ThemeId } from './diagram-frame.js';
 import { TITLE_BLOCK_H, titleBlockSvg, todayIso } from './svg-title-block.js';
 import { parseCanonicalFGCA } from '../../packages/diagrams/src/fgca/parse-canonical.js';
+import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 
 // ── Inline types ──────────────────────────────────────────────────────────────
 //
@@ -429,7 +430,7 @@ export class FGCAPreview {
     let warnings: string[] = [];
 
     try {
-      const parsed = yaml.load(yamlText) as unknown;
+      const parsed = coerceDatesToIsoStrings(yaml.load(yamlText) as unknown);
       const meta = (parsed && typeof parsed === 'object' ? parsed : {}) as { version?: unknown; date?: unknown };
       const docVersion = typeof meta.version === 'string' ? meta.version : undefined;
       const docDate = typeof meta.date === 'string' ? meta.date : todayIso();
@@ -523,7 +524,7 @@ export class FGAPreview {
     let warnings: string[] = [];
 
     try {
-      const parsed = yaml.load(yamlText) as unknown;
+      const parsed = coerceDatesToIsoStrings(yaml.load(yamlText) as unknown);
       const meta = (parsed && typeof parsed === 'object' ? parsed : {}) as { version?: unknown; date?: unknown };
       const docVersion = typeof meta.version === 'string' ? meta.version : undefined;
       const docDate = typeof meta.date === 'string' ? meta.date : todayIso();

--- a/extension/src/goals-preview.ts
+++ b/extension/src/goals-preview.ts
@@ -9,6 +9,7 @@ import {
   type LaidOutEdge,
 } from '../../packages/diagrams/src/goals/index.js';
 import { parseCanonicalGoals } from '../../packages/diagrams/src/goals/parse-canonical.js';
+import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 
 // ── SVG renderer ─────────────────────────────────────────────────────────────
 //
@@ -133,7 +134,7 @@ export class GoalsPreview {
     let warnings: string[] = [];
 
     try {
-      const parsedYaml = yaml.load(yamlText) as unknown;
+      const parsedYaml = coerceDatesToIsoStrings(yaml.load(yamlText) as unknown);
       const v = parseCanonicalGoals(parsedYaml);
       warnings = v.warnings.map(w => `${w.code}: ${w.message}`);
       if (!v.valid || !v.parsed) {

--- a/extension/src/issues-preview.ts
+++ b/extension/src/issues-preview.ts
@@ -10,6 +10,7 @@ import {
   type IssuesLayout,
   type IssueStatus,
 } from '../../packages/diagrams/src/issues/index.js';
+import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 
 function escXml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
@@ -166,7 +167,7 @@ export class IssuesPreview {
     let warnings: string[] = [];
 
     try {
-      const parsed = yaml.load(yamlText) as unknown;
+      const parsed = coerceDatesToIsoStrings(yaml.load(yamlText) as unknown);
       const v = validateIssues(parsed);
       warnings = v.warnings.map((w) => `${w.code}: ${w.message}`);
       if (!v.valid) {

--- a/extension/src/process-blueprint-preview.ts
+++ b/extension/src/process-blueprint-preview.ts
@@ -9,6 +9,7 @@ import {
   type ProcessBlueprintFile,
   type ProcessBlueprintLayout,
 } from '../../packages/diagrams/src/process-blueprint/index.js';
+import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 
 function escXml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
@@ -142,7 +143,7 @@ export class ProcessBlueprintPreview {
     let warnings: string[] = [];
 
     try {
-      const parsed = yaml.load(yamlText) as unknown;
+      const parsed = coerceDatesToIsoStrings(yaml.load(yamlText) as unknown);
       const v = validateProcessBlueprint(parsed);
       warnings = v.warnings.map(w => `${w.code}: ${w.message}`);
       if (!v.valid) {

--- a/extension/src/process-map-preview.ts
+++ b/extension/src/process-map-preview.ts
@@ -2,6 +2,7 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, CATALOGUE_STYLES, type ThemeId } from './diagram-frame.js';
+import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 
 // ── Inline types (mirror packages/diagrams/src/process-map/types.ts) ──────────
 
@@ -263,7 +264,7 @@ export class ProcessMapPreview {
     let date: string | undefined;
 
     try {
-      const parsed = yaml.load(yamlText) as unknown;
+      const parsed = coerceDatesToIsoStrings(yaml.load(yamlText) as unknown);
 
       if (parsed && typeof parsed === 'object') {
         const raw = parsed as Record<string, unknown>;

--- a/extension/src/products-preview.ts
+++ b/extension/src/products-preview.ts
@@ -2,6 +2,7 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, CATALOGUE_STYLES, type ThemeId } from './diagram-frame.js';
+import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 
 // ── Inline types (mirror packages/diagrams/src/products/types.ts) ─────────────
 
@@ -228,7 +229,7 @@ export class ProductsPreview {
     let date: string | undefined;
 
     try {
-      const parsed = yaml.load(yamlText) as unknown;
+      const parsed = coerceDatesToIsoStrings(yaml.load(yamlText) as unknown);
 
       if (parsed && typeof parsed === 'object') {
         const raw = parsed as Record<string, unknown>;

--- a/extension/src/scenarios-preview.ts
+++ b/extension/src/scenarios-preview.ts
@@ -2,6 +2,7 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, CATALOGUE_STYLES, type ThemeId } from './diagram-frame.js';
+import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 
 // ── Inline types (mirror packages/diagrams/src/scenarios/types.ts) ────────────
 
@@ -261,7 +262,7 @@ export class ScenariosPreview {
     let date: string | undefined;
 
     try {
-      const parsed = yaml.load(yamlText) as unknown;
+      const parsed = coerceDatesToIsoStrings(yaml.load(yamlText) as unknown);
       if (parsed && typeof parsed === 'object') {
         const raw = parsed as Record<string, unknown>;
         if (typeof raw['title'] === 'string') title = raw['title'];

--- a/packages/diagrams/src/__tests__/yaml-normalize.test.ts
+++ b/packages/diagrams/src/__tests__/yaml-normalize.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import yaml from 'js-yaml';
+import { coerceDatesToIsoStrings } from '../yaml-normalize.js';
+import { validateActivities } from '../activities/index.js';
+
+describe('coerceDatesToIsoStrings', () => {
+  it('replaces top-level Date with ISO YYYY-MM-DD string', () => {
+    const out = coerceDatesToIsoStrings(new Date(Date.UTC(2026, 5, 1))); // 2026-06-01 UTC
+    expect(out).toBe('2026-06-01');
+  });
+
+  it('replaces Date values inside nested arrays of objects', () => {
+    const input = {
+      activities: [
+        { id: 'A-001', start_date: new Date(Date.UTC(2026, 5, 1)), end_date: new Date(Date.UTC(2026, 5, 5)) },
+        { id: 'A-002', start_date: '2026-06-06' },
+      ],
+    };
+    coerceDatesToIsoStrings(input);
+    expect(input.activities[0].start_date).toBe('2026-06-01');
+    expect(input.activities[0].end_date).toBe('2026-06-05');
+    expect(input.activities[1].start_date).toBe('2026-06-06');
+  });
+
+  it('walks objects recursively', () => {
+    const input = {
+      project: { start_date: new Date(Date.UTC(2026, 0, 15)) },
+    };
+    coerceDatesToIsoStrings(input);
+    expect(input.project.start_date).toBe('2026-01-15');
+  });
+
+  it('leaves non-Date values untouched', () => {
+    const input = {
+      notation: 'activities',
+      activities: [{ id: 'A-001', duration: 3, start_date: '2026-06-01' }],
+    };
+    const out = coerceDatesToIsoStrings(input);
+    expect(out).toBe(input);
+    expect(input.activities[0].start_date).toBe('2026-06-01');
+    expect(input.activities[0].duration).toBe(3);
+  });
+
+  it('handles null, undefined, and primitive scalars', () => {
+    expect(coerceDatesToIsoStrings(null)).toBe(null);
+    expect(coerceDatesToIsoStrings(undefined)).toBe(undefined);
+    expect(coerceDatesToIsoStrings('hello')).toBe('hello');
+    expect(coerceDatesToIsoStrings(42)).toBe(42);
+    expect(coerceDatesToIsoStrings(true)).toBe(true);
+  });
+
+  it('handles arrays that contain bare Date elements', () => {
+    const arr = [new Date(Date.UTC(2026, 5, 1)), 'x', { d: new Date(Date.UTC(2026, 5, 2)) }];
+    coerceDatesToIsoStrings(arr);
+    expect(arr[0]).toBe('2026-06-01');
+    expect(arr[1]).toBe('x');
+    expect((arr[2] as { d: unknown }).d).toBe('2026-06-02');
+  });
+});
+
+describe('coerceDatesToIsoStrings — js-yaml integration', () => {
+  it('quoted ISO dates are preserved untouched', () => {
+    const text = [
+      'notation: activities',
+      'activities:',
+      '  - id: "A-001"',
+      '    name: "Quoted dates"',
+      '    duration: 3',
+      '    start_date: "2026-06-01"',
+      '    end_date: "2026-06-03"',
+      '',
+    ].join('\n');
+    const parsed = yaml.load(text) as { activities: { start_date: unknown; end_date: unknown }[] };
+    coerceDatesToIsoStrings(parsed);
+    expect(parsed.activities[0].start_date).toBe('2026-06-01');
+    expect(parsed.activities[0].end_date).toBe('2026-06-03');
+    const v = validateActivities(parsed);
+    expect(v.valid).toBe(true);
+  });
+
+  it('bare ISO dates are coerced to ISO strings and pass validation', () => {
+    const text = [
+      'notation: activities',
+      'activities:',
+      '  - id: "A-001"',
+      '    name: "Bare dates"',
+      '    duration: 3',
+      '    start_date: 2026-06-01',
+      '    end_date: 2026-06-03',
+      '',
+    ].join('\n');
+    const parsed = yaml.load(text) as { activities: { start_date: unknown; end_date: unknown }[] };
+    // Without coercion, js-yaml returns Date instances and the validator
+    // would emit ACT-008 because typeof !== 'string'. Sanity-check that
+    // assumption before normalisation.
+    expect(parsed.activities[0].start_date).toBeInstanceOf(Date);
+    coerceDatesToIsoStrings(parsed);
+    expect(parsed.activities[0].start_date).toBe('2026-06-01');
+    expect(parsed.activities[0].end_date).toBe('2026-06-03');
+    const v = validateActivities(parsed);
+    expect(v.valid).toBe(true);
+  });
+});
+
+// The issue calls out the timezone trap: a Date built from a bare ISO
+// date is midnight UTC, but if we used `getFullYear / getMonth / getDate`
+// instead of the UTC variants, a non-UTC process timezone would shift the
+// day. Pin a non-UTC TZ for this block so the regression bites if anyone
+// later swaps to local-time accessors.
+describe('coerceDatesToIsoStrings — non-UTC timezone', () => {
+  const originalTz = process.env.TZ;
+  beforeAll(() => {
+    // Pacific/Auckland is UTC+12/+13 — the most aggressive eastward shift
+    // available without DST gymnastics. If local-time accessors are used,
+    // `2026-06-01` parsed as midnight UTC reads back as `2026-06-01 12:00
+    // local`, which is still the right day — so use a westward TZ for the
+    // real test below. Auckland is here as a sanity case.
+    process.env.TZ = 'Pacific/Auckland';
+  });
+  afterAll(() => {
+    if (originalTz === undefined) {
+      delete process.env.TZ;
+    } else {
+      process.env.TZ = originalTz;
+    }
+  });
+
+  it('does not drift the day forward in an eastward timezone', () => {
+    const text = 'd: 2026-06-01\n';
+    const parsed = yaml.load(text) as { d: unknown };
+    coerceDatesToIsoStrings(parsed);
+    expect(parsed.d).toBe('2026-06-01');
+  });
+});
+
+describe('coerceDatesToIsoStrings — westward (negative offset) timezone', () => {
+  const originalTz = process.env.TZ;
+  beforeAll(() => {
+    // Pacific/Honolulu is UTC-10, no DST. Midnight UTC `2026-06-01` reads
+    // back as `2026-05-31 14:00 local`. Local-time accessors would yield
+    // `2026-05-31` — wrong by one day. UTC accessors yield `2026-06-01`.
+    process.env.TZ = 'Pacific/Honolulu';
+  });
+  afterAll(() => {
+    if (originalTz === undefined) {
+      delete process.env.TZ;
+    } else {
+      process.env.TZ = originalTz;
+    }
+  });
+
+  it('does not drift the day backward in a westward timezone', () => {
+    const text = 'd: 2026-06-01\n';
+    const parsed = yaml.load(text) as { d: unknown };
+    coerceDatesToIsoStrings(parsed);
+    expect(parsed.d).toBe('2026-06-01');
+  });
+});

--- a/packages/diagrams/src/index.ts
+++ b/packages/diagrams/src/index.ts
@@ -11,3 +11,4 @@ export * from "./products/index";
 export * from "./scenarios/index";
 export * from "./theme/index";
 export * from "./validation-types";
+export { coerceDatesToIsoStrings } from "./yaml-normalize";

--- a/packages/diagrams/src/yaml-normalize.ts
+++ b/packages/diagrams/src/yaml-normalize.ts
@@ -1,0 +1,56 @@
+/**
+ * Coerce native `Date` instances inside a parsed YAML document into ISO
+ * `YYYY-MM-DD` strings.
+ *
+ * Background: per the YAML 1.1 timestamp tag, a bare `2026-06-01` is parsed
+ * by `js-yaml` as a native `Date`, not a string. Every notation validator in
+ * this package expects ISO date strings (`typeof === 'string'` +
+ * `YYYY-MM-DD` regex), so a Date reaching validation would falsely fail
+ * shape checks even though the user followed the spec, minus quotes.
+ *
+ * The canonical, methodology-correct form is the quoted ISO string. This
+ * coercion is a backstop so the unquoted form does not silently bite.
+ *
+ * UTC-safe: uses `getUTC*` so the JS process timezone cannot drift the day.
+ * A bare `2026-06-01` parses to midnight UTC and round-trips to
+ * `"2026-06-01"` regardless of `process.env.TZ`.
+ *
+ * Walks in place and returns the same reference for convenience.
+ */
+export function coerceDatesToIsoStrings<T>(value: T): T {
+  if (value === null || value === undefined) return value;
+  if (value instanceof Date) {
+    return dateToIsoYmd(value) as unknown as T;
+  }
+  if (typeof value !== 'object') return value;
+
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      const v = value[i];
+      if (v instanceof Date) {
+        value[i] = dateToIsoYmd(v) as unknown as typeof v;
+      } else if (v !== null && typeof v === 'object') {
+        coerceDatesToIsoStrings(v);
+      }
+    }
+    return value;
+  }
+
+  const obj = value as Record<string, unknown>;
+  for (const key of Object.keys(obj)) {
+    const v = obj[key];
+    if (v instanceof Date) {
+      obj[key] = dateToIsoYmd(v);
+    } else if (v !== null && typeof v === 'object') {
+      coerceDatesToIsoStrings(v);
+    }
+  }
+  return value;
+}
+
+function dateToIsoYmd(d: Date): string {
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(d.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}


### PR DESCRIPTION
## Summary

- Adds `coerceDatesToIsoStrings` in `@transitrix/diagrams` (new `packages/diagrams/src/yaml-normalize.ts`) — walks a parsed YAML document in place and replaces any native `Date` with an ISO `YYYY-MM-DD` string, UTC-safe via `getUTC*` so the JS process timezone cannot drift the day.
- Wires the coercion into every YAML parse boundary in the extension previews — 12 `yaml.load` sites across 11 files — so every notation validator sees strings, never `Date` instances.
- Vitest fixtures: 10 new tests in `packages/diagrams/src/__tests__/yaml-normalize.test.ts` covering quoted + bare ISO dates (both pass validation via `validateActivities`), plus eastward (`Pacific/Auckland`) and westward (`Pacific/Honolulu`) non-UTC timezone overrides as a tripwire if anyone later swaps to local-time accessors.

## Context

Strategy decision in vkgeorgia/strategy#64 — the canonical methodology form is quoted ISO 8601, but Studio coerces bare `Date` instances back to ISO strings so the trap can't bite users who follow the spec literally but drop quotes for cleanliness. Closes vkgeorgia/strategy#71. Paired with the methodology counterpart in vkgeorgia/strategy#70.

No behaviour change for files that already use quoted ISO strings — round-trips through `coerceDatesToIsoStrings` are no-ops on string values.

## Test plan

- [x] `npm test` — 432/432 vitest pass (10 new), including the existing 40-test `validateActivities` suite that exercises `start_date` / `end_date` shape checks.
- [x] `npx tsc --noEmit` clean at root and in `extension/`.
- [ ] Manual: open an `.activities.transitrix.yaml` preview in the extension with **bare** `start_date: 2026-06-01` (no quotes) — should render the Gantt/network without ACT-008 errors.
- [ ] Manual: same file but with quoted `start_date: "2026-06-01"` — unchanged behaviour.

Do not auto-merge. Valerii gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)