### PR TITLE
fix(goals): compress non-contiguous levels into adjacent layout columns

### DIFF
--- a/packages/diagrams/src/goals/__tests__/layout.test.ts
+++ b/packages/diagrams/src/goals/__tests__/layout.test.ts
@@ -76,6 +76,33 @@ describe('layoutGoalTree', () => {
     expect(layout.nodes.every(n => n.data.level <= 1)).toBe(true);
   });
 
+  it('compresses non-contiguous levels into adjacent columns (no phantom empty columns)', () => {
+    // Legacy / non-canonical input: goal_types skip levels 1 and 3, so
+    // goals sit at levels 0, 2, 4. Column x must advance by exactly one
+    // step per used level, not per absolute level value — otherwise the
+    // skipped levels open empty columns and double the horizontal spacing.
+    const gapped: GoalTree = {
+      goal_types: [
+        { name: 'Strategy', level: 0 },
+        { name: 'Strategic Goal', level: 2 },
+        { name: 'Project Goal', level: 4 },
+      ],
+      goals: [
+        { id: 1, name: 'Root', type: 'Strategy', level: 0, parent_id: 0 },
+        { id: 2, name: 'Mid', type: 'Strategic Goal', level: 2, parent_id: 1 },
+        { id: 3, name: 'Leaf', type: 'Project Goal', level: 4, parent_id: 2 },
+      ],
+    };
+    const layout = layoutGoalTree(gapped);
+    const byId = new Map(layout.nodes.map(n => [n.id, n]));
+    const step = byId.get(2)!.x - byId.get(1)!.x;
+    // Root→Mid and Mid→Leaf must use the same single-column step despite
+    // the level numbers jumping by 2 each time.
+    expect(byId.get(3)!.x - byId.get(2)!.x).toBe(step);
+    // And that step is one node width + one rank separator (250 + 80).
+    expect(step).toBe(250 + 80);
+  });
+
   // Pre-release blocker regression (orchestrator review 2026-05-21).
   it('[blocker] does not stack-overflow on a self-parent cycle', () => {
     const cyclic: GoalTree = {

--- a/packages/diagrams/src/goals/layout.ts
+++ b/packages/diagrams/src/goals/layout.ts
@@ -27,6 +27,16 @@ export function layoutGoalTree(tree: GoalTree, options: LayoutOptions = {}): Goa
     children.get(g.parent_id)!.push(g.id);
   }
 
+  // Compress the levels actually used into contiguous column ranks. The
+  // canonical N+1 rule (GOALS-013) keeps `level` contiguous from 0, so for
+  // conforming input this is the identity map. It only rescues legacy /
+  // non-canonical documents whose `goal_types` skip levels (e.g. 0, 2, 4):
+  // without it those gaps open phantom empty columns and double the
+  // horizontal spacing between rendered tiers.
+  const usedLevels = Array.from(new Set(goals.map(g => g.level))).sort((a, b) => a - b);
+  const levelToCol = new Map<number, number>();
+  usedLevels.forEach((lvl, i) => levelToCol.set(lvl, i));
+
   // Find effective roots: level 0 or parent_id === 0 or broken ref
   const allIds = new Set(goals.map(g => g.id));
   const roots = goals.filter(g => g.parent_id === 0 || !allIds.has(g.parent_id));
@@ -70,7 +80,7 @@ export function layoutGoalTree(tree: GoalTree, options: LayoutOptions = {}): Goa
     if (placed.has(id)) return { top: 0, bottom: 0 };
     placed.add(id);
 
-    const col = goal.level;
+    const col = levelToCol.get(goal.level) ?? 0;
     const childIds = (children.get(id) ?? []).filter(c => !hiddenSubtrees.has(c) && !placed.has(c));
     const isCollapsedRoot = hiddenSet.has(id) && childIds.length > 0;
     const hasHiddenChildren = childIds.length < (children.get(id) ?? []).length;


### PR DESCRIPTION
## Summary

The goal-tree layout positioned each node at `x = level * (nodeWidth + rankSep)`, using the raw `goal_types` level as the column index ([packages/diagrams/src/goals/layout.ts](packages/diagrams/src/goals/layout.ts)). When a document's levels skip values — e.g. `strategy-2026.goals.transitrix.yaml` uses `Strategy=0`, `Strategic Goal=2`, `Project Goal=4` — the unused levels (1, 3) opened phantom empty columns and **doubled the horizontal spacing** between rendered tiers.

Fix: map the distinct levels actually used to contiguous column ranks (0, 1, 2, …) and position by rank. Under the canonical N+1 rule (GOALS-013) levels are already contiguous, so this is the identity map for conforming documents — it only tightens spacing for legacy / non-canonical inputs.

## Before / after

For the strategy-2026 example (levels 0, 2, 4):
- **Before:** columns at x = 0, 660, 1320 — 410px gaps (one empty column + rankSep each).
- **After:** columns at x = 0, 330, 660 — even 80px rankSep gaps.

## Context

Surfaced during 1.x hand-testing. This is the rendering counterpart to the GOALS-013 validation rule in PR #66: that rule rejects non-contiguous levels at validation time; this makes the *renderer* degrade gracefully when it sees them anyway (the canonical preview path doesn't yet enforce GOALS-013).

## Test plan

- [x] `npm test` — 434/434 green (1 new layout test asserting equal single-column steps across level jumps of 2).
- [x] `tsc --noEmit` clean in `extension/`.
- [x] Extension bundle rebuilt (`npm run extension:prep`).
- [ ] Manual: open `examples/goals/strategy-2026.goals.transitrix.yaml` — tiers now sit one column apart with no wide gaps.

Do not auto-merge. Valerii gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)