### PR TITLE
chore(examples): migrate scenarios IDs to canonical grammar

### DIFF
--- a/examples/scenarios/README.md
+++ b/examples/scenarios/README.md
@@ -25,7 +25,7 @@ notation: scenarios
 
 | Field | Description |
 |---|---|
-| `scenario.id` | Unique scenario ID |
+| `scenario.id` | Unique scenario ID — canonical form `SCENARIO-[<middle>-]<INTEGER>` (e.g. `SCENARIO-OPT-1`) |
 | `scenario.name` | Human-readable name |
 | `scenario.status` | One of: `Draft`, `Active`, `Archived` |
 
@@ -37,7 +37,7 @@ notation: scenarios
 | `scenario.created_at` | Date in `YYYY-MM-DD` format |
 | `scenario.vision` | Narrative description of the future under this scenario |
 | `scenario.factors_view` | Per-scenario relevance and impact for factors from the shared catalogue |
-| `scenario.goals` / `capabilities` / `activities` / `products` / `processes` / `applications` | Reference lists with `{goal_id, capability_id, ...}` entries |
+| `scenario.goals` / `capabilities` / `activities` / `products` / `processes` / `applications` | Reference lists with `{goal_id, capability_id, ...}` entries. Each entry references its owning notation's canonical ID — e.g. `GOAL-…-1`, `CAPABILITY-V1.2.2`, `ACTIVITY-…-1`, `PROCESS-…-1`, `APPLICATION-…-1` |
 
 Factor relevance, if specified, must be one of `High`, `Medium`, `Low`.
 

--- a/examples/scenarios/omnichannel-2028.scenarios.transitrix.yaml
+++ b/examples/scenarios/omnichannel-2028.scenarios.transitrix.yaml
@@ -6,7 +6,7 @@ version: "1.0"
 date: "2026-05-12"
 
 scenario:
-  id: SCN-NB-OMNI-2028
+  id: SCENARIO-NB-OMNI-1
   name: NorthBay — Omnichannel 2028
   description: Unify in-store, e-commerce, and mobile into a single customer-centric platform; aggressive build of demand-forecasting and last-mile capabilities.
   status: Active
@@ -21,50 +21,50 @@ scenario:
     ahead of the new EU regulatory regime taking effect in 2028.
 
   factors_view:
-    - factor_id: FAC-MARKET-CEE-001
+    - factor_id: FACTOR-MARKET-CEE-1
       relevance: High
       impact: 30% YoY e-commerce growth in CEE region opens room for two new market entries.
-    - factor_id: FAC-TECH-AI-001
+    - factor_id: FACTOR-TECH-AI-1
       relevance: High
       impact: Mature AI/ML tooling makes SKU-level demand forecasting and personalisation economically viable.
-    - factor_id: FAC-REG-NIS2-2028
+    - factor_id: FACTOR-REG-NIS2-1
       relevance: High
       impact: NIS2 directive requires uplift of cyber controls — affects every digital touchpoint and supplier integration.
-    - factor_id: FAC-SUPPLY-DISRUPTION-001
+    - factor_id: FACTOR-SUPPLY-DISRUPTION-1
       relevance: Medium
       impact: Continued geopolitical instability requires sourcing diversification and inventory buffer reviews.
-    - factor_id: FAC-TALENT-TECH-001
+    - factor_id: FACTOR-TALENT-TECH-1
       relevance: Medium
       impact: Tech talent shortage in CEE — partnership-based delivery and upskilling preferred over hiring.
-    - factor_id: FAC-ESG-CARBON-001
+    - factor_id: FACTOR-ESG-CARBON-1
       relevance: Low
       impact: Carbon reporting becomes table stakes by 2028 but does not yet constrain strategic moves.
 
   goals:
-    - goal_id: GOAL-REVENUE-3X-DIGITAL-2028
-    - goal_id: GOAL-OMNI-LOYALTY-LAUNCH-2027
-    - goal_id: GOAL-MOBILE-30PCT-SALES-2028
-    - goal_id: GOAL-DEMAND-FORECAST-L5-2027
-    - goal_id: GOAL-CYBER-L4-2027
+    - goal_id: GOAL-REVENUE-3X-DIGITAL-1
+    - goal_id: GOAL-OMNI-LOYALTY-LAUNCH-1
+    - goal_id: GOAL-MOBILE-30PCT-SALES-1
+    - goal_id: GOAL-DEMAND-FORECAST-L5-1
+    - goal_id: GOAL-CYBER-L4-1
 
   capabilities:
-    - capability_id: V1.1
-    - capability_id: V1.1.2
-    - capability_id: V1.2.2
-    - capability_id: V1.2.3
-    - capability_id: V1.3.2
-    - capability_id: V2.2.1
-    - capability_id: V2.3.2
-    - capability_id: H1
-    - capability_id: H2
+    - capability_id: CAPABILITY-V1.1
+    - capability_id: CAPABILITY-V1.1.2
+    - capability_id: CAPABILITY-V1.2.2
+    - capability_id: CAPABILITY-V1.2.3
+    - capability_id: CAPABILITY-V1.3.2
+    - capability_id: CAPABILITY-V2.2.1
+    - capability_id: CAPABILITY-V2.3.2
+    - capability_id: CAPABILITY-H1
+    - capability_id: CAPABILITY-H2
 
   activities:
-    - activity_id: ACT-UNIFIED-LOYALTY-PLATFORM
-    - activity_id: ACT-NATIVE-MOBILE-APP-V2
-    - activity_id: ACT-DEMAND-FORECAST-AI-ROLLOUT
-    - activity_id: ACT-LAST-MILE-3PL-EXPANSION
-    - activity_id: ACT-NIS2-CYBER-UPLIFT
-    - activity_id: ACT-MDM-CONSOLIDATION
+    - activity_id: ACTIVITY-UNIFIED-LOYALTY-PLATFORM-1
+    - activity_id: ACTIVITY-NATIVE-MOBILE-APP-V2-1
+    - activity_id: ACTIVITY-DEMAND-FORECAST-AI-ROLLOUT-1
+    - activity_id: ACTIVITY-LAST-MILE-3PL-EXPANSION-1
+    - activity_id: ACTIVITY-NIS2-CYBER-UPLIFT-1
+    - activity_id: ACTIVITY-MDM-CONSOLIDATION-1
 
   products:
     - product_id: prod-mobile-app
@@ -73,17 +73,17 @@ scenario:
     - product_id: prod-supplier-portal
 
   processes:
-    - process_id: PROC-NB-INV-FORECAST-001
-    - process_id: PROC-NB-ORD-FULFILL-001
-    - process_id: PROC-NB-DELIVERY-001
-    - process_id: PROC-NB-LOYALTY-001
-    - process_id: PROC-NB-IT-INCIDENT-001
-    - process_id: PROC-NB-DATA-QUALITY-001
+    - process_id: PROCESS-NB-INV-FORECAST-1
+    - process_id: PROCESS-NB-ORD-FULFILL-1
+    - process_id: PROCESS-NB-DELIVERY-1
+    - process_id: PROCESS-NB-LOYALTY-1
+    - process_id: PROCESS-NB-IT-INCIDENT-1
+    - process_id: PROCESS-NB-DATA-QUALITY-1
 
   applications:
-    - app_id: APP-CRM-001
-    - app_id: APP-OMS-001
-    - app_id: APP-WEB-STORE-001
-    - app_id: APP-MARKETING-CLOUD-001
-    - app_id: APP-DATA-WAREHOUSE-001
-    - app_id: APP-LOYALTY-CLOUD-001
+    - app_id: APPLICATION-CRM-1
+    - app_id: APPLICATION-OMS-1
+    - app_id: APPLICATION-WEB-STORE-1
+    - app_id: APPLICATION-MARKETING-CLOUD-1
+    - app_id: APPLICATION-DATA-WAREHOUSE-1
+    - app_id: APPLICATION-LOYALTY-CLOUD-1

--- a/examples/scenarios/optimistic-2027.scenarios.transitrix.yaml
+++ b/examples/scenarios/optimistic-2027.scenarios.transitrix.yaml
@@ -6,7 +6,7 @@ version: "1.0"
 date: "2026-01-01"
 
 scenario:
-  id: SCN-001
+  id: SCENARIO-OPT-1
   name: Optimistic Growth 2027
   description: Aggressive expansion scenario assuming 30% market growth.
   status: Active
@@ -18,40 +18,40 @@ scenario:
     across all core capabilities.
 
   factors_view:
-    - factor_id: FAC-MARKET-001
+    - factor_id: FACTOR-MARKET-1
       relevance: High
       impact: Revenue growth opportunity in CEE region
-    - factor_id: FAC-TECH-001
+    - factor_id: FACTOR-TECH-1
       relevance: Medium
       impact: AI adoption accelerates product differentiation
-    - factor_id: FAC-REG-001
+    - factor_id: FACTOR-REG-1
       relevance: Low
       impact: Minor compliance friction, manageable in current quarter
 
   goals:
-    - goal_id: GOAL-REV-001
-    - goal_id: GOAL-MARKET-001
-    - goal_id: GOAL-CUST-001
+    - goal_id: GOAL-REV-1
+    - goal_id: GOAL-MARKET-1
+    - goal_id: GOAL-CUST-1
 
   capabilities:
-    - capability_id: CAP-ECOMM-001
-    - capability_id: CAP-DATA-001
-    - capability_id: CAP-MARKETING-001
+    - capability_id: CAPABILITY-V1.2.2     # E-commerce
+    - capability_id: CAPABILITY-H1         # Master Data Management
+    - capability_id: CAPABILITY-V1.1.1     # Campaign Management
 
   activities:
-    - activity_id: ACT-EXPAND-CEE-001
-    - activity_id: ACT-DIGITAL-PLATFORM-001
-    - activity_id: ACT-AI-PILOT-001
+    - activity_id: ACTIVITY-EXPAND-CEE-1
+    - activity_id: ACTIVITY-DIGITAL-PLATFORM-1
+    - activity_id: ACTIVITY-AI-PILOT-1
 
   products:
-    - product_id: PROD-PLATFORM-001
-    - product_id: PROD-MOBILE-001
+    - product_id: prod-platform
+    - product_id: prod-mobile
 
   processes:
-    - process_id: PROC-DELIVERY-001
-    - process_id: PROC-CUST-ONBOARD-001
+    - process_id: PROCESS-DELIVERY-1
+    - process_id: PROCESS-CUST-ONBOARD-1
 
   applications:
-    - app_id: APP-CRM-001
-    - app_id: APP-OMS-001
-    - app_id: APP-DATA-WAREHOUSE-001
+    - app_id: APPLICATION-CRM-1
+    - app_id: APPLICATION-OMS-1
+    - app_id: APPLICATION-DATA-WAREHOUSE-1


### PR DESCRIPTION
## Summary

Final slice of Scope A in vkgeorgia/strategy#36. The two scenarios files previously used **two different ID schemes** — optimistic-2027 with legacy uppercase + leading-zero forms, omnichannel-2028 with year-suffixed mixed forms. This PR unifies both onto the canonical scheme already established by the migrated owner notations.

### Changes per file

[examples/scenarios/optimistic-2027.scenarios.transitrix.yaml](examples/scenarios/optimistic-2027.scenarios.transitrix.yaml):
- `SCN-001` → `SCENARIO-OPT-1`
- `FAC-…-001` → `FACTOR-…-1` (3 refs)
- `GOAL-…-001` → `GOAL-…-1` (3 refs)
- `CAP-ECOMM-001` / `CAP-DATA-001` / `CAP-MARKETING-001` → `CAPABILITY-V1.2.2` / `CAPABILITY-H1` / `CAPABILITY-V1.1.1` (the invented IDs now point at capabilities that actually exist in `northbay-retail.capability-map`: E-commerce / MDM / Campaign Management)
- `ACT-…-001` → `ACTIVITY-…-1` (3 refs)
- `PROD-…-001` → `prod-…` (2 refs, lowercase-kebab to match the products notation IDs)
- `PROC-…-001` → `PROCESS-…-1` (2 refs)
- `APP-…-001` → `APPLICATION-…-1` (3 refs)

[examples/scenarios/omnichannel-2028.scenarios.transitrix.yaml](examples/scenarios/omnichannel-2028.scenarios.transitrix.yaml):
- `SCN-NB-OMNI-2028` → `SCENARIO-NB-OMNI-1` (terminal integer instead of year suffix)
- `FAC-…-001` / `FAC-…-2028` → `FACTOR-…-1` (6 refs)
- `GOAL-…-2028` / `GOAL-…-2027` → `GOAL-…-1` (5 refs, year suffix → plain terminal integer)
- Bare `V1.1` / `H1` etc. → `CAPABILITY-V1.1` / `CAPABILITY-H1` (9 refs, picked up the canonical prefix added in PR #69)
- `ACT-…` (no terminal int) → `ACTIVITY-…-1` (6 refs, terminal integer added)
- Products kept as lowercase-kebab (`prod-mobile-app` etc.) — products notation isn't on the migration list in #36
- `PROC-NB-…-001` → `PROCESS-NB-…-1` (6 refs)
- `APP-…-001` → `APPLICATION-…-1` (6 refs)

[examples/scenarios/README.md](examples/scenarios/README.md) updated with the canonical pattern for `scenario.id` and a note on the canonical reference forms.

## Scope decisions

- **Products refs**: products notation is not on the per-notation migration list in #36, so I kept the lowercase-kebab form (`prod-…`) that matches the actual products notation IDs. `prod-platform` / `prod-mobile` were invented IDs in optimistic-2027 — they remain invented but now match the products-notation style.
- **Capability refs in optimistic-2027**: the invented `CAP-ECOMM-001` style didn't conform to the canonical `CAPABILITY-V…` grammar at all. I mapped them to real capabilities in the northbay-retail capability map so the demo refs resolve textually.

## Test plan

- [x] `npm test` — 433/433 green (scenarios validator does not enforce ID grammar).
- [x] `tsc --noEmit` clean in `extension/`.
- [ ] Manual: open both `.scenarios.transitrix.yaml` files in Studio preview — factors-view table + reference sections render.

## With this merge, Scope A of #36 is done — slices 1–5

1. activities — PR #67 (merged)
2. fga/fgca/goals READMEs — PR #68 (merged)
3. capability-map — PR #69 (merged)
4. applications + process-map — PR #70 (merged)
5. scenarios — this PR

Scope B (duplicate BPMN file) already shipped in PR #57.

Do not auto-merge. Valerii gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)