### PR TITLE
feat(diagrams): enforce GOALS-012/013 N+1 hierarchy in Goals validator

### DIFF
--- a/packages/diagrams/src/goals/__tests__/validate.test.ts
+++ b/packages/diagrams/src/goals/__tests__/validate.test.ts
@@ -126,4 +126,77 @@ describe('validateGoalTree', () => {
     expect(r.valid).toBe(false);
     expect(r.errors.some(e => e.code === 'SCHEMA_INVALID' && /level/.test(e.message))).toBe(true);
   });
+
+  // GOALS-012 / GOALS-013 — N+1 parent/child hierarchy keyed on goal_types[]
+  // (decision in vkgeorgia/strategy#66; spec in transitrix/methodology
+  // notations/04-goals.md §6).
+  it('GOALS-012/013: accepts a contiguous goal_types + N+1 parent/child tree', () => {
+    const r = validateGoalTree(VALID_TREE);
+    expect(r.valid).toBe(true);
+    expect(r.errors.some(e => e.code === 'GOALS-012')).toBe(false);
+    expect(r.errors.some(e => e.code === 'GOALS-013')).toBe(false);
+  });
+
+  it('GOALS-013: rejects a gap in goal_types[].level', () => {
+    const tree = {
+      goal_types: [
+        { name: 'Strategy', level: 0 },
+        { name: 'Strategic Goal', level: 2 },
+        { name: 'Project Goal', level: 4 },
+      ],
+      goals: [
+        { id: 1, name: 'Root', type: 'Strategy', level: 0, parent_id: 0 },
+      ],
+    };
+    const r = validateGoalTree(tree);
+    expect(r.valid).toBe(false);
+    expect(r.errors.some(e => e.code === 'GOALS-013')).toBe(true);
+  });
+
+  it('GOALS-013: rejects goal_types[].level that does not start at 0', () => {
+    const tree = {
+      goal_types: [
+        { name: 'Mid', level: 1 },
+        { name: 'Deep', level: 2 },
+      ],
+      goals: [
+        { id: 1, name: 'A', type: 'Mid', level: 1, parent_id: 0 },
+      ],
+    };
+    const r = validateGoalTree(tree);
+    expect(r.valid).toBe(false);
+    expect(r.errors.some(e => e.code === 'GOALS-013')).toBe(true);
+  });
+
+  it('GOALS-012: rejects a parent–child level gap > 1', () => {
+    const tree = {
+      goal_types: [
+        { name: 'Strategy', level: 0 },
+        { name: 'Business Goal', level: 1 },
+        { name: 'Project', level: 2 },
+      ],
+      goals: [
+        { id: 1, name: 'Root', type: 'Strategy', level: 0, parent_id: 0 },
+        // Skips level 1: a Project (level 2) attached directly to a Strategy
+        // (level 0) violates N+1.
+        { id: 2, name: 'Sub', type: 'Project', level: 2, parent_id: 1 },
+      ],
+    };
+    const r = validateGoalTree(tree);
+    expect(r.valid).toBe(false);
+    expect(r.errors.some(e => e.code === 'GOALS-012')).toBe(true);
+  });
+
+  it('GOALS-012: does not fire when the parent reference is broken (BROKEN_PARENT_REF covers it)', () => {
+    const tree = {
+      ...VALID_TREE,
+      goals: [
+        { id: 1, name: 'Root', type: 'Strategy', level: 0, parent_id: 0 },
+        { id: 2, name: 'Orphan', type: 'Project', level: 2, parent_id: 99 },
+      ],
+    };
+    const r = validateGoalTree(tree);
+    expect(r.errors.some(e => e.code === 'GOALS-012')).toBe(false);
+    expect(r.warnings.some(w => w.code === 'BROKEN_PARENT_REF')).toBe(true);
+  });
 });

--- a/packages/diagrams/src/goals/validate.ts
+++ b/packages/diagrams/src/goals/validate.ts
@@ -19,9 +19,31 @@ export function validateGoalTree(input: unknown): ValidationResult {
   if (errors.length > 0) return { valid: false, errors, warnings };
 
   const tree = raw as unknown as GoalTree;
+
+  // GOALS-013 — goal_types[].level values must be contiguous starting from 0.
+  // Per the N+1 rule (decision in vkgeorgia/strategy#66), the level set must
+  // be exactly {0, 1, …, N}; a gap breaks the parent→child level invariant
+  // and means GOALS-012 cannot be enforced consistently.
+  const levels = tree.goal_types
+    .map(gt => gt.level)
+    .filter(l => typeof l === 'number' && Number.isFinite(l));
+  if (levels.length > 0) {
+    const unique = Array.from(new Set(levels)).sort((a, b) => a - b);
+    const expected = Array.from({ length: unique.length }, (_, i) => i);
+    const contiguous = unique.length === expected.length && unique.every((v, i) => v === expected[i]);
+    if (!contiguous) {
+      errors.push({
+        code: 'GOALS-013',
+        message: `goal_types[].level values must be contiguous starting from 0; got [${unique.join(', ')}]`,
+        path: 'goal_types',
+      });
+    }
+  }
+
   const maxLevel = Math.max(...tree.goal_types.map(gt => gt.level), 0);
   const typeMap = new Map(tree.goal_types.map(gt => [gt.name, gt.level]));
   const idSet = new Set<number>();
+  const levelById = new Map<number, number>();
 
   for (let i = 0; i < tree.goals.length; i++) {
     const g = tree.goals[i] as unknown;
@@ -54,6 +76,7 @@ export function validateGoalTree(input: unknown): ValidationResult {
     if (goal.level > maxLevel) {
       errors.push({ code: 'MAX_LEVEL_EXCEEDED', message: `Goal ${goal.id} level ${goal.level} exceeds max ${maxLevel}`, path });
     }
+    levelById.set(goal.id, goal.level);
 
     const expectedLevel = typeof goal.type === 'string' ? typeMap.get(goal.type) : undefined;
     if (expectedLevel !== undefined && expectedLevel !== goal.level) {
@@ -70,6 +93,20 @@ export function validateGoalTree(input: unknown): ValidationResult {
     if (!g || typeof g !== 'object') continue;
     if (g.parent_id !== 0 && !idSet.has(g.parent_id)) {
       warnings.push({ code: 'BROKEN_PARENT_REF', message: `Goal ${g.id} references missing parent ${g.parent_id} — moved to backlog`, path });
+      continue;
+    }
+    // GOALS-012 — parent must be exactly one level above the child (N+1
+    // hierarchy, decision in vkgeorgia/strategy#66). Only enforced when the
+    // parent is resolvable; a missing parent is covered by BROKEN_PARENT_REF.
+    if (g.parent_id !== 0) {
+      const parentLevel = levelById.get(g.parent_id);
+      if (parentLevel !== undefined && g.level !== parentLevel + 1) {
+        errors.push({
+          code: 'GOALS-012',
+          message: `Goal ${g.id} (level ${g.level}) must have a parent at level ${g.level - 1}; parent ${g.parent_id} is at level ${parentLevel}`,
+          path,
+        });
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Adds two new error codes to `validateGoalTree` in [packages/diagrams/src/goals/validate.ts](packages/diagrams/src/goals/validate.ts), keyed on the document's declared `goal_types[]`:

- **GOALS-013** — `goal_types[].level` values must be contiguous starting from 0 (no gaps). A gap breaks the parent→child level invariant and would make GOALS-012 inconsistent.
- **GOALS-012** — a goal's parent must reference an existing goal whose `level` equals the child's `level - 1`. Only fires when the parent is resolvable; a missing parent remains a `BROKEN_PARENT_REF` warning (no double-reporting).

Five new vitest fixtures in [packages/diagrams/src/goals/__tests__/validate.test.ts](packages/diagrams/src/goals/__tests__/validate.test.ts): contiguous + N+1 positive, gap in `goal_types[].level`, non-zero-start `goal_types`, parent–child level gap > 1, and a guard that GOALS-012 does not fire when the parent is missing.

## Context

Per the strategy decision in vkgeorgia/strategy#66, methodology `notations/04-goals.md` §6 makes N+1 normative. Closes vkgeorgia/strategy#69.

The methodology counterpart vkgeorgia/strategy#68 is still **open**. Per the issue sequencing, this Studio PR is opened early for review; do not merge before #68 is merged — the current `examples/goals/strategy-2026.goals.transitrix.yaml` uses non-contiguous `goal_types[].level` ([0, 1, 2, 4]) and a level-0 → level-2 parent jump, so once #68 lands the example needs to be pulled fresh from `transitrix/methodology@main` before this merges.

This PR touches only `validate.ts` (the internal-form validator) per the issue's literal acceptance criteria #1. The canonical-form `parseCanonicalGoals` (the path actually wired into the extension preview) does **not** gain GOALS-012/013 in this PR — that's a deliberate scope decision since the current `goals/__tests__/parse-canonical.test.ts` runs the example file through the canonical parser and would otherwise turn red. Threading the same checks through the canonical parser is a natural follow-up once the example is updated.

## Test plan

- [x] `npm --workspace packages/diagrams test` — 437/437 (5 new) green.
- [x] No regression in the existing 13 `validateGoalTree` tests (including the 2026-05-21 blocker-regression set).
- [ ] After methodology vkgeorgia/strategy#68 merges: pull `notations/examples/goals/*.goals.transitrix.yaml` fresh from `transitrix/methodology@main`, confirm the canonical example passes; optionally extend GOALS-012/013 into `parseCanonicalGoals` as a follow-up.

Do not auto-merge. Valerii gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)