### PR TITLE
feat(extension): PNG export — Save as .png + Copy as PNG

### DIFF
--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,0 +1,54 @@
+# Packaging the VS Code extension
+
+Most of the extension is pure TypeScript/JS and packages into a single,
+platform-neutral `.vsix`. **PNG export is the exception:** it depends on
+`@resvg/resvg-js`, a native module whose rasterizer binary is shipped as a
+per-OS optional dependency (`@resvg/resvg-js-win32-x64-msvc`,
+`@resvg/resvg-js-darwin-arm64`, …). `npm install` lays down only the binary
+matching the machine doing the install.
+
+That makes the extension **platform-specific** for distribution purposes
+(vkgeorgia/strategy#32 chose per-platform VSIX over one ~10 MB fat bundle).
+
+## Build a VSIX for the current platform
+
+```bash
+npm run package-extension
+```
+
+`extension:prep` installs the runtime deps into `extension/node_modules`
+(including the resvg binary for *this* OS/arch) and bundles the extension;
+`build-compiler-bundle.mjs` fails loudly if no `@resvg/resvg-js-<platform>`
+binary landed. The resulting `.vsix` is correct **only for the OS/arch it was
+built on** — installing it elsewhere makes PNG export fail at runtime
+(SVG export and previews are unaffected).
+
+## Build per-platform VSIXs for the Marketplace
+
+Tag each VSIX with `vsce package --target <target>` so the Marketplace serves
+the right artifact per client. Because the resvg binary is fetched per OS,
+**each target must be built on a matching OS/arch** (a CI matrix is the
+clean way):
+
+```bash
+# on a Windows x64 runner
+npm run extension:prep
+cd extension && npx vsce package --target win32-x64
+
+# on a macOS arm64 runner
+npm run extension:prep
+cd extension && npx vsce package --target darwin-arm64
+
+# on a Linux x64 runner
+npm run extension:prep
+cd extension && npx vsce package --target linux-x64
+```
+
+Targets to cover the common desktop set: `win32-x64`, `win32-arm64`,
+`darwin-x64`, `darwin-arm64`, `linux-x64`, `linux-arm64`. `vsce publish`
+accepts the same `--target` flag.
+
+> A `vsce package` with **no** `--target` still works, but the produced VSIX
+> claims universal compatibility while carrying only the build machine's
+> binary — avoid it for Marketplace publishing now that a native dependency
+> is in play.

--- a/extension/README.md
+++ b/extension/README.md
@@ -20,6 +20,8 @@ Every vector preview toolbar provides:
 - **Title** — toggle the diagram caption on/off
 - **Zoom** — discrete 50 / 75 / 100 / 150 / 200 % steps
 - **Save .svg** — export the rendered diagram to a self-contained `.svg` file
+- **Save .png** — export the diagram as a rasterized PNG (2× for crisp output)
+- **Copy PNG** — copy the diagram to the clipboard as a PNG image (Windows; macOS/Linux planned)
 
 The preview panel opens automatically when you open a recognised file, and refreshes on every save.
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -371,6 +371,76 @@
         "title": "Transitrix: Save issues register as SVG",
         "category": "Transitrix",
         "icon": "$(save)"
+      },
+      {
+        "command": "transitrixStudio.saveBlocksAsPng",
+        "title": "Transitrix: Save block diagram as PNG",
+        "category": "Transitrix"
+      },
+      {
+        "command": "transitrixStudio.copyBlocksAsPng",
+        "title": "Transitrix: Copy block diagram as PNG",
+        "category": "Transitrix"
+      },
+      {
+        "command": "transitrixStudio.saveGoalsAsPng",
+        "title": "Transitrix: Save goal tree as PNG",
+        "category": "Transitrix"
+      },
+      {
+        "command": "transitrixStudio.copyGoalsAsPng",
+        "title": "Transitrix: Copy goal tree as PNG",
+        "category": "Transitrix"
+      },
+      {
+        "command": "transitrixStudio.saveFGCAAsPng",
+        "title": "Transitrix: Save FGCA diagram as PNG",
+        "category": "Transitrix"
+      },
+      {
+        "command": "transitrixStudio.copyFGCAAsPng",
+        "title": "Transitrix: Copy FGCA diagram as PNG",
+        "category": "Transitrix"
+      },
+      {
+        "command": "transitrixStudio.saveFGAAsPng",
+        "title": "Transitrix: Save FGA diagram as PNG",
+        "category": "Transitrix"
+      },
+      {
+        "command": "transitrixStudio.copyFGAAsPng",
+        "title": "Transitrix: Copy FGA diagram as PNG",
+        "category": "Transitrix"
+      },
+      {
+        "command": "transitrixStudio.saveActivitiesAsPng",
+        "title": "Transitrix: Save activity network as PNG",
+        "category": "Transitrix"
+      },
+      {
+        "command": "transitrixStudio.copyActivitiesAsPng",
+        "title": "Transitrix: Copy activity network as PNG",
+        "category": "Transitrix"
+      },
+      {
+        "command": "transitrixStudio.saveProcessBlueprintAsPng",
+        "title": "Transitrix: Save process blueprint as PNG",
+        "category": "Transitrix"
+      },
+      {
+        "command": "transitrixStudio.copyProcessBlueprintAsPng",
+        "title": "Transitrix: Copy process blueprint as PNG",
+        "category": "Transitrix"
+      },
+      {
+        "command": "transitrixStudio.saveIssuesAsPng",
+        "title": "Transitrix: Save issues register as PNG",
+        "category": "Transitrix"
+      },
+      {
+        "command": "transitrixStudio.copyIssuesAsPng",
+        "title": "Transitrix: Copy issues register as PNG",
+        "category": "Transitrix"
       }
     ],
     "menus": {
@@ -517,6 +587,7 @@
     "vscode:prepublish": "cd .. && npm run extension:prep"
   },
   "dependencies": {
+    "@resvg/resvg-js": "^2.6.2",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
     "bpmn-moddle": "^10.0.0",

--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -15,6 +15,7 @@ import {
   type GanttResult,
 } from '../../packages/diagrams/src/activities/index.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
+import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
 
 // ── Shared helpers ───────────────────────────────────────────────────────────
 
@@ -571,7 +572,7 @@ export class ActivitiesPreview {
         'activitiesPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveActivitiesAsSvg'] },
+        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveActivitiesAsSvg', 'transitrixStudio.saveActivitiesAsPng', 'transitrixStudio.copyActivitiesAsPng'] },
       );
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
     }
@@ -634,6 +635,64 @@ export class ActivitiesPreview {
       themeId,
       extraStyles: ACTIVITIES_STYLES,
       saveSvgCommand: 'transitrixStudio.saveActivitiesAsSvg',
+      savePngCommand: 'transitrixStudio.saveActivitiesAsPng',
+      copyPngCommand: 'transitrixStudio.copyActivitiesAsPng',
+    });
+  }
+
+  /**
+   * Resolve which of the two views (network / Gantt) to export. The CSS-only
+   * switcher state is invisible to the extension, so when both are present we
+   * ask; when only one rendered (Gantt-unavailable mode) we skip the prompt.
+   * Returns undefined when nothing is rendered or the user cancels.
+   */
+  private async pickExportView(): Promise<'network' | 'gantt' | undefined> {
+    const hasNetwork = Boolean(this.lastNetworkSvg);
+    const hasGantt = Boolean(this.lastGanttSvg);
+    if (!hasNetwork && !hasGantt) {
+      vscode.window.showWarningMessage('No diagram rendered yet. Open a *.activities.transitrix.yaml file first.');
+      return undefined;
+    }
+    if (hasNetwork && hasGantt) {
+      const choice = await vscode.window.showQuickPick(
+        [
+          { label: 'Network view', description: 'Project Schedule Network Diagram (PSND)', view: 'network' as const },
+          { label: 'Gantt view',   description: 'Timeline',                                  view: 'gantt'   as const },
+        ],
+        { placeHolder: 'Which view do you want to export?' },
+      );
+      return choice?.view;
+    }
+    return hasNetwork ? 'network' : 'gantt';
+  }
+
+  async saveAsPng(): Promise<void> {
+    const view = await this.pickExportView();
+    if (!view) return;
+    const rawSvg = view === 'network' ? this.lastNetworkSvg : this.lastGanttSvg;
+    const themeId = vscode.workspace.getConfiguration('transitrix').get<ThemeId>('theme', 'transitrix');
+    const sourceUri = this.trackedUri ? vscode.Uri.parse(this.trackedUri) : undefined;
+    await savePngFromSvg({
+      rawSvg: rawSvg || undefined,
+      themeId,
+      notationCss: ACTIVITIES_DIAGRAM_CSS,
+      sourceUri,
+      stripExt: /\.activities\.transitrix\.yaml$/,
+      viewSuffix: `-${view}`,
+      emptyMessage: 'No diagram rendered yet. Open a *.activities.transitrix.yaml file first.',
+    });
+  }
+
+  async copyAsPng(): Promise<void> {
+    const view = await this.pickExportView();
+    if (!view) return;
+    const rawSvg = view === 'network' ? this.lastNetworkSvg : this.lastGanttSvg;
+    const themeId = vscode.workspace.getConfiguration('transitrix').get<ThemeId>('theme', 'transitrix');
+    await copyPngFromSvg({
+      rawSvg: rawSvg || undefined,
+      themeId,
+      notationCss: ACTIVITIES_DIAGRAM_CSS,
+      emptyMessage: 'No diagram rendered yet. Open a *.activities.transitrix.yaml file first.',
     });
   }
 

--- a/extension/src/blocks-preview.ts
+++ b/extension/src/blocks-preview.ts
@@ -2,6 +2,7 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, prepareSvgForExport, type ThemeId } from './diagram-frame.js';
+import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
 import { TITLE_BLOCK_H, titleBlockSvg, todayIso } from './svg-title-block.js';
 import {
   validateNestedBlocks,
@@ -101,7 +102,7 @@ export class BlocksPreview {
         {
           enableScripts: false,
           retainContextWhenHidden: true,
-          enableCommandUris: ['transitrixStudio.saveBlocksAsSvg'],
+          enableCommandUris: ['transitrixStudio.saveBlocksAsSvg', 'transitrixStudio.saveBlocksAsPng', 'transitrixStudio.copyBlocksAsPng'],
         },
       );
       this.panel.onDidDispose(() => {
@@ -164,7 +165,26 @@ export class BlocksPreview {
       warnings,
       themeId,
       saveSvgCommand: 'transitrixStudio.saveBlocksAsSvg',
+      savePngCommand: 'transitrixStudio.saveBlocksAsPng',
+      copyPngCommand: 'transitrixStudio.copyBlocksAsPng',
     });
+  }
+
+  private pngTarget() {
+    return {
+      rawSvg: this.lastSvg || undefined,
+      themeId: vscode.workspace.getConfiguration('transitrix').get<ThemeId>('theme', 'transitrix'),
+      emptyMessage: 'No diagram rendered yet. Open a *.blocks.transitrix.yaml file first.',
+    };
+  }
+
+  saveAsPng(): Promise<void> {
+    const sourceUri = this.trackedUri ? vscode.Uri.parse(this.trackedUri) : undefined;
+    return savePngFromSvg({ ...this.pngTarget(), sourceUri, stripExt: /\.blocks\.transitrix\.yaml$/ });
+  }
+
+  copyAsPng(): Promise<void> {
+    return copyPngFromSvg(this.pngTarget());
   }
 
   async saveAsSvg(): Promise<void> {

--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -135,9 +135,13 @@ const FRAME_HEADER_CSS = `
  */
 const TITLE_TOGGLE_CSS = `
 .title-toggle-cb { position: absolute; left: -9999px; width: 1px; height: 1px; opacity: 0; }
-#toolbar { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
-.toolbar-label { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.toolbar-actions { display: flex; gap: 4px; align-items: center; flex-shrink: 0; }
+/* The toolbar wraps: with Title + Zoom + Save .svg / .png + Copy PNG the
+   action row can exceed a narrow side-by-side preview pane. Without wrapping
+   the rightmost button (Copy PNG) overflowed off-screen. flex-wrap lets the
+   actions drop to a second line instead of vanishing. */
+#toolbar { display: flex; align-items: center; justify-content: space-between; gap: 8px; flex-wrap: wrap; }
+.toolbar-label { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.toolbar-actions { display: flex; gap: 4px; align-items: center; flex-wrap: wrap; justify-content: flex-end; }
 .title-toggle,
 .toolbar-btn {
   cursor: pointer;

--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -59,6 +59,17 @@ export interface DiagramFrameOpts {
    * Omit on previews that don't render a vector diagram (HTML catalogues).
    */
   saveSvgCommand?: string;
+  /**
+   * Command ID for the "Save .png" toolbar button. Rendered next to
+   * "Save .svg" when provided and a vector diagram is on screen. PNG is
+   * rasterized in the Node host (resvg) — see `raster.ts`.
+   */
+  savePngCommand?: string;
+  /**
+   * Command ID for the "Copy PNG" toolbar button (clipboard). Rendered next
+   * to "Save .png" when provided and a vector diagram is on screen.
+   */
+  copyPngCommand?: string;
 }
 
 function escXml(s: string): string {
@@ -247,7 +258,7 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
     errorMsg = '', warnings = [],
     themeId = 'transitrix', extraStyles = '', fixPrompt = '',
     title, subtitle, version, date,
-    saveSvgCommand,
+    saveSvgCommand, savePngCommand, copyPngCommand,
   } = opts;
 
   const canvasContent = bodyContent ?? svgContent;
@@ -289,6 +300,8 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
   // Save .svg button — only render when both (a) a vector diagram is on screen
   // and (b) the preview supplied a command id (HTML catalogues never do).
   const showSaveSvg = Boolean(canvasContent) && Boolean(saveSvgCommand);
+  const showSavePng = Boolean(canvasContent) && Boolean(savePngCommand);
+  const showCopyPng = Boolean(canvasContent) && Boolean(copyPngCommand);
   // Zoom control gates on the same signal as Save .svg — the six vector
   // previews opt in by passing a saveSvgCommand. HTML catalogues are out of
   // scope per the orchestrator's call on issue #30.
@@ -312,6 +325,12 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
   }
   if (showSaveSvg) {
     actionParts.push(`<a href="command:${escXml(saveSvgCommand!)}" class="toolbar-btn" title="Save the current diagram as an .svg file">Save .svg</a>`);
+  }
+  if (showSavePng) {
+    actionParts.push(`<a href="command:${escXml(savePngCommand!)}" class="toolbar-btn" title="Save the current diagram as a .png file">Save .png</a>`);
+  }
+  if (showCopyPng) {
+    actionParts.push(`<a href="command:${escXml(copyPngCommand!)}" class="toolbar-btn" title="Copy the current diagram to the clipboard as a PNG image">Copy PNG</a>`);
   }
   const toolbarRight = actionParts.length > 0
     ? `<div class="toolbar-actions">${actionParts.join('')}</div>`

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -208,6 +208,18 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     vscode.commands.registerCommand('transitrixStudio.saveActivitiesAsSvg', () =>
       activitiesPreview.saveAsSvg(),
     ),
+    // PNG export — save-to-file + copy-to-clipboard per vector notation
+    // (vkgeorgia/strategy#32). Rasterized in the Node host via resvg.
+    vscode.commands.registerCommand('transitrixStudio.saveBlocksAsPng', () => blocksPreview.saveAsPng()),
+    vscode.commands.registerCommand('transitrixStudio.copyBlocksAsPng', () => blocksPreview.copyAsPng()),
+    vscode.commands.registerCommand('transitrixStudio.saveGoalsAsPng', () => goalsPreview.saveAsPng()),
+    vscode.commands.registerCommand('transitrixStudio.copyGoalsAsPng', () => goalsPreview.copyAsPng()),
+    vscode.commands.registerCommand('transitrixStudio.saveFGCAAsPng', () => fgcaPreview.saveAsPng()),
+    vscode.commands.registerCommand('transitrixStudio.copyFGCAAsPng', () => fgcaPreview.copyAsPng()),
+    vscode.commands.registerCommand('transitrixStudio.saveFGAAsPng', () => fgaPreview.saveAsPng()),
+    vscode.commands.registerCommand('transitrixStudio.copyFGAAsPng', () => fgaPreview.copyAsPng()),
+    vscode.commands.registerCommand('transitrixStudio.saveActivitiesAsPng', () => activitiesPreview.saveAsPng()),
+    vscode.commands.registerCommand('transitrixStudio.copyActivitiesAsPng', () => activitiesPreview.copyAsPng()),
     vscode.commands.registerCommand('transitrixStudio.previewApplications', async () => {
       const doc = vscode.window.activeTextEditor?.document;
       if (!doc || !isApplicationsFile(doc)) {
@@ -259,6 +271,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     vscode.commands.registerCommand('transitrixStudio.saveProcessBlueprintAsSvg', async () => {
       await processBlueprintPreview.saveAsSvg();
     }),
+    vscode.commands.registerCommand('transitrixStudio.saveProcessBlueprintAsPng', () => processBlueprintPreview.saveAsPng()),
+    vscode.commands.registerCommand('transitrixStudio.copyProcessBlueprintAsPng', () => processBlueprintPreview.copyAsPng()),
     vscode.commands.registerCommand('transitrixStudio.previewIssues', async () => {
       const doc = vscode.window.activeTextEditor?.document;
       if (!doc || !isIssuesFile(doc)) {
@@ -270,6 +284,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     vscode.commands.registerCommand('transitrixStudio.saveIssuesAsSvg', async () => {
       await issuesPreview.saveAsSvg();
     }),
+    vscode.commands.registerCommand('transitrixStudio.saveIssuesAsPng', () => issuesPreview.saveAsPng()),
+    vscode.commands.registerCommand('transitrixStudio.copyIssuesAsPng', () => issuesPreview.copyAsPng()),
     vscode.workspace.onDidSaveTextDocument((doc) => {
       if (isGoalsFile(doc)) { void goalsPreview.refreshSaved(doc); return; }
       if (isFGCAFile(doc)) { void fgcaPreview.refreshSaved(doc); return; }

--- a/extension/src/fgca-preview.ts
+++ b/extension/src/fgca-preview.ts
@@ -5,6 +5,7 @@ import { buildDiagramFrame, prepareSvgForExport, type ThemeId } from './diagram-
 import { TITLE_BLOCK_H, titleBlockSvg, todayIso } from './svg-title-block.js';
 import { parseCanonicalFGCA } from '../../packages/diagrams/src/fgca/parse-canonical.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
+import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
 
 // ── Inline types ──────────────────────────────────────────────────────────────
 //
@@ -407,7 +408,7 @@ export class FGCAPreview {
         'fgcaPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveFGCAAsSvg'] },
+        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveFGCAAsSvg', 'transitrixStudio.saveFGCAAsPng', 'transitrixStudio.copyFGCAAsPng'] },
       );
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
     }
@@ -455,7 +456,29 @@ export class FGCAPreview {
       .getConfiguration('transitrix')
       .get<ThemeId>('theme', 'transitrix');
 
-    return buildDiagramFrame({ filename, notation: 'FGCA', svgContent, errorMsg, warnings, themeId, saveSvgCommand: 'transitrixStudio.saveFGCAAsSvg' });
+    return buildDiagramFrame({
+      filename, notation: 'FGCA', svgContent, errorMsg, warnings, themeId,
+      saveSvgCommand: 'transitrixStudio.saveFGCAAsSvg',
+      savePngCommand: 'transitrixStudio.saveFGCAAsPng',
+      copyPngCommand: 'transitrixStudio.copyFGCAAsPng',
+    });
+  }
+
+  private pngTarget() {
+    return {
+      rawSvg: this.lastSvg || undefined,
+      themeId: vscode.workspace.getConfiguration('transitrix').get<ThemeId>('theme', 'transitrix'),
+      emptyMessage: 'No diagram rendered yet. Open a *.fgca.transitrix.yaml file first.',
+    };
+  }
+
+  saveAsPng(): Promise<void> {
+    const sourceUri = this.trackedUri ? vscode.Uri.parse(this.trackedUri) : undefined;
+    return savePngFromSvg({ ...this.pngTarget(), sourceUri, stripExt: /\.fgca\.transitrix\.yaml$/ });
+  }
+
+  copyAsPng(): Promise<void> {
+    return copyPngFromSvg(this.pngTarget());
   }
 
   async saveAsSvg(): Promise<void> {
@@ -501,7 +524,7 @@ export class FGAPreview {
         'fgaPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveFGAAsSvg'] },
+        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveFGAAsSvg', 'transitrixStudio.saveFGAAsPng', 'transitrixStudio.copyFGAAsPng'] },
       );
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
     }
@@ -546,7 +569,29 @@ export class FGAPreview {
       .getConfiguration('transitrix')
       .get<ThemeId>('theme', 'transitrix');
 
-    return buildDiagramFrame({ filename, notation: 'FGA', svgContent, errorMsg, warnings, themeId, saveSvgCommand: 'transitrixStudio.saveFGAAsSvg' });
+    return buildDiagramFrame({
+      filename, notation: 'FGA', svgContent, errorMsg, warnings, themeId,
+      saveSvgCommand: 'transitrixStudio.saveFGAAsSvg',
+      savePngCommand: 'transitrixStudio.saveFGAAsPng',
+      copyPngCommand: 'transitrixStudio.copyFGAAsPng',
+    });
+  }
+
+  private pngTarget() {
+    return {
+      rawSvg: this.lastSvg || undefined,
+      themeId: vscode.workspace.getConfiguration('transitrix').get<ThemeId>('theme', 'transitrix'),
+      emptyMessage: 'No diagram rendered yet. Open a *.fga.transitrix.yaml file first.',
+    };
+  }
+
+  saveAsPng(): Promise<void> {
+    const sourceUri = this.trackedUri ? vscode.Uri.parse(this.trackedUri) : undefined;
+    return savePngFromSvg({ ...this.pngTarget(), sourceUri, stripExt: /\.fga\.transitrix\.yaml$/ });
+  }
+
+  copyAsPng(): Promise<void> {
+    return copyPngFromSvg(this.pngTarget());
   }
 
   async saveAsSvg(): Promise<void> {

--- a/extension/src/goals-preview.ts
+++ b/extension/src/goals-preview.ts
@@ -2,6 +2,7 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, prepareSvgForExport, type ThemeId } from './diagram-frame.js';
+import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
 import { TITLE_BLOCK_H, titleBlockSvg, todayIso } from './svg-title-block.js';
 import {
   layoutGoalTree,
@@ -111,7 +112,7 @@ export class GoalsPreview {
         'goalsPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveGoalsAsSvg'] },
+        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveGoalsAsSvg', 'transitrixStudio.saveGoalsAsPng', 'transitrixStudio.copyGoalsAsPng'] },
       );
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
     }
@@ -162,7 +163,32 @@ export class GoalsPreview {
       .getConfiguration('transitrix')
       .get<ThemeId>('theme', 'transitrix');
 
-    return buildDiagramFrame({ filename, notation: 'Goal tree', svgContent, errorMsg, warnings, themeId, saveSvgCommand: 'transitrixStudio.saveGoalsAsSvg' });
+    return buildDiagramFrame({
+      filename, notation: 'Goal tree', svgContent, errorMsg, warnings, themeId,
+      saveSvgCommand: 'transitrixStudio.saveGoalsAsSvg',
+      savePngCommand: 'transitrixStudio.saveGoalsAsPng',
+      copyPngCommand: 'transitrixStudio.copyGoalsAsPng',
+    });
+  }
+
+  private pngTarget(): { rawSvg: string | undefined; themeId: ThemeId; emptyMessage: string } {
+    return {
+      rawSvg: this.lastSvg || undefined,
+      themeId: vscode.workspace.getConfiguration('transitrix').get<ThemeId>('theme', 'transitrix'),
+      emptyMessage: 'No diagram rendered yet. Open a *.goals.transitrix.yaml file first.',
+    };
+  }
+
+  private sourceUri(): vscode.Uri | undefined {
+    return this.trackedUri ? vscode.Uri.parse(this.trackedUri) : undefined;
+  }
+
+  saveAsPng(): Promise<void> {
+    return savePngFromSvg({ ...this.pngTarget(), sourceUri: this.sourceUri(), stripExt: /\.goals\.transitrix\.yaml$/ });
+  }
+
+  copyAsPng(): Promise<void> {
+    return copyPngFromSvg(this.pngTarget());
   }
 
   async saveAsSvg(): Promise<void> {

--- a/extension/src/issues-preview.ts
+++ b/extension/src/issues-preview.ts
@@ -11,6 +11,7 @@ import {
   type IssueStatus,
 } from '../../packages/diagrams/src/issues/index.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
+import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
 
 function escXml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
@@ -140,7 +141,7 @@ export class IssuesPreview {
         {
           enableScripts: false,
           retainContextWhenHidden: true,
-          enableCommandUris: ['transitrixStudio.saveIssuesAsSvg'],
+          enableCommandUris: ['transitrixStudio.saveIssuesAsSvg', 'transitrixStudio.saveIssuesAsPng', 'transitrixStudio.copyIssuesAsPng'],
         },
       );
       this.panel.onDidDispose(() => {
@@ -199,7 +200,26 @@ export class IssuesPreview {
       warnings,
       themeId,
       saveSvgCommand: 'transitrixStudio.saveIssuesAsSvg',
+      savePngCommand: 'transitrixStudio.saveIssuesAsPng',
+      copyPngCommand: 'transitrixStudio.copyIssuesAsPng',
     });
+  }
+
+  private pngTarget() {
+    return {
+      rawSvg: this.lastSvg || undefined,
+      themeId: vscode.workspace.getConfiguration('transitrix').get<ThemeId>('theme', 'transitrix'),
+      emptyMessage: 'No diagram rendered yet. Open a *.issues.transitrix.yaml file first.',
+    };
+  }
+
+  saveAsPng(): Promise<void> {
+    const sourceUri = this.trackedUri ? vscode.Uri.parse(this.trackedUri) : undefined;
+    return savePngFromSvg({ ...this.pngTarget(), sourceUri, stripExt: /\.issues\.transitrix\.yaml$/ });
+  }
+
+  copyAsPng(): Promise<void> {
+    return copyPngFromSvg(this.pngTarget());
   }
 
   async saveAsSvg(): Promise<void> {

--- a/extension/src/png-export.ts
+++ b/extension/src/png-export.ts
@@ -1,0 +1,126 @@
+/**
+ * VS Code glue for PNG export — save-to-file and copy-to-clipboard.
+ *
+ * The pure rasterization lives in `raster.ts` (no `vscode` import). This
+ * module owns the editor-facing parts: the save dialog, file write, and the
+ * OS-specific clipboard path.
+ *
+ * Clipboard scope (vkgeorgia/strategy#32): `vscode.env.clipboard` is
+ * text-only, so an image copy needs an OS-specific path. Windows ships here;
+ * macOS (`osascript`) and Linux (`xclip` / `wl-copy`) are a documented
+ * follow-up — `copyPngToClipboard` degrades to a clear notice there.
+ */
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { promises as fsp } from 'node:fs';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import * as vscode from 'vscode';
+import { prepareSvgForExport, type ThemeId } from './diagram-frame.js';
+import { rasterizeSvgToPng } from './raster.js';
+
+const execFileP = promisify(execFile);
+
+export interface PngCopyTarget {
+  /** Raw rendered SVG (pre-export). Undefined/empty → nothing to export. */
+  rawSvg: string | undefined;
+  themeId: ThemeId;
+  /** Per-notation class CSS to embed — same value passed to prepareSvgForExport. */
+  notationCss?: string;
+  /** Message shown when no diagram has been rendered yet. */
+  emptyMessage: string;
+}
+
+export interface PngSaveTarget extends PngCopyTarget {
+  /** URI of the source document, for the default save location + filename. */
+  sourceUri?: vscode.Uri;
+  /** Regex stripping the notation suffix from the source filename. */
+  stripExt: RegExp;
+  /** Optional suffix before `.png` (e.g. "-network" for the activities views). */
+  viewSuffix?: string;
+}
+
+function rasterizeOrReport(svg: string): Promise<Buffer | undefined> {
+  return rasterizeSvgToPng(svg).catch((e: unknown) => {
+    vscode.window.showErrorMessage(`PNG export failed: ${(e as Error).message ?? String(e)}`);
+    return undefined;
+  });
+}
+
+/** Save the current diagram as a `.png` via a save dialog. */
+export async function savePngFromSvg(t: PngSaveTarget): Promise<void> {
+  if (!t.rawSvg) {
+    vscode.window.showWarningMessage(t.emptyMessage);
+    return;
+  }
+  const stem = t.sourceUri
+    ? path.basename(t.sourceUri.fsPath).replace(t.stripExt, '')
+    : 'diagram';
+  const filename = `${stem}${t.viewSuffix ?? ''}.png`;
+  const defaultUri = t.sourceUri
+    ? vscode.Uri.file(path.join(path.dirname(t.sourceUri.fsPath), filename))
+    : vscode.Uri.file(filename);
+  const target = await vscode.window.showSaveDialog({ defaultUri, filters: { 'PNG Image': ['png'] } });
+  if (!target) return;
+
+  const svg = prepareSvgForExport(t.rawSvg, t.themeId, t.notationCss ?? '');
+  const png = await rasterizeOrReport(svg);
+  if (!png) return;
+  await vscode.workspace.fs.writeFile(target, png);
+  vscode.window.showInformationMessage(`Saved: ${path.basename(target.fsPath)}`);
+}
+
+/** Copy the current diagram to the clipboard as a PNG image. */
+export async function copyPngFromSvg(t: PngCopyTarget): Promise<void> {
+  if (!t.rawSvg) {
+    vscode.window.showWarningMessage(t.emptyMessage);
+    return;
+  }
+  const svg = prepareSvgForExport(t.rawSvg, t.themeId, t.notationCss ?? '');
+  const png = await rasterizeOrReport(svg);
+  if (!png) return;
+  await copyPngToClipboard(png);
+}
+
+async function copyPngToClipboard(png: Buffer): Promise<void> {
+  if (process.platform === 'win32') {
+    try {
+      await copyPngWindows(png);
+      vscode.window.showInformationMessage('Diagram copied to clipboard as PNG.');
+    } catch (e) {
+      vscode.window.showErrorMessage(`Copy as PNG failed: ${(e as Error).message ?? String(e)}`);
+    }
+    return;
+  }
+  // macOS / Linux: not yet wired (Windows-first, vkgeorgia/strategy#32).
+  vscode.window.showWarningMessage(
+    'Copy as PNG is not yet available on macOS/Linux — use “Save .png” instead. (Tracked in vkgeorgia/strategy#32.)',
+  );
+}
+
+/**
+ * Windows clipboard image copy.
+ *
+ * `vscode.env.clipboard` is text-only and there is no Node API for image
+ * clipboard, so shell out to Windows PowerShell. `Clipboard.SetImage` must
+ * run on an STA thread — `powershell.exe` (Windows PowerShell 5.1, always
+ * present) is STA by default; we pass `-STA` to be explicit. The PNG is
+ * staged through a temp file (simpler and more robust than piping binary on
+ * stdin). `execFile` with an argv array — never a shell string — keeps the
+ * generated, non-user path clear of any command-injection surface.
+ */
+async function copyPngWindows(png: Buffer): Promise<void> {
+  const tmp = path.join(os.tmpdir(), `transitrix-clip-${process.pid}-${Date.now()}.png`);
+  await fsp.writeFile(tmp, png);
+  const escaped = tmp.replace(/'/g, "''"); // PowerShell single-quote escape
+  const psScript =
+    'Add-Type -AssemblyName System.Windows.Forms,System.Drawing; ' +
+    `$img = [System.Drawing.Image]::FromFile('${escaped}'); ` +
+    '[System.Windows.Forms.Clipboard]::SetImage($img); ' +
+    '$img.Dispose()';
+  try {
+    await execFileP('powershell.exe', ['-NoProfile', '-NonInteractive', '-STA', '-Command', psScript]);
+  } finally {
+    await fsp.unlink(tmp).catch(() => undefined);
+  }
+}

--- a/extension/src/process-blueprint-preview.ts
+++ b/extension/src/process-blueprint-preview.ts
@@ -10,6 +10,7 @@ import {
   type ProcessBlueprintLayout,
 } from '../../packages/diagrams/src/process-blueprint/index.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
+import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
 
 function escXml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
@@ -120,7 +121,7 @@ export class ProcessBlueprintPreview {
         'processBlueprintPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveProcessBlueprintAsSvg'] },
+        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveProcessBlueprintAsSvg', 'transitrixStudio.saveProcessBlueprintAsPng', 'transitrixStudio.copyProcessBlueprintAsPng'] },
       );
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
     }
@@ -168,7 +169,29 @@ export class ProcessBlueprintPreview {
       .getConfiguration('transitrix')
       .get<ThemeId>('theme', 'transitrix');
 
-    return buildDiagramFrame({ filename, notation: 'Process Blueprint', svgContent, errorMsg, warnings, themeId, saveSvgCommand: 'transitrixStudio.saveProcessBlueprintAsSvg' });
+    return buildDiagramFrame({
+      filename, notation: 'Process Blueprint', svgContent, errorMsg, warnings, themeId,
+      saveSvgCommand: 'transitrixStudio.saveProcessBlueprintAsSvg',
+      savePngCommand: 'transitrixStudio.saveProcessBlueprintAsPng',
+      copyPngCommand: 'transitrixStudio.copyProcessBlueprintAsPng',
+    });
+  }
+
+  private pngTarget() {
+    return {
+      rawSvg: this.lastSvg || undefined,
+      themeId: vscode.workspace.getConfiguration('transitrix').get<ThemeId>('theme', 'transitrix'),
+      emptyMessage: 'No diagram rendered yet. Open a *.process-blueprint.transitrix.yaml file first.',
+    };
+  }
+
+  saveAsPng(): Promise<void> {
+    const sourceUri = this.trackedUri ? vscode.Uri.parse(this.trackedUri) : undefined;
+    return savePngFromSvg({ ...this.pngTarget(), sourceUri, stripExt: /\.process-blueprint\.transitrix\.yaml$/ });
+  }
+
+  copyAsPng(): Promise<void> {
+    return copyPngFromSvg(this.pngTarget());
   }
 
   async saveAsSvg(): Promise<void> {

--- a/extension/src/raster.ts
+++ b/extension/src/raster.ts
@@ -1,0 +1,93 @@
+/**
+ * SVG → PNG rasterization for diagram export.
+ *
+ * Kept deliberately free of any `vscode` import so it can be unit-tested in
+ * plain Node and — per the architectural note on vkgeorgia/strategy#32 —
+ * lifted into the shared `@transitrix/diagrams` library later without
+ * untangling editor glue. The VS Code wiring (save dialog, clipboard) lives
+ * in `png-export.ts`.
+ *
+ * Rasterizer: `@resvg/resvg-js` (Rust/usvg, prebuilt per-platform binaries).
+ * Chosen over a headless browser (tens of MB, heavy startup) and `sharp`
+ * (librsvg SVG path is weaker on fonts/CSS, larger binary). Decision recorded
+ * on vkgeorgia/strategy#32.
+ */
+
+/**
+ * resvg's usvg engine does NOT resolve CSS custom properties: a
+ * `fill:var(--ts-x)` rule renders as the initial value (black), verified
+ * against resvg-js 2.6.2. Our exported SVGs define every colour as a
+ * `--ts-*` custom property on `:root` and reference it through `var(...)`
+ * (see `generateSvgEmbedCss`), so without this pass every shape and label
+ * would rasterize black.
+ *
+ * `flattenCssVars` collects `--name: value` declarations from the embedded
+ * `<style>` and substitutes each `var(--name[, fallback])` with the resolved
+ * literal. It iterates so custom properties that reference other custom
+ * properties (`--c: var(--base)`) resolve too, and falls back to the
+ * `var(..., fallback)` argument when a name is undefined.
+ */
+export function flattenCssVars(svg: string): string {
+  const defs = new Map<string, string>();
+  const declRe = /(--[A-Za-z0-9-]+)\s*:\s*([^;}]+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = declRe.exec(svg)) !== null) {
+    defs.set(m[1], m[2].trim());
+  }
+
+  const varRe = /var\(\s*(--[A-Za-z0-9-]+)\s*(?:,\s*([^)]*))?\)/g;
+  const resolve = (name: string, fallback?: string): string => {
+    if (defs.has(name)) return defs.get(name)!;
+    return fallback !== undefined ? fallback.trim() : `var(${name})`;
+  };
+
+  let out = svg;
+  let prev = '';
+  let pass = 0;
+  // Iterate until stable (handles var → var chains); cap passes to avoid
+  // pathological self-referential definitions spinning forever.
+  while (out !== prev && pass < 10) {
+    prev = out;
+    pass += 1;
+    out = out.replace(varRe, (_whole, name: string, fb?: string) => resolve(name, fb));
+  }
+  return out;
+}
+
+export interface RasterizeOptions {
+  /** Output scale. 2 ≈ retina-quality; the default for crisp paste/embed. */
+  scale?: number;
+  /** Background fill. Defaults to white — clipboard bitmaps drop alpha. */
+  background?: string;
+}
+
+type ResvgModule = typeof import('@resvg/resvg-js');
+let resvgModule: Promise<ResvgModule> | undefined;
+
+/**
+ * Lazily load the native `@resvg/resvg-js` binding. Deferred so opening a
+ * preview never pays the native-module load cost — it happens only on the
+ * first PNG export. The module is marked `external` in the esbuild bundle so
+ * its platform `.node` binary resolves from the shipped `node_modules`.
+ */
+function loadResvg(): Promise<ResvgModule> {
+  if (!resvgModule) resvgModule = import('@resvg/resvg-js');
+  return resvgModule;
+}
+
+/**
+ * Rasterize a standalone SVG string (already self-contained via
+ * `prepareSvgForExport`) into a PNG buffer. CSS custom properties are
+ * flattened first so resvg renders true colours.
+ */
+export async function rasterizeSvgToPng(svg: string, opts: RasterizeOptions = {}): Promise<Buffer> {
+  const { scale = 2, background = 'white' } = opts;
+  const { Resvg } = await loadResvg();
+  const flattened = flattenCssVars(svg);
+  const resvg = new Resvg(flattened, {
+    background,
+    fitTo: { mode: 'zoom', value: scale },
+    font: { loadSystemFonts: true },
+  });
+  return Buffer.from(resvg.render().asPng());
+}

--- a/scripts/build-compiler-bundle.mjs
+++ b/scripts/build-compiler-bundle.mjs
@@ -128,4 +128,30 @@ for (const dep of RUNTIME_DEPS_EXTERNAL) {
   }
 }
 
+// @resvg/resvg-js (PNG export, vkgeorgia/strategy#32) is a NATIVE module: its
+// platform `.node` binary ships as a per-OS optional dependency, so `npm
+// install` lays down only the binary matching the build machine. That is
+// exactly right for per-platform VSIX packaging (`vsce package --target`),
+// but it means a build on one OS cannot produce a working VSIX for another —
+// build each target on its own OS (or CI runner). Fail loudly if neither the
+// package nor any platform binary landed, so a broken PNG build is caught at
+// prep time rather than by the user.
+try {
+  await fs.access(resolve(extNodeModules, '@resvg', 'resvg-js', 'package.json'));
+} catch {
+  throw new Error(
+    'extension/node_modules/@resvg/resvg-js not found after install. ' +
+    'Check extension/package.json declares "@resvg/resvg-js" in dependencies.',
+  );
+}
+const resvgScoped = await fs.readdir(resolve(extNodeModules, '@resvg')).catch(() => []);
+const hasResvgBinary = resvgScoped.some((d) => d.startsWith('resvg-js-'));
+if (!hasResvgBinary) {
+  throw new Error(
+    'No @resvg/resvg-js platform binary (@resvg/resvg-js-<platform>) installed. ' +
+    'PNG export would fail at runtime. Build the VSIX on the target platform, ' +
+    'or install the matching optional dependency before packaging.',
+  );
+}
+
 console.log('Compiler bundle → extension/compiler/  |  schemas → extension/schemas/  |  backends → extension/backends/  |  runtime deps → extension/node_modules/');

--- a/scripts/build-extension-bundle.mjs
+++ b/scripts/build-extension-bundle.mjs
@@ -19,6 +19,9 @@ await esbuild.build({
   outfile: resolve(root, 'extension/out/extension.js'),
   external: [
     'vscode',
+    // Native module — its platform .node binary cannot be bundled; resolved
+    // at runtime from the node_modules shipped inside the VSIX.
+    '@resvg/resvg-js',
     'node:path',
     'node:url',
     'node:fs',

--- a/tests/raster.test.ts
+++ b/tests/raster.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { flattenCssVars } from '../extension/src/raster.js';
+
+// resvg's usvg engine does not resolve CSS custom properties, so the PNG
+// export pipeline pre-flattens `var(--x)` into literal values. These lock
+// that contract — a regression here means exported PNGs render black.
+describe('flattenCssVars', () => {
+  it('substitutes a single custom property into a fill', () => {
+    const svg = '<svg><style>:root{--c:#22aa44;}.box{fill:var(--c);}</style></svg>';
+    expect(flattenCssVars(svg)).toContain('fill:#22aa44;');
+    expect(flattenCssVars(svg)).not.toContain('var(--c)');
+  });
+
+  it('resolves custom properties that reference other custom properties', () => {
+    const svg = '<svg><style>:root{--base:#123456;--c:var(--base);}.box{fill:var(--c);}</style></svg>';
+    expect(flattenCssVars(svg)).toContain('fill:#123456;');
+    expect(flattenCssVars(svg)).not.toContain('var(');
+  });
+
+  it('uses the fallback when the property is undefined', () => {
+    const svg = '<svg><style>.box{fill:var(--missing, #ff0000);}</style></svg>';
+    expect(flattenCssVars(svg)).toContain('fill:#ff0000;');
+  });
+
+  it('leaves an unresolvable var without fallback intact (no crash)', () => {
+    const svg = '<svg><style>.box{fill:var(--nope);}</style></svg>';
+    expect(flattenCssVars(svg)).toContain('var(--nope)');
+  });
+
+  it('resolves multiple distinct properties in one document', () => {
+    const svg =
+      '<svg><style>:root{--a:#111111;--b:#222222;}' +
+      '.x{fill:var(--a);}.y{stroke:var(--b);}</style></svg>';
+    const out = flattenCssVars(svg);
+    expect(out).toContain('fill:#111111;');
+    expect(out).toContain('stroke:#222222;');
+  });
+
+  it('is a no-op on markup with no custom properties', () => {
+    const svg = '<svg><rect fill="#000" /></svg>';
+    expect(flattenCssVars(svg)).toBe(svg);
+  });
+});


### PR DESCRIPTION
## Summary

Adds **Save .png** and **Copy PNG** toolbar buttons next to **Save .svg** on every vector notation preview (goals, FGCA, FGA, activities, blocks, process-blueprint, issues), implementing vkgeorgia/strategy#32.

## Decisions (confirmed with Valerii)

| Decision | Choice |
|---|---|
| Rasterizer | **@resvg/resvg-js** (Rust/usvg, prebuilt per-platform binaries) — over headless browser (tens of MB) and sharp (weaker SVG path) |
| Packaging | **Per-platform VSIX** (`vsce package --target`) |
| Copy-as-PNG scope | **Windows first**; macOS/Linux degrade to a documented notice |
| Code placement | **In extension behind a clean, vscode-free module** so it can later move to `@transitrix/diagrams` |

## Key technical finding — resvg does not resolve CSS `var()`

Our exported SVGs define every colour as a `--ts-*` custom property and reference it via `var(...)`. resvg's usvg engine **does not resolve custom properties** — verified that `fill:var(--ts-x)` rasterizes to black (hash-identical to an explicit black fill). So [extension/src/raster.ts](extension/src/raster.ts) runs a `flattenCssVars` pass that resolves `var(--name[, fallback])` to literals (including `var → var` chains) before handing the SVG to resvg. Output is rendered at 2× for crisp paste/embed.

## What's here

- **[extension/src/raster.ts](extension/src/raster.ts)** — pure, `vscode`-free: `flattenCssVars` + `rasterizeSvgToPng` (lazy-loads the native binding so opening a preview never pays the load cost).
- **[extension/src/png-export.ts](extension/src/png-export.ts)** — vscode glue: save dialog + write; Windows clipboard via PowerShell `-STA Clipboard.SetImage` (staged through a temp file, `execFile`/argv — no shell, no injection surface). macOS/Linux show a clear "use Save .png" notice (Windows-first per #32).
- All 7 previews gain `saveAsPng()` / `copyAsPng()`; activities reuses its network/Gantt view picker and suffixes the filename. 14 commands registered + declared in `package.json`; each webview's `enableCommandUris` allowlist extended so the toolbar `command:` URIs are permitted.
- esbuild marks `@resvg/resvg-js` external (native `.node` can't be inlined); [build-compiler-bundle.mjs](scripts/build-compiler-bundle.mjs) fails loudly if no platform binary landed.
- **[docs/packaging.md](docs/packaging.md)** — per-platform VSIX flow; the native binary makes the extension platform-specific for distribution, so each target builds on its own OS.

## Test plan

- [x] `npm test` — 434/434 green incl. [tests/raster.test.ts](tests/raster.test.ts) (6 cases locking the `flattenCssVars` contract).
- [x] `tsc --noEmit` clean in `extension/`.
- [x] End-to-end: a themed SVG (`:root{--ts-*}` + `var()`) flattens and rasterizes via resvg to a 2× PNG (400×200 from 200×100), non-trivial output.
- [x] Extension bundle builds; resvg win32-x64 binary present in `extension/node_modules`.
- [ ] **Manual (Valerii, Windows):** open each vector preview → **Save .png** writes a file matching the SVG; **Copy PNG** puts the image on the clipboard (paste into e.g. Word/Slack). Activities prompts network/Gantt.

## Follow-ups (out of scope, documented)

- Copy-as-PNG on macOS (`osascript`) and Linux (`xclip`/`wl-copy`).
- Moving rasterization into `@transitrix/diagrams` once that library is extracted (epic referenced in #32) — the module boundary is already clean.

Do not auto-merge. Valerii gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)