### PR TITLE
fix(diagrams): lock flat-canon FGCA/FGA rendering + consolidate FGA parser

### DIFF
--- a/extension/src/fgca-preview.ts
+++ b/extension/src/fgca-preview.ts
@@ -3,24 +3,19 @@ import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, prepareSvgForExport, type ThemeId } from './diagram-frame.js';
 import { TITLE_BLOCK_H, titleBlockSvg, todayIso } from './svg-title-block.js';
-import { parseCanonicalFGCA } from '../../packages/diagrams/src/fgca/parse-canonical.js';
+import { parseCanonicalFGCA, parseCanonicalFGA } from '../../packages/diagrams/src/fgca/parse-canonical.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
 
-// ── Inline types ──────────────────────────────────────────────────────────────
+// ── Inline render types ─────────────────────────────────────────────────────
 //
-// FGCA (spec: notations/02-fgca.md) — flat arrays at top level; spec and
-// example are consistent.
-//
-// FGA (spec: notations/03-fga.md v0.1) — nested root key `fga:`:
-//   fga:
-//     id: "FGA-..."
-//     factors:
-//       - id: "FACTOR-..." name: "..." type: external|internal
-//         goals:
-//           - id: "GOAL-..." name: "..."
-//             activities:
-//               - id: "ACT-..." name: "..."
+// FGCA (notations/02-fgca.md) and FGA (notations/03-fga.md) are both the
+// canonical FLAT shape — top-level `factors[]` / `goals[]` / `changes[]`
+// (FGCA only) / `activities[]`, no `fgca:` / `fga:` wrapper. Parsing +
+// validation live in `@transitrix/diagrams` (parseCanonicalFGCA /
+// parseCanonicalFGA), which return this internal `FGCADoc` (numeric IDs,
+// singular `goal_id`, `activity_ids`). This file only renders that doc —
+// FGA reuses the FGCA renderer with the Changes column hidden.
 
 interface FactorItem { id: number | string; name: string; }
 interface GoalItem { id: number | string; name: string; level?: number; factor?: Array<{ id: number | string }>; }
@@ -33,190 +28,6 @@ interface FGCADoc {
   goals: GoalItem[];
   changes?: ChangeItem[];
   activities: ActivityItem[];
-}
-
-interface ValidationError { code: string; message: string; }
-interface ValidationResult { valid: boolean; errors: ValidationError[]; warnings: Array<{ code: string; message: string }>; }
-
-// ── Inline validation ─────────────────────────────────────────────────────────
-
-function validateFGCA(input: unknown): ValidationResult {
-  const errors: ValidationError[] = [];
-  const warnings: Array<{ code: string; message: string }> = [];
-
-  if (!input || typeof input !== 'object') {
-    return { valid: false, errors: [{ code: 'SCHEMA_INVALID', message: 'Input must be an object' }], warnings };
-  }
-
-  const raw = input as Record<string, unknown>;
-
-  if (raw.notation === undefined) {
-    errors.push({ code: 'MISSING_NOTATION', message: 'notation field is required' });
-    return { valid: false, errors, warnings };
-  }
-  if (raw.notation !== 'fgca') {
-    errors.push({ code: 'WRONG_NOTATION', message: `notation must be "fgca", got "${String(raw.notation)}"` });
-    return { valid: false, errors, warnings };
-  }
-
-  if (!Array.isArray(raw.factors)) errors.push({ code: 'SCHEMA_INVALID', message: 'factors must be an array' });
-  if (!Array.isArray(raw.goals)) errors.push({ code: 'SCHEMA_INVALID', message: 'goals must be an array' });
-  if (!Array.isArray(raw.changes)) errors.push({ code: 'SCHEMA_INVALID', message: 'changes must be an array' });
-  if (!Array.isArray(raw.activities)) errors.push({ code: 'SCHEMA_INVALID', message: 'activities must be an array' });
-  if (errors.length > 0) return { valid: false, errors, warnings };
-
-  const doc = raw as unknown as FGCADoc;
-  const factorIds = new Set(doc.factors.map(f => f.id));
-  const goalIds = new Set(doc.goals.map(g => g.id));
-  const activityIds = new Set(doc.activities.map(a => a.id));
-
-  for (const g of doc.goals) {
-    for (const f of (g.factor ?? [])) {
-      if (!factorIds.has(f.id)) {
-        warnings.push({ code: 'BROKEN_REF', message: `Goal ${g.id} references missing factor ${f.id}` });
-      }
-    }
-  }
-  for (const c of (doc.changes ?? [])) {
-    if (!goalIds.has(c.goal_id)) {
-      warnings.push({ code: 'BROKEN_REF', message: `Change ${c.id} references missing goal ${c.goal_id}` });
-    }
-    for (const aid of (c.activity_ids ?? [])) {
-      if (!activityIds.has(aid)) {
-        warnings.push({ code: 'BROKEN_REF', message: `Change ${c.id} references missing activity ${aid}` });
-      }
-    }
-  }
-
-  return { valid: errors.length === 0, errors, warnings };
-}
-
-/**
- * FGA shares the FLAT shape of FGCA — top-level `factors[]` + `goals[]` +
- * `activities[]` with `goal_id` references — minus the `changes[]` column.
- * The example file's own description puts it plainly: "Factor–Goal–Activity
- * view (Changes column hidden)". A previously-shipped NESTED variant
- * (`fga.factors[].goals[].activities[]`) didn't match any example or
- * methodology spec and broke `examples/fga/strategy-2026.fga.transitrix.yaml`
- * on open with "fga root key is required". Validation now mirrors validateFGCA
- * exactly, just with `changes` optional/empty.
- *
- * NOTE: this is a **provisional 1.0.0 shape**, not the canonical decision.
- * The family-wide flat-vs-nested-root choice for FGCA / FGA / Goals /
- * Activities is filed for methodology-level resolution in strategy hub
- * issue #37 — post-1.0.0. If that lands on nested-root, all four notations
- * migrate together; FGA is not specially burdened.
- */
-/**
- * Canonical-form FGA parser + validator. Same shape as canonical FGCA
- * minus the `changes[]` array. Wraps parseCanonicalFGCA by injecting
- * an empty `changes` and remapping the validation codes (FGCA-xxx →
- * FGA-yyy).
- */
-function parseCanonicalFGA(input: unknown): { valid: boolean; errors: ValidationError[]; warnings: Array<{ code: string; message: string }>; parsed?: FGCADoc } {
-  if (!input || typeof input !== 'object') {
-    return { valid: false, errors: [{ code: 'FGA-001', message: 'document root is not an object' }], warnings: [] };
-  }
-  const raw = input as Record<string, unknown>;
-  if ('notation' in raw && raw['notation'] !== 'fga') {
-    return {
-      valid: false,
-      errors: [{ code: 'FGA-001', message: `notation must be "fga", got "${String(raw['notation'])}"` }],
-      warnings: [],
-    };
-  }
-  // Doc id grammar — `FGA-[<middle>-]<INTEGER>`.
-  const fgaDocIdRe = /^FGA(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
-  if (raw['id'] === undefined) {
-    return {
-      valid: false,
-      errors: [{ code: 'FGA-002', message: 'document id is required' }],
-      warnings: [],
-    };
-  }
-  if (typeof raw['id'] !== 'string' || !fgaDocIdRe.test(raw['id'])) {
-    return {
-      valid: false,
-      errors: [{
-        code: 'FGA-002',
-        message: `id "${String(raw['id'])}" must match FGA-[<middle>-]<INTEGER>`,
-      }],
-      warnings: [],
-    };
-  }
-
-  // Forward to parseCanonicalFGCA with synthetic FGCA notation + doc id +
-  // empty changes array. Per-layer / per-ref checks all reuse the FGCA
-  // implementation; codes get remapped on the way out.
-  const synth = { ...raw, notation: 'fgca', id: 'FGCA-FROM-FGA-1', changes: [] };
-  const r = parseCanonicalFGCA(synth);
-  // FGCA → FGA code remap. Items not in the map keep their FGCA-prefix —
-  // those would be FGCA-only codes (changes-related), which can't fire
-  // with our synthetic `changes: []`. FGCA-009 / FGCA-010 / FGCA-014 are
-  // therefore unreachable here.
-  const remap: Record<string, string> = {
-    'FGCA-001': 'FGA-001',
-    'FGCA-002': 'FGA-002',
-    'FGCA-003': 'FGA-003',
-    'FGCA-004': 'FGA-004',
-    'FGCA-005': 'FGA-005',
-    'FGCA-006': 'FGA-006',
-    'FGCA-007': 'FGA-007',
-    'FGCA-008': 'FGA-008',
-    'FGCA-011': 'FGA-009',
-    'FGCA-012': 'FGA-010',
-    'FGCA-015': 'FGA-007',
-  };
-  const remapCode = (c: string): string => remap[c] ?? c;
-  return {
-    valid: r.valid,
-    errors: r.errors.map((e) => ({ ...e, code: remapCode(e.code) })),
-    warnings: r.warnings.map((w) => ({ ...w, code: remapCode(w.code) })),
-    parsed: r.parsed,
-  };
-}
-
-function validateFGA(input: unknown): ValidationResult {
-  const errors: ValidationError[] = [];
-  const warnings: Array<{ code: string; message: string }> = [];
-
-  if (!input || typeof input !== 'object') {
-    return { valid: false, errors: [{ code: 'SCHEMA_INVALID', message: 'Input must be an object' }], warnings };
-  }
-
-  const raw = input as Record<string, unknown>;
-
-  if (raw.notation === undefined) {
-    errors.push({ code: 'MISSING_NOTATION', message: 'notation field is required' });
-    return { valid: false, errors, warnings };
-  }
-  if (raw.notation !== 'fga') {
-    errors.push({ code: 'WRONG_NOTATION', message: `notation must be "fga", got "${String(raw.notation)}"` });
-    return { valid: false, errors, warnings };
-  }
-
-  if (!Array.isArray(raw.factors)) errors.push({ code: 'SCHEMA_INVALID', message: 'factors must be an array' });
-  if (!Array.isArray(raw.goals)) errors.push({ code: 'SCHEMA_INVALID', message: 'goals must be an array' });
-  if (!Array.isArray(raw.activities)) errors.push({ code: 'SCHEMA_INVALID', message: 'activities must be an array' });
-  if (errors.length > 0) return { valid: false, errors, warnings };
-
-  const factorIds = new Set((raw.factors as Array<{ id: number | string }>).map(f => f.id));
-  const goalIds = new Set((raw.goals as Array<{ id: number | string }>).map(g => g.id));
-
-  for (const g of raw.goals as Array<{ id: number | string; factor?: Array<{ id: number | string }> }>) {
-    for (const f of (g.factor ?? [])) {
-      if (!factorIds.has(f.id)) {
-        warnings.push({ code: 'BROKEN_REF', message: `Goal ${g.id} references missing factor ${f.id}` });
-      }
-    }
-  }
-  for (const a of raw.activities as Array<{ id: number | string; goal_id?: number | string | null }>) {
-    if (a.goal_id != null && !goalIds.has(a.goal_id)) {
-      warnings.push({ code: 'BROKEN_REF', message: `Activity ${a.id} references missing goal ${a.goal_id}` });
-    }
-  }
-
-  return { valid: errors.length === 0, errors, warnings };
 }
 
 // ── Inline layout ─────────────────────────────────────────────────────────────

--- a/packages/diagrams/src/fgca/__tests__/parse-canonical.test.ts
+++ b/packages/diagrams/src/fgca/__tests__/parse-canonical.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import yaml from 'js-yaml';
-import { parseCanonicalFGCA } from '../parse-canonical.js';
+import { parseCanonicalFGCA, parseCanonicalFGA } from '../parse-canonical.js';
 
 const VALID = {
   notation: 'fgca',
@@ -145,6 +145,75 @@ describe('parseCanonicalFGCA', () => {
   });
 });
 
+// The "FGCA preview blank / FGA no edges" regression (vkgeorgia/strategy#65,
+// transitrix/methodology#65) was a data defect: the canonical flat shape was
+// not being mapped to the internal cross-ref fields the renderer turns into
+// edges. These assert the edge-driving fields are populated, so the renderer
+// has something to draw — locking the fix.
+describe('parseCanonicalFGCA — edge-driving fields populated', () => {
+  it('maps goal.factors → goal.factor[], change.goals → change.goal_id, activity.changes → change.activity_ids', () => {
+    const r = parseCanonicalFGCA(VALID);
+    expect(r.valid).toBe(true);
+    const parsed = r.parsed!;
+    // factor → goal edge source
+    expect(parsed.goals[0].factor).toHaveLength(1);
+    // goal → change edge
+    expect(parsed.changes[0].goal_id).not.toBe(0);
+    // change → activity edge
+    expect(parsed.changes[0].activity_ids).toHaveLength(1);
+  });
+});
+
+describe('parseCanonicalFGA', () => {
+  const VALID_FGA = {
+    notation: 'fga',
+    spec_version: '0.1',
+    id: 'FGA-SAMPLE-1',
+    name: 'Sample FGA chain',
+    factors: [{ id: 'FACTOR-1', name: 'Driver' }],
+    goals: [{ id: 'GOAL-1', name: 'Outcome', factors: ['FACTOR-1'] }],
+    activities: [{ id: 'ACTIVITY-1', name: 'Workstream', goals: ['GOAL-1'] }],
+  };
+
+  it('accepts a valid canonical FGA document (no changes layer)', () => {
+    const r = parseCanonicalFGA(VALID_FGA);
+    expect(r.valid).toBe(true);
+    expect(r.errors).toEqual([]);
+    expect(r.parsed?.factors).toHaveLength(1);
+    expect(r.parsed?.goals).toHaveLength(1);
+    expect(r.parsed?.activities).toHaveLength(1);
+  });
+
+  it('populates activity.goal_id from activity.goals[] (the FGA edge-driving field)', () => {
+    // The "FGA nodes render, no edges" bug: activities had no resolvable
+    // goal_id, so the renderer drew no goal → activity edges.
+    const r = parseCanonicalFGA(VALID_FGA);
+    expect(r.valid).toBe(true);
+    expect(r.parsed?.activities[0].goal_id).not.toBeNull();
+    expect(r.parsed?.activities[0].goal_id).not.toBe(0);
+  });
+
+  it('FGA-001: rejects wrong notation', () => {
+    const r = parseCanonicalFGA({ ...VALID_FGA, notation: 'fgca' });
+    expect(r.valid).toBe(false);
+    expect(r.errors.some((e) => e.code === 'FGA-001')).toBe(true);
+  });
+
+  it('FGA-002: rejects malformed doc id', () => {
+    const r = parseCanonicalFGA({ ...VALID_FGA, id: 'fga-lower-1' });
+    expect(r.valid).toBe(false);
+    expect(r.errors.some((e) => e.code === 'FGA-002')).toBe(true);
+  });
+
+  it('remaps FGCA layer codes into the FGA registry (e.g. FGA-007 for a bad id)', () => {
+    const r = parseCanonicalFGA({ ...VALID_FGA, factors: [{ id: 'F-1', name: 'bad' }] });
+    expect(r.valid).toBe(false);
+    expect(r.errors.some((e) => e.code === 'FGA-007')).toBe(true);
+    // No raw FGCA-prefixed code should leak through the remap.
+    expect(r.errors.every((e) => !e.code.startsWith('FGCA-'))).toBe(true);
+  });
+});
+
 describe('parseCanonicalFGCA — example file regression', () => {
   const EXAMPLES_DIR = path.resolve(process.cwd(), '..', '..', 'examples', 'fgca');
   const files = fs.existsSync(EXAMPLES_DIR)
@@ -157,6 +226,23 @@ describe('parseCanonicalFGCA — example file regression', () => {
       const r = parseCanonicalFGCA(parsedYaml);
       expect(r.errors).toEqual([]);
       expect(r.valid).toBe(true);
+    });
+  }
+});
+
+describe('parseCanonicalFGA — example file regression', () => {
+  const EXAMPLES_DIR = path.resolve(process.cwd(), '..', '..', 'examples', 'fga');
+  const files = fs.existsSync(EXAMPLES_DIR)
+    ? fs.readdirSync(EXAMPLES_DIR).filter((f) => f.endsWith('.transitrix.yaml'))
+    : [];
+  for (const file of files) {
+    it(`accepts examples/fga/${file} and resolves every activity to a goal`, () => {
+      const text = fs.readFileSync(path.join(EXAMPLES_DIR, file), 'utf8');
+      const r = parseCanonicalFGA(yaml.load(text));
+      expect(r.errors).toEqual([]);
+      expect(r.valid).toBe(true);
+      // Every activity must carry a goal_id, or the FGA preview draws no edges.
+      expect(r.parsed!.activities.every((a) => a.goal_id != null && a.goal_id !== 0)).toBe(true);
     });
   }
 });

--- a/packages/diagrams/src/fgca/parse-canonical.ts
+++ b/packages/diagrams/src/fgca/parse-canonical.ts
@@ -323,3 +323,78 @@ export function parseCanonicalFGCA(input: unknown): CanonicalFGCAResult {
 
   return { valid: true, errors, warnings, parsed };
 }
+
+const FGA_DOC_ID_RE = /^FGA(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
+
+/** On success, the internal-form FGCADoc derived from canonical FGA input. */
+export interface CanonicalFGAResult extends ValidationResult {
+  parsed?: FGCADoc;
+}
+
+/**
+ * Canonical-form FGA parser + validator.
+ *
+ * FGA is the canonical FGCA chain minus the `changes[]` layer — flat
+ * top-level `factors[]` + `goals[]` + `activities[]`, with `activity.goals[]`
+ * linking activities straight to goals (no intermediate change). It reuses
+ * `parseCanonicalFGCA` by injecting an empty `changes` array and remapping
+ * the FGCA-NNN codes to the FGA-NNN registry (`notations/03-fga.md`,
+ * FGA-001..011). The resulting internal `FGCADoc` carries `activity.goal_id`,
+ * which is exactly what the renderer needs to draw goal → activity edges —
+ * the field whose absence produced the "FGA nodes render, no edges" bug
+ * (transitrix/methodology#65 / vkgeorgia/strategy#65).
+ *
+ * Lives beside `parseCanonicalFGCA` (rather than inline in the extension) so
+ * the canonical FGA path is unit-testable and the library owns the single
+ * canon shape — flat form only, no `fga:` wrapper.
+ */
+export function parseCanonicalFGA(input: unknown): CanonicalFGAResult {
+  if (!input || typeof input !== 'object') {
+    return { valid: false, errors: [{ code: 'FGA-001', message: 'document root is not an object' }], warnings: [] };
+  }
+  const raw = input as Record<string, unknown>;
+  if ('notation' in raw && raw['notation'] !== 'fga') {
+    return {
+      valid: false,
+      errors: [{ code: 'FGA-001', message: `notation must be "fga", got "${String(raw['notation'])}"` }],
+      warnings: [],
+    };
+  }
+  if (raw['id'] === undefined) {
+    return { valid: false, errors: [{ code: 'FGA-002', message: 'document id is required' }], warnings: [] };
+  }
+  if (typeof raw['id'] !== 'string' || !FGA_DOC_ID_RE.test(raw['id'])) {
+    return {
+      valid: false,
+      errors: [{ code: 'FGA-002', message: `id "${String(raw['id'])}" must match FGA-[<middle>-]<INTEGER>` }],
+      warnings: [],
+    };
+  }
+
+  // Forward to the FGCA parser with synthetic FGCA notation + doc id + empty
+  // changes. Per-layer / per-ref checks all reuse the FGCA implementation;
+  // codes are remapped on the way out. FGCA-009 / 010 / 014 (changes-related)
+  // are unreachable here because `changes` is empty.
+  const synth = { ...raw, notation: 'fgca', id: 'FGCA-FROM-FGA-1', changes: [] };
+  const r = parseCanonicalFGCA(synth);
+  const remap: Record<string, string> = {
+    'FGCA-001': 'FGA-001',
+    'FGCA-002': 'FGA-002',
+    'FGCA-003': 'FGA-003',
+    'FGCA-004': 'FGA-004',
+    'FGCA-005': 'FGA-005',
+    'FGCA-006': 'FGA-006',
+    'FGCA-007': 'FGA-007',
+    'FGCA-008': 'FGA-008',
+    'FGCA-011': 'FGA-009',
+    'FGCA-012': 'FGA-010',
+    'FGCA-015': 'FGA-007',
+  };
+  const remapCode = (c: string): string => remap[c] ?? c;
+  return {
+    valid: r.valid,
+    errors: r.errors.map((e) => ({ ...e, code: remapCode(e.code) })),
+    warnings: r.warnings.map((w) => ({ ...w, code: remapCode(w.code) })),
+    parsed: r.parsed,
+  };
+}


### PR DESCRIPTION
## Summary

Closes the FGCA/FGA flat-canon pair — bug **vkgeorgia/strategy#65** ("FGCA preview blank, FGA nodes without edges") and task **vkgeorgia/strategy#67** (align renderers + validators with flat canon).

## Diagnosis

The bug was a **data/parse defect on the flat canonical form, already resolved on `main`** by the canonical-input work (#63) + example sync (#64). It persists only in the **unreleased Marketplace build** the methodology agent tested. Confirmed:

- `parseCanonicalFGCA` maps the canonical cross-refs to the internal fields the renderer turns into edges: `goal.factors → goal.factor[]`, `change.goals → change.goal_id`, `activity.changes → change.activity_ids`, `activity.goals → activity.goal_id`.
- The renderer (`layoutFGCA` in the extension) was never broken — it just had no resolvable cross-refs to draw from in the old build.
- The example-regression tests (`examples/fgca/*`, `examples/goals/*`) already parse green on `main`.

So this PR **locks the fix** and finishes the **library alignment** #67 asked for.

## Changes

- **Consolidate** `parseCanonicalFGA` out of the extension (it was inline in `fgca-preview.ts`) into `@transitrix/diagrams` beside `parseCanonicalFGCA` — the canonical FGA path is now unit-testable and the library owns the single flat canon shape. The extension imports it.
- **Remove dead pre-canonical paths** from `fgca-preview.ts`: the never-called `validateFGCA` / `validateFGA` functions + their local `Validation*` types, and the stale `nested root key \`fga:\`` comment describing a wrapper shape no longer in canon (#67 acceptance #5 — flat is the single shape).
- **Tests** ([packages/diagrams/src/fgca/__tests__/parse-canonical.test.ts](packages/diagrams/src/fgca/__tests__/parse-canonical.test.ts)):
  - FGA example-regression — every activity resolves to a `goal_id` (the FGA edge-driving field whose absence was the "no edges" symptom).
  - FGCA edge-field assertions — `goal.factor[]` / `change.goal_id` / `change.activity_ids` populated.
  - FGA-001 / 002 / 007 code-remap coverage (no raw `FGCA-` code leaks through the FGA remap).

## Acceptance criteria (#67)

1. Canonical examples (fgca/fga/goals) parse + render — ✅ (example-regression green for all three).
2. Nodes **and** edges present — ✅ locked via edge-field assertions.
3. Vitest fixtures per notation in `packages/diagrams/src/{fgca,fga,goals}/__tests__/` — ✅ (fgca + goals already had example-regression; **fga added** here).
4. Codes match the spec registries — ✅ verified: FGCA-001..015, FGA-001..011, GOALS-001..011, nothing out of range.
5. Remove wrapped (`fgca:`/`fga:`/`goals_tree:`) parsing path — ✅ no wrapped parser exists; removed the dead validate funcs + stale wrapper comment.

## Test plan

- [x] `npm test` — 441/441 (7 new fgca cases).
- [x] `tsc --noEmit` clean in `extension/`.
- [x] Extension bundle rebuilt.
- [ ] **Manual (Valerii, Windows):** open `examples/fgca/strategy-2026.fgca.transitrix.yaml` and `constraint-driven…` (full F→G→C→A chain with edges), `examples/fga/strategy-2026.fga.transitrix.yaml` (F→G→A with edges), `examples/goals/strategy-2026.goals.transitrix.yaml` (tree).

> Note: the underlying fix already lives on `main`; the user-visible resolution of #65 lands when a new Marketplace build ships. This PR guarantees it can't regress and removes the legacy cruft.

Do not auto-merge. Valerii gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)