### PR TITLE
chore(examples): migrate activities example IDs to canonical grammar

### DIFF
--- a/examples/activities/README.md
+++ b/examples/activities/README.md
@@ -14,19 +14,19 @@ notation: activities
 spec_version: "0.1"
 
 activities:
-  - id: A-001
+  - id: ACTIVITY-A-1
     name: "Requirements analysis"
     duration: 5                # duration in any consistent unit (days, weeks, sprints)
 
-  - id: A-002
+  - id: ACTIVITY-A-2
     name: "Architecture design"
     duration: 8
-    predecessors: [A-001]      # IDs of activities that must finish before this one starts
+    predecessors: [ACTIVITY-A-1]   # IDs of activities that must finish before this one starts
 
-  - id: A-003
+  - id: ACTIVITY-A-3
     name: "Implementation"
     duration: 15
-    predecessors: [A-002]
+    predecessors: [ACTIVITY-A-2]
 ```
 
 ## Optional header fields
@@ -77,7 +77,7 @@ A document can alternatively pin per-activity dates (`start_date` + `end_date` o
 
 ## Rules
 
-- Activity IDs must be unique strings within the file (e.g. `A-001`, `TASK-5`).
+- Activity IDs must be unique strings within the file. The canonical grammar is `ACTIVITY-[<middle>-]<INTEGER>` (e.g. `ACTIVITY-A-1`, `ACTIVITY-M-DECISION-1`); other shapes parse but are non-canonical.
 - Activities without `predecessors` are treated as start nodes.
 - Multiple predecessors create a merge point (all must finish before the activity starts).
 - The critical path is computed automatically using the PMBoK forward/backward pass (ES, EF, LS, LF, float).

--- a/examples/activities/discovery-research.activities.transitrix.yaml
+++ b/examples/activities/discovery-research.activities.transitrix.yaml
@@ -20,42 +20,42 @@ author: "Valerii Korobeinikov"
 # discovery stage. The Gantt view will not render; the network view does.
 
 activities:
-  - id: D-001
+  - id: ACTIVITY-D-1
     name: Stakeholder interviews
     duration: 8
     sort: 10
     tags: [discovery, research]
 
-  - id: D-002
+  - id: ACTIVITY-D-2
     name: Competitive landscape scan
     duration: 5
     sort: 20
     tags: [discovery, research]
 
-  - id: D-003
+  - id: ACTIVITY-D-3
     name: Synthesise findings
     duration: 4
     sort: 30
-    predecessors: [D-001, D-002]
+    predecessors: [ACTIVITY-D-1, ACTIVITY-D-2]
     tags: [discovery, synthesis]
 
-  - id: D-004
+  - id: ACTIVITY-D-4
     name: Concept options workshop
     duration: 3
     sort: 40
-    predecessors: [D-003]
+    predecessors: [ACTIVITY-D-3]
     tags: [discovery, workshop]
 
-  - id: D-005
+  - id: ACTIVITY-D-5
     name: Feasibility assessment
     duration: 6
     sort: 50
-    predecessors: [D-004]
+    predecessors: [ACTIVITY-D-4]
     tags: [discovery, feasibility]
 
-  - id: M-DECISION
+  - id: ACTIVITY-M-DECISION-1
     name: Go / no-go decision
     duration: 0                # milestone — zero-duration leaf
     sort: 60
-    predecessors: [D-005]
+    predecessors: [ACTIVITY-D-5]
     tags: [milestone, gate]

--- a/examples/activities/platform-launch.activities.transitrix.yaml
+++ b/examples/activities/platform-launch.activities.transitrix.yaml
@@ -11,7 +11,7 @@ date: "2026-05-12"
 author: "Valerii Korobeinikov"
 
 activities:
-  - id: A-001
+  - id: ACTIVITY-A-1
     name: Requirements analysis
     duration: 5
     sort: 10
@@ -22,85 +22,85 @@ activities:
       Gather and document all requirements for the customer platform.
       Include both functional and non-functional requirements.
 
-  - id: A-002
+  - id: ACTIVITY-A-2
     name: Architecture design
     duration: 8
     sort: 20
-    predecessors: [A-001]
+    predecessors: [ACTIVITY-A-1]
     goals: [GOAL-CUST-001, GOAL-PLATFORM-002]
     tags: [q3-priority]
     unit: UNIT-ENGINEERING
 
-  - id: A-003
+  - id: ACTIVITY-A-3
     name: Backend implementation
     duration: 15
     sort: 30
-    predecessors: [A-002]
+    predecessors: [ACTIVITY-A-2]
     goals: [GOAL-PLATFORM-002]
     tags: [q3-priority]
     unit: UNIT-ENGINEERING
     delivers_changes: [CHG-PLATFORM-001]
 
-  - id: A-004
+  - id: ACTIVITY-A-4
     name: Frontend implementation
     duration: 12
     sort: 40
-    predecessors: [A-002]
+    predecessors: [ACTIVITY-A-2]
     goals: [GOAL-CUST-001]
     tags: [q3-priority]
     unit: UNIT-ENGINEERING
     delivers_changes: [CHG-UX-001]
 
-  - id: A-005
+  - id: ACTIVITY-A-5
     name: Infrastructure setup
     duration: 4
     sort: 50
-    predecessors: [A-002]
+    predecessors: [ACTIVITY-A-2]
     goals: [GOAL-PLATFORM-002]
     tags: [devops]
     unit: UNIT-INFRA
 
-  - id: A-006
+  - id: ACTIVITY-A-6
     name: Integration testing
     duration: 7
     sort: 60
-    predecessors: [A-003, A-004, A-005]
+    predecessors: [ACTIVITY-A-3, ACTIVITY-A-4, ACTIVITY-A-5]
     goals: [GOAL-CUST-001, GOAL-PLATFORM-002]
     tags: [q3-priority, qa]
     unit: UNIT-QA
 
-  - id: A-007
+  - id: ACTIVITY-A-7
     name: Performance testing
     duration: 3
     sort: 70
-    predecessors: [A-006]
+    predecessors: [ACTIVITY-A-6]
     goals: [GOAL-PLATFORM-002]
     tags: [qa]
     unit: UNIT-QA
 
-  - id: A-008
+  - id: ACTIVITY-A-8
     name: Security review
     duration: 4
     sort: 80
-    predecessors: [A-006]
+    predecessors: [ACTIVITY-A-6]
     goals: [GOAL-COMPLIANCE-001]
     tags: [security]
     unit: UNIT-SECURITY
 
-  - id: A-009
+  - id: ACTIVITY-A-9
     name: Stakeholder sign-off
     duration: 2
     sort: 90
-    predecessors: [A-007, A-008]
+    predecessors: [ACTIVITY-A-7, ACTIVITY-A-8]
     goals: [GOAL-CUST-001]
     tags: [q3-priority]
     unit: UNIT-PRODUCT
 
-  - id: A-010
+  - id: ACTIVITY-A-10
     name: Production deployment
     duration: 1
     sort: 100
-    predecessors: [A-009]
+    predecessors: [ACTIVITY-A-9]
     goals: [GOAL-CUST-001, GOAL-PLATFORM-002]
     tags: [q3-priority, devops]
     unit: UNIT-INFRA


### PR DESCRIPTION
## Summary

Slice 1 of the per-notation ID grammar migration in vkgeorgia/strategy#36 (Scope A). Renames activity IDs in both shipped activities examples to the canonical `ACTIVITY-[<middle>-]<INTEGER>` form per `transitrix/methodology` `notations/IDS_AND_REFERENCES.md`.

- `A-001..A-010` → `ACTIVITY-A-1..ACTIVITY-A-10` ([examples/activities/platform-launch.activities.transitrix.yaml](examples/activities/platform-launch.activities.transitrix.yaml))
- `D-001..D-005` → `ACTIVITY-D-1..ACTIVITY-D-5` ([examples/activities/discovery-research.activities.transitrix.yaml](examples/activities/discovery-research.activities.transitrix.yaml))
- Milestone `M-DECISION` → `ACTIVITY-M-DECISION-1` (was missing a terminal integer — invalid under canonical grammar)
- `predecessors[]` within each file updated to match
- [examples/activities/README.md](examples/activities/README.md) inline sample + the "Rules" bullet updated to reflect the new shape

External cross-references (`goals: [GOAL-CUST-001]`, `delivers_changes: [CHG-PLATFORM-001]`, `unit: UNIT-PRODUCT`) are deliberately left as-is — they migrate together with their owning notations in the remaining slices of vkgeorgia/strategy#36.

## Why this is safe

Renderers do not validate the ID grammar (called out in the issue body) — this is demo-content consistency, not a functional change. The activities validator regression test in [packages/diagrams/src/activities/\_\_tests\_\_/validate.test.ts](packages/diagrams/src/activities/__tests__/validate.test.ts#L391-L403) walks every `*.yaml` in `examples/activities/` and asserts `r.valid === true`, so the rename is covered.

## Test plan

- [x] `npm test` — 432/432 green, including the regression suite that loads both example files.
- [x] `tsc --noEmit` clean in `extension/`.
- [ ] Manual: open both `*.activities.transitrix.yaml` files in Studio preview — network + Gantt still render, predecessors resolve.

Do not auto-merge. Valerii gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)