### PR TITLE
feat(scope): scope-to-subtree/level filter for Goals/FGA/FGCA previews (#77 PR1)

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -182,6 +182,39 @@
           "maximum": 3,
           "default": 1,
           "description": "Activities preview: CPM dependency-arrow curvature. 0 = straight lines, 1 = default, higher = stronger arc."
+        },
+        "transitrix.scope.goals.rootId": {
+          "type": "string",
+          "default": "",
+          "description": "Goals preview: scope to a single goal's subtree. Set the goal id to show only that goal and its descendants. Empty = show all. Takes precedence over the level cap."
+        },
+        "transitrix.scope.goals.maxLevel": {
+          "type": "integer",
+          "minimum": -1,
+          "default": -1,
+          "description": "Goals preview: scope to a level cap. Show only goals at this level and above (e.g. 1 = top two levels). -1 = no cap. Ignored when a scope root id is set."
+        },
+        "transitrix.scope.fgca.rootId": {
+          "type": "string",
+          "default": "",
+          "description": "FGCA preview: scope to a single goal. Set the goal id to show only that goal plus the factors/changes/activities connected to it. Empty = show all. Takes precedence over the level cap."
+        },
+        "transitrix.scope.fgca.maxLevel": {
+          "type": "integer",
+          "minimum": -1,
+          "default": -1,
+          "description": "FGCA preview: scope to a goal-level cap. Show only goals at this level and above, plus their connected factors/changes/activities. -1 = no cap. Ignored when a scope root id is set."
+        },
+        "transitrix.scope.fga.rootId": {
+          "type": "string",
+          "default": "",
+          "description": "FGA preview: scope to a single goal. Set the goal id to show only that goal plus the factors/activities connected to it. Empty = show all. Takes precedence over the level cap."
+        },
+        "transitrix.scope.fga.maxLevel": {
+          "type": "integer",
+          "minimum": -1,
+          "default": -1,
+          "description": "FGA preview: scope to a goal-level cap. Show only goals at this level and above, plus their connected factors/activities. -1 = no cap. Ignored when a scope root id is set."
         }
       }
     },
@@ -540,6 +573,12 @@
         "title": "Transitrix: Open diagram edge-curvature settings",
         "category": "Transitrix",
         "icon": "$(settings-gear)"
+      },
+      {
+        "command": "transitrixStudio.openScopeSettings",
+        "title": "Transitrix: Open diagram scope (level/root) settings",
+        "category": "Transitrix",
+        "icon": "$(filter)"
       }
     ],
     "menus": {

--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -84,6 +84,12 @@ export interface DiagramFrameOpts {
    * opt-in contract as `spacingCommand`.
    */
   curvatureCommand?: string;
+  /**
+   * Command ID for the "Scope…" toolbar link (opens Settings filtered to the
+   * per-notation level/root scope controls — vkgeorgia/strategy#77). Same
+   * opt-in contract as `spacingCommand`.
+   */
+  scopeCommand?: string;
 }
 
 function escXml(s: string): string {
@@ -276,7 +282,7 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
     errorMsg = '', warnings = [],
     themeId = 'transitrix', extraStyles = '', fixPrompt = '',
     title, subtitle, version, date,
-    saveSvgCommand, savePngCommand, copyPngCommand, spacingCommand, curvatureCommand,
+    saveSvgCommand, savePngCommand, copyPngCommand, spacingCommand, curvatureCommand, scopeCommand,
   } = opts;
 
   const canvasContent = bodyContent ?? svgContent;
@@ -320,10 +326,11 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
   const showSaveSvg = Boolean(canvasContent) && Boolean(saveSvgCommand);
   const showSavePng = Boolean(canvasContent) && Boolean(savePngCommand);
   const showCopyPng = Boolean(canvasContent) && Boolean(copyPngCommand);
-  // Spacing/curvature links show whenever the preview opts in — including error
-  // renders, so the user can adjust the settings and trigger a re-render.
+  // Spacing/curvature/scope links show whenever the preview opts in — including
+  // error renders, so the user can adjust the settings and trigger a re-render.
   const showSpacing = Boolean(spacingCommand);
   const showCurvature = Boolean(curvatureCommand);
+  const showScope = Boolean(scopeCommand);
   // Zoom control gates on the same signal as Save .svg — the six vector
   // previews opt in by passing a saveSvgCommand. HTML catalogues are out of
   // scope per the orchestrator's call on issue #30.
@@ -359,6 +366,9 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
   }
   if (showCurvature) {
     actionParts.push(`<a href="command:${escXml(curvatureCommand!)}" class="toolbar-btn" title="Adjust the edge curvature for this notation in Settings">Curvature…</a>`);
+  }
+  if (showScope) {
+    actionParts.push(`<a href="command:${escXml(scopeCommand!)}" class="toolbar-btn" title="Scope this preview to a level cap or a single goal's subtree in Settings">Scope…</a>`);
   }
   const toolbarRight = actionParts.length > 0
     ? `<div class="toolbar-actions">${actionParts.join('')}</div>`

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -26,6 +26,8 @@ import {
   SPACING_CONFIG_SECTION,
   OPEN_CURVATURE_SETTINGS_COMMAND,
   CURVATURE_CONFIG_SECTION,
+  OPEN_SCOPE_SETTINGS_COMMAND,
+  SCOPE_CONFIG_SECTION,
 } from './spacing-config.js';
 
 function isGoalsFile(doc: vscode.TextDocument): boolean {
@@ -298,13 +300,20 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     vscode.commands.registerCommand(OPEN_CURVATURE_SETTINGS_COMMAND, () =>
       vscode.commands.executeCommand('workbench.action.openSettings', CURVATURE_CONFIG_SECTION),
     ),
-    // Re-render the spacing/curvature-aware previews when a gap or curvature
-    // setting changes — the settings-driven persistence mechanism
-    // (vkgeorgia/strategy#75, #76). Previews keep `enableScripts: false`; the
-    // change is applied host-side by rebuilding the webview HTML from the
+    vscode.commands.registerCommand(OPEN_SCOPE_SETTINGS_COMMAND, () =>
+      vscode.commands.executeCommand('workbench.action.openSettings', SCOPE_CONFIG_SECTION),
+    ),
+    // Re-render the spacing/curvature/scope-aware previews when a gap, curvature
+    // or scope setting changes — the settings-driven persistence mechanism
+    // (vkgeorgia/strategy#75, #76, #77). Previews keep `enableScripts: false`;
+    // the change is applied host-side by rebuilding the webview HTML from the
     // tracked document.
     vscode.workspace.onDidChangeConfiguration((e) => {
-      if (!e.affectsConfiguration(SPACING_CONFIG_SECTION) && !e.affectsConfiguration(CURVATURE_CONFIG_SECTION)) return;
+      if (
+        !e.affectsConfiguration(SPACING_CONFIG_SECTION) &&
+        !e.affectsConfiguration(CURVATURE_CONFIG_SECTION) &&
+        !e.affectsConfiguration(SCOPE_CONFIG_SECTION)
+      ) return;
       void goalsPreview.refreshConfig();
       void fgcaPreview.refreshConfig();
       void fgaPreview.refreshConfig();

--- a/extension/src/fgca-preview.ts
+++ b/extension/src/fgca-preview.ts
@@ -15,8 +15,9 @@ import {
 } from '../../packages/diagrams/src/fgca/preview-layout.js';
 import { horizontalCubicEdgePath, DEFAULT_EDGE_CURVATURE } from '../../packages/diagrams/src/edge-path.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
+import { checkScopeRoot, type Scope } from '../../packages/diagrams/src/scope.js';
 import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
-import { readSpacing, readCurvature, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND } from './spacing-config.js';
+import { readSpacing, readCurvature, readScope, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND } from './spacing-config.js';
 
 // ── Inline render types ─────────────────────────────────────────────────────
 //
@@ -64,7 +65,7 @@ function escXml(s: string): string {
 function buildSvg(
   doc: FGCADoc,
   hideChanges = false,
-  opts: { colGap?: number; rowGap?: number; curvature?: number } = {},
+  opts: { colGap?: number; rowGap?: number; curvature?: number; scope?: Scope } = {},
   heading?: string,
   filename?: string,
   date?: string,
@@ -75,6 +76,7 @@ function buildSvg(
     hideChanges,
     colGap: opts.colGap,
     rowGap: opts.rowGap,
+    scope: opts.scope,
   });
   const showTitle = heading != null && filename != null && date != null;
   const titleH = showTitle ? TITLE_BLOCK_H : 0;
@@ -158,7 +160,7 @@ export class FGCAPreview {
         'fgcaPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveFGCAAsSvg', 'transitrixStudio.saveFGCAAsPng', 'transitrixStudio.copyFGCAAsPng', OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND] },
+        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveFGCAAsSvg', 'transitrixStudio.saveFGCAAsPng', 'transitrixStudio.copyFGCAAsPng', OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND] },
       );
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
     }
@@ -202,7 +204,11 @@ export class FGCAPreview {
         // inline FGCADoc / buildSvg here accept both forms (number | string
         // unions) — pass through.
         const gaps = readSpacing('fgca', { horizontalGap: FGCA_DEFAULT_COL_GAP, verticalGap: FGCA_DEFAULT_ROW_GAP });
-        svgContent = buildSvg(v.parsed as unknown as FGCADoc, false, { colGap: gaps.horizontalGap, rowGap: gaps.verticalGap, curvature: readCurvature('fgca') }, 'FGCA — Factor → Goal → Change → Activity', filename, docDate, docVersion);
+        const scope = readScope('fgca');
+        const fgcaDoc = v.parsed as unknown as FGCADoc;
+        const scopeWarning = checkScopeRoot(scope, fgcaDoc.goals.map(g => g.id));
+        if (scopeWarning) warnings.push(`${scopeWarning.code}: ${scopeWarning.message}`);
+        svgContent = buildSvg(fgcaDoc, false, { colGap: gaps.horizontalGap, rowGap: gaps.verticalGap, curvature: readCurvature('fgca'), scope }, 'FGCA — Factor → Goal → Change → Activity', filename, docDate, docVersion);
       }
     } catch (e) {
       errorMsg = (e as Error).message ?? 'Parse error';
@@ -221,6 +227,7 @@ export class FGCAPreview {
       copyPngCommand: 'transitrixStudio.copyFGCAAsPng',
       spacingCommand: OPEN_SPACING_SETTINGS_COMMAND,
       curvatureCommand: OPEN_CURVATURE_SETTINGS_COMMAND,
+      scopeCommand: OPEN_SCOPE_SETTINGS_COMMAND,
     });
   }
 
@@ -284,7 +291,7 @@ export class FGAPreview {
         'fgaPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveFGAAsSvg', 'transitrixStudio.saveFGAAsPng', 'transitrixStudio.copyFGAAsPng', OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND] },
+        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveFGAAsSvg', 'transitrixStudio.saveFGAAsPng', 'transitrixStudio.copyFGAAsPng', OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND] },
       );
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
     }
@@ -325,7 +332,11 @@ export class FGAPreview {
       } else {
         // FGA shares FGCA's FLAT shape; just hide the (absent) Changes column.
         const gaps = readSpacing('fga', { horizontalGap: FGCA_DEFAULT_COL_GAP, verticalGap: FGCA_DEFAULT_ROW_GAP });
-        svgContent = buildSvg(v.parsed as unknown as FGCADoc, true, { colGap: gaps.horizontalGap, rowGap: gaps.verticalGap, curvature: readCurvature('fga') }, 'FGA — Factor → Goal → Activity', filename, docDate, docVersion);
+        const scope = readScope('fga');
+        const fgaDoc = v.parsed as unknown as FGCADoc;
+        const scopeWarning = checkScopeRoot(scope, fgaDoc.goals.map(g => g.id));
+        if (scopeWarning) warnings.push(`${scopeWarning.code}: ${scopeWarning.message}`);
+        svgContent = buildSvg(fgaDoc, true, { colGap: gaps.horizontalGap, rowGap: gaps.verticalGap, curvature: readCurvature('fga'), scope }, 'FGA — Factor → Goal → Activity', filename, docDate, docVersion);
       }
     } catch (e) {
       errorMsg = (e as Error).message ?? 'Parse error';
@@ -344,6 +355,7 @@ export class FGAPreview {
       copyPngCommand: 'transitrixStudio.copyFGAAsPng',
       spacingCommand: OPEN_SPACING_SETTINGS_COMMAND,
       curvatureCommand: OPEN_CURVATURE_SETTINGS_COMMAND,
+      scopeCommand: OPEN_SCOPE_SETTINGS_COMMAND,
     });
   }
 

--- a/extension/src/goals-preview.ts
+++ b/extension/src/goals-preview.ts
@@ -12,7 +12,8 @@ import {
 import { parseCanonicalGoals } from '../../packages/diagrams/src/goals/parse-canonical.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 import { horizontalCubicEdgePath, DEFAULT_EDGE_CURVATURE } from '../../packages/diagrams/src/edge-path.js';
-import { readSpacing, readCurvature, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND } from './spacing-config.js';
+import { checkScopeRoot } from '../../packages/diagrams/src/scope.js';
+import { readSpacing, readCurvature, readScope, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND } from './spacing-config.js';
 
 // ── SVG renderer ─────────────────────────────────────────────────────────────
 //
@@ -108,7 +109,7 @@ export class GoalsPreview {
         'goalsPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveGoalsAsSvg', 'transitrixStudio.saveGoalsAsPng', 'transitrixStudio.copyGoalsAsPng', OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND] },
+        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveGoalsAsSvg', 'transitrixStudio.saveGoalsAsPng', 'transitrixStudio.copyGoalsAsPng', OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND] },
       );
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
     }
@@ -149,11 +150,15 @@ export class GoalsPreview {
         const docVersion = typeof meta.version === 'string' ? meta.version : undefined;
         const docDate = typeof meta.date === 'string' ? meta.date : todayIso();
         const gaps = readSpacing('goals', { horizontalGap: RANK_SEP, verticalGap: NODE_SEP });
+        const scope = readScope('goals');
+        const scopeWarning = checkScopeRoot(scope, v.parsed.goals.map(g => g.id));
+        if (scopeWarning) warnings.push(`${scopeWarning.code}: ${scopeWarning.message}`);
         const layout = layoutGoalTree(v.parsed, {
           nodeWidth: NODE_W,
           nodeHeight: NODE_H,
           rankSep: gaps.horizontalGap,
           nodeSep: gaps.verticalGap,
+          scope,
         });
         svgContent = layoutToSvg(layout, treeName, filename, docDate, docVersion, readCurvature('goals'));
       }
@@ -174,6 +179,7 @@ export class GoalsPreview {
       copyPngCommand: 'transitrixStudio.copyGoalsAsPng',
       spacingCommand: OPEN_SPACING_SETTINGS_COMMAND,
       curvatureCommand: OPEN_CURVATURE_SETTINGS_COMMAND,
+      scopeCommand: OPEN_SCOPE_SETTINGS_COMMAND,
     });
   }
 

--- a/extension/src/spacing-config.ts
+++ b/extension/src/spacing-config.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import type { Scope } from '../../packages/diagrams/src/scope.js';
 
 // Per-notation spacing controls (vkgeorgia/strategy#75). PR1 persists the
 // chosen gaps in VS Code configuration (`transitrix.spacing.<notation>.*`),
@@ -51,3 +52,31 @@ export const CURVATURE_CONFIG_SECTION = 'transitrix.curvature';
 
 /** Command that opens Settings filtered to the curvature controls. */
 export const OPEN_CURVATURE_SETTINGS_COMMAND = 'transitrixStudio.openCurvatureSettings';
+
+// ── Scope filter (vkgeorgia/strategy#77) ────────────────────────────────────
+//
+// Trim a preview to a subtree root or a level cap. Same PR1 persistence
+// pattern as spacing: settings-backed, re-rendered on change. The in-preview
+// root-picker dropdown is deferred to the joint enableScripts PR2.
+
+export type ScopeNotation = 'goals' | 'fgca' | 'fga';
+
+/**
+ * Resolves the configured scope for a notation. A non-empty `rootId` wins over
+ * a `maxLevel` cap (the two settings model the "only one mode active at a time"
+ * rule from #77); both unset → 'all'.
+ */
+export function readScope(notation: ScopeNotation): Scope {
+  const cfg = vscode.workspace.getConfiguration('transitrix');
+  const rootId = (cfg.get<string>(`scope.${notation}.rootId`, '') ?? '').trim();
+  if (rootId) return { mode: 'root', rootGoalId: rootId };
+  const maxLevel = cfg.get<number>(`scope.${notation}.maxLevel`, -1);
+  if (typeof maxLevel === 'number' && maxLevel >= 0) return { mode: 'level', maxLevel };
+  return { mode: 'all' };
+}
+
+/** Config section that, when changed, re-renders scope-aware previews. */
+export const SCOPE_CONFIG_SECTION = 'transitrix.scope';
+
+/** Command that opens Settings filtered to the scope controls. */
+export const OPEN_SCOPE_SETTINGS_COMMAND = 'transitrixStudio.openScopeSettings';

--- a/packages/diagrams/src/__tests__/scope.test.ts
+++ b/packages/diagrams/src/__tests__/scope.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { checkScopeRoot, SCOPE_MISSING_ROOT_CODE, type Scope } from '../scope.js';
+
+describe('checkScopeRoot', () => {
+  it('returns null for non-root scopes', () => {
+    expect(checkScopeRoot({ mode: 'all' }, [1, 2])).toBeNull();
+    expect(checkScopeRoot({ mode: 'level', maxLevel: 1 }, [1, 2])).toBeNull();
+  });
+
+  it('returns null when the root id is present (numeric ids compared as strings)', () => {
+    const scope: Scope = { mode: 'root', rootGoalId: '2' };
+    expect(checkScopeRoot(scope, [1, 2, 3])).toBeNull();
+  });
+
+  it('returns a SCOPE-001 warning when the root id is absent', () => {
+    const scope: Scope = { mode: 'root', rootGoalId: '99' };
+    const w = checkScopeRoot(scope, [1, 2, 3]);
+    expect(w).not.toBeNull();
+    expect(w!.code).toBe(SCOPE_MISSING_ROOT_CODE);
+    expect(w!.message).toContain('99');
+  });
+
+  it('handles string goal ids', () => {
+    expect(checkScopeRoot({ mode: 'root', rootGoalId: 'g1' }, ['g1', 'g2'])).toBeNull();
+    expect(checkScopeRoot({ mode: 'root', rootGoalId: 'gX' }, ['g1', 'g2'])).not.toBeNull();
+  });
+});

--- a/packages/diagrams/src/fgca/__tests__/preview-layout.test.ts
+++ b/packages/diagrams/src/fgca/__tests__/preview-layout.test.ts
@@ -75,4 +75,50 @@ describe('layoutFGCAPreview', () => {
     };
     expect(gapOf(120)).toBeGreaterThan(gapOf(20));
   });
+
+  // vkgeorgia/strategy#77 — scope filtering. FGCA goals are flat, so 'root'
+  // selects the single matching goal plus the factors/changes/activities that
+  // touch it.
+  describe('scope', () => {
+    const idsOf = (layout: ReturnType<typeof layoutFGCAPreview>) => new Set(layout.nodes.map(n => n.id));
+
+    it("mode 'root' keeps only the root goal and what connects to it", () => {
+      // root 10 → factor 1 (referenced by G10), change 20 (goal_id 10),
+      // activity 30 (via change 20). G11/F2/A31 are dropped.
+      const layout = layoutFGCAPreview(doc, { scope: { mode: 'root', rootGoalId: '10' } });
+      expect(idsOf(layout)).toEqual(new Set(['factor_1', 'goal_10', 'change_20', 'activity_30']));
+    });
+
+    it("mode 'root' filters factors and activities to those touching the visible goal", () => {
+      // root 11 → factor 2, activity 31 (direct goal link); no change touches G11.
+      const layout = layoutFGCAPreview(doc, { scope: { mode: 'root', rootGoalId: '11' } });
+      expect(idsOf(layout)).toEqual(new Set(['factor_2', 'goal_11', 'activity_31']));
+      // F1, A30, C20 (which only touch the hidden G10) are excluded.
+      expect(layout.nodes.some(n => n.id === 'factor_1')).toBe(false);
+      expect(layout.nodes.some(n => n.id === 'activity_30')).toBe(false);
+    });
+
+    it("mode 'level' trims goals above the cap and their connections", () => {
+      const leveled: FGCAPreviewDoc = {
+        factors: [{ id: 1, name: 'F1' }, { id: 2, name: 'F2' }],
+        goals: [
+          { id: 10, name: 'G1', level: 0, factor: [{ id: 1 }] },
+          { id: 11, name: 'G2', level: 1, factor: [{ id: 2 }] },
+        ],
+        changes: [],
+        activities: [
+          { id: 30, name: 'A1', goal_id: 10 },
+          { id: 31, name: 'A2', goal_id: 11 },
+        ],
+      };
+      const layout = layoutFGCAPreview(leveled, { scope: { mode: 'level', maxLevel: 0 } });
+      expect(idsOf(layout)).toEqual(new Set(['factor_1', 'goal_10', 'activity_30']));
+    });
+
+    it("mode 'root' returns an empty layout when the root is absent", () => {
+      const layout = layoutFGCAPreview(doc, { scope: { mode: 'root', rootGoalId: '999' } });
+      expect(layout.nodes).toHaveLength(0);
+      expect(layout.edges).toHaveLength(0);
+    });
+  });
 });

--- a/packages/diagrams/src/fgca/index.ts
+++ b/packages/diagrams/src/fgca/index.ts
@@ -2,6 +2,7 @@ export { buildFGCALayout, NODE_WIDTH, NODE_HEIGHT, COLUMN_GAP, ROW_GAP, COLUMN_B
 export type { FGCALayoutInput } from "./layout";
 export {
   layoutFGCAPreview,
+  selectScopedFGCA,
   FGCA_NODE_W,
   FGCA_NODE_H,
   FGCA_HEADER_H,

--- a/packages/diagrams/src/fgca/preview-layout.ts
+++ b/packages/diagrams/src/fgca/preview-layout.ts
@@ -7,6 +7,8 @@
 //
 // No React, no DOM, no vscode. Safe to call in Node.js or a test environment.
 
+import type { Scope } from '../scope.js';
+
 export type FGCAPreviewColumn = 'factor' | 'goal' | 'change' | 'activity';
 
 export interface FGCAPreviewFactor {
@@ -46,6 +48,49 @@ export interface FGCAPreviewLayoutOptions {
   colGap?: number;
   /** Vertical gap (px) between stacked nodes within a column. Default matches the historical hardcoded value. */
   rowGap?: number;
+  /** Trim to a level cap or a single root goal (vkgeorgia/strategy#77). Defaults to 'all'. */
+  scope?: Scope;
+}
+
+/**
+ * Trims an FGCA/FGA doc to a scope (vkgeorgia/strategy#77).
+ *
+ * FGCA/FGA goals are flat (no parent_id), so:
+ *   - 'level' → goals with `(level ?? 0) <= maxLevel`.
+ *   - 'root'  → the single goal whose id matches `rootGoalId` (empty when absent).
+ *
+ * Factors, changes and activities are then kept only when they touch a visible
+ * goal: a factor referenced by a visible goal, a change whose `goal_id` is
+ * visible, an activity bound to a visible goal directly or via a visible
+ * change. Pure and exported so an access-control layer can reuse it.
+ */
+export function selectScopedFGCA(doc: FGCAPreviewDoc, scope: Scope): FGCAPreviewDoc {
+  if (scope.mode === 'all') return doc;
+
+  const visibleGoals =
+    scope.mode === 'level'
+      ? doc.goals.filter(g => (g.level ?? 0) <= scope.maxLevel)
+      : doc.goals.filter(g => String(g.id) === scope.rootGoalId);
+
+  const visibleGoalIds = new Set(visibleGoals.map(g => g.id));
+
+  const changes = doc.changes ?? [];
+  const visibleChanges = changes.filter(c => visibleGoalIds.has(c.goal_id));
+  const activityIdsViaChange = new Set(visibleChanges.flatMap(c => c.activity_ids));
+
+  const visibleActivities = doc.activities.filter(
+    a => (a.goal_id != null && visibleGoalIds.has(a.goal_id)) || activityIdsViaChange.has(a.id),
+  );
+
+  const factorIds = new Set(visibleGoals.flatMap(g => (g.factor ?? []).map(f => f.id)));
+  const visibleFactors = doc.factors.filter(f => factorIds.has(f.id));
+
+  return {
+    factors: visibleFactors,
+    goals: visibleGoals,
+    changes: doc.changes === undefined ? undefined : visibleChanges,
+    activities: visibleActivities,
+  };
 }
 
 export interface FGCAPreviewNode {
@@ -84,14 +129,18 @@ export const FGCA_DEFAULT_COL_GAP = 160;
 export const FGCA_DEFAULT_ROW_GAP = 20;
 
 export function layoutFGCAPreview(
-  doc: FGCAPreviewDoc,
+  inputDoc: FGCAPreviewDoc,
   options: FGCAPreviewLayoutOptions = {},
 ): FGCAPreviewLayout {
   const {
     hideChanges = false,
     colGap = FGCA_DEFAULT_COL_GAP,
     rowGap = FGCA_DEFAULT_ROW_GAP,
+    scope = { mode: 'all' },
   } = options;
+
+  // Trim to scope first; everything below lays out the visible subset only.
+  const doc = selectScopedFGCA(inputDoc, scope);
 
   const colStride = FGCA_NODE_W + colGap;
   const cols: FGCAPreviewColumn[] = hideChanges

--- a/packages/diagrams/src/goals/__tests__/layout.test.ts
+++ b/packages/diagrams/src/goals/__tests__/layout.test.ts
@@ -144,4 +144,32 @@ describe('layoutGoalTree', () => {
     };
     expect(() => layoutGoalTree(cyclic)).not.toThrow();
   });
+
+  // vkgeorgia/strategy#77 — scope filtering.
+  describe('scope', () => {
+    const ids = (l: ReturnType<typeof layoutGoalTree>) => l.nodes.map(n => n.id).sort((a, b) => a - b);
+
+    it("mode 'all' matches the baseline", () => {
+      expect(ids(layoutGoalTree(TREE, { scope: { mode: 'all' } }))).toEqual(ids(layoutGoalTree(TREE)));
+    });
+
+    it("mode 'level' trims goals strictly above the cap", () => {
+      // TREE: id1 level0, id2 level1, id3/id4 level2.
+      const layout = layoutGoalTree(TREE, { scope: { mode: 'level', maxLevel: 1 } });
+      expect(ids(layout)).toEqual([1, 2]);
+      expect(layout.nodes.every(n => n.data.level <= 1)).toBe(true);
+    });
+
+    it("mode 'root' keeps the chosen goal and its descendants", () => {
+      // root id2 → itself + children id3, id4.
+      const layout = layoutGoalTree(TREE, { scope: { mode: 'root', rootGoalId: '2' } });
+      expect(ids(layout)).toEqual([2, 3, 4]);
+    });
+
+    it("mode 'root' returns an empty layout when the root is absent", () => {
+      const layout = layoutGoalTree(TREE, { scope: { mode: 'root', rootGoalId: '999' } });
+      expect(layout.nodes).toHaveLength(0);
+      expect(layout.edges).toHaveLength(0);
+    });
+  });
 });

--- a/packages/diagrams/src/goals/index.ts
+++ b/packages/diagrams/src/goals/index.ts
@@ -15,5 +15,5 @@ export type {
 } from './types.js';
 
 export { validateGoalTree } from './validate.js';
-export { layoutGoalTree } from './layout.js';
+export { layoutGoalTree, selectScopedGoals } from './layout.js';
 export { reparent, addChild, deleteWithDescendants, moveToBacklog, restoreFromBacklog } from './mutations.js';

--- a/packages/diagrams/src/goals/layout.ts
+++ b/packages/diagrams/src/goals/layout.ts
@@ -1,9 +1,40 @@
 import type { Goal, GoalTree, LayoutOptions, GoalTreeLayout, LaidOutNode, LaidOutEdge } from './types.js';
+import type { Scope } from '../scope.js';
 
 const DEFAULT_NODE_WIDTH = 250;
 const DEFAULT_NODE_HEIGHT = 80;
 const DEFAULT_RANK_SEP = 80;
 const DEFAULT_NODE_SEP = 40;
+
+/**
+ * Trims a flat goal list to a scope (vkgeorgia/strategy#77).
+ *   - 'level' → goals with `level <= maxLevel`.
+ *   - 'root'  → the root goal (matched by string id) plus all its descendants
+ *               via `parent_id`; an empty list when the root is absent.
+ * Pure and exported so a future access-control layer can reuse it.
+ */
+export function selectScopedGoals(goals: Goal[], scope: Scope): Goal[] {
+  if (scope.mode === 'all') return goals;
+  if (scope.mode === 'level') return goals.filter(g => g.level <= scope.maxLevel);
+
+  // root mode: collect the subtree rooted at rootGoalId (descendants via parent_id).
+  const children = new Map<number, number[]>();
+  for (const g of goals) {
+    if (!children.has(g.parent_id)) children.set(g.parent_id, []);
+    children.get(g.parent_id)!.push(g.id);
+  }
+  const root = goals.find(g => String(g.id) === scope.rootGoalId);
+  if (!root) return [];
+  const keep = new Set<number>();
+  const stack = [root.id];
+  while (stack.length > 0) {
+    const id = stack.pop()!;
+    if (keep.has(id)) continue; // guard against malformed cycles
+    keep.add(id);
+    for (const c of children.get(id) ?? []) stack.push(c);
+  }
+  return goals.filter(g => keep.has(g.id));
+}
 
 export function layoutGoalTree(tree: GoalTree, options: LayoutOptions = {}): GoalTreeLayout {
   const {
@@ -13,10 +44,11 @@ export function layoutGoalTree(tree: GoalTree, options: LayoutOptions = {}): Goa
     nodeSep = DEFAULT_NODE_SEP,
     hideCollapsed = [],
     viewDepth = null,
+    scope = { mode: 'all' },
   } = options;
 
   const hiddenSet = new Set(hideCollapsed);
-  const goals = tree.goals;
+  const goals = selectScopedGoals(tree.goals, scope);
 
   // Build parent→children map
   const children = new Map<number, number[]>();

--- a/packages/diagrams/src/goals/types.ts
+++ b/packages/diagrams/src/goals/types.ts
@@ -48,6 +48,8 @@ export interface MutationResult<T> {
   error?: ValidationError;
 }
 
+import type { Scope } from '../scope.js';
+
 export interface LayoutOptions {
   rankdir?: 'LR' | 'TB';
   nodeWidth?: number;
@@ -56,6 +58,8 @@ export interface LayoutOptions {
   nodeSep?: number;
   hideCollapsed?: number[];
   viewDepth?: number | null;
+  /** Trim the tree to a level cap or a subtree root (vkgeorgia/strategy#77). Defaults to 'all'. */
+  scope?: Scope;
 }
 
 export interface LaidOutNode {

--- a/packages/diagrams/src/scope.ts
+++ b/packages/diagrams/src/scope.ts
@@ -1,0 +1,46 @@
+// Scope filtering for hierarchical / relational previews (Goals, FGA, FGCA).
+//
+// A `Scope` trims what a preview renders to part of the hierarchy:
+//   - 'all'   → everything (default, today's behaviour)
+//   - 'level' → only goals at or below a level cap, plus the factors /
+//               changes / activities that touch a visible goal
+//   - 'root'  → only a chosen goal's subtree (Goals: descendants via
+//               parent_id; FGA/FGCA goals are flat, so the subtree is the
+//               single root goal), plus its connected factors / changes /
+//               activities
+//
+// This is intentionally a small, pure rendering primitive: a role's view in
+// a future access-control layer (DSM) can be expressed as a level cap or a
+// subtree root and reuse exactly this filter. No RBAC here — just the filter.
+
+import type { ValidationWarning } from './validation-types.js';
+
+export type Scope =
+  | { mode: 'all' }
+  | { mode: 'level'; maxLevel: number }
+  | { mode: 'root'; rootGoalId: string };
+
+/** Default scope — render everything. */
+export const SCOPE_ALL: Scope = { mode: 'all' };
+
+/** Warning code emitted when a root-mode scope names a goal that isn't in the document. */
+export const SCOPE_MISSING_ROOT_CODE = 'SCOPE-001';
+
+/**
+ * Returns the SCOPE-001 warning when `scope` is root-mode and `rootGoalId` is
+ * not among the document's goal ids; otherwise null. Goal ids are compared as
+ * strings so numeric (FGCA/Goals) and string ids both work.
+ *
+ * Previews call this to surface the warning in their panel — the layout
+ * functions independently return an empty layout in the same situation.
+ */
+export function checkScopeRoot(scope: Scope, goalIds: Iterable<string | number>): ValidationWarning | null {
+  if (scope.mode !== 'root') return null;
+  for (const id of goalIds) {
+    if (String(id) === scope.rootGoalId) return null;
+  }
+  return {
+    code: SCOPE_MISSING_ROOT_CODE,
+    message: `Scope root goal "${scope.rootGoalId}" was not found in this document — nothing to show. Clear the scope or pick a goal that exists.`,
+  };
+}


### PR DESCRIPTION
## What

Scope-to-subtree / level filter for the **Goals, FGA and FGCA** previews — PR1 (library + settings), following the #75/#76 **Path 4** pattern. The in-preview **root-picker dropdown + level input are deferred to the joint PR2** (the `enableScripts` posture call shared across #75/#76/#77); previews keep `enableScripts: false`.

**Default = show all** → no behaviour change unless the user sets a scope.

## How

**Library (`@transitrix/diagrams`)**
- New `packages/diagrams/src/scope.ts` — the `Scope` type (`{ mode: 'all' } | { mode: 'level'; maxLevel } | { mode: 'root'; rootGoalId }`), `checkScopeRoot()` (emits **SCOPE-001** when a root-mode id is absent), and the `SCOPE-001` code. A pure rendering primitive that a future access-control layer (DSM role-scoped views) can reuse — the API surface the issue asked to design cleanly now.
- `layoutGoalTree` accepts `options.scope`; `selectScopedGoals` trims by level cap or by subtree (root goal + descendants via `parent_id`; empty when the root is absent).
- `layoutFGCAPreview` accepts `options.scope`; `selectScopedFGCA` picks visible goals (level cap, or the single matching goal — FGCA/FGA goals are flat, no hierarchy) and keeps only the factors/changes/activities that **touch a visible goal** (per AC's inclusion rule).

**Extension**
- New `transitrix.scope.<goals|fgca|fga>.{rootId,maxLevel}` settings, independent per notation. `readScope()` resolves them: a non-empty `rootId` wins over a `maxLevel` cap (models AC's "only one mode active at a time"); both unset → `all`.
- Previews pass the scope into layout and surface **SCOPE-001** in the warnings panel when the configured root is missing (AC#1).
- **"Scope…"** toolbar link + `transitrixStudio.openScopeSettings` command opens the filtered Settings; added to each preview's `enableCommandUris`.
- `onDidChangeConfiguration` re-renders previews on `transitrix.spacing` **or** `transitrix.scope` changes.

## Tests (AC#4)
- `scope`: `checkScopeRoot` across all/level/root, present/absent, string + numeric ids.
- Goals layout: `all` == baseline; level cap trims strictly; root keeps the subtree; absent root → empty layout.
- FGCA preview-layout: root keeps the goal + connected factors/changes/activities; items touching only hidden goals are excluded; level cap; absent root → empty.
- Full diagrams suite (470) + core (225) green; `tsc` core + extension clean.

## Notes
- **Scope:** Goals / FGA / FGCA, per the issue. Activities is **not** in #77.
- **Deferred to PR2** (with #75 sliders / #76 slider): the in-preview Scope control panel — root-picker dropdown (needs the live goal list) + level input. PR1 exposes the same controls as Settings, consistent with the merged #75 and the pending #76 (#81).
- Branches off `main` (has #75). Shares the toolbar-link / persistence / re-render machinery with #76 (#81) — expect a trivial conflict resolution depending on merge order; both only append to the same lists.
- FGA carries its own independent scope state, separate from FGCA.

Do not merge — Valerii gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
