### PR TITLE
chore(examples): align fga/fgca/goals READMEs with canonical lexicon

### DIFF
--- a/examples/fga/README.md
+++ b/examples/fga/README.md
@@ -11,18 +11,18 @@ Use this format when you want a direct mapping from goals to activities without 
 notation: fga
 
 factors:
-  - id: 1
+  - id: FACTOR-1
     name: "Market growth"
 
 goals:
-  - id: 1
+  - id: GOAL-1
     name: "Expand market share"
-    factor: [{ id: 1 }]      # one or more factor IDs
+    factors: [FACTOR-1]      # one or more factor IDs
 
 activities:
-  - id: 1
+  - id: ACTIVITY-1
     name: "Launch in two new regions"
-    goal_id: 1               # which goal this activity delivers
+    goals: [GOAL-1]          # which goal(s) this activity delivers
 ```
 
 ## Optional header fields
@@ -37,14 +37,14 @@ author: "Your Name"
 
 ## Difference from FGCA
 
-FGA omits the `changes` section entirely. Activities link directly to goals via `goal_id`.
+FGA omits the `changes` section entirely. Activities link directly to goals via `goals[]`.
 Use FGCA (`.fgca.transitrix.yaml`) when you need to track discrete change packages between goals and activities.
 
 ## Rules
 
-- All IDs must be unique integers within their section.
-- A goal can reference multiple factors: `factor: [{ id: 1 }, { id: 2 }]`.
-- Each activity belongs to exactly one goal.
+- IDs follow the canonical grammar `<TYPE>-[<middle>-]<INTEGER>` (`FACTOR-…`, `GOAL-…`, `ACTIVITY-…`) and are unique within their section.
+- A goal can reference multiple factors via `factors: [FACTOR-…, …]`.
+- An activity can target multiple goals via `goals: [GOAL-…, …]`.
 
 ## Examples in this folder
 

--- a/examples/fgca/README.md
+++ b/examples/fgca/README.md
@@ -12,27 +12,26 @@ notation: fgca
 spec_version: "0.1"
 
 factors:
-  - id: 1
+  - id: FACTOR-1
     name: "External factor driving change"
 
 goals:
-  - id: 1
+  - id: GOAL-1
     name: "Strategic goal"
-    factor: [{ id: 1 }]      # one or more factor IDs
+    factors: [FACTOR-1]      # one or more factor IDs
 
 changes:
-  - id: 1
+  - id: CHANGE-1
     name: "Transformation programme"
-    goal_id: 1               # which goal this change addresses
-    activity_ids: [1, 2]     # activities that deliver this change
+    goals: [GOAL-1]          # which goal(s) this change addresses
 
 activities:
-  - id: 1
+  - id: ACTIVITY-1
     name: "Research phase"
-    goal_id: 1
-  - id: 2
+    changes: [CHANGE-1]      # which change(s) this activity delivers
+  - id: ACTIVITY-2
     name: "Rollout phase"
-    goal_id: 1
+    changes: [CHANGE-1]
 ```
 
 ## Optional header fields
@@ -47,10 +46,11 @@ author: "Your Name"
 
 ## Rules
 
-- All IDs (`factors`, `goals`, `changes`, `activities`) must be unique integers within their section.
-- A goal can reference multiple factors: `factor: [{ id: 1 }, { id: 2 }]`.
-- A change belongs to exactly one goal (`goal_id`) but can list multiple delivering activities.
-- An activity belongs to exactly one goal (`goal_id`).
+- IDs (`factors`, `goals`, `changes`, `activities`) follow the canonical grammar `<TYPE>-[<middle>-]<INTEGER>` (`FACTOR-…`, `GOAL-…`, `CHANGE-…`, `ACTIVITY-…`) and are unique within their section.
+- Cross-layer references are **upstream** plurals on each layer: `goal.factors[]`, `change.goals[]`, `activity.changes[]`.
+- A goal can reference multiple factors via `factors: [FACTOR-…, …]`.
+- A change can address multiple goals via `goals: [GOAL-…, …]`.
+- An activity can deliver multiple changes via `changes: [CHANGE-…, …]`.
 
 ## Examples in this folder
 

--- a/examples/goals/README.md
+++ b/examples/goals/README.md
@@ -16,17 +16,17 @@ goal_types:
   - { name: "Project",       level: 2 }
 
 goals:
-  - id: 1
+  - id: GOAL-1
     name: "Top-level goal"
     type: "Strategy"
     level: 0
-    parent_id: 0        # 0 = root (no parent)
+    # No `parent` — this is a root goal.
 
-  - id: 2
+  - id: GOAL-2
     name: "Sub-goal"
     type: "Business Goal"
     level: 1
-    parent_id: 1
+    parent: GOAL-1
 ```
 
 ## Optional header fields
@@ -41,10 +41,10 @@ author: "Your Name"
 
 ## Rules
 
-- `parent_id: 0` marks a root node.
+- Omit `parent` on root goals (any goal whose level matches a `goal_types[].level` of `0`).
 - `level` in each goal must match the `level` defined in `goal_types`.
-- Goal IDs must be unique integers within the file.
-- Each goal has exactly one parent (`parent_id`).
+- Goal IDs follow the canonical grammar `GOAL-[<middle>-]<INTEGER>` (e.g. `GOAL-REVENUE-1`) and are unique within the file.
+- Each goal has exactly one `parent`.
 - Any number of levels is supported; add entries to `goal_types` and goals accordingly.
 
 ## Examples in this folder


### PR DESCRIPTION
## Summary

Slice 2 of vkgeorgia/strategy#36 (Scope A). Brings the FGA / FGCA / Goals README files in `examples/` in line with the canonical lexicon their accompanying YAML files already use.

The YAML examples in these three folders were migrated to flat canonical form during the methodology canon sync (PR #49/#64) — typed string IDs (`FACTOR-1`, `GOAL-1`, `CHANGE-1`, `ACTIVITY-1`), upstream plural cross-refs (`factors[]`, `goals[]`, `changes[]`), no wrapper keys. The README docs alongside them, however, still showed the legacy shape: bare integer IDs (`id: 1`), nested-object factor refs (`factor: [{ id: 1 }]`), singular cross-refs (`goal_id`, `parent_id`).

This PR updates only the three READMEs so a user opening the docs sees the same form they'll be writing:

- [examples/fga/README.md](examples/fga/README.md), [examples/fgca/README.md](examples/fgca/README.md), [examples/goals/README.md](examples/goals/README.md)
- `id: 1` → `id: GOAL-1` / `FACTOR-1` / `CHANGE-1` / `ACTIVITY-1`
- `factor: [{ id: 1 }]` → `factors: [FACTOR-1]`
- `goal_id: 1` → `goals: [GOAL-1]` / `changes: [CHANGE-1]` (upstream plurals)
- `parent_id: 0` → omit `parent` on root goals; `parent: GOAL-…` elsewhere
- "Rules" bullets restated in terms of `<TYPE>-[<middle>-]<INTEGER>` grammar

No YAML, code, or test-fixture changes — docs only.

## Test plan

- [x] `npm test` — 432/432 (no fixture touched; nothing to regress).
- [x] Visual proofread of the three READMEs — examples match the actual YAML in each folder.

Do not auto-merge. Valerii gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)