### PR TITLE
feat(spacing): configurable gaps for Goals/FGCA/FGA/Activities previews (#75 PR1)

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -98,6 +98,62 @@
           ],
           "default": "transitrix",
           "description": "Color theme for Transitrix diagram previews (Goals, FGCA, and other static notation previews)."
+        },
+        "transitrix.spacing.goals.horizontalGap": {
+          "type": "number",
+          "minimum": 20,
+          "maximum": 300,
+          "default": 100,
+          "description": "Goals preview: horizontal gap (px) between hierarchy columns."
+        },
+        "transitrix.spacing.goals.verticalGap": {
+          "type": "number",
+          "minimum": 20,
+          "maximum": 300,
+          "default": 24,
+          "description": "Goals preview: vertical gap (px) between stacked goal nodes."
+        },
+        "transitrix.spacing.fgca.horizontalGap": {
+          "type": "number",
+          "minimum": 20,
+          "maximum": 300,
+          "default": 160,
+          "description": "FGCA preview: horizontal gap (px) between the Factor/Goal/Change/Activity columns."
+        },
+        "transitrix.spacing.fgca.verticalGap": {
+          "type": "number",
+          "minimum": 20,
+          "maximum": 300,
+          "default": 20,
+          "description": "FGCA preview: vertical gap (px) between stacked nodes within a column."
+        },
+        "transitrix.spacing.fga.horizontalGap": {
+          "type": "number",
+          "minimum": 20,
+          "maximum": 300,
+          "default": 160,
+          "description": "FGA preview: horizontal gap (px) between the Factor/Goal/Activity columns."
+        },
+        "transitrix.spacing.fga.verticalGap": {
+          "type": "number",
+          "minimum": 20,
+          "maximum": 300,
+          "default": 20,
+          "description": "FGA preview: vertical gap (px) between stacked nodes within a column."
+        },
+        "transitrix.spacing.activities.horizontalGap": {
+          "type": "number",
+          "minimum": 20,
+          "maximum": 300,
+          "default": 80,
+          "description": "Activities preview: horizontal gap (px) between CPM columns."
+        },
+        "transitrix.spacing.activities.verticalGap": {
+          "type": "number",
+          "minimum": 20,
+          "maximum": 300,
+          "default": 24,
+          "description": "Activities preview: vertical gap (px) between stacked activity nodes."
         }
       }
     },
@@ -444,6 +500,12 @@
         "command": "transitrixStudio.copyIssuesAsPng",
         "title": "Transitrix: Copy issues register as PNG",
         "category": "Transitrix"
+      },
+      {
+        "command": "transitrixStudio.openSpacingSettings",
+        "title": "Transitrix: Open diagram spacing settings",
+        "category": "Transitrix",
+        "icon": "$(settings-gear)"
       }
     ],
     "menus": {

--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -11,11 +11,18 @@ import {
   isGanttUnavailable,
   type ActivityDoc,
   type ActivitiesLayout,
+  type ActivitiesLayoutOptions,
   type GanttLayout,
   type GanttResult,
 } from '../../packages/diagrams/src/activities/index.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
+import { readSpacing, OPEN_SPACING_SETTINGS_COMMAND } from './spacing-config.js';
+
+// Default network (PSND) gaps — must match the layoutActivities defaults
+// (H_GAP / V_GAP) so an unconfigured preview is visually unchanged.
+const ACTIVITIES_DEFAULT_H_GAP = 80;
+const ACTIVITIES_DEFAULT_V_GAP = 24;
 
 // ── Shared helpers ───────────────────────────────────────────────────────────
 
@@ -36,8 +43,8 @@ const N_NODE_W = 200;
 const N_NODE_H = 80;
 const N_PAD = 24;
 
-function networkSvg(doc: ActivityDoc, heading?: string, filename?: string, date?: string, version?: string): string {
-  const layout: ActivitiesLayout = layoutActivities(doc);
+function networkSvg(doc: ActivityDoc, gaps: ActivitiesLayoutOptions = {}, heading?: string, filename?: string, date?: string, version?: string): string {
+  const layout: ActivitiesLayout = layoutActivities(doc, gaps);
   if (layout.nodes.length === 0) {
     return '<svg xmlns="http://www.w3.org/2000/svg" width="200" height="60"><text class="text-primary" x="10" y="40">No activities</text></svg>';
   }
@@ -428,9 +435,9 @@ interface ActivityViews {
   ganttSvg: string;
 }
 
-function buildActivityViews(doc: ActivityDoc, filename: string, date: string, version?: string): ActivityViews {
+function buildActivityViews(doc: ActivityDoc, gaps: ActivitiesLayoutOptions, filename: string, date: string, version?: string): ActivityViews {
   const networkHeading = 'Network view — Project Schedule Network Diagram (PSND)';
-  const networkSvgStr = networkSvg(doc, networkHeading, filename, date, version);
+  const networkSvgStr = networkSvg(doc, gaps, networkHeading, filename, date, version);
   const gantt: GanttResult = computeGanttLayout(doc);
 
   // Mirror titleBlockSvg's date line: `v{version} · {date}` when version is set.
@@ -572,7 +579,7 @@ export class ActivitiesPreview {
         'activitiesPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveActivitiesAsSvg', 'transitrixStudio.saveActivitiesAsPng', 'transitrixStudio.copyActivitiesAsPng'] },
+        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveActivitiesAsSvg', 'transitrixStudio.saveActivitiesAsPng', 'transitrixStudio.copyActivitiesAsPng', OPEN_SPACING_SETTINGS_COMMAND] },
       );
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
     }
@@ -581,6 +588,13 @@ export class ActivitiesPreview {
 
   async refreshSaved(doc: vscode.TextDocument): Promise<void> {
     if (!this.isShowingDocument(doc.uri)) return;
+    await this.pushDocument(doc);
+  }
+
+  /** Re-render the tracked document — used when a spacing/theme setting changes. */
+  async refreshConfig(): Promise<void> {
+    if (!this.panel || !this.trackedUri) return;
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.parse(this.trackedUri));
     await this.pushDocument(doc);
   }
 
@@ -608,7 +622,8 @@ export class ActivitiesPreview {
       if (!v.valid) {
         errorMsg = v.errors.map(e => `${e.code}: ${e.message}`).join('\n');
       } else {
-        const views = buildActivityViews(parsed as ActivityDoc, filename, docDate, docVersion);
+        const spacing = readSpacing('activities', { horizontalGap: ACTIVITIES_DEFAULT_H_GAP, verticalGap: ACTIVITIES_DEFAULT_V_GAP });
+        const views = buildActivityViews(parsed as ActivityDoc, { horizontalGap: spacing.horizontalGap, verticalGap: spacing.verticalGap }, filename, docDate, docVersion);
         bodyContent = buildCanvasContent(views);
         this.lastNetworkSvg = views.networkSvg;
         this.lastGanttSvg = views.ganttSvg;
@@ -637,6 +652,7 @@ export class ActivitiesPreview {
       saveSvgCommand: 'transitrixStudio.saveActivitiesAsSvg',
       savePngCommand: 'transitrixStudio.saveActivitiesAsPng',
       copyPngCommand: 'transitrixStudio.copyActivitiesAsPng',
+      spacingCommand: OPEN_SPACING_SETTINGS_COMMAND,
     });
   }
 

--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -70,6 +70,14 @@ export interface DiagramFrameOpts {
    * to "Save .png" when provided and a vector diagram is on screen.
    */
   copyPngCommand?: string;
+  /**
+   * Command ID for the "Spacing…" toolbar link (opens Settings filtered to the
+   * per-notation gap controls — vkgeorgia/strategy#75). Rendered for previews
+   * that honour `transitrix.spacing.*`. Shown even on error renders so the user
+   * can widen/tighten and re-render. The preview's webview must opt into command
+   * URIs via `enableCommandUris`.
+   */
+  spacingCommand?: string;
 }
 
 function escXml(s: string): string {
@@ -262,7 +270,7 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
     errorMsg = '', warnings = [],
     themeId = 'transitrix', extraStyles = '', fixPrompt = '',
     title, subtitle, version, date,
-    saveSvgCommand, savePngCommand, copyPngCommand,
+    saveSvgCommand, savePngCommand, copyPngCommand, spacingCommand,
   } = opts;
 
   const canvasContent = bodyContent ?? svgContent;
@@ -306,6 +314,9 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
   const showSaveSvg = Boolean(canvasContent) && Boolean(saveSvgCommand);
   const showSavePng = Boolean(canvasContent) && Boolean(savePngCommand);
   const showCopyPng = Boolean(canvasContent) && Boolean(copyPngCommand);
+  // Spacing link shows whenever the preview opts in — including error renders,
+  // so the user can adjust the gap settings and trigger a re-render.
+  const showSpacing = Boolean(spacingCommand);
   // Zoom control gates on the same signal as Save .svg — the six vector
   // previews opt in by passing a saveSvgCommand. HTML catalogues are out of
   // scope per the orchestrator's call on issue #30.
@@ -335,6 +346,9 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
   }
   if (showCopyPng) {
     actionParts.push(`<a href="command:${escXml(copyPngCommand!)}" class="toolbar-btn" title="Copy the current diagram to the clipboard as a PNG image">Copy PNG</a>`);
+  }
+  if (showSpacing) {
+    actionParts.push(`<a href="command:${escXml(spacingCommand!)}" class="toolbar-btn" title="Adjust the horizontal/vertical spacing for this notation in Settings">Spacing…</a>`);
   }
   const toolbarRight = actionParts.length > 0
     ? `<div class="toolbar-actions">${actionParts.join('')}</div>`

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -21,6 +21,7 @@ import {
   formatExtensionHint,
   getConfiguredExtensions,
 } from './source-files.js';
+import { OPEN_SPACING_SETTINGS_COMMAND, SPACING_CONFIG_SECTION } from './spacing-config.js';
 
 function isGoalsFile(doc: vscode.TextDocument): boolean {
   return doc.fileName.endsWith('.goals.transitrix.yaml');
@@ -286,6 +287,20 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     }),
     vscode.commands.registerCommand('transitrixStudio.saveIssuesAsPng', () => issuesPreview.saveAsPng()),
     vscode.commands.registerCommand('transitrixStudio.copyIssuesAsPng', () => issuesPreview.copyAsPng()),
+    vscode.commands.registerCommand(OPEN_SPACING_SETTINGS_COMMAND, () =>
+      vscode.commands.executeCommand('workbench.action.openSettings', SPACING_CONFIG_SECTION),
+    ),
+    // Re-render the spacing-aware previews when a gap setting changes — the
+    // PR1 persistence mechanism (vkgeorgia/strategy#75). Previews keep
+    // `enableScripts: false`; the change is applied host-side by rebuilding
+    // the webview HTML from the tracked document.
+    vscode.workspace.onDidChangeConfiguration((e) => {
+      if (!e.affectsConfiguration(SPACING_CONFIG_SECTION)) return;
+      void goalsPreview.refreshConfig();
+      void fgcaPreview.refreshConfig();
+      void fgaPreview.refreshConfig();
+      void activitiesPreview.refreshConfig();
+    }),
     vscode.workspace.onDidSaveTextDocument((doc) => {
       if (isGoalsFile(doc)) { void goalsPreview.refreshSaved(doc); return; }
       if (isFGCAFile(doc)) { void fgcaPreview.refreshSaved(doc); return; }

--- a/extension/src/fgca-preview.ts
+++ b/extension/src/fgca-preview.ts
@@ -4,8 +4,18 @@ import yaml from 'js-yaml';
 import { buildDiagramFrame, prepareSvgForExport, type ThemeId } from './diagram-frame.js';
 import { TITLE_BLOCK_H, titleBlockSvg, todayIso } from './svg-title-block.js';
 import { parseCanonicalFGCA, parseCanonicalFGA } from '../../packages/diagrams/src/fgca/parse-canonical.js';
+import {
+  layoutFGCAPreview,
+  FGCA_NODE_W as NODE_W,
+  FGCA_NODE_H as NODE_H,
+  FGCA_HEADER_H as HEADER_H,
+  FGCA_PAD as PAD,
+  FGCA_DEFAULT_COL_GAP,
+  FGCA_DEFAULT_ROW_GAP,
+} from '../../packages/diagrams/src/fgca/preview-layout.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
+import { readSpacing, OPEN_SPACING_SETTINGS_COMMAND } from './spacing-config.js';
 
 // ── Inline render types ─────────────────────────────────────────────────────
 //
@@ -30,15 +40,12 @@ interface FGCADoc {
   activities: ActivityItem[];
 }
 
-// ── Inline layout ─────────────────────────────────────────────────────────────
-
-const NODE_W = 220;
-const NODE_H = 72;
-const COL_GAP = 160;
-const ROW_GAP = 20;
-const HEADER_H = 32;
-const PAD = 20;
-const COL_STRIDE = NODE_W + COL_GAP;
+// ── Column layout ─────────────────────────────────────────────────────────────
+//
+// Geometry + edge routing now live in @transitrix/diagrams
+// (`layoutFGCAPreview`) so the configurable-gap behaviour (vkgeorgia/strategy#75)
+// is unit-tested. This file owns only the SVG presentation of that layout and
+// the column header labels.
 
 const COL_LABELS: Record<string, string> = {
   factor: 'Factors (F)',
@@ -47,95 +54,30 @@ const COL_LABELS: Record<string, string> = {
   activity: 'Activities (A)',
 };
 
-interface LayoutNode { id: string; x: number; y: number; label: string; col: string; }
-interface LayoutEdge { sx: number; sy: number; tx: number; ty: number; }
-
-function layoutFGCA(doc: FGCADoc, hideChanges = false): { nodes: LayoutNode[]; edges: LayoutEdge[]; width: number; height: number } {
-  const cols = hideChanges
-    ? (['factor', 'goal', 'activity'] as const)
-    : (['factor', 'goal', 'change', 'activity'] as const);
-  const changes = doc.changes ?? [];
-  const colItems: Record<string, Array<{ id: string; label: string }>> = {
-    factor:   doc.factors.map(f => ({ id: `factor_${f.id}`,   label: f.name })),
-    goal:     doc.goals.map(g   => ({ id: `goal_${g.id}`,     label: g.name })),
-    change:   changes.map(c => ({ id: `change_${c.id}`,   label: c.name })),
-    activity: doc.activities.map(a => ({ id: `activity_${a.id}`, label: a.name })),
-  };
-
-  const nodeMap = new Map<string, LayoutNode>();
-  const nodes: LayoutNode[] = [];
-
-  for (let ci = 0; ci < cols.length; ci++) {
-    const col = cols[ci];
-    const x = PAD + ci * COL_STRIDE;
-    let y = PAD + HEADER_H + ROW_GAP;
-    for (const item of colItems[col]) {
-      const node: LayoutNode = { id: item.id, x, y, label: item.label, col };
-      nodes.push(node);
-      nodeMap.set(item.id, node);
-      y += NODE_H + ROW_GAP;
-    }
-  }
-
-  const edges: LayoutEdge[] = [];
-
-  function addEdge(sourceId: string, targetId: string): void {
-    const s = nodeMap.get(sourceId);
-    const t = nodeMap.get(targetId);
-    if (!s || !t) return;
-    edges.push({ sx: s.x + NODE_W, sy: s.y + NODE_H / 2, tx: t.x, ty: t.y + NODE_H / 2 });
-  }
-
-  for (const g of doc.goals) {
-    for (const f of (g.factor ?? [])) addEdge(`factor_${f.id}`, `goal_${g.id}`);
-  }
-  if (hideChanges) {
-    const connectedViaChange = new Set<number | string>();
-    for (const c of changes) {
-      for (const aid of c.activity_ids) {
-        addEdge(`goal_${c.goal_id}`, `activity_${aid}`);
-        connectedViaChange.add(aid);
-      }
-    }
-    for (const a of doc.activities) {
-      if (a.goal_id != null && !connectedViaChange.has(a.id)) {
-        addEdge(`goal_${a.goal_id}`, `activity_${a.id}`);
-      }
-    }
-  } else {
-    for (const c of changes) addEdge(`goal_${c.goal_id}`, `change_${c.id}`);
-    for (const c of changes) for (const aid of c.activity_ids) addEdge(`change_${c.id}`, `activity_${aid}`);
-    const coveredActivities = new Set(changes.flatMap(c => c.activity_ids));
-    for (const a of doc.activities) {
-      if (a.goal_id != null && !coveredActivities.has(a.id)) {
-        addEdge(`goal_${a.goal_id}`, `activity_${a.id}`);
-      }
-    }
-  }
-
-  const maxNodeBottom = nodes.reduce((m, n) => Math.max(m, n.y + NODE_H), PAD + HEADER_H + ROW_GAP + NODE_H);
-  const width = PAD * 2 + cols.length * COL_STRIDE - COL_GAP;
-  const height = maxNodeBottom + PAD;
-
-  return { nodes, edges, width, height };
-}
-
 // ── SVG renderer ──────────────────────────────────────────────────────────────
 
 function escXml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
 
-function buildSvg(doc: FGCADoc, hideChanges = false, heading?: string, filename?: string, date?: string, version?: string): string {
-  const { nodes, edges, width, height } = layoutFGCA(doc, hideChanges);
+function buildSvg(
+  doc: FGCADoc,
+  hideChanges = false,
+  gaps: { colGap?: number; rowGap?: number } = {},
+  heading?: string,
+  filename?: string,
+  date?: string,
+  version?: string,
+): string {
+  const { nodes, edges, columns, width, height } = layoutFGCAPreview(doc, {
+    hideChanges,
+    colGap: gaps.colGap,
+    rowGap: gaps.rowGap,
+  });
   const showTitle = heading != null && filename != null && date != null;
   const titleH = showTitle ? TITLE_BLOCK_H : 0;
-  const cols = hideChanges
-    ? (['factor', 'goal', 'activity'] as const)
-    : (['factor', 'goal', 'change', 'activity'] as const);
 
-  const headerSvg = cols.map((col, ci) => {
-    const x = PAD + ci * COL_STRIDE;
+  const headerSvg = columns.map(({ col, x }) => {
     return [
       `<rect class="diagram-node layer-${col}" x="${x}" y="${PAD}" width="${NODE_W}" height="${HEADER_H}" rx="6"/>`,
       `<text class="text-header" x="${x + NODE_W / 2}" y="${PAD + HEADER_H / 2}" text-anchor="middle" dominant-baseline="central">${escXml(COL_LABELS[col])}</text>`,
@@ -219,7 +161,7 @@ export class FGCAPreview {
         'fgcaPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveFGCAAsSvg', 'transitrixStudio.saveFGCAAsPng', 'transitrixStudio.copyFGCAAsPng'] },
+        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveFGCAAsSvg', 'transitrixStudio.saveFGCAAsPng', 'transitrixStudio.copyFGCAAsPng', OPEN_SPACING_SETTINGS_COMMAND] },
       );
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
     }
@@ -228,6 +170,13 @@ export class FGCAPreview {
 
   async refreshSaved(doc: vscode.TextDocument): Promise<void> {
     if (!this.isShowingDocument(doc.uri)) return;
+    await this.pushDocument(doc);
+  }
+
+  /** Re-render the tracked document — used when a spacing/theme setting changes. */
+  async refreshConfig(): Promise<void> {
+    if (!this.panel || !this.trackedUri) return;
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.parse(this.trackedUri));
     await this.pushDocument(doc);
   }
 
@@ -255,7 +204,8 @@ export class FGCAPreview {
         // IDs and singular `change.goal_id` / `change.activity_ids`. The
         // inline FGCADoc / buildSvg here accept both forms (number | string
         // unions) — pass through.
-        svgContent = buildSvg(v.parsed as unknown as FGCADoc, false, 'FGCA — Factor → Goal → Change → Activity', filename, docDate, docVersion);
+        const gaps = readSpacing('fgca', { horizontalGap: FGCA_DEFAULT_COL_GAP, verticalGap: FGCA_DEFAULT_ROW_GAP });
+        svgContent = buildSvg(v.parsed as unknown as FGCADoc, false, { colGap: gaps.horizontalGap, rowGap: gaps.verticalGap }, 'FGCA — Factor → Goal → Change → Activity', filename, docDate, docVersion);
       }
     } catch (e) {
       errorMsg = (e as Error).message ?? 'Parse error';
@@ -272,6 +222,7 @@ export class FGCAPreview {
       saveSvgCommand: 'transitrixStudio.saveFGCAAsSvg',
       savePngCommand: 'transitrixStudio.saveFGCAAsPng',
       copyPngCommand: 'transitrixStudio.copyFGCAAsPng',
+      spacingCommand: OPEN_SPACING_SETTINGS_COMMAND,
     });
   }
 
@@ -335,7 +286,7 @@ export class FGAPreview {
         'fgaPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveFGAAsSvg', 'transitrixStudio.saveFGAAsPng', 'transitrixStudio.copyFGAAsPng'] },
+        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveFGAAsSvg', 'transitrixStudio.saveFGAAsPng', 'transitrixStudio.copyFGAAsPng', OPEN_SPACING_SETTINGS_COMMAND] },
       );
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
     }
@@ -344,6 +295,13 @@ export class FGAPreview {
 
   async refreshSaved(doc: vscode.TextDocument): Promise<void> {
     if (!this.isShowingDocument(doc.uri)) return;
+    await this.pushDocument(doc);
+  }
+
+  /** Re-render the tracked document — used when a spacing/theme setting changes. */
+  async refreshConfig(): Promise<void> {
+    if (!this.panel || !this.trackedUri) return;
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.parse(this.trackedUri));
     await this.pushDocument(doc);
   }
 
@@ -368,7 +326,8 @@ export class FGAPreview {
         errorMsg = v.errors.map(e => `${e.code}: ${e.message}`).join('\n');
       } else {
         // FGA shares FGCA's FLAT shape; just hide the (absent) Changes column.
-        svgContent = buildSvg(v.parsed as unknown as FGCADoc, true, 'FGA — Factor → Goal → Activity', filename, docDate, docVersion);
+        const gaps = readSpacing('fga', { horizontalGap: FGCA_DEFAULT_COL_GAP, verticalGap: FGCA_DEFAULT_ROW_GAP });
+        svgContent = buildSvg(v.parsed as unknown as FGCADoc, true, { colGap: gaps.horizontalGap, rowGap: gaps.verticalGap }, 'FGA — Factor → Goal → Activity', filename, docDate, docVersion);
       }
     } catch (e) {
       errorMsg = (e as Error).message ?? 'Parse error';
@@ -385,6 +344,7 @@ export class FGAPreview {
       saveSvgCommand: 'transitrixStudio.saveFGAAsSvg',
       savePngCommand: 'transitrixStudio.saveFGAAsPng',
       copyPngCommand: 'transitrixStudio.copyFGAAsPng',
+      spacingCommand: OPEN_SPACING_SETTINGS_COMMAND,
     });
   }
 

--- a/extension/src/goals-preview.ts
+++ b/extension/src/goals-preview.ts
@@ -11,6 +11,7 @@ import {
 } from '../../packages/diagrams/src/goals/index.js';
 import { parseCanonicalGoals } from '../../packages/diagrams/src/goals/parse-canonical.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
+import { readSpacing, OPEN_SPACING_SETTINGS_COMMAND } from './spacing-config.js';
 
 // ── SVG renderer ─────────────────────────────────────────────────────────────
 //
@@ -112,7 +113,7 @@ export class GoalsPreview {
         'goalsPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveGoalsAsSvg', 'transitrixStudio.saveGoalsAsPng', 'transitrixStudio.copyGoalsAsPng'] },
+        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveGoalsAsSvg', 'transitrixStudio.saveGoalsAsPng', 'transitrixStudio.copyGoalsAsPng', OPEN_SPACING_SETTINGS_COMMAND] },
       );
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
     }
@@ -121,6 +122,13 @@ export class GoalsPreview {
 
   async refreshSaved(doc: vscode.TextDocument): Promise<void> {
     if (!this.isShowingDocument(doc.uri)) return;
+    await this.pushDocument(doc);
+  }
+
+  /** Re-render the tracked document — used when a spacing/theme setting changes. */
+  async refreshConfig(): Promise<void> {
+    if (!this.panel || !this.trackedUri) return;
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.parse(this.trackedUri));
     await this.pushDocument(doc);
   }
 
@@ -145,11 +153,12 @@ export class GoalsPreview {
         const treeName = typeof meta.name === 'string' ? meta.name : '';
         const docVersion = typeof meta.version === 'string' ? meta.version : undefined;
         const docDate = typeof meta.date === 'string' ? meta.date : todayIso();
+        const gaps = readSpacing('goals', { horizontalGap: RANK_SEP, verticalGap: NODE_SEP });
         const layout = layoutGoalTree(v.parsed, {
           nodeWidth: NODE_W,
           nodeHeight: NODE_H,
-          rankSep: RANK_SEP,
-          nodeSep: NODE_SEP,
+          rankSep: gaps.horizontalGap,
+          nodeSep: gaps.verticalGap,
         });
         svgContent = layoutToSvg(layout, treeName, filename, docDate, docVersion);
       }
@@ -168,6 +177,7 @@ export class GoalsPreview {
       saveSvgCommand: 'transitrixStudio.saveGoalsAsSvg',
       savePngCommand: 'transitrixStudio.saveGoalsAsPng',
       copyPngCommand: 'transitrixStudio.copyGoalsAsPng',
+      spacingCommand: OPEN_SPACING_SETTINGS_COMMAND,
     });
   }
 

--- a/extension/src/spacing-config.ts
+++ b/extension/src/spacing-config.ts
@@ -1,0 +1,30 @@
+import * as vscode from 'vscode';
+
+// Per-notation spacing controls (vkgeorgia/strategy#75). PR1 persists the
+// chosen gaps in VS Code configuration (`transitrix.spacing.<notation>.*`),
+// mirroring the existing `transitrix.theme` pattern, and re-renders previews
+// on change. In-preview live sliders are deferred to PR2.
+
+export type SpacingNotation = 'goals' | 'fgca' | 'fga' | 'activities';
+
+export interface SpacingGaps {
+  /** px gap between columns (horizontal). */
+  horizontalGap: number;
+  /** px gap between stacked nodes (vertical). */
+  verticalGap: number;
+}
+
+/** Reads the user's configured spacing for a notation, falling back to the layout defaults. */
+export function readSpacing(notation: SpacingNotation, defaults: SpacingGaps): SpacingGaps {
+  const cfg = vscode.workspace.getConfiguration('transitrix');
+  return {
+    horizontalGap: cfg.get<number>(`spacing.${notation}.horizontalGap`, defaults.horizontalGap),
+    verticalGap: cfg.get<number>(`spacing.${notation}.verticalGap`, defaults.verticalGap),
+  };
+}
+
+/** Config section that, when changed, re-renders spacing-aware previews. */
+export const SPACING_CONFIG_SECTION = 'transitrix.spacing';
+
+/** Command that opens Settings filtered to the spacing controls. */
+export const OPEN_SPACING_SETTINGS_COMMAND = 'transitrixStudio.openSpacingSettings';

--- a/packages/diagrams/src/activities/__tests__/layout.test.ts
+++ b/packages/diagrams/src/activities/__tests__/layout.test.ts
@@ -85,4 +85,28 @@ describe('layoutActivities', () => {
     expect(layout.bounds.width).toBeGreaterThan(0);
     expect(layout.bounds.height).toBeGreaterThan(0);
   });
+
+  // vkgeorgia/strategy#75 — configurable spacing.
+  it('empty options reproduce the default no-arg layout', () => {
+    const a = layoutActivities(diamondDoc);
+    const b = layoutActivities(diamondDoc, {});
+    expect(b.nodes.map(n => `${n.id}:${n.x},${n.y}`)).toEqual(a.nodes.map(n => `${n.id}:${n.x},${n.y}`));
+  });
+
+  it('larger horizontalGap pushes downstream columns further right', () => {
+    const xOfD = (h: number) =>
+      layoutActivities(diamondDoc, { horizontalGap: h }).nodes.find(n => n.id === 'D')!.x;
+    expect(xOfD(200)).toBeGreaterThan(xOfD(80));
+  });
+
+  it('larger verticalGap increases the gap between stacked column nodes', () => {
+    const gapOf = (v: number) => {
+      const ys = layoutActivities(diamondDoc, { verticalGap: v })
+        .nodes.filter(n => n.id === 'B' || n.id === 'C')
+        .map(n => n.y)
+        .sort((a, b) => a - b);
+      return ys[1] - ys[0];
+    };
+    expect(gapOf(100)).toBeGreaterThan(gapOf(24));
+  });
 });

--- a/packages/diagrams/src/activities/index.ts
+++ b/packages/diagrams/src/activities/index.ts
@@ -9,6 +9,7 @@ export type {
   LayoutNode,
   LayoutEdge,
   ActivitiesLayout,
+  ActivitiesLayoutOptions,
   Weekday,
   ProjectCalendar,
   ProjectBlock,

--- a/packages/diagrams/src/activities/layout.ts
+++ b/packages/diagrams/src/activities/layout.ts
@@ -1,4 +1,4 @@
-import type { ActivityDoc, Activity, ActivitiesLayout, LayoutNode, LayoutEdge } from './types.js';
+import type { ActivityDoc, Activity, ActivitiesLayout, ActivitiesLayoutOptions, LayoutNode, LayoutEdge } from './types.js';
 import { computeCpm } from './cpm.js';
 
 const NODE_W = 200;
@@ -6,7 +6,8 @@ const NODE_H = 80;
 const H_GAP = 80;
 const V_GAP = 24;
 
-export function layoutActivities(doc: ActivityDoc): ActivitiesLayout {
+export function layoutActivities(doc: ActivityDoc, options: ActivitiesLayoutOptions = {}): ActivitiesLayout {
+  const { horizontalGap = H_GAP, verticalGap = V_GAP } = options;
   const activities = doc.activities;
   if (activities.length === 0) {
     return { nodes: [], edges: [], bounds: { x: 0, y: 0, width: 0, height: 0 } };
@@ -69,7 +70,7 @@ export function layoutActivities(doc: ActivityDoc): ActivitiesLayout {
 
   for (let c = 0; c < colCount; c++) {
     const list = cols.get(c) ?? [];
-    const x = c * (NODE_W + H_GAP);
+    const x = c * (NODE_W + horizontalGap);
     let y = 0;
     for (const a of list) {
       const node: LayoutNode = {
@@ -83,7 +84,7 @@ export function layoutActivities(doc: ActivityDoc): ActivitiesLayout {
       };
       nodes.push(node);
       nodeMap.set(a.id, node);
-      y += NODE_H + V_GAP;
+      y += NODE_H + verticalGap;
     }
   }
 

--- a/packages/diagrams/src/activities/types.ts
+++ b/packages/diagrams/src/activities/types.ts
@@ -94,6 +94,13 @@ export interface ActivitiesLayout {
   bounds: { x: number; y: number; width: number; height: number };
 }
 
+export interface ActivitiesLayoutOptions {
+  /** Horizontal gap (px) between CPM columns. Default matches the historical hardcoded value. */
+  horizontalGap?: number;
+  /** Vertical gap (px) between stacked activity nodes. Default matches the historical hardcoded value. */
+  verticalGap?: number;
+}
+
 // ── Gantt view (spec §9) ─────────────────────────────────────────────────────
 
 export type GanttMode = 'computed' | 'pinned';

--- a/packages/diagrams/src/fgca/__tests__/preview-layout.test.ts
+++ b/packages/diagrams/src/fgca/__tests__/preview-layout.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import {
+  layoutFGCAPreview,
+  FGCA_PAD,
+  FGCA_NODE_W,
+  type FGCAPreviewDoc,
+} from '../preview-layout.js';
+
+const doc: FGCAPreviewDoc = {
+  factors: [
+    { id: 1, name: 'F1' },
+    { id: 2, name: 'F2' },
+  ],
+  goals: [
+    { id: 10, name: 'G1', factor: [{ id: 1 }] },
+    { id: 11, name: 'G2', factor: [{ id: 2 }] },
+  ],
+  changes: [{ id: 20, name: 'C1', goal_id: 10, activity_ids: [30] }],
+  activities: [
+    { id: 30, name: 'A1', goal_id: 10 },
+    { id: 31, name: 'A2', goal_id: 11 },
+  ],
+};
+
+describe('layoutFGCAPreview', () => {
+  it('lays out all four columns in order (FGCA)', () => {
+    const layout = layoutFGCAPreview(doc);
+    expect(layout.columns.map(c => c.col)).toEqual(['factor', 'goal', 'change', 'activity']);
+    // 2 factors + 2 goals + 1 change + 2 activities
+    expect(layout.nodes).toHaveLength(7);
+    expect(layout.width).toBeGreaterThan(0);
+    expect(layout.height).toBeGreaterThan(0);
+  });
+
+  it('produces the expected FGCA edge set', () => {
+    // F1→G1, F2→G2 (2), G1→C1 (1), C1→A1 (1), G2→A2 direct (1) = 5
+    const layout = layoutFGCAPreview(doc);
+    expect(layout.edges).toHaveLength(5);
+  });
+
+  it('hideChanges (FGA) drops the Changes column and links goals to activities', () => {
+    const layout = layoutFGCAPreview(doc, { hideChanges: true });
+    expect(layout.columns.map(c => c.col)).toEqual(['factor', 'goal', 'activity']);
+    // 2 factors + 2 goals + 2 activities
+    expect(layout.nodes).toHaveLength(6);
+    // F1→G1, F2→G2 (2), G1→A1, G2→A2 (2) = 4
+    expect(layout.edges).toHaveLength(4);
+  });
+
+  it('first column sits at the pad origin', () => {
+    const layout = layoutFGCAPreview(doc);
+    expect(layout.columns[0].x).toBe(FGCA_PAD);
+  });
+
+  it('empty options reproduce the default layout', () => {
+    const a = layoutFGCAPreview(doc);
+    const b = layoutFGCAPreview(doc, {});
+    expect(b.nodes.map(n => `${n.id}:${n.x},${n.y}`)).toEqual(a.nodes.map(n => `${n.id}:${n.x},${n.y}`));
+  });
+
+  it('larger colGap widens the column step', () => {
+    const stepOf = (colGap: number) => {
+      const cols = layoutFGCAPreview(doc, { colGap }).columns;
+      return cols[1].x - cols[0].x;
+    };
+    expect(stepOf(80)).toBe(FGCA_NODE_W + 80);
+    expect(stepOf(240)).toBe(FGCA_NODE_W + 240);
+    expect(stepOf(240)).toBeGreaterThan(stepOf(80));
+  });
+
+  it('larger rowGap increases the gap between stacked nodes', () => {
+    const gapOf = (rowGap: number) => {
+      const factors = layoutFGCAPreview(doc, { rowGap }).nodes.filter(n => n.col === 'factor');
+      return factors[1].y - factors[0].y;
+    };
+    expect(gapOf(120)).toBeGreaterThan(gapOf(20));
+  });
+});

--- a/packages/diagrams/src/fgca/index.ts
+++ b/packages/diagrams/src/fgca/index.ts
@@ -1,5 +1,23 @@
 export { buildFGCALayout, NODE_WIDTH, NODE_HEIGHT, COLUMN_GAP, ROW_GAP, COLUMN_BG } from "./layout";
 export type { FGCALayoutInput } from "./layout";
+export {
+  layoutFGCAPreview,
+  FGCA_NODE_W,
+  FGCA_NODE_H,
+  FGCA_HEADER_H,
+  FGCA_PAD,
+  FGCA_DEFAULT_COL_GAP,
+  FGCA_DEFAULT_ROW_GAP,
+} from "./preview-layout";
+export type {
+  FGCAPreviewColumn,
+  FGCAPreviewDoc,
+  FGCAPreviewLayout,
+  FGCAPreviewLayoutOptions,
+  FGCAPreviewNode,
+  FGCAPreviewEdge,
+  FGCAPreviewColumnPos,
+} from "./preview-layout";
 export { validateFGCADoc } from "./validate";
 export type { FGCADoc, FGCAValidationResult, FGCAValidationError, FGCAValidationWarning } from "./validate";
 export {

--- a/packages/diagrams/src/fgca/preview-layout.ts
+++ b/packages/diagrams/src/fgca/preview-layout.ts
@@ -1,0 +1,168 @@
+// Pure column-layout geometry for the static FGCA / FGA previews.
+//
+// This is the layout the Studio extension's `fgca-preview.ts` renders to SVG
+// (NOT the ReactFlow `buildFGCALayout` in `./layout.ts`, which targets the
+// interactive web UI). It lives here — rather than inline in the extension —
+// so the gap geometry is unit-testable: the extension has no test harness.
+//
+// No React, no DOM, no vscode. Safe to call in Node.js or a test environment.
+
+export type FGCAPreviewColumn = 'factor' | 'goal' | 'change' | 'activity';
+
+export interface FGCAPreviewFactor {
+  id: number | string;
+  name: string;
+}
+export interface FGCAPreviewGoal {
+  id: number | string;
+  name: string;
+  level?: number;
+  factor?: Array<{ id: number | string }>;
+}
+export interface FGCAPreviewChange {
+  id: number | string;
+  name: string;
+  goal_id: number | string;
+  activity_ids: Array<number | string>;
+}
+export interface FGCAPreviewActivity {
+  id: number | string;
+  name: string;
+  goal_id?: number | string | null;
+}
+
+/** Structural input the preview layout needs — a subset of the parsed FGCA/FGA doc. */
+export interface FGCAPreviewDoc {
+  factors: FGCAPreviewFactor[];
+  goals: FGCAPreviewGoal[];
+  changes?: FGCAPreviewChange[];
+  activities: FGCAPreviewActivity[];
+}
+
+export interface FGCAPreviewLayoutOptions {
+  /** FGA hides the Changes column and links Goal → Activity directly. */
+  hideChanges?: boolean;
+  /** Horizontal gap (px) between columns. Default matches the historical hardcoded value. */
+  colGap?: number;
+  /** Vertical gap (px) between stacked nodes within a column. Default matches the historical hardcoded value. */
+  rowGap?: number;
+}
+
+export interface FGCAPreviewNode {
+  id: string;
+  x: number;
+  y: number;
+  label: string;
+  col: FGCAPreviewColumn;
+}
+export interface FGCAPreviewEdge {
+  sx: number;
+  sy: number;
+  tx: number;
+  ty: number;
+}
+/** Per-column header anchor — lets the renderer draw column headers without recomputing the stride. */
+export interface FGCAPreviewColumnPos {
+  col: FGCAPreviewColumn;
+  x: number;
+}
+export interface FGCAPreviewLayout {
+  nodes: FGCAPreviewNode[];
+  edges: FGCAPreviewEdge[];
+  columns: FGCAPreviewColumnPos[];
+  width: number;
+  height: number;
+}
+
+// Fixed node + frame geometry. Only the inter-node gaps are user-configurable
+// (vkgeorgia/strategy#75); node size and padding stay constant.
+export const FGCA_NODE_W = 220;
+export const FGCA_NODE_H = 72;
+export const FGCA_HEADER_H = 32;
+export const FGCA_PAD = 20;
+export const FGCA_DEFAULT_COL_GAP = 160;
+export const FGCA_DEFAULT_ROW_GAP = 20;
+
+export function layoutFGCAPreview(
+  doc: FGCAPreviewDoc,
+  options: FGCAPreviewLayoutOptions = {},
+): FGCAPreviewLayout {
+  const {
+    hideChanges = false,
+    colGap = FGCA_DEFAULT_COL_GAP,
+    rowGap = FGCA_DEFAULT_ROW_GAP,
+  } = options;
+
+  const colStride = FGCA_NODE_W + colGap;
+  const cols: FGCAPreviewColumn[] = hideChanges
+    ? ['factor', 'goal', 'activity']
+    : ['factor', 'goal', 'change', 'activity'];
+  const changes = doc.changes ?? [];
+  const colItems: Record<FGCAPreviewColumn, Array<{ id: string; label: string }>> = {
+    factor:   doc.factors.map(f => ({ id: `factor_${f.id}`,     label: f.name })),
+    goal:     doc.goals.map(g   => ({ id: `goal_${g.id}`,       label: g.name })),
+    change:   changes.map(c     => ({ id: `change_${c.id}`,     label: c.name })),
+    activity: doc.activities.map(a => ({ id: `activity_${a.id}`, label: a.name })),
+  };
+
+  const nodeMap = new Map<string, FGCAPreviewNode>();
+  const nodes: FGCAPreviewNode[] = [];
+  const columns: FGCAPreviewColumnPos[] = [];
+
+  for (let ci = 0; ci < cols.length; ci++) {
+    const col = cols[ci];
+    const x = FGCA_PAD + ci * colStride;
+    columns.push({ col, x });
+    let y = FGCA_PAD + FGCA_HEADER_H + rowGap;
+    for (const item of colItems[col]) {
+      const node: FGCAPreviewNode = { id: item.id, x, y, label: item.label, col };
+      nodes.push(node);
+      nodeMap.set(item.id, node);
+      y += FGCA_NODE_H + rowGap;
+    }
+  }
+
+  const edges: FGCAPreviewEdge[] = [];
+  function addEdge(sourceId: string, targetId: string): void {
+    const s = nodeMap.get(sourceId);
+    const t = nodeMap.get(targetId);
+    if (!s || !t) return;
+    edges.push({ sx: s.x + FGCA_NODE_W, sy: s.y + FGCA_NODE_H / 2, tx: t.x, ty: t.y + FGCA_NODE_H / 2 });
+  }
+
+  for (const g of doc.goals) {
+    for (const f of (g.factor ?? [])) addEdge(`factor_${f.id}`, `goal_${g.id}`);
+  }
+  if (hideChanges) {
+    const connectedViaChange = new Set<number | string>();
+    for (const c of changes) {
+      for (const aid of c.activity_ids) {
+        addEdge(`goal_${c.goal_id}`, `activity_${aid}`);
+        connectedViaChange.add(aid);
+      }
+    }
+    for (const a of doc.activities) {
+      if (a.goal_id != null && !connectedViaChange.has(a.id)) {
+        addEdge(`goal_${a.goal_id}`, `activity_${a.id}`);
+      }
+    }
+  } else {
+    for (const c of changes) addEdge(`goal_${c.goal_id}`, `change_${c.id}`);
+    for (const c of changes) for (const aid of c.activity_ids) addEdge(`change_${c.id}`, `activity_${aid}`);
+    const coveredActivities = new Set(changes.flatMap(c => c.activity_ids));
+    for (const a of doc.activities) {
+      if (a.goal_id != null && !coveredActivities.has(a.id)) {
+        addEdge(`goal_${a.goal_id}`, `activity_${a.id}`);
+      }
+    }
+  }
+
+  const maxNodeBottom = nodes.reduce(
+    (m, n) => Math.max(m, n.y + FGCA_NODE_H),
+    FGCA_PAD + FGCA_HEADER_H + rowGap + FGCA_NODE_H,
+  );
+  const width = FGCA_PAD * 2 + cols.length * colStride - colGap;
+  const height = maxNodeBottom + FGCA_PAD;
+
+  return { nodes, edges, columns, width, height };
+}

--- a/packages/diagrams/src/goals/__tests__/layout.test.ts
+++ b/packages/diagrams/src/goals/__tests__/layout.test.ts
@@ -64,6 +64,27 @@ describe('layoutGoalTree', () => {
     expect(layout.nodes[0].height).toBe(60);
   });
 
+  // vkgeorgia/strategy#75 — configurable spacing. The preview maps
+  // horizontalGap → rankSep and verticalGap → nodeSep.
+  it('larger rankSep widens the column step', () => {
+    const tight = layoutGoalTree(TREE, { rankSep: 80 });
+    const wide = layoutGoalTree(TREE, { rankSep: 200 });
+    const stepOf = (l: ReturnType<typeof layoutGoalTree>) => {
+      const byId = new Map(l.nodes.map(n => [n.id, n]));
+      return byId.get(2)!.x - byId.get(1)!.x;
+    };
+    expect(stepOf(wide)).toBeGreaterThan(stepOf(tight));
+  });
+
+  it('larger nodeSep increases the gap between stacked siblings', () => {
+    const gapOf = (sep: number) => {
+      const l = layoutGoalTree(TREE, { nodeSep: sep });
+      const byId = new Map(l.nodes.map(n => [n.id, n]));
+      return Math.abs(byId.get(4)!.y - byId.get(3)!.y);
+    };
+    expect(gapOf(120)).toBeGreaterThan(gapOf(24));
+  });
+
   it('each node carries original goal data', () => {
     const layout = layoutGoalTree(TREE);
     const node1 = layout.nodes.find(n => n.id === 1)!;


### PR DESCRIPTION
## What

PR1 of the two-PR split agreed on strategy hub #75 (**Path 4**): the **library API + settings-driven persistence + `onDidChangeConfiguration` re-render**. In-preview live sliders are deferred to **PR2**, gated on the joint `enableScripts` security-posture call for #75 / #76 / #77.

Users can now adjust horizontal/vertical block spacing for the **Goals, FGCA, FGA and Activities** previews via Settings. Defaults match today's hardcoded gaps exactly — **no visual change** unless the user touches a control. Previews keep `enableScripts: false`.

## How

**Library (`@transitrix/diagrams`)**
- `layoutActivities` now accepts `ActivitiesLayoutOptions { horizontalGap, verticalGap }`.
- Extracted the static FGCA/FGA column layout out of the extension into `packages/diagrams/src/fgca/preview-layout.ts` (`layoutFGCAPreview`) with `colGap` / `rowGap` params, so the gap geometry is **unit-testable** (the extension has no test harness). It returns per-column header anchors so the renderer stays in sync with the gap. FGA reuses it with `hideChanges`.
- Goals already exposed `rankSep` / `nodeSep` — no library change needed.

**Extension**
- New settings `transitrix.spacing.<goals|fgca|fga|activities>.{horizontalGap,verticalGap}` — bounds 20–300, defaults = prior hardcoded gaps, **independent per notation** (AC#4). Persisted via VS Code configuration, mirroring the existing `transitrix.theme` pattern (AC#3-faithful).
- Each preview reads its settings and threads them into the layout call.
- A **"Spacing…"** toolbar link + `transitrixStudio.openSpacingSettings` command opens Settings filtered to the gap controls; added to each preview's `enableCommandUris` allowlist.
- `onDidChangeConfiguration` re-renders the four previews when `transitrix.spacing` changes (`refreshConfig()` rebuilds the webview HTML from the tracked document) — no scripts in the webview.

## Tests (AC#5)
- **Goals**: larger `rankSep` widens the column step; larger `nodeSep` widens the sibling gap.
- **Activities**: empty options reproduce the default no-arg layout; `horizontalGap` / `verticalGap` change coordinates.
- **FGCA preview-layout**: column order, edge sets (FGCA & FGA), `hideChanges`, default reproduction, and `colGap` / `rowGap` changing coordinates.
- Full diagrams suite (458) + core suite (225) green; `tsc` core + extension clean.

## Notes
- **Scope per #75's latest comment:** Activities **is** included (the contradictory note on #76 is superseded).
- FGA gets its **own** independent spacing state (`transitrix.spacing.fga.*`), separate from FGCA, even though both render through the shared FGCA preview.
- Pre-existing (not introduced here): `npm --workspace packages/diagrams run build` (`tsc -p .`) fails on a `LayoutBounds` re-export ambiguity in `src/index.ts` — reproduces on `main`, and is off the CI/test path (which uses the root tsconfig + vitest). Flagging, not fixing here.

Do not merge — Valerii gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
