### PR TITLE
chore(examples): migrate capability-map example IDs to canonical grammar

### DIFF
--- a/examples/capability-map/README.md
+++ b/examples/capability-map/README.md
@@ -4,7 +4,7 @@ File extension: **`.capability-map.transitrix.yaml`**
 
 ## Format overview
 
-A capability map is a hierarchical view of what an organisation can do (its capabilities) and how mature each capability is on the CMMI V2.0 1–5 scale. Vertical capabilities (`V1`, `V1.1`, …) are core business domains; horizontal capabilities (`H1`, `H1.2`, …) cut across domains (master data management, compliance, ESG).
+A capability map is a hierarchical view of what an organisation can do (its capabilities) and how mature each capability is on the CMMI V2.0 1–5 scale. Vertical capabilities (`CAPABILITY-V1`, `CAPABILITY-V1.1`, …) are core business domains; horizontal capabilities (`CAPABILITY-H1`, `CAPABILITY-H1.2`, …) cut across domains (master data management, compliance, ESG).
 
 ## Files in this folder
 
@@ -25,10 +25,10 @@ notation: capability-map
 
 | Field | Description |
 |---|---|
-| `capability_map.id` | Unique identifier for this map |
+| `capability_map.id` | Unique identifier for this map — canonical form `CAPABILITY_MAP-[<middle>-]<INTEGER>` (e.g. `CAPABILITY_MAP-BUSINESS-1`) |
 | `capability_map.name` | Display name |
 | `capability_map.assessment_date` | Date in `YYYY-MM-DD` format |
-| `capabilities[].id` | Pattern `V[n]` or `H[n]` with optional `.n` segments — unique across the tree |
+| `capabilities[].id` | Canonical form `CAPABILITY-V[n](.n)*` (verticals) or `CAPABILITY-H[n](.n)*` (horizontals) — unique across the tree |
 | `capabilities[].name` | Capability name |
 | `capabilities[].current_maturity` | Integer 1–5 (CMMI level) |
 

--- a/examples/capability-map/business.capability-map.transitrix.yaml
+++ b/examples/capability-map/business.capability-map.transitrix.yaml
@@ -6,13 +6,13 @@ version: "1.0"
 date: "2026-05-08"
 
 capability_map:
-  id: CM-BUSINESS-001
+  id: CAPABILITY_MAP-BUSINESS-1
   name: Business Capabilities Map
   description: Core business capabilities with current and target maturity.
   assessment_date: "2026-05-08"
 
   capabilities:
-    - id: V1
+    - id: CAPABILITY-V1
       name: Order Management
       type: domain
       current_maturity: 2
@@ -24,30 +24,30 @@ capability_map:
         - APP-OMS-001
         - APP-CRM-001
       children:
-        - id: V1.1
+        - id: CAPABILITY-V1.1
           name: Order Intake
           type: domain
           current_maturity: 3
           target_maturity: 3
-        - id: V1.2
+        - id: CAPABILITY-V1.2
           name: Order Fulfilment
           type: domain
           current_maturity: 2
           target_maturity: 3
           target_date: "2026-09-30"
           children:
-            - id: V1.2.1
+            - id: CAPABILITY-V1.2.1
               name: Pick & Pack
               type: domain
               current_maturity: 2
               target_maturity: 3
-            - id: V1.2.2
+            - id: CAPABILITY-V1.2.2
               name: Last-mile Delivery
               type: domain
               current_maturity: 1
               target_maturity: 3
 
-    - id: V2
+    - id: CAPABILITY-V2
       name: Customer Relationship Management
       type: domain
       current_maturity: 3
@@ -57,25 +57,25 @@ capability_map:
       applications:
         - APP-CRM-001
       children:
-        - id: V2.1
+        - id: CAPABILITY-V2.1
           name: Customer Acquisition
           type: domain
           current_maturity: 2
           target_maturity: 4
-        - id: V2.2
+        - id: CAPABILITY-V2.2
           name: Customer Service
           type: domain
           current_maturity: 3
           target_maturity: 4
 
-    - id: V3
+    - id: CAPABILITY-V3
       name: Financial Management
       type: domain
       current_maturity: 4
       target_maturity: 5
       owner_role: ROLE-FIN-001
 
-    - id: H1
+    - id: CAPABILITY-H1
       name: Master Data Management
       type: supporting
       description: Cross-cutting capability ensuring data quality across domains.
@@ -83,7 +83,7 @@ capability_map:
       target_maturity: 3
       target_date: "2027-12-31"
 
-    - id: H2
+    - id: CAPABILITY-H2
       name: ESG & Compliance
       type: supporting
       description: Environmental, social, governance, and regulatory compliance.

--- a/examples/capability-map/northbay-retail.capability-map.transitrix.yaml
+++ b/examples/capability-map/northbay-retail.capability-map.transitrix.yaml
@@ -6,13 +6,13 @@ version: "2.0"
 date: "2026-05-12"
 
 capability_map:
-  id: CM-NB-RETAIL-001
+  id: CAPABILITY_MAP-NB-RETAIL-1
   name: NorthBay Retail — Business Capabilities Map
   description: Three core verticals (Customer Engagement, Supply Chain, Financial Management) plus three cross-cutting horizontals (MDM, Cybersecurity, ESG).
   assessment_date: "2026-05-12"
 
   capabilities:
-    - id: V1
+    - id: CAPABILITY-V1
       name: Customer Engagement
       type: domain
       description: All capabilities involved in attracting, retaining, and servicing the customer.
@@ -24,44 +24,44 @@ capability_map:
         - APP-CRM-001
         - APP-MARKETING-CLOUD-001
       children:
-        - id: V1.1
+        - id: CAPABILITY-V1.1
           name: Marketing
           type: domain
           current_maturity: 2
           target_maturity: 4
           target_date: "2027-06-30"
           children:
-            - id: V1.1.1
+            - id: CAPABILITY-V1.1.1
               name: Campaign Management
               type: domain
               current_maturity: 2
               target_maturity: 4
               owner_role: ROLE-MKTG-001
-            - id: V1.1.2
+            - id: CAPABILITY-V1.1.2
               name: Loyalty Programmes
               type: domain
               current_maturity: 3
               target_maturity: 4
               owner_role: ROLE-LOYALTY-001
-            - id: V1.1.3
+            - id: CAPABILITY-V1.1.3
               name: Brand & Content
               type: domain
               current_maturity: 2
               target_maturity: 3
-        - id: V1.2
+        - id: CAPABILITY-V1.2
           name: Sales Channels
           type: domain
           current_maturity: 2
           target_maturity: 4
           target_date: "2027-12-31"
           children:
-            - id: V1.2.1
+            - id: CAPABILITY-V1.2.1
               name: In-store Retail
               type: domain
               current_maturity: 3
               target_maturity: 4
               owner_role: Director of Retail Operations
-            - id: V1.2.2
+            - id: CAPABILITY-V1.2.2
               name: E-commerce
               type: domain
               current_maturity: 2
@@ -70,35 +70,35 @@ capability_map:
               applications:
                 - APP-OMS-001
                 - APP-WEB-STORE-001
-            - id: V1.2.3
+            - id: CAPABILITY-V1.2.3
               name: Mobile App Commerce
               type: domain
               current_maturity: 1
               target_maturity: 3
               target_date: "2026-12-31"
-        - id: V1.3
+        - id: CAPABILITY-V1.3
           name: Customer Service
           type: domain
           current_maturity: 2
           target_maturity: 4
           children:
-            - id: V1.3.1
+            - id: CAPABILITY-V1.3.1
               name: Pre-sale Support
               type: domain
               current_maturity: 2
               target_maturity: 3
-            - id: V1.3.2
+            - id: CAPABILITY-V1.3.2
               name: Post-sale Service
               type: domain
               current_maturity: 2
               target_maturity: 4
-            - id: V1.3.3
+            - id: CAPABILITY-V1.3.3
               name: Returns & Refunds
               type: domain
               current_maturity: 3
               target_maturity: 4
 
-    - id: V2
+    - id: CAPABILITY-V2
       name: Supply Chain Management
       type: domain
       description: From supplier selection through inbound logistics to last-mile delivery.
@@ -107,64 +107,64 @@ capability_map:
       target_date: "2027-09-30"
       owner_role: ROLE-CSCO-001
       children:
-        - id: V2.1
+        - id: CAPABILITY-V2.1
           name: Sourcing & Procurement
           type: domain
           current_maturity: 3
           target_maturity: 4
           children:
-            - id: V2.1.1
+            - id: CAPABILITY-V2.1.1
               name: Supplier Management
               type: domain
               current_maturity: 3
               target_maturity: 4
-            - id: V2.1.2
+            - id: CAPABILITY-V2.1.2
               name: Contract Negotiation
               type: domain
               current_maturity: 2
               target_maturity: 4
-        - id: V2.2
+        - id: CAPABILITY-V2.2
           name: Inventory Management
           type: domain
           current_maturity: 3
           target_maturity: 5
           target_date: "2027-12-31"
           children:
-            - id: V2.2.1
+            - id: CAPABILITY-V2.2.1
               name: Demand Forecasting
               type: domain
               current_maturity: 2
               target_maturity: 5
               target_date: "2027-06-30"
-            - id: V2.2.2
+            - id: CAPABILITY-V2.2.2
               name: Replenishment
               type: domain
               current_maturity: 3
               target_maturity: 5
-            - id: V2.2.3
+            - id: CAPABILITY-V2.2.3
               name: Allocation & Assortment
               type: domain
               current_maturity: 3
               target_maturity: 4
-        - id: V2.3
+        - id: CAPABILITY-V2.3
           name: Logistics
           type: domain
           current_maturity: 3
           target_maturity: 4
           children:
-            - id: V2.3.1
+            - id: CAPABILITY-V2.3.1
               name: Inbound Logistics
               type: domain
               current_maturity: 4
               target_maturity: 4
-            - id: V2.3.2
+            - id: CAPABILITY-V2.3.2
               name: Outbound Logistics & Last-mile
               type: domain
               current_maturity: 2
               target_maturity: 4
               target_date: "2027-09-30"
 
-    - id: V3
+    - id: CAPABILITY-V3
       name: Financial Management
       type: domain
       description: Treasury, accounting, controlling, tax.
@@ -172,24 +172,24 @@ capability_map:
       target_maturity: 5
       owner_role: ROLE-FIN-001
       children:
-        - id: V3.1
+        - id: CAPABILITY-V3.1
           name: Treasury & Cash Management
           type: domain
           current_maturity: 4
           target_maturity: 5
-        - id: V3.2
+        - id: CAPABILITY-V3.2
           name: Accounting & Reporting
           type: domain
           current_maturity: 4
           target_maturity: 5
           target_date: "2026-12-31"
-        - id: V3.3
+        - id: CAPABILITY-V3.3
           name: Controlling & Planning
           type: domain
           current_maturity: 3
           target_maturity: 5
 
-    - id: H1
+    - id: CAPABILITY-H1
       name: Master Data Management
       type: supporting
       description: Cross-cutting capability ensuring product, customer, and supplier data quality across all domains.
@@ -198,7 +198,7 @@ capability_map:
       target_date: "2027-12-31"
       owner_role: ROLE-DATAGOV-001
 
-    - id: H2
+    - id: CAPABILITY-H2
       name: Cybersecurity
       type: supporting
       description: Information security, identity & access management, incident response.
@@ -207,7 +207,7 @@ capability_map:
       target_date: "2027-06-30"
       owner_role: ROLE-CISO-001
 
-    - id: H3
+    - id: CAPABILITY-H3
       name: ESG & Compliance
       type: supporting
       description: Environmental reporting, social responsibility, regulatory compliance across all markets.

--- a/packages/diagrams/src/capability-map/__tests__/validate.test.ts
+++ b/packages/diagrams/src/capability-map/__tests__/validate.test.ts
@@ -174,6 +174,17 @@ describe('validateCapabilityMap', () => {
     }
   });
 
+  it('CMAP-009: accepts the canonical CAPABILITY- prefix', () => {
+    for (const id of ['CAPABILITY-V1', 'CAPABILITY-V1.2', 'CAPABILITY-V1.2.3', 'CAPABILITY-H1', 'CAPABILITY-H1.2']) {
+      const map = {
+        ...VALID_MAP.capability_map,
+        capabilities: [{ id, name: 'A', current_maturity: 2 }],
+      };
+      const r = validateCapabilityMap({ ...VALID_MAP, capability_map: map });
+      expect(r.errors.some(e => e.code === 'CMAP-009')).toBe(false);
+    }
+  });
+
   it('validates children recursively', () => {
     const map = {
       ...VALID_MAP.capability_map,

--- a/packages/diagrams/src/capability-map/validate.ts
+++ b/packages/diagrams/src/capability-map/validate.ts
@@ -5,7 +5,12 @@ export type { ValidationError, ValidationWarning, ValidationResult };
 
 const VALID_TYPES = new Set<CapabilityType>(['domain', 'supporting']);
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
-const CAP_ID_RE = /^(V|H)\d+(\.\d+)*$/;
+// Canonical form per `IDS_AND_REFERENCES.md` §2: `CAPABILITY-V…` /
+// `CAPABILITY-H…` with the dotted address (`V1`, `V1.2.1`, `H1`). The bare
+// legacy form (`V1`, `H1`) is still accepted so existing maps without the
+// canonical prefix do not break — migration is tracked under
+// vkgeorgia/strategy#36.
+const CAP_ID_RE = /^(CAPABILITY-)?(V|H)\d+(\.\d+)*$/;
 
 export function validateCapabilityMap(input: unknown): ValidationResult {
   const errors: ValidationError[] = [];
@@ -79,7 +84,7 @@ function validateCapabilityTree(
       }
       seenIds.add(id);
       if (!CAP_ID_RE.test(id)) {
-        errors.push({ code: 'CMAP-009', message: `${nodePath}: id "${id}" must match pattern V[n] or H[n] with optional .n segments (e.g. V1, V1.2, H1.3)` });
+        errors.push({ code: 'CMAP-009', message: `${nodePath}: id "${id}" must match the canonical pattern CAPABILITY-V[n] or CAPABILITY-H[n] with optional .n segments (e.g. CAPABILITY-V1, CAPABILITY-V1.2, CAPABILITY-H1.3); the bare V[n] / H[n] form is also accepted for legacy compatibility` });
       }
     }
 


### PR DESCRIPTION
## Summary

Slice 3 of vkgeorgia/strategy#36 (Scope A). Migrates capability-map example IDs to the canonical address form per `IDS_AND_REFERENCES.md` §2.

- Doc ids: `CM-BUSINESS-001` → `CAPABILITY_MAP-BUSINESS-1`, `CM-NB-RETAIL-001` → `CAPABILITY_MAP-NB-RETAIL-1`.
- Capability ids: `V1` / `V1.2.1` / `H1` → `CAPABILITY-V1` / `CAPABILITY-V1.2.1` / `CAPABILITY-H1` in both [examples/capability-map/business.capability-map.transitrix.yaml](examples/capability-map/business.capability-map.transitrix.yaml) and [examples/capability-map/northbay-retail.capability-map.transitrix.yaml](examples/capability-map/northbay-retail.capability-map.transitrix.yaml).
- [examples/capability-map/README.md](examples/capability-map/README.md) grammar bullets and overview prose restated.
- Validator `CMAP-009` regex extended to accept the canonical prefix while still accepting the bare `V[n]` / `H[n]` form, so existing maps don't break. New vitest fixture locks the canonical-prefix branch ([packages/diagrams/src/capability-map/__tests__/validate.test.ts](packages/diagrams/src/capability-map/__tests__/validate.test.ts)).

External cross-refs (`owner_role: ROLE-…-001`, `applications: [APP-…-001]`, `business_process: PROC-…-001`) are deliberately left as-is and migrate together with their owning notations.

## Why a code change snuck into this "example-only" slice

Unlike activities, the capability-map validator does enforce ID grammar (`CMAP-009`). The pre-existing regex `^(V|H)\d+(\.\d+)*$` would have rejected the canonical `CAPABILITY-…` IDs and turned the example regression test red. The fix is one-line — `^(CAPABILITY-)?(V|H)\d+(\.\d+)*$` — and is backwards-compatible.

## Test plan

- [x] `npm test` — 433/433 (1 new test for the canonical-prefix branch).
- [x] `tsc --noEmit` clean in `extension/`.
- [ ] Manual: open both `.capability-map.transitrix.yaml` files in Studio preview — tree renders, maturity pills resolve.

Do not auto-merge. Valerii gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)