### PR TITLE
chore(examples): migrate applications + process-map IDs to canonical grammar

### DIFF
--- a/examples/applications/README.md
+++ b/examples/applications/README.md
@@ -24,10 +24,10 @@ notation: applications
 
 | Field | Description |
 |---|---|
-| `applications_catalogue.id` | Unique identifier for the catalogue |
+| `applications_catalogue.id` | Unique identifier for the catalogue — canonical form `APPLICATIONS_CAT-[<middle>-]<INTEGER>` (e.g. `APPLICATIONS_CAT-ENTERPRISE-1`) |
 | `applications_catalogue.name` | Display name |
 | `applications_catalogue.updated_at` | Date in `YYYY-MM-DD` format |
-| `applications[].app_id` | Unique identifier within the catalogue |
+| `applications[].app_id` | Canonical `APPLICATION-[<middle>-]<INTEGER>` (e.g. `APPLICATION-CRM-1`) for applications/platforms/data stores; `INTEGRATION-[<middle>-]<INTEGER>` for entries with `type: integration` |
 | `applications[].name` | Application name |
 | `applications[].type` | One of: `application`, `integration`, `platform`, `data_store` |
 | `applications[].status` | One of: `Draft`, `Active`, `Deprecated`, `Decommissioning` |

--- a/examples/applications/portfolio-2026.applications.transitrix.yaml
+++ b/examples/applications/portfolio-2026.applications.transitrix.yaml
@@ -6,12 +6,12 @@ version: "1.0"
 date: "2026-05-14"
 
 applications_catalogue:
-  id: APP-CAT-ENTERPRISE-001
+  id: APPLICATIONS_CAT-ENTERPRISE-1
   name: Enterprise Applications Portfolio 2026
   updated_at: "2026-05-14"
 
   applications:
-    - app_id: APP-OMS-001
+    - app_id: APPLICATION-OMS-1
       name: Order Management System
       type: application
       status: Active
@@ -28,16 +28,16 @@ applications_catalogue:
         - prod-mobile-app
         - prod-partner-bundle
       integrations:
-        - target: APP-CRM-001
+        - target: APPLICATION-CRM-1
           direction: outbound
           protocol: REST
           description: Sends order events to CRM on state change
-        - target: APP-EBS-001
+        - target: APPLICATION-EBS-1
           direction: outbound
           protocol: Kafka
           description: Publishes order domain events to event bus
 
-    - app_id: APP-CRM-001
+    - app_id: APPLICATION-CRM-1
       name: CRM System
       type: application
       status: Active
@@ -50,7 +50,7 @@ applications_catalogue:
         - V2.1    # Customer Acquisition — lead management, opportunity tracking
         - V2      # CRM — customer 360 view
 
-    - app_id: APP-EBS-001
+    - app_id: APPLICATION-EBS-1
       name: Enterprise Event Bus
       type: platform
       status: Active
@@ -60,12 +60,12 @@ applications_catalogue:
       maturity: 5
       description: Centralised Kafka-based event streaming platform for domain event distribution.
       integrations:
-        - target: APP-DWH-001
+        - target: APPLICATION-DWH-1
           direction: outbound
           protocol: Kafka
           description: Streams events to data warehouse for analytics
 
-    - app_id: APP-DWH-001
+    - app_id: APPLICATION-DWH-1
       name: Data Warehouse
       type: data_store
       status: Active
@@ -79,7 +79,7 @@ applications_catalogue:
         - V4.2    # Analytics — historical analysis
         - H1      # Master Data Management — data cataloguing
 
-    - app_id: APP-LEGACY-PORTAL-001
+    - app_id: APPLICATION-LEGACY-PORTAL-1
       name: Legacy Customer Portal
       type: application
       status: Deprecated
@@ -88,7 +88,7 @@ applications_catalogue:
       maturity: 2
       description: Original web portal for customer self-service. Being replaced by the mobile app.
 
-    - app_id: APP-ERP-LEGACY-001
+    - app_id: APPLICATION-ERP-LEGACY-1
       name: Legacy ERP Module
       type: application
       status: Decommissioning
@@ -98,13 +98,13 @@ applications_catalogue:
       maturity: 1
       description: On-premise ERP module being decommissioned in Q3 2026. Migration to cloud ERP in progress.
 
-    - app_id: INT-OMS-CRM-001
+    - app_id: INTEGRATION-OMS-CRM-1
       name: OMS → CRM Order Events Integration
       type: integration
       status: Draft
       domain: Operations
       owner_role: ROLE-INTARCH-001
       description: Event-driven integration forwarding order state changes from OMS to CRM.
-      source: APP-OMS-001
-      target: APP-CRM-001
+      source: APPLICATION-OMS-1
+      target: APPLICATION-CRM-1
       protocol: Kafka

--- a/examples/process-map/README.md
+++ b/examples/process-map/README.md
@@ -25,13 +25,13 @@ notation: process-map
 
 | Field | Description |
 |---|---|
-| `process_map.id` | Unique identifier for the map |
+| `process_map.id` | Unique identifier for the map — canonical form `PROCESS_MAP-[<middle>-]<INTEGER>` (e.g. `PROCESS_MAP-ENT-1`) |
 | `process_map.name` | Display name |
 | `process_map.updated_at` | Date in `YYYY-MM-DD` format |
-| `groups[].id` | Group identifier |
+| `groups[].id` | Canonical `PROCESS_GROUP-[<middle>-]<INTEGER>` (e.g. `PROCESS_GROUP-OPERATING-1`) |
 | `groups[].name` | Group display name |
 | `groups[].type` | One of: `operating`, `supporting`, `management` |
-| `processes[].process_id` | Unique within the map |
+| `processes[].process_id` | Canonical `PROCESS-[<middle>-]<INTEGER>` (e.g. `PROCESS-ORD-FULFILL-1`); unique within the map |
 | `processes[].name` | Process name |
 | `processes[].status` | One of: `Draft`, `Active`, `Deprecated` |
 
@@ -40,7 +40,7 @@ notation: process-map
 | Field | Description |
 |---|---|
 | `owner_role` | Responsible role |
-| `capability` | Capability ID this process realises (e.g. `V1`, `H1`) |
+| `capability` | Capability ID this process realises (e.g. `CAPABILITY-V1`, `CAPABILITY-H1`); the bare legacy form (`V1`, `H1`) is also accepted |
 | `maturity` | Integer 1–5 |
 | `bpmn_file` | Path to the detailed BPMN diagram |
 | `description` | Short description |

--- a/examples/process-map/enterprise.process-map.transitrix.yaml
+++ b/examples/process-map/enterprise.process-map.transitrix.yaml
@@ -6,19 +6,19 @@ version: "1.0"
 date: "2026-05-08"
 
 process_map:
-  id: PM-ENT-001
+  id: PROCESS_MAP-ENT-1
   name: Enterprise Process Landscape
   description: Top-level catalogue of all organisational processes.
   version: "1.0"
   updated_at: "2026-05-08"
 
   groups:
-    - id: GRP-OPERATING
+    - id: PROCESS_GROUP-OPERATING-1
       name: Operating Processes
       type: operating
       description: Core processes that deliver value to customers.
       processes:
-        - process_id: PROC-ORD-FULFILL-001
+        - process_id: PROCESS-ORD-FULFILL-1
           name: Order Fulfilment
           owner_role: ROLE-OPS-001
           capability: V1
@@ -26,56 +26,56 @@ process_map:
           status: Active
           bpmn_file: views/bpmn/ORDER_FULFILLMENT_process.bpmn.transitrix.yaml
           description: End-to-end fulfilment from order placement to delivery.
-        - process_id: PROC-CUST-ONBOARD-001
+        - process_id: PROCESS-CUST-ONBOARD-1
           name: Customer Onboarding
           owner_role: ROLE-SALES-001
           capability: V2
           maturity: 2
           status: Active
-        - process_id: PROC-DELIV-001
+        - process_id: PROCESS-DELIV-1
           name: Last-mile Delivery
           owner_role: ROLE-LOG-001
           capability: V1
           maturity: 1
           status: Draft
 
-    - id: GRP-SUPPORTING
+    - id: PROCESS_GROUP-SUPPORTING-1
       name: Supporting Processes
       type: supporting
       description: Internal enablers for operating processes.
       processes:
-        - process_id: PROC-HR-RECRUIT-001
+        - process_id: PROCESS-HR-RECRUIT-1
           name: Recruitment
           owner_role: ROLE-HR-001
           status: Active
           maturity: 3
-        - process_id: PROC-FIN-CLOSE-001
+        - process_id: PROCESS-FIN-CLOSE-1
           name: Monthly Financial Close
           owner_role: ROLE-FIN-001
           status: Active
           maturity: 4
-        - process_id: PROC-IT-INCIDENT-001
+        - process_id: PROCESS-IT-INCIDENT-1
           name: IT Incident Response
           owner_role: ROLE-IT-001
           status: Active
           maturity: 2
 
-    - id: GRP-MANAGEMENT
+    - id: PROCESS_GROUP-MANAGEMENT-1
       name: Management Processes
       type: management
       description: Governance, planning, and oversight.
       processes:
-        - process_id: PROC-STRAT-PLAN-001
+        - process_id: PROCESS-STRAT-PLAN-1
           name: Annual Strategy Planning
           owner_role: ROLE-CEO-001
           status: Active
           maturity: 3
-        - process_id: PROC-RISK-MGT-001
+        - process_id: PROCESS-RISK-MGT-1
           name: Risk Management Review
           owner_role: ROLE-RISK-001
           status: Active
           maturity: 2
-        - process_id: PROC-COMPLIANCE-001
+        - process_id: PROCESS-COMPLIANCE-1
           name: Compliance Audit
           owner_role: ROLE-LEGAL-001
           status: Deprecated

--- a/examples/process-map/northbay-retail.process-map.transitrix.yaml
+++ b/examples/process-map/northbay-retail.process-map.transitrix.yaml
@@ -6,32 +6,32 @@ version: "2.0"
 date: "2026-05-12"
 
 process_map:
-  id: PM-NB-RETAIL-001
+  id: PROCESS_MAP-NB-RETAIL-1
   name: NorthBay Retail — Enterprise Process Landscape
   description: Top-level inventory of operating, supporting, and management processes. Capability references map to the NorthBay capability map.
   version: "2.0"
   updated_at: "2026-05-12"
 
   groups:
-    - id: GRP-OPERATING
+    - id: PROCESS_GROUP-OPERATING-1
       name: Operating Processes
       type: operating
       description: Core value-delivering processes from sourcing through fulfilment.
       processes:
-        - process_id: PROC-NB-SOURCE-001
+        - process_id: PROCESS-NB-SOURCE-1
           name: Strategic Sourcing
           owner_role: ROLE-SOURCING-001
           capability: V2.1.1
           maturity: 3
           status: Active
           description: Identify, evaluate, and onboard strategic suppliers.
-        - process_id: PROC-NB-PURCHASE-001
+        - process_id: PROCESS-NB-PURCHASE-1
           name: Purchase Order Processing
           owner_role: ROLE-PROC-001
           capability: V2.1
           maturity: 4
           status: Active
-        - process_id: PROC-NB-INV-FORECAST-001
+        - process_id: PROCESS-NB-INV-FORECAST-1
           name: Demand Forecasting
           owner_role: ROLE-SUPPLY-001
           capability: V2.2.1
@@ -39,97 +39,97 @@ process_map:
           status: Active
           bpmn_file: views/bpmn/DEMAND_FORECAST_process.bpmn.transitrix.yaml
           description: AI-assisted SKU-level demand prediction.
-        - process_id: PROC-NB-INV-REPLEN-001
+        - process_id: PROCESS-NB-INV-REPLEN-1
           name: Store Replenishment
           owner_role: ROLE-INV-001
           capability: V2.2.2
           maturity: 3
           status: Active
-        - process_id: PROC-NB-RECEIVE-001
+        - process_id: PROCESS-NB-RECEIVE-1
           name: Inbound Receiving
           owner_role: ROLE-WH-001
           capability: V2.3.1
           maturity: 4
           status: Active
-        - process_id: PROC-NB-ORD-FULFILL-001
+        - process_id: PROCESS-NB-ORD-FULFILL-1
           name: Online Order Fulfilment
           owner_role: ROLE-FULFILL-001
           capability: V1.2.2
           maturity: 3
           status: Active
           bpmn_file: views/bpmn/ORDER_FULFILLMENT_process.bpmn.transitrix.yaml
-        - process_id: PROC-NB-DELIVERY-001
+        - process_id: PROCESS-NB-DELIVERY-1
           name: Last-mile Delivery
           owner_role: ROLE-LOG-001
           capability: V2.3.2
           maturity: 2
           status: Active
           description: Self-operated and 3PL hybrid delivery to home and pickup points.
-        - process_id: PROC-NB-CUST-ONBOARD-001
+        - process_id: PROCESS-NB-CUST-ONBOARD-1
           name: Customer Onboarding & Account Creation
           owner_role: ROLE-DIGITAL-001
           capability: V1.2
           maturity: 2
           status: Active
-        - process_id: PROC-NB-RETURNS-001
+        - process_id: PROCESS-NB-RETURNS-1
           name: Returns & Refunds Processing
           owner_role: ROLE-CS-001
           capability: V1.3.3
           maturity: 3
           status: Active
-        - process_id: PROC-NB-LOYALTY-001
+        - process_id: PROCESS-NB-LOYALTY-1
           name: Loyalty Programme Operations
           owner_role: ROLE-LOYALTY-001
           capability: V1.1.2
           maturity: 3
           status: Active
 
-    - id: GRP-SUPPORTING
+    - id: PROCESS_GROUP-SUPPORTING-1
       name: Supporting Processes
       type: supporting
       description: Enabling and shared services across the enterprise.
       processes:
-        - process_id: PROC-NB-HR-RECRUIT-001
+        - process_id: PROCESS-NB-HR-RECRUIT-1
           name: Recruitment
           owner_role: ROLE-HR-001
           maturity: 3
           status: Active
-        - process_id: PROC-NB-HR-PAYROLL-001
+        - process_id: PROCESS-NB-HR-PAYROLL-1
           name: Payroll Operations
           owner_role: ROLE-PAYROLL-001
           maturity: 4
           status: Active
-        - process_id: PROC-NB-FIN-CLOSE-001
+        - process_id: PROCESS-NB-FIN-CLOSE-1
           name: Monthly Financial Close
           owner_role: ROLE-CONTROLLER-001
           capability: V3.2
           maturity: 4
           status: Active
-        - process_id: PROC-NB-IT-INCIDENT-001
+        - process_id: PROCESS-NB-IT-INCIDENT-1
           name: IT Incident Response
           owner_role: ROLE-IT-001
           capability: H2
           maturity: 2
           status: Active
           description: 24/7 incident response with severity-based escalation.
-        - process_id: PROC-NB-MKT-CAMPAIGN-001
+        - process_id: PROCESS-NB-MKT-CAMPAIGN-1
           name: Marketing Campaign Management
           owner_role: ROLE-MKTG-001
           capability: V1.1.1
           maturity: 2
           status: Active
-        - process_id: PROC-NB-LEGAL-REVIEW-001
+        - process_id: PROCESS-NB-LEGAL-REVIEW-1
           name: Contract Legal Review
           owner_role: ROLE-LEGAL-001
           maturity: 3
           status: Active
-        - process_id: PROC-NB-VENDOR-MGT-001
+        - process_id: PROCESS-NB-VENDOR-MGT-1
           name: Vendor Management
           owner_role: ROLE-VENDOR-001
           capability: V2.1.1
           maturity: 3
           status: Active
-        - process_id: PROC-NB-DATA-QUALITY-001
+        - process_id: PROCESS-NB-DATA-QUALITY-1
           name: Master Data Quality Reviews
           owner_role: ROLE-DATAGOV-001
           capability: H1
@@ -137,44 +137,44 @@ process_map:
           status: Draft
           description: Quarterly product, customer, and supplier MDM audits.
 
-    - id: GRP-MANAGEMENT
+    - id: PROCESS_GROUP-MANAGEMENT-1
       name: Management Processes
       type: management
       description: Governance, planning, and oversight.
       processes:
-        - process_id: PROC-NB-STRAT-PLAN-001
+        - process_id: PROCESS-NB-STRAT-PLAN-1
           name: Annual Strategy Planning
           owner_role: ROLE-CEO-001
           maturity: 3
           status: Active
-        - process_id: PROC-NB-BUDGET-001
+        - process_id: PROCESS-NB-BUDGET-1
           name: Annual Budget Cycle
           owner_role: ROLE-FIN-001
           capability: V3.3
           maturity: 4
           status: Active
-        - process_id: PROC-NB-RISK-001
+        - process_id: PROCESS-NB-RISK-1
           name: Enterprise Risk Review
           owner_role: ROLE-RISK-001
           maturity: 2
           status: Active
-        - process_id: PROC-NB-COMPLIANCE-001
+        - process_id: PROCESS-NB-COMPLIANCE-1
           name: Compliance Audit
           owner_role: ROLE-LEGAL-001
           capability: H3
           maturity: 2
           status: Active
-        - process_id: PROC-NB-PERF-REVIEW-001
+        - process_id: PROCESS-NB-PERF-REVIEW-1
           name: Quarterly Business Performance Review
           owner_role: ROLE-COO-001
           maturity: 3
           status: Active
-        - process_id: PROC-NB-BOARD-REPORT-001
+        - process_id: PROCESS-NB-BOARD-REPORT-1
           name: Board Reporting
           owner_role: ROLE-CEO-001
           maturity: 4
           status: Active
-        - process_id: PROC-NB-MA-PIPELINE-001
+        - process_id: PROCESS-NB-MA-PIPELINE-1
           name: M&A Pipeline Review
           owner_role: ROLE-CORPDEV-001
           maturity: 1


### PR DESCRIPTION
## Summary

Slice 4 of vkgeorgia/strategy#36 (Scope A). Migrates IDs in `examples/applications/` and `examples/process-map/` to the canonical grammar per `IDS_AND_REFERENCES.md`.

### Applications — [examples/applications/portfolio-2026.applications.transitrix.yaml](examples/applications/portfolio-2026.applications.transitrix.yaml)

- `APP-CAT-ENTERPRISE-001` → `APPLICATIONS_CAT-ENTERPRISE-1` (doc id).
- All `app_id: APP-…-001` → `APPLICATION-…-1` (6 entries: OMS, CRM, EBS, DWH, LEGACY-PORTAL, ERP-LEGACY).
- `INT-OMS-CRM-001` → `INTEGRATION-OMS-CRM-1` (the `type: integration` entry uses the singular noun).
- Internal `target` / `source` refs updated to match the new app_ids.

### Process Map — [examples/process-map/enterprise.process-map.transitrix.yaml](examples/process-map/enterprise.process-map.transitrix.yaml) + [examples/process-map/northbay-retail.process-map.transitrix.yaml](examples/process-map/northbay-retail.process-map.transitrix.yaml)

- Doc ids `PM-…-001` → `PROCESS_MAP-…-1`.
- Group ids `GRP-OPERATING` / `-SUPPORTING` / `-MANAGEMENT` → `PROCESS_GROUP-OPERATING-1` / `-SUPPORTING-1` / `-MANAGEMENT-1` (these previously had no terminal integer — explicitly called out as invalid in the issue body).
- `process_id: PROC-…-001` → `PROCESS-…-1` (9 in enterprise + 25 in northbay).

### READMEs

Both [examples/applications/README.md](examples/applications/README.md) and [examples/process-map/README.md](examples/process-map/README.md) updated to describe the canonical patterns in the "Required fields" tables.

### Scope decisions

External cross-references are deliberately left as-is, consistent with the activities + capability-map slices:

- `owner_role: ROLE-…-001` — roles migrate with their own notation (if/when one is opened).
- `capability: V1` / `H1` (process-map → capability-map) — capability-map validator accepts both legacy and canonical forms after PR #69, so leaving these doesn't break validation. README note added that the canonical form is `CAPABILITY-V…`.
- `products: [prod-mobile-app, …]` (applications → products) — migrates with the products slice.
- `business_process: PROC-ORD-FULFILL-001` *from* `examples/capability-map/business.capability-map.transitrix.yaml` — now points at a renamed id in this PR. That's a cross-notation drift the products + scenarios slice will clean up; intra-file validation still resolves.

## Test plan

- [x] `npm test` — 433/433 green (validators don't enforce ID grammar for these notations, so the regression tests pass unchanged).
- [x] `tsc --noEmit` clean in `extension/`.
- [ ] Manual: open all three migrated files in Studio preview — applications table renders, process-map groups render.

Do not auto-merge. Valerii gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)