### PR TITLE
docs(extension): correct the marketplace description (drop legacy cervin line + fix native-binaries claim)

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -2,7 +2,7 @@
 
 Live **preview** for Transitrix diagram formats inside VS Code:
 
-- **BPMN** — `.bpmn.transitrix.yaml` (YAML DSL → BPMN 2.0); legacy `.cervin.yaml` also supported
+- **BPMN** — `.bpmn.transitrix.yaml` (YAML DSL → BPMN 2.0)
 - **Goals tree** — `.goals.transitrix.yaml` (hierarchical goal decomposition)
 - **FGCA** — `.fgca.transitrix.yaml` (factors, goals, changes, activities map)
 - **FGA** — `.fga.transitrix.yaml` (factors, goals, activities — change-free view)

--- a/extension/package.json
+++ b/extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
   "version": "1.2.0",
-  "description": "Preview Transitrix enterprise-architecture diagrams in VS Code — BPMN, Goals, FGCA, FGA, Activity Network (PSND + Gantt), Process Map, Process Blueprint, Capability Map, Scenarios, Applications, Products, Nested Blocks. Native TypeScript rendering — no external binaries required.",
+  "description": "Preview Transitrix enterprise-architecture diagrams in VS Code — BPMN, Goals, FGCA, FGA, Activity Network (PSND + Gantt), Process Map, Process Blueprint, Capability Map, Scenarios, Applications, Products, Nested Blocks. Native rendering — no external tools to install.",
   "license": "MIT",
   "icon": "icon.png",
   "homepage": "https://github.com/transitrix/transitrix-studio#readme",


### PR DESCRIPTION
## Summary

Two accuracy fixes to the extension's user-facing description.

1. **Drop legacy cervin from the BPMN line** ([extension/README.md](extension/README.md)) — removes `; legacy \`.cervin.yaml\` also supported` from the notation list. The canonical extension is `.bpmn.transitrix.yaml`; the legacy suffix stays accepted (still in `activationEvents` / `contributes.languages`), it just no longer needs surfacing.

2. **Fix the marketplace `description`** ([extension/package.json](extension/package.json)) — "Native TypeScript rendering — no external binaries required" predates PNG export (#73), which bundles a native rasterizer (`@resvg/resvg-js`). Reworded to **"Native rendering — no external tools to install"** — still true for the user (the binary ships inside the VSIX; nothing to install) without the overclaim.

The Nested-blocks line keeps its "native TypeScript renderer — no external binaries" note: that is notation-specific and still accurate (the blocks renderer is pure TS; resvg is only the PNG export path).

Scope: extension README + package.json description. The root README "Legacy identifiers" note and `docs/notation.md` are left as-is.

Do not auto-merge. Valerii gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)