### PR TITLE
chore(release): 1.2.0

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Transitrix Studio — changelog
 
+## 1.2.0 — 2026-05-27
+
+Adds PNG export across every vector preview and brings the FGCA / FGA / Goals notations onto the canonical flat shape from `transitrix/methodology`, fixing the blank-FGCA / edgeless-FGA rendering on canonical examples.
+
+### Added
+
+- **PNG export** — every vector preview toolbar now has **Save .png** (rasterized, 2× for crisp output) and **Copy PNG** (clipboard) alongside **Save .svg**. Rendering uses a native rasterizer (`@resvg/resvg-js`); Copy-as-PNG ships on Windows (macOS/Linux save-to-file works, clipboard is a planned follow-up). The extension is now published per-platform.
+- **Canonical flat-form input** for FGCA / FGA / Goals — typed string IDs (`FACTOR-1`, `GOAL-RET-1`, …), plural cross-references (`goal.factors[]`, `change.goals[]`, `activity.changes[]` / `activity.goals[]`), and per-notation validation codes (FGCA-001…015, FGA-001…011, GOALS-001…011).
+- Bare (unquoted) `YYYY-MM-DD` dates are accepted everywhere — they are coerced to ISO strings at the YAML parse boundary, so a date written without quotes no longer trips validation.
+
+### Changed
+
+- BPMN sources are recognised under `.bpmn.transitrix.yaml` (the legacy `.cervin.yaml` suffix still works).
+- Bundled demo examples migrated to the canonical ID grammar from `IDS_AND_REFERENCES.md` and synced from the methodology canon.
+
+### Fixed
+
+- **FGCA preview no longer renders blank and FGA edges now draw** on the canonical flat-form examples — the flat cross-references are mapped to the internal edge fields the renderer consumes.
+- Goal trees with non-contiguous `goal_types` levels (e.g. 0, 2, 4) render with even column spacing instead of wide gaps from phantom empty columns.
+
 ## 1.1.0 — 2026-05-26
 
 Closes the 1.0.0 "Nested blocks needs Python + svgbob" known limitation with a native TS renderer, and adds the **Issues register** notation. The blocks notation moves to a structured-YAML schema with a new file extension — breaking for the small `.blocks.transitrix.txt` corpus that existed before 1.1.0.

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Preview Transitrix enterprise-architecture diagrams in VS Code — BPMN, Goals, FGCA, FGA, Activity Network (PSND + Gantt), Process Map, Process Blueprint, Capability Map, Scenarios, Applications, Products, Nested Blocks. Native TypeScript rendering — no external binaries required.",
   "license": "MIT",
   "icon": "icon.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
## Summary

Cuts **1.2.0** — minor bump from 1.1.0 (root + extension `package.json`) + the 1.2.0 changelog entry.

### What's in 1.2.0 (since the v1.1.0 tag)

**Added**
- **PNG export** — Save .png + Copy PNG on every vector preview (#73). Native resvg rasterizer; Copy-as-PNG on Windows.
- **Canonical flat-form input** for FGCA / FGA / Goals (#63).
- Bare (unquoted) `YYYY-MM-DD` dates coerced to ISO at the parse boundary (#65).

**Changed**
- BPMN sources recognised under `.bpmn.transitrix.yaml` (legacy `.cervin.yaml` still works) (#62).
- Demo example IDs migrated to the canonical grammar + synced from methodology canon (#64, #67–#71).

**Fixed**
- FGCA blank / FGA edgeless rendering on canonical examples (#75 / #67 / #65).
- Goal-tree spacing for non-contiguous `goal_types` levels (#72).

### Packaging note

The extension is now **platform-specific** (native resvg binary). Build per target on its own OS — see [docs/packaging.md](docs/packaging.md). A `win32-x64` VSIX (`transitrix-studio-win32-x64-1.2.0.vsix`, ~5 MB) is built locally for hand-testing; it is gitignored, not committed.

### Not included

- #66 (GOALS-012/013) — still open, waiting on methodology counterpart.

## Test plan

- [x] `npm test` — 441/441 green at 1.2.0.
- [x] `win32-x64` VSIX packaged successfully (resvg binary bundled).
- [ ] **Manual (Valerii):** install the 1.2.0 VSIX, smoke-test PNG export + FGCA/FGA/Goals rendering.
- [ ] After merge: tag `v1.2.0`, build the remaining platform VSIXs (darwin-arm64/x64, linux-x64/arm64), publish.

Do not auto-merge. Valerii gates the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)