### PR TITLE
chore(release): 1.2.1

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Transitrix Studio — changelog
 
+## 1.2.1 — 2026-05-28
+
+Patch release. Refreshes the Marketplace description that was bundled into 1.2.0 stale (the rewrite landed after publish), and adds the N+1 hierarchy validator for Goals trees.
+
+### Added
+
+- **GOALS-012 / GOALS-013** validation in the internal Goals validator — keyed on the document's declared `goal_types[]`, mirrors the methodology canon (`notations/04-goals.md` §6). `GOALS-013` rejects gaps in `goal_types[].level` (must be contiguous from 0); `GOALS-012` rejects a parent–child level gap > 1 (the parent must be exactly one level above the child).
+
+### Changed
+
+- Marketplace description refreshed to a value-first pitch + preview image. Notation list cleaned up — the "legacy `.cervin.yaml` also supported" mention dropped from the BPMN line (the legacy suffix is still accepted internally, just no longer surfaced in the user-facing list).
+
 ## 1.2.0 — 2026-05-27
 
 Adds PNG export across every vector preview and brings the FGCA / FGA / Goals notations onto the canonical flat shape from `transitrix/methodology`, fixing the blank-FGCA / edgeless-FGA rendering on canonical examples.

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Architecture-as-code for the modern enterprise. Author 13 notations — goals, processes, capabilities, BPMN, applications, more — as plain YAML, get live diagrams in VS Code. Diffable in git. AI-friendly. Open source. Built on ArchiMate 3.2 and BPMN 2.0.",
   "license": "MIT",
   "icon": "icon.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
## Summary

Patch bump 1.2.0 → 1.2.1.

The published 1.2.0 on Marketplace still carries the stale "Native TypeScript rendering — no external binaries required" copy because the Marketplace-description rewrite (#78) landed **after** 1.2.0 was published. 1.2.1 ships:

- **The refreshed Marketplace description** — value-first pitch + preview image (#78, already on main).
- **GOALS-012 / GOALS-013** N+1 hierarchy validator for Goals trees (#66, just merged).

## Test plan

- [x] `npm test` — 446/446 (+5 from #66).
- [x] `tsc --noEmit` clean in `extension/`.
- [x] `win32-x64` VSIX packaged: `transitrix-studio-win32-x64-1.2.1.vsix` (5.19 MB, resvg binary bundled).
- [ ] After merge: tag `v1.2.1`, `vsce publish --packagePath …` from each platform's VSIX.

Pre-authorized for self-merge per the accelerated-pace go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)