### PR TITLE
feat(curvature): configurable edge curvature for Goals/FGCA/FGA/Activities previews (#76)

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -154,6 +154,34 @@
           "maximum": 300,
           "default": 24,
           "description": "Activities preview: vertical gap (px) between stacked activity nodes."
+        },
+        "transitrix.curvature.goals": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 3,
+          "default": 1,
+          "description": "Goals preview: edge curvature. 0 = straight lines, 1 = default, higher = stronger arc."
+        },
+        "transitrix.curvature.fgca": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 3,
+          "default": 1,
+          "description": "FGCA preview: edge curvature. 0 = straight lines, 1 = default, higher = stronger arc."
+        },
+        "transitrix.curvature.fga": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 3,
+          "default": 1,
+          "description": "FGA preview: edge curvature. 0 = straight lines, 1 = default, higher = stronger arc."
+        },
+        "transitrix.curvature.activities": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 3,
+          "default": 1,
+          "description": "Activities preview: CPM dependency-arrow curvature. 0 = straight lines, 1 = default, higher = stronger arc."
         }
       }
     },
@@ -504,6 +532,12 @@
       {
         "command": "transitrixStudio.openSpacingSettings",
         "title": "Transitrix: Open diagram spacing settings",
+        "category": "Transitrix",
+        "icon": "$(settings-gear)"
+      },
+      {
+        "command": "transitrixStudio.openCurvatureSettings",
+        "title": "Transitrix: Open diagram edge-curvature settings",
         "category": "Transitrix",
         "icon": "$(settings-gear)"
       }

--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -16,8 +16,9 @@ import {
   type GanttResult,
 } from '../../packages/diagrams/src/activities/index.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
+import { horizontalCubicEdgePath, DEFAULT_EDGE_CURVATURE } from '../../packages/diagrams/src/edge-path.js';
 import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
-import { readSpacing, OPEN_SPACING_SETTINGS_COMMAND } from './spacing-config.js';
+import { readSpacing, readCurvature, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND } from './spacing-config.js';
 
 // Default network (PSND) gaps — must match the layoutActivities defaults
 // (H_GAP / V_GAP) so an unconfigured preview is visually unchanged.
@@ -43,7 +44,7 @@ const N_NODE_W = 200;
 const N_NODE_H = 80;
 const N_PAD = 24;
 
-function networkSvg(doc: ActivityDoc, gaps: ActivitiesLayoutOptions = {}, heading?: string, filename?: string, date?: string, version?: string): string {
+function networkSvg(doc: ActivityDoc, gaps: ActivitiesLayoutOptions = {}, curvature: number = DEFAULT_EDGE_CURVATURE, heading?: string, filename?: string, date?: string, version?: string): string {
   const layout: ActivitiesLayout = layoutActivities(doc, gaps);
   if (layout.nodes.length === 0) {
     return '<svg xmlns="http://www.w3.org/2000/svg" width="200" height="60"><text class="text-primary" x="10" y="40">No activities</text></svg>';
@@ -64,18 +65,12 @@ function networkSvg(doc: ActivityDoc, gaps: ActivitiesLayoutOptions = {}, headin
   const orderedEdges = [...layout.edges].sort(
     (a, b) => Number(Boolean(a.isCritical)) - Number(Boolean(b.isCritical)),
   );
-  // Edge path = a single cubic Bézier with horizontal control handles. Each
-  // control point shares its endpoint's Y, so the tangent is horizontal at
-  // both ends — the curve meets the vertical node edge at a true right angle
-  // and the marker-end arrow (orient="auto") reads as perpendicular. The
-  // handle length grows with both the horizontal and the vertical span so the
-  // curve stays visibly horizontal long enough for the arrowhead to sit flush:
-  // short handles leave the curve horizontal only at the exact endpoint, so a
-  // rigid arrowhead visibly mismatches the curve behind it. No straight stubs —
-  // a stub→curve joint is tangent-continuous but shows a curvature jump
-  // (0 → non-zero) the eye reads as a kink. Marker refX = markerWidth anchors
-  // the tip at the path endpoint, on the node's edge rather than inside it.
-  const EDGE_MIN_HANDLE = 64;
+  // Edge path = a single cubic Bézier with horizontal control handles (shared
+  // geometry in @transitrix/diagrams). The control points share their
+  // endpoint's Y so the tangent is horizontal at both ends — the curve meets
+  // the vertical node edge at a right angle and the marker-end arrow reads as
+  // perpendicular. `curvature` scales the handle length: 1 = default, 0 =
+  // straight, higher = stronger arc (vkgeorgia/strategy#76).
   const edgeSvg = orderedEdges.map(e => {
     const s = nodeMap.get(e.sourceId);
     const t = nodeMap.get(e.targetId);
@@ -84,16 +79,9 @@ function networkSvg(doc: ActivityDoc, gaps: ActivitiesLayoutOptions = {}, headin
     const sy = s.y + oy + s.height / 2;
     const tx = t.x + ox;
     const ty = t.y + oy + t.height / 2;
-    const dx = tx - sx;
-    const dy = ty - sy;
-    // Handle length is a magnitude only — the tangent stays horizontal
-    // regardless, so perpendicular entry/exit is guaranteed. When handle >
-    // dx/2 the control points cross over: intentional, it produces the
-    // graceful "lazy S" for vertically stacked nodes.
-    const handle = Math.max(EDGE_MIN_HANDLE, Math.abs(dx) * 0.5, Math.abs(dy) * 0.8);
     const cls = e.isCritical ? 'diagram-edge critical-edge' : 'diagram-edge';
     const marker = `url(#${e.isCritical ? 'arrow-crit' : 'arrow'})`;
-    return `<path d="M${sx},${sy} C${sx + handle},${sy} ${tx - handle},${ty} ${tx},${ty}" class="${cls}" marker-end="${marker}"/>`;
+    return `<path d="${horizontalCubicEdgePath(sx, sy, tx, ty, curvature)}" class="${cls}" marker-end="${marker}"/>`;
   }).join('\n');
 
   const nodeSvg = layout.nodes.map(n => {
@@ -435,9 +423,9 @@ interface ActivityViews {
   ganttSvg: string;
 }
 
-function buildActivityViews(doc: ActivityDoc, gaps: ActivitiesLayoutOptions, filename: string, date: string, version?: string): ActivityViews {
+function buildActivityViews(doc: ActivityDoc, gaps: ActivitiesLayoutOptions, curvature: number, filename: string, date: string, version?: string): ActivityViews {
   const networkHeading = 'Network view — Project Schedule Network Diagram (PSND)';
-  const networkSvgStr = networkSvg(doc, gaps, networkHeading, filename, date, version);
+  const networkSvgStr = networkSvg(doc, gaps, curvature, networkHeading, filename, date, version);
   const gantt: GanttResult = computeGanttLayout(doc);
 
   // Mirror titleBlockSvg's date line: `v{version} · {date}` when version is set.
@@ -579,7 +567,7 @@ export class ActivitiesPreview {
         'activitiesPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveActivitiesAsSvg', 'transitrixStudio.saveActivitiesAsPng', 'transitrixStudio.copyActivitiesAsPng', OPEN_SPACING_SETTINGS_COMMAND] },
+        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveActivitiesAsSvg', 'transitrixStudio.saveActivitiesAsPng', 'transitrixStudio.copyActivitiesAsPng', OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND] },
       );
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
     }
@@ -623,7 +611,7 @@ export class ActivitiesPreview {
         errorMsg = v.errors.map(e => `${e.code}: ${e.message}`).join('\n');
       } else {
         const spacing = readSpacing('activities', { horizontalGap: ACTIVITIES_DEFAULT_H_GAP, verticalGap: ACTIVITIES_DEFAULT_V_GAP });
-        const views = buildActivityViews(parsed as ActivityDoc, { horizontalGap: spacing.horizontalGap, verticalGap: spacing.verticalGap }, filename, docDate, docVersion);
+        const views = buildActivityViews(parsed as ActivityDoc, { horizontalGap: spacing.horizontalGap, verticalGap: spacing.verticalGap }, readCurvature('activities'), filename, docDate, docVersion);
         bodyContent = buildCanvasContent(views);
         this.lastNetworkSvg = views.networkSvg;
         this.lastGanttSvg = views.ganttSvg;
@@ -653,6 +641,7 @@ export class ActivitiesPreview {
       savePngCommand: 'transitrixStudio.saveActivitiesAsPng',
       copyPngCommand: 'transitrixStudio.copyActivitiesAsPng',
       spacingCommand: OPEN_SPACING_SETTINGS_COMMAND,
+      curvatureCommand: OPEN_CURVATURE_SETTINGS_COMMAND,
     });
   }
 

--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -78,6 +78,12 @@ export interface DiagramFrameOpts {
    * URIs via `enableCommandUris`.
    */
   spacingCommand?: string;
+  /**
+   * Command ID for the "Curvature…" toolbar link (opens Settings filtered to
+   * the per-notation edge-curvature control — vkgeorgia/strategy#76). Same
+   * opt-in contract as `spacingCommand`.
+   */
+  curvatureCommand?: string;
 }
 
 function escXml(s: string): string {
@@ -270,7 +276,7 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
     errorMsg = '', warnings = [],
     themeId = 'transitrix', extraStyles = '', fixPrompt = '',
     title, subtitle, version, date,
-    saveSvgCommand, savePngCommand, copyPngCommand, spacingCommand,
+    saveSvgCommand, savePngCommand, copyPngCommand, spacingCommand, curvatureCommand,
   } = opts;
 
   const canvasContent = bodyContent ?? svgContent;
@@ -314,9 +320,10 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
   const showSaveSvg = Boolean(canvasContent) && Boolean(saveSvgCommand);
   const showSavePng = Boolean(canvasContent) && Boolean(savePngCommand);
   const showCopyPng = Boolean(canvasContent) && Boolean(copyPngCommand);
-  // Spacing link shows whenever the preview opts in — including error renders,
-  // so the user can adjust the gap settings and trigger a re-render.
+  // Spacing/curvature links show whenever the preview opts in — including error
+  // renders, so the user can adjust the settings and trigger a re-render.
   const showSpacing = Boolean(spacingCommand);
+  const showCurvature = Boolean(curvatureCommand);
   // Zoom control gates on the same signal as Save .svg — the six vector
   // previews opt in by passing a saveSvgCommand. HTML catalogues are out of
   // scope per the orchestrator's call on issue #30.
@@ -349,6 +356,9 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
   }
   if (showSpacing) {
     actionParts.push(`<a href="command:${escXml(spacingCommand!)}" class="toolbar-btn" title="Adjust the horizontal/vertical spacing for this notation in Settings">Spacing…</a>`);
+  }
+  if (showCurvature) {
+    actionParts.push(`<a href="command:${escXml(curvatureCommand!)}" class="toolbar-btn" title="Adjust the edge curvature for this notation in Settings">Curvature…</a>`);
   }
   const toolbarRight = actionParts.length > 0
     ? `<div class="toolbar-actions">${actionParts.join('')}</div>`

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -21,7 +21,12 @@ import {
   formatExtensionHint,
   getConfiguredExtensions,
 } from './source-files.js';
-import { OPEN_SPACING_SETTINGS_COMMAND, SPACING_CONFIG_SECTION } from './spacing-config.js';
+import {
+  OPEN_SPACING_SETTINGS_COMMAND,
+  SPACING_CONFIG_SECTION,
+  OPEN_CURVATURE_SETTINGS_COMMAND,
+  CURVATURE_CONFIG_SECTION,
+} from './spacing-config.js';
 
 function isGoalsFile(doc: vscode.TextDocument): boolean {
   return doc.fileName.endsWith('.goals.transitrix.yaml');
@@ -290,12 +295,16 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     vscode.commands.registerCommand(OPEN_SPACING_SETTINGS_COMMAND, () =>
       vscode.commands.executeCommand('workbench.action.openSettings', SPACING_CONFIG_SECTION),
     ),
-    // Re-render the spacing-aware previews when a gap setting changes — the
-    // PR1 persistence mechanism (vkgeorgia/strategy#75). Previews keep
-    // `enableScripts: false`; the change is applied host-side by rebuilding
-    // the webview HTML from the tracked document.
+    vscode.commands.registerCommand(OPEN_CURVATURE_SETTINGS_COMMAND, () =>
+      vscode.commands.executeCommand('workbench.action.openSettings', CURVATURE_CONFIG_SECTION),
+    ),
+    // Re-render the spacing/curvature-aware previews when a gap or curvature
+    // setting changes — the settings-driven persistence mechanism
+    // (vkgeorgia/strategy#75, #76). Previews keep `enableScripts: false`; the
+    // change is applied host-side by rebuilding the webview HTML from the
+    // tracked document.
     vscode.workspace.onDidChangeConfiguration((e) => {
-      if (!e.affectsConfiguration(SPACING_CONFIG_SECTION)) return;
+      if (!e.affectsConfiguration(SPACING_CONFIG_SECTION) && !e.affectsConfiguration(CURVATURE_CONFIG_SECTION)) return;
       void goalsPreview.refreshConfig();
       void fgcaPreview.refreshConfig();
       void fgaPreview.refreshConfig();

--- a/extension/src/fgca-preview.ts
+++ b/extension/src/fgca-preview.ts
@@ -13,9 +13,10 @@ import {
   FGCA_DEFAULT_COL_GAP,
   FGCA_DEFAULT_ROW_GAP,
 } from '../../packages/diagrams/src/fgca/preview-layout.js';
+import { horizontalCubicEdgePath, DEFAULT_EDGE_CURVATURE } from '../../packages/diagrams/src/edge-path.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
-import { readSpacing, OPEN_SPACING_SETTINGS_COMMAND } from './spacing-config.js';
+import { readSpacing, readCurvature, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND } from './spacing-config.js';
 
 // ── Inline render types ─────────────────────────────────────────────────────
 //
@@ -63,16 +64,17 @@ function escXml(s: string): string {
 function buildSvg(
   doc: FGCADoc,
   hideChanges = false,
-  gaps: { colGap?: number; rowGap?: number } = {},
+  opts: { colGap?: number; rowGap?: number; curvature?: number } = {},
   heading?: string,
   filename?: string,
   date?: string,
   version?: string,
 ): string {
+  const curvature = opts.curvature ?? DEFAULT_EDGE_CURVATURE;
   const { nodes, edges, columns, width, height } = layoutFGCAPreview(doc, {
     hideChanges,
-    colGap: gaps.colGap,
-    rowGap: gaps.rowGap,
+    colGap: opts.colGap,
+    rowGap: opts.rowGap,
   });
   const showTitle = heading != null && filename != null && date != null;
   const titleH = showTitle ? TITLE_BLOCK_H : 0;
@@ -84,17 +86,12 @@ function buildSvg(
     ].join('\n');
   }).join('\n');
 
-  // Cubic bezier with horizontal control handles that grow with both spans —
-  // the curve stays visibly horizontal long enough at each endpoint for the
-  // marker-end arrowhead to sit flush against the line and read as
-  // perpendicular to the node's vertical edge.
-  const EDGE_MIN_HANDLE = 64;
-  const edgeSvg = edges.map(e => {
-    const dx = e.tx - e.sx;
-    const dy = e.ty - e.sy;
-    const handle = Math.max(EDGE_MIN_HANDLE, Math.abs(dx) * 0.5, Math.abs(dy) * 0.8);
-    return `<path d="M${e.sx},${e.sy} C${e.sx + handle},${e.sy} ${e.tx - handle},${e.ty} ${e.tx},${e.ty}" class="diagram-edge" marker-end="url(#arrow)"/>`;
-  }).join('\n');
+  // Cubic bezier with horizontal control handles (shared geometry in
+  // @transitrix/diagrams). `curvature` scales the handle length: 1 = default,
+  // 0 = straight, higher = stronger arc (vkgeorgia/strategy#76).
+  const edgeSvg = edges.map(e =>
+    `<path d="${horizontalCubicEdgePath(e.sx, e.sy, e.tx, e.ty, curvature)}" class="diagram-edge" marker-end="url(#arrow)"/>`
+  ).join('\n');
 
   const nodeSvg = nodes.map(n => {
     const words = n.label.split(' ');
@@ -161,7 +158,7 @@ export class FGCAPreview {
         'fgcaPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveFGCAAsSvg', 'transitrixStudio.saveFGCAAsPng', 'transitrixStudio.copyFGCAAsPng', OPEN_SPACING_SETTINGS_COMMAND] },
+        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveFGCAAsSvg', 'transitrixStudio.saveFGCAAsPng', 'transitrixStudio.copyFGCAAsPng', OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND] },
       );
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
     }
@@ -205,7 +202,7 @@ export class FGCAPreview {
         // inline FGCADoc / buildSvg here accept both forms (number | string
         // unions) — pass through.
         const gaps = readSpacing('fgca', { horizontalGap: FGCA_DEFAULT_COL_GAP, verticalGap: FGCA_DEFAULT_ROW_GAP });
-        svgContent = buildSvg(v.parsed as unknown as FGCADoc, false, { colGap: gaps.horizontalGap, rowGap: gaps.verticalGap }, 'FGCA — Factor → Goal → Change → Activity', filename, docDate, docVersion);
+        svgContent = buildSvg(v.parsed as unknown as FGCADoc, false, { colGap: gaps.horizontalGap, rowGap: gaps.verticalGap, curvature: readCurvature('fgca') }, 'FGCA — Factor → Goal → Change → Activity', filename, docDate, docVersion);
       }
     } catch (e) {
       errorMsg = (e as Error).message ?? 'Parse error';
@@ -223,6 +220,7 @@ export class FGCAPreview {
       savePngCommand: 'transitrixStudio.saveFGCAAsPng',
       copyPngCommand: 'transitrixStudio.copyFGCAAsPng',
       spacingCommand: OPEN_SPACING_SETTINGS_COMMAND,
+      curvatureCommand: OPEN_CURVATURE_SETTINGS_COMMAND,
     });
   }
 
@@ -286,7 +284,7 @@ export class FGAPreview {
         'fgaPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveFGAAsSvg', 'transitrixStudio.saveFGAAsPng', 'transitrixStudio.copyFGAAsPng', OPEN_SPACING_SETTINGS_COMMAND] },
+        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveFGAAsSvg', 'transitrixStudio.saveFGAAsPng', 'transitrixStudio.copyFGAAsPng', OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND] },
       );
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
     }
@@ -327,7 +325,7 @@ export class FGAPreview {
       } else {
         // FGA shares FGCA's FLAT shape; just hide the (absent) Changes column.
         const gaps = readSpacing('fga', { horizontalGap: FGCA_DEFAULT_COL_GAP, verticalGap: FGCA_DEFAULT_ROW_GAP });
-        svgContent = buildSvg(v.parsed as unknown as FGCADoc, true, { colGap: gaps.horizontalGap, rowGap: gaps.verticalGap }, 'FGA — Factor → Goal → Activity', filename, docDate, docVersion);
+        svgContent = buildSvg(v.parsed as unknown as FGCADoc, true, { colGap: gaps.horizontalGap, rowGap: gaps.verticalGap, curvature: readCurvature('fga') }, 'FGA — Factor → Goal → Activity', filename, docDate, docVersion);
       }
     } catch (e) {
       errorMsg = (e as Error).message ?? 'Parse error';
@@ -345,6 +343,7 @@ export class FGAPreview {
       savePngCommand: 'transitrixStudio.saveFGAAsPng',
       copyPngCommand: 'transitrixStudio.copyFGAAsPng',
       spacingCommand: OPEN_SPACING_SETTINGS_COMMAND,
+      curvatureCommand: OPEN_CURVATURE_SETTINGS_COMMAND,
     });
   }
 

--- a/extension/src/goals-preview.ts
+++ b/extension/src/goals-preview.ts
@@ -11,7 +11,8 @@ import {
 } from '../../packages/diagrams/src/goals/index.js';
 import { parseCanonicalGoals } from '../../packages/diagrams/src/goals/parse-canonical.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
-import { readSpacing, OPEN_SPACING_SETTINGS_COMMAND } from './spacing-config.js';
+import { horizontalCubicEdgePath, DEFAULT_EDGE_CURVATURE } from '../../packages/diagrams/src/edge-path.js';
+import { readSpacing, readCurvature, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND } from './spacing-config.js';
 
 // ── SVG renderer ─────────────────────────────────────────────────────────────
 //
@@ -30,7 +31,7 @@ function escXml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
 
-function layoutToSvg(layout: GoalTreeLayout, treeName: string, filename?: string, date?: string, version?: string): string {
+function layoutToSvg(layout: GoalTreeLayout, treeName: string, filename?: string, date?: string, version?: string, curvature: number = DEFAULT_EDGE_CURVATURE): string {
   const pad = 24;
   const showTitle = filename != null && date != null;
   const titleH = showTitle ? TITLE_BLOCK_H : 0;
@@ -41,12 +42,9 @@ function layoutToSvg(layout: GoalTreeLayout, treeName: string, filename?: string
 
   const nodeMap = new Map(layout.nodes.map(n => [n.id, n]));
 
-  // Cubic bezier with horizontal control handles. Each control point shares
-  // its endpoint's Y, so the tangent is horizontal at both ends and the
-  // marker-end arrow reads as perpendicular to the node's vertical edge.
-  // Handle length grows with both spans so the curve stays visibly
-  // horizontal long enough for the arrowhead to sit flush against the line.
-  const EDGE_MIN_HANDLE = 64;
+  // Cubic bezier with horizontal control handles (shared geometry in
+  // @transitrix/diagrams). `curvature` scales the handle length: 1 = default,
+  // 0 = straight, higher = stronger arc (vkgeorgia/strategy#76).
   function edgePath(e: LaidOutEdge): string {
     const s = nodeMap.get(e.source);
     const t = nodeMap.get(e.target);
@@ -55,10 +53,7 @@ function layoutToSvg(layout: GoalTreeLayout, treeName: string, filename?: string
     const sy = s.y + oy + s.height / 2;
     const tx = t.x + ox;
     const ty = t.y + oy + t.height / 2;
-    const dx = tx - sx;
-    const dy = ty - sy;
-    const handle = Math.max(EDGE_MIN_HANDLE, Math.abs(dx) * 0.5, Math.abs(dy) * 0.8);
-    return `M${sx},${sy} C${sx + handle},${sy} ${tx - handle},${ty} ${tx},${ty}`;
+    return horizontalCubicEdgePath(sx, sy, tx, ty, curvature);
   }
 
   const edgeSvg = layout.edges.map(e =>
@@ -113,7 +108,7 @@ export class GoalsPreview {
         'goalsPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveGoalsAsSvg', 'transitrixStudio.saveGoalsAsPng', 'transitrixStudio.copyGoalsAsPng', OPEN_SPACING_SETTINGS_COMMAND] },
+        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveGoalsAsSvg', 'transitrixStudio.saveGoalsAsPng', 'transitrixStudio.copyGoalsAsPng', OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND] },
       );
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
     }
@@ -160,7 +155,7 @@ export class GoalsPreview {
           rankSep: gaps.horizontalGap,
           nodeSep: gaps.verticalGap,
         });
-        svgContent = layoutToSvg(layout, treeName, filename, docDate, docVersion);
+        svgContent = layoutToSvg(layout, treeName, filename, docDate, docVersion, readCurvature('goals'));
       }
     } catch (e) {
       errorMsg = (e as Error).message ?? 'Parse error';
@@ -178,6 +173,7 @@ export class GoalsPreview {
       savePngCommand: 'transitrixStudio.saveGoalsAsPng',
       copyPngCommand: 'transitrixStudio.copyGoalsAsPng',
       spacingCommand: OPEN_SPACING_SETTINGS_COMMAND,
+      curvatureCommand: OPEN_CURVATURE_SETTINGS_COMMAND,
     });
   }
 

--- a/extension/src/spacing-config.ts
+++ b/extension/src/spacing-config.ts
@@ -28,3 +28,26 @@ export const SPACING_CONFIG_SECTION = 'transitrix.spacing';
 
 /** Command that opens Settings filtered to the spacing controls. */
 export const OPEN_SPACING_SETTINGS_COMMAND = 'transitrixStudio.openSpacingSettings';
+
+// ── Edge curvature (vkgeorgia/strategy#76) ──────────────────────────────────
+//
+// A single per-notation multiplier on the edge control-handle length. Same
+// PR1 persistence pattern as spacing: settings-backed, re-rendered on change,
+// in-preview slider deferred to the joint enableScripts call.
+
+export type CurvatureNotation = 'goals' | 'fgca' | 'fga' | 'activities';
+
+// Must match DEFAULT_EDGE_CURVATURE in @transitrix/diagrams so an unconfigured
+// preview is visually unchanged.
+const DEFAULT_CURVATURE = 1;
+
+/** Reads the user's configured edge curvature for a notation (default 1 = historical). */
+export function readCurvature(notation: CurvatureNotation): number {
+  return vscode.workspace.getConfiguration('transitrix').get<number>(`curvature.${notation}`, DEFAULT_CURVATURE);
+}
+
+/** Config section that, when changed, re-renders curvature-aware previews. */
+export const CURVATURE_CONFIG_SECTION = 'transitrix.curvature';
+
+/** Command that opens Settings filtered to the curvature controls. */
+export const OPEN_CURVATURE_SETTINGS_COMMAND = 'transitrixStudio.openCurvatureSettings';

--- a/packages/diagrams/src/__tests__/edge-path.test.ts
+++ b/packages/diagrams/src/__tests__/edge-path.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { horizontalCubicEdgePath, EDGE_MIN_HANDLE } from '../edge-path.js';
+
+describe('horizontalCubicEdgePath', () => {
+  // A short horizontal edge: |dx|=40 < EDGE_MIN_HANDLE*2, |dy|=0, so the
+  // base handle is the floor (64).
+  const sx = 0, sy = 0, tx = 40, ty = 0;
+
+  it('curvature 1 uses the floor handle (historical appearance)', () => {
+    const d = horizontalCubicEdgePath(sx, sy, tx, ty, 1);
+    // handle = max(64, 20, 0) = 64
+    expect(d).toBe(`M0,0 C${EDGE_MIN_HANDLE},0 ${40 - EDGE_MIN_HANDLE},0 40,0`);
+  });
+
+  it('default curvature equals explicit curvature 1', () => {
+    expect(horizontalCubicEdgePath(sx, sy, tx, ty)).toBe(horizontalCubicEdgePath(sx, sy, tx, ty, 1));
+  });
+
+  it('curvature 0 collapses control points onto the endpoints (straight line)', () => {
+    const d = horizontalCubicEdgePath(sx, sy, tx, ty, 0);
+    expect(d).toBe('M0,0 C0,0 40,0 40,0');
+  });
+
+  it('changing curvature changes the path output (AC#6)', () => {
+    const a = horizontalCubicEdgePath(sx, sy, tx, ty, 1);
+    const b = horizontalCubicEdgePath(sx, sy, tx, ty, 2);
+    expect(b).not.toBe(a);
+  });
+
+  it('larger curvature pushes the control handles further out', () => {
+    const handleOf = (curv: number) => {
+      // First control point x is `sx + handle`; parse it back out.
+      const m = horizontalCubicEdgePath(0, 0, 40, 0, curv).match(/^M0,0 C(-?\d+(?:\.\d+)?),0/);
+      return Number(m![1]);
+    };
+    expect(handleOf(2)).toBeGreaterThan(handleOf(1));
+    expect(handleOf(0.5)).toBeLessThan(handleOf(1));
+    expect(handleOf(2)).toBe(2 * EDGE_MIN_HANDLE);
+  });
+
+  it('handle scales with the vertical span for stacked nodes', () => {
+    // |dy|=200 ⇒ base handle = max(64, 0, 160) = 160; ×1 = 160.
+    const d = horizontalCubicEdgePath(0, 0, 0, 200, 1);
+    expect(d).toBe('M0,0 C160,0 -160,200 0,200');
+  });
+});

--- a/packages/diagrams/src/edge-path.ts
+++ b/packages/diagrams/src/edge-path.ts
@@ -1,0 +1,44 @@
+// Shared edge geometry for the static notation previews (Goals, FGCA, FGA,
+// Activities). All four render dependency/relationship edges as a single cubic
+// Bézier with horizontal control handles: each control point shares its
+// endpoint's Y, so the tangent is horizontal at both ends and the marker-end
+// arrow reads as perpendicular to the node's vertical edge.
+//
+// Pulling the path math here (rather than duplicating it inline in each
+// preview) makes the configurable-curvature behaviour (vkgeorgia/strategy#76)
+// unit-testable — the extension has no test harness.
+
+/**
+ * Base handle length floor + span factors. The handle grows with both the
+ * horizontal and vertical span so the curve stays visibly horizontal long
+ * enough for the arrowhead to sit flush against the line.
+ */
+export const EDGE_MIN_HANDLE = 64;
+const DX_FACTOR = 0.5;
+const DY_FACTOR = 0.8;
+
+/** Multiplier applied to the base handle length. 1 = historical appearance. */
+export const DEFAULT_EDGE_CURVATURE = 1;
+
+/**
+ * Builds the SVG `d` for a horizontal-tangent cubic Bézier from (sx,sy) to
+ * (tx,ty).
+ *
+ * `curvature` scales the control-handle length:
+ *   - 0   → control points collapse onto the endpoints ⇒ a straight line.
+ *   - 1   → the historical curve (no visual change from before #76).
+ *   - >1  → progressively stronger arc.
+ */
+export function horizontalCubicEdgePath(
+  sx: number,
+  sy: number,
+  tx: number,
+  ty: number,
+  curvature: number = DEFAULT_EDGE_CURVATURE,
+): string {
+  const dx = tx - sx;
+  const dy = ty - sy;
+  const baseHandle = Math.max(EDGE_MIN_HANDLE, Math.abs(dx) * DX_FACTOR, Math.abs(dy) * DY_FACTOR);
+  const handle = baseHandle * curvature;
+  return `M${sx},${sy} C${sx + handle},${sy} ${tx - handle},${ty} ${tx},${ty}`;
+}


### PR DESCRIPTION
## What

Configurable **edge curvature** for the **Goals, FGCA, FGA and Activities** previews — one combined PR. Settings-driven, mirroring the #75 spacing pattern (**Path 4**): library API + per-notation persistence + `onDidChangeConfiguration` re-render. Previews keep `enableScripts: false`; the in-preview slider is deferred to the joint **PR2** `enableScripts` call for #75/#76/#77.

Defaults match today's appearance **exactly** (curvature `1` produces a byte-identical path) — no visual change unless the user touches the control.

**Scope:** all four notations, per #76's scope-update comment (Activities CPM dependency arrows included).

## How

**Library (`@transitrix/diagrams`)**
- New `packages/diagrams/src/edge-path.ts` → `horizontalCubicEdgePath(sx, sy, tx, ty, curvature)`. All four previews already drew edges with the *identical* cubic-Bézier + horizontal-handle formula (`handle = max(64, |dx|·0.5, |dy|·0.8)`); this consolidates it into one **tested** helper.
- `curvature` scales the control-handle length — a single natural parameter (AC#3):
  - `0` → control points collapse onto the endpoints ⇒ **straight line**
  - `1` → the historical curve (default, unchanged)
  - `>1` → progressively stronger arc

**Extension**
- New settings `transitrix.curvature.<goals|fgca|fga|activities>` — bounds 0–3, default 1, **independent per notation**. Persisted via VS Code configuration.
- Each preview routes its edge paths through the shared helper with the configured curvature.
- A **"Curvature…"** toolbar link + `transitrixStudio.openCurvatureSettings` command opens Settings filtered to the controls; added to each preview's `enableCommandUris`.
- `onDidChangeConfiguration` now re-renders the four previews on `transitrix.spacing` **or** `transitrix.curvature` changes.

## Tests (AC#6)
- `curvature 1` = floor-handle path (historical); default == explicit `1`.
- `curvature 0` collapses control points → straight line.
- Changing curvature changes the path output; handle scales monotonically and with the vertical span.
- Full diagrams suite (464) + core (225) green; `tsc` core + extension clean.

## Notes
- Shares the persistence + toolbar-link + re-render machinery introduced in #75 (now merged), so the toolbar carries both **Spacing…** and **Curvature…** links.
- Coordinates with #77 (scope filter): same control-panel/persistence pattern; no overlap in this PR.

Do not merge — Valerii gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
