### PR TITLE
feat(activity-card): diagrams types + cross-doc resolver + validator + layout (#134 PR1)

### DIFF
--- a/packages/diagrams/src/activity-card/__tests__/layout.test.ts
+++ b/packages/diagrams/src/activity-card/__tests__/layout.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { layoutActivityCard, ARCHIMATE_CLASS } from '../layout.js';
+import type { ResolvedActivityCard } from '../types.js';
+
+const RESOLVED: ResolvedActivityCard = {
+  cardId: 'ACTIVITY_CARD-EU-PROGRAMME-1',
+  cardDescription: 'Summary',
+  project: {
+    id: 'ACTIVITY-EU-PROGRAMME-1',
+    name: 'EU MDR conformity programme',
+    valid_from: '2026-04-01',
+    start_date: '2026-04-15',
+    end_date: '2027-03-15',
+  },
+  milestones: [
+    { id: 'MILESTONE-CERT-1', name: 'Cert', date: '2027-01-31', deliversChanges: ['CHANGE-EU-COMPLIANCE-1'] },
+  ],
+  motivation: {
+    factors: [{ id: 'FACTOR-EU-MDR-1', name: 'EU MDR regulation' }],
+    goals: [{ id: 'GOAL-EU-MARKET-1', name: 'Access EU market', factorIds: ['FACTOR-EU-MDR-1'] }],
+    changes: [{ id: 'CHANGE-EU-COMPLIANCE-1', name: 'Achieve MDR compliance', goalIds: ['GOAL-EU-MARKET-1'] }],
+  },
+  childActivities: [
+    { id: 'ACTIVITY-EU-CHILD-1', name: 'Notified-body engagement', start_date: '2026-05-01', end_date: '2026-12-01', owner: 'UNIT-REGULATORY' },
+  ],
+};
+
+describe('layoutActivityCard', () => {
+  it('produces all sections with positive geometry', () => {
+    const l = layoutActivityCard(RESOLVED);
+    expect(l.bounds.width).toBeGreaterThan(0);
+    expect(l.bounds.height).toBeGreaterThan(0);
+    expect(l.title.name).toBe('EU MDR conformity programme');
+    expect(l.dateFields).toHaveLength(3);
+    expect(l.dateFields[0]).toMatchObject({ label: 'Initiation', value: '2026-04-01' });
+    expect(l.milestones).toHaveLength(1);
+    expect(l.milestones[0].archimateClass).toBe(ARCHIMATE_CLASS.MILESTONE);
+    expect(l.childActivities[0].archimateClass).toBe(ARCHIMATE_CLASS.ACTIVITY);
+  });
+
+  it('builds F→G and G→C edges', () => {
+    const l = layoutActivityCard(RESOLVED);
+    expect(l.chainEdges).toContainEqual({ sourceId: 'FACTOR-EU-MDR-1', targetId: 'GOAL-EU-MARKET-1' });
+    expect(l.chainEdges).toContainEqual({ sourceId: 'GOAL-EU-MARKET-1', targetId: 'CHANGE-EU-COMPLIANCE-1' });
+  });
+
+  it('renders "—" for absent dates', () => {
+    const l = layoutActivityCard({ ...RESOLVED, project: { id: 'A', name: 'n' } });
+    expect(l.dateFields.map((d) => d.value)).toEqual(['—', '—', '—']);
+  });
+
+  it('handles an empty card without throwing', () => {
+    const l = layoutActivityCard({
+      cardId: 'ACTIVITY_CARD-X-1',
+      project: { id: 'ACTIVITY-X-1', name: 'Empty' },
+      milestones: [],
+      motivation: { factors: [], goals: [], changes: [] },
+      childActivities: [],
+    });
+    expect(l.milestones).toHaveLength(0);
+    expect(l.bounds.height).toBeGreaterThan(0);
+  });
+});

--- a/packages/diagrams/src/activity-card/__tests__/resolver.test.ts
+++ b/packages/diagrams/src/activity-card/__tests__/resolver.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import { resolveActivityCard } from '../resolver.js';
+import type { ActivityCardDoc } from '../types.js';
+
+const CARD: ActivityCardDoc = {
+  notation: 'activity-card',
+  spec_version: '0.1',
+  activity_card: {
+    id: 'ACTIVITY_CARD-EU-PROGRAMME-1',
+    project: 'ACTIVITY-EU-PROGRAMME-1',
+    description: 'Executive summary.',
+    milestones: [
+      { id: 'MILESTONE-CERT-1', name: 'Cert', date: '2027-01-31', delivers_changes: ['CHANGE-EU-COMPLIANCE-1'] },
+    ],
+  },
+};
+
+const ACTIVITIES_DOC = {
+  notation: 'activities',
+  activities: [
+    {
+      id: 'ACTIVITY-EU-PROGRAMME-1',
+      name: 'EU MDR conformity programme',
+      activity_type: 'Project',
+      valid_from: '2026-04-01',
+      valid_to: null,
+      start_date: '2026-04-15',
+      end_date: '2027-03-15',
+      goals: ['GOAL-EU-MARKET-1'],
+      delivers_changes: ['CHANGE-EU-COMPLIANCE-1'],
+    },
+    {
+      id: 'ACTIVITY-EU-CHILD-1',
+      name: 'Notified-body engagement',
+      parent: 'ACTIVITY-EU-PROGRAMME-1',
+      start_date: '2026-05-01',
+      end_date: '2026-12-01',
+      owner: 'UNIT-REGULATORY',
+    },
+    { id: 'ACTIVITY-UNRELATED-1', name: 'Other', parent: 'ACTIVITY-SOMETHING-ELSE-1' },
+  ],
+};
+
+const FGCA_DOC = {
+  notation: 'fgca',
+  id: 'FGCA-EU-1',
+  name: 'EU chain',
+  factors: [{ id: 'FACTOR-EU-MDR-1', name: 'EU MDR regulation' }],
+  goals: [{ id: 'GOAL-EU-MARKET-1', name: 'Access EU market', factors: ['FACTOR-EU-MDR-1'] }],
+  changes: [{ id: 'CHANGE-EU-COMPLIANCE-1', name: 'Achieve MDR compliance', goals: ['GOAL-EU-MARKET-1'] }],
+};
+
+const sources = { activitiesDocs: [ACTIVITIES_DOC], fgcaDocs: [FGCA_DOC] };
+
+describe('resolveActivityCard', () => {
+  it('resolves a full card', () => {
+    const r = resolveActivityCard(CARD, sources);
+    expect(r.valid).toBe(true);
+    const c = r.resolved!;
+    expect(c.project.name).toBe('EU MDR conformity programme');
+    expect(c.project.valid_from).toBe('2026-04-01');
+    expect(c.project.start_date).toBe('2026-04-15');
+    expect(c.milestones).toHaveLength(1);
+    expect(c.motivation.factors.map((f) => f.id)).toEqual(['FACTOR-EU-MDR-1']);
+    expect(c.motivation.goals.map((g) => g.id)).toEqual(['GOAL-EU-MARKET-1']);
+    expect(c.motivation.changes.map((ch) => ch.id)).toEqual(['CHANGE-EU-COMPLIANCE-1']);
+    // only the activity whose parent = the project
+    expect(c.childActivities.map((a) => a.id)).toEqual(['ACTIVITY-EU-CHILD-1']);
+  });
+
+  it('PC-001 when the project activity is absent', () => {
+    const r = resolveActivityCard(CARD, { activitiesDocs: [], fgcaDocs: [FGCA_DOC] });
+    expect(r.valid).toBe(false);
+    expect(r.errors.some((e) => e.code === 'PC-001')).toBe(true);
+  });
+
+  it('PC-002 when the activity is not a Project', () => {
+    const acts = {
+      ...ACTIVITIES_DOC,
+      activities: [{ ...ACTIVITIES_DOC.activities[0], activity_type: 'Task' }],
+    };
+    const r = resolveActivityCard(CARD, { activitiesDocs: [acts], fgcaDocs: [FGCA_DOC] });
+    expect(r.errors.some((e) => e.code === 'PC-002')).toBe(true);
+  });
+
+  it('PC-003 when a milestone change is not in the project changes', () => {
+    const card: ActivityCardDoc = {
+      ...CARD,
+      activity_card: {
+        ...CARD.activity_card,
+        milestones: [{ id: 'MILESTONE-X-1', name: 'x', date: '2027-01-01', delivers_changes: ['CHANGE-NOT-THERE-1'] }],
+      },
+    };
+    const r = resolveActivityCard(card, sources);
+    expect(r.errors.some((e) => e.code === 'PC-003')).toBe(true);
+  });
+
+  it('PC-004 warns when a milestone falls outside the lifecycle window', () => {
+    const acts = {
+      ...ACTIVITIES_DOC,
+      activities: [{ ...ACTIVITIES_DOC.activities[0], valid_to: '2026-12-31' }],
+    };
+    const r = resolveActivityCard(CARD, { activitiesDocs: [acts], fgcaDocs: [FGCA_DOC] });
+    expect(r.valid).toBe(true);
+    expect(r.warnings.some((w) => w.code === 'PC-004')).toBe(true);
+  });
+
+  it('LIFECYCLE-001 when valid_from is missing', () => {
+    const acts = {
+      ...ACTIVITIES_DOC,
+      activities: [{ ...ACTIVITIES_DOC.activities[0], valid_from: undefined }],
+    };
+    const r = resolveActivityCard(CARD, { activitiesDocs: [acts], fgcaDocs: [FGCA_DOC] });
+    expect(r.errors.some((e) => e.code === 'LIFECYCLE-001')).toBe(true);
+  });
+
+  it('LIFECYCLE-003 when valid_to precedes valid_from', () => {
+    const acts = {
+      ...ACTIVITIES_DOC,
+      activities: [{ ...ACTIVITIES_DOC.activities[0], valid_to: '2025-01-01' }],
+    };
+    const r = resolveActivityCard(CARD, { activitiesDocs: [acts], fgcaDocs: [FGCA_DOC] });
+    expect(r.errors.some((e) => e.code === 'LIFECYCLE-003')).toBe(true);
+  });
+
+  it('warns and omits when a change is not found in any FGCA doc', () => {
+    const r = resolveActivityCard(CARD, { activitiesDocs: [ACTIVITIES_DOC], fgcaDocs: [] });
+    expect(r.valid).toBe(true);
+    expect(r.resolved!.motivation.changes).toHaveLength(0);
+    expect(r.warnings.some((w) => w.code === 'PC-001')).toBe(true);
+  });
+
+  it('does not crash on malformed sibling docs', () => {
+    const r = resolveActivityCard(CARD, {
+      activitiesDocs: [null, 'x', { activities: [null, 42, ACTIVITIES_DOC.activities[0]] }],
+      fgcaDocs: [null, { goals: [null] }],
+    });
+    expect(r.valid).toBe(true);
+  });
+});

--- a/packages/diagrams/src/activity-card/__tests__/validate.test.ts
+++ b/packages/diagrams/src/activity-card/__tests__/validate.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+import { validateActivityCard } from '../validate.js';
+
+const VALID = {
+  notation: 'activity-card',
+  spec_version: '0.1',
+  activity_card: {
+    id: 'ACTIVITY_CARD-EU-PROGRAMME-1',
+    project: 'ACTIVITY-EU-PROGRAMME-1',
+    description: 'Executive summary.',
+    milestones: [
+      {
+        id: 'MILESTONE-EU-CONFORMITY-CERT-1',
+        name: 'Certification obtained',
+        date: '2027-01-31',
+        delivers_changes: ['CHANGE-EU-COMPLIANCE-1'],
+      },
+    ],
+  },
+};
+
+describe('validateActivityCard', () => {
+  it('accepts a well-formed card', () => {
+    const r = validateActivityCard(VALID);
+    expect(r.valid).toBe(true);
+    expect(r.errors).toHaveLength(0);
+  });
+
+  it('rejects non-object input', () => {
+    expect(validateActivityCard('x').valid).toBe(false);
+    expect(validateActivityCard(null).valid).toBe(false);
+  });
+
+  it('HDR-001 on missing notation', () => {
+    const { notation: _drop, ...rest } = VALID;
+    const r = validateActivityCard(rest);
+    expect(r.valid).toBe(false);
+    expect(r.errors.some((e) => e.code === 'HDR-001')).toBe(true);
+  });
+
+  it('HDR-002 on wrong notation', () => {
+    const r = validateActivityCard({ ...VALID, notation: 'activities' });
+    expect(r.errors.some((e) => e.code === 'HDR-002')).toBe(true);
+  });
+
+  it('AC-001 on missing activity_card block', () => {
+    const r = validateActivityCard({ notation: 'activity-card' });
+    expect(r.valid).toBe(false);
+    expect(r.errors.some((e) => e.code === 'AC-001')).toBe(true);
+  });
+
+  it('AC-002 on malformed card id', () => {
+    const r = validateActivityCard({ ...VALID, activity_card: { ...VALID.activity_card, id: 'CARD-1' } });
+    expect(r.errors.some((e) => e.code === 'AC-002')).toBe(true);
+  });
+
+  it('PC-001 on missing project', () => {
+    const r = validateActivityCard({
+      ...VALID,
+      activity_card: { ...VALID.activity_card, project: undefined },
+    });
+    expect(r.errors.some((e) => e.code === 'PC-001')).toBe(true);
+  });
+
+  it('PC-001 on malformed project id', () => {
+    const r = validateActivityCard({
+      ...VALID,
+      activity_card: { ...VALID.activity_card, project: 'GOAL-1' },
+    });
+    expect(r.errors.some((e) => e.code === 'PC-001')).toBe(true);
+  });
+
+  it('AC-003 on milestone missing required fields', () => {
+    const r = validateActivityCard({
+      ...VALID,
+      activity_card: { ...VALID.activity_card, milestones: [{ id: 'MILESTONE-X-1' }] },
+    });
+    expect(r.valid).toBe(false);
+    expect(r.errors.some((e) => e.code === 'AC-003')).toBe(true);
+  });
+
+  it('AC-004 on malformed milestone id', () => {
+    const r = validateActivityCard({
+      ...VALID,
+      activity_card: {
+        ...VALID.activity_card,
+        milestones: [{ id: 'MS-1', name: 'x', date: '2027-01-01' }],
+      },
+    });
+    expect(r.errors.some((e) => e.code === 'AC-004')).toBe(true);
+  });
+
+  it('AC-004 on duplicate milestone id', () => {
+    const m = { id: 'MILESTONE-X-1', name: 'x', date: '2027-01-01' };
+    const r = validateActivityCard({
+      ...VALID,
+      activity_card: { ...VALID.activity_card, milestones: [m, { ...m }] },
+    });
+    expect(r.errors.some((e) => e.code === 'AC-004' && /Duplicate/.test(e.message))).toBe(true);
+  });
+
+  it('AC-005 on bad milestone date format', () => {
+    const r = validateActivityCard({
+      ...VALID,
+      activity_card: {
+        ...VALID.activity_card,
+        milestones: [{ id: 'MILESTONE-X-1', name: 'x', date: '31/01/2027' }],
+      },
+    });
+    expect(r.errors.some((e) => e.code === 'AC-005')).toBe(true);
+  });
+
+  it('AC-006 on malformed delivers_changes entry', () => {
+    const r = validateActivityCard({
+      ...VALID,
+      activity_card: {
+        ...VALID.activity_card,
+        milestones: [{ id: 'MILESTONE-X-1', name: 'x', date: '2027-01-01', delivers_changes: ['GOAL-1'] }],
+      },
+    });
+    expect(r.errors.some((e) => e.code === 'AC-006')).toBe(true);
+  });
+
+  it('accepts a card with no milestones', () => {
+    const r = validateActivityCard({
+      ...VALID,
+      activity_card: { id: 'ACTIVITY_CARD-X-1', project: 'ACTIVITY-X-1' },
+    });
+    expect(r.valid).toBe(true);
+  });
+});

--- a/packages/diagrams/src/activity-card/index.ts
+++ b/packages/diagrams/src/activity-card/index.ts
@@ -1,0 +1,33 @@
+export type {
+  RawMilestone,
+  ActivityCardBlock,
+  ActivityCardDoc,
+  ActivityCardSources,
+  ResolvedProject,
+  ResolvedMilestone,
+  ResolvedFactor,
+  ResolvedGoal,
+  ResolvedChange,
+  ResolvedMotivation,
+  ResolvedChildActivity,
+  ResolvedActivityCard,
+  LayoutBounds,
+  DateField,
+  MilestoneMarker,
+  ChainNode,
+  ChainEdge,
+  ChildActivityRow,
+  SectionHeader,
+  ActivityCardLayoutOptions,
+  ActivityCardLayout,
+  ActivityCardValidationError,
+  ActivityCardValidationWarning,
+  ActivityCardValidationResult,
+} from './types.js';
+
+export { validateActivityCard } from './validate.js';
+
+export { resolveActivityCard } from './resolver.js';
+export type { ActivityCardResolution } from './resolver.js';
+
+export { layoutActivityCard, ARCHIMATE_CLASS } from './layout.js';

--- a/packages/diagrams/src/activity-card/layout.ts
+++ b/packages/diagrams/src/activity-card/layout.ts
@@ -1,0 +1,194 @@
+// Activity Card — single-page layout (pure geometry; the preview paints SVG).
+//
+// Top-to-bottom card sections (spec §4 / §5):
+//   1. Title         — project name
+//   2. Dates band    — Initiation (valid_from) · Planned start · Planned end
+//   3. Milestones    — narrative timeline, markers left→right by date
+//   4. Motivation    — Factors → Goals → Changes columns with F→G→C edges
+//   5. Child activities — activities whose parent = the project
+//
+// The §5.1 ArchiMate-class convention ("(Work Package)", "(Implementation
+// Event)") is applied HERE, derived from element TYPE — there is no
+// archimate_class data field.
+
+import type {
+  ActivityCardLayout,
+  ActivityCardLayoutOptions,
+  ChainEdge,
+  ChainNode,
+  ChildActivityRow,
+  DateField,
+  MilestoneMarker,
+  ResolvedActivityCard,
+  SectionHeader,
+} from './types.js';
+
+const DEFAULTS = {
+  cardWidth: 780,
+  columnGap: 28,
+  rowGap: 12,
+} as const;
+
+// Fixed metrics (px). Kept local — the card has no user-tunable spacing yet.
+const PAD = 20;
+const TITLE_H = 38;
+const DATES_H = 56;
+const SECTION_HEADER_H = 26;
+const SECTION_GAP = 16;
+const MILESTONE_W = 168;
+const MILESTONE_H = 64;
+const MILESTONE_GAP = 16;
+const CHAIN_NODE_H = 46;
+const CHILD_ROW_H = 42;
+
+/** ArchiMate class per §5.1 — derived from element TYPE, never stored. */
+export const ARCHIMATE_CLASS = {
+  ACTIVITY: 'Work Package',
+  MILESTONE: 'Implementation Event',
+} as const;
+
+export function layoutActivityCard(
+  card: ResolvedActivityCard,
+  options?: ActivityCardLayoutOptions,
+): ActivityCardLayout {
+  const opts = { ...DEFAULTS, ...(options ?? {}) };
+  const contentX = PAD;
+  const contentW = opts.cardWidth - PAD * 2;
+
+  let cursorY = PAD;
+
+  // 1. Title
+  const title = { name: card.project.name, x: contentX, y: cursorY + TITLE_H / 2 };
+  cursorY += TITLE_H;
+
+  // 2. Dates band — three equal cells.
+  const dateDefs: Array<{ label: string; value: string }> = [
+    { label: 'Initiation', value: card.project.valid_from ?? '—' },
+    { label: 'Planned start', value: card.project.start_date ?? '—' },
+    { label: 'Planned end', value: card.project.end_date ?? '—' },
+  ];
+  const dateGap = 12;
+  const dateCellW = (contentW - dateGap * (dateDefs.length - 1)) / dateDefs.length;
+  const dateFields: DateField[] = dateDefs.map((d, i) => ({
+    label: d.label,
+    value: d.value,
+    x: contentX + i * (dateCellW + dateGap),
+    y: cursorY,
+    width: dateCellW,
+    height: DATES_H,
+  }));
+  cursorY += DATES_H + SECTION_GAP;
+
+  const sectionHeaders: SectionHeader[] = [];
+  const pushHeader = (label: string): void => {
+    sectionHeaders.push({ label, x: contentX, y: cursorY, width: contentW, height: SECTION_HEADER_H });
+    cursorY += SECTION_HEADER_H + 8;
+  };
+
+  // 3. Milestones — timeline markers, wrapped left→right.
+  const milestones: MilestoneMarker[] = [];
+  if (card.milestones.length > 0) {
+    pushHeader('Milestones');
+    const perRow = Math.max(1, Math.floor((contentW + MILESTONE_GAP) / (MILESTONE_W + MILESTONE_GAP)));
+    const rowStartY = cursorY;
+    card.milestones.forEach((m, i) => {
+      const col = i % perRow;
+      const row = Math.floor(i / perRow);
+      milestones.push({
+        id: m.id,
+        name: m.name,
+        date: m.date,
+        archimateClass: ARCHIMATE_CLASS.MILESTONE,
+        x: contentX + col * (MILESTONE_W + MILESTONE_GAP),
+        y: rowStartY + row * (MILESTONE_H + opts.rowGap),
+        width: MILESTONE_W,
+        height: MILESTONE_H,
+      });
+    });
+    const rows = Math.ceil(card.milestones.length / perRow);
+    cursorY = rowStartY + rows * (MILESTONE_H + opts.rowGap) - opts.rowGap + SECTION_GAP;
+  }
+
+  // 4. Motivation chain — Factors | Goals | Changes columns.
+  const chainEdges: ChainEdge[] = [];
+  const factorsCol: ChainNode[] = [];
+  const goalsCol: ChainNode[] = [];
+  const changesCol: ChainNode[] = [];
+  const { factors, goals, changes } = card.motivation;
+  if (factors.length + goals.length + changes.length > 0) {
+    pushHeader('Motivation — Factors → Goals → Changes');
+    const colW = (contentW - opts.columnGap * 2) / 3;
+    const colX = [contentX, contentX + colW + opts.columnGap, contentX + (colW + opts.columnGap) * 2];
+    const colStartY = cursorY;
+
+    const stack = (items: { id: string; name: string }[], colIndex: number, into: ChainNode[]) => {
+      items.forEach((it, i) => {
+        into.push({
+          id: it.id,
+          name: it.name,
+          x: colX[colIndex],
+          y: colStartY + i * (CHAIN_NODE_H + opts.rowGap),
+          width: colW,
+          height: CHAIN_NODE_H,
+        });
+      });
+    };
+    stack(factors, 0, factorsCol);
+    stack(goals, 1, goalsCol);
+    stack(changes, 2, changesCol);
+
+    // Edges: factor→goal (goal.factorIds), goal→change (change.goalIds).
+    const factorIds = new Set(factorsCol.map((n) => n.id));
+    const goalIds = new Set(goalsCol.map((n) => n.id));
+    for (const g of goals) {
+      for (const fid of g.factorIds) {
+        if (factorIds.has(fid)) chainEdges.push({ sourceId: fid, targetId: g.id });
+      }
+    }
+    for (const c of changes) {
+      for (const gid of c.goalIds) {
+        if (goalIds.has(gid)) chainEdges.push({ sourceId: gid, targetId: c.id });
+      }
+    }
+
+    const tallest = Math.max(factorsCol.length, goalsCol.length, changesCol.length);
+    cursorY = colStartY + tallest * (CHAIN_NODE_H + opts.rowGap) - opts.rowGap + SECTION_GAP;
+  }
+
+  // 5. Child activities — full-width rows.
+  const childActivities: ChildActivityRow[] = [];
+  if (card.childActivities.length > 0) {
+    pushHeader('Child activities');
+    const rowStartY = cursorY;
+    card.childActivities.forEach((a, i) => {
+      const metaBits: string[] = [];
+      if (a.start_date || a.end_date) metaBits.push(`${a.start_date ?? '?'} → ${a.end_date ?? '?'}`);
+      if (a.owner) metaBits.push(a.owner);
+      childActivities.push({
+        id: a.id,
+        name: a.name,
+        archimateClass: ARCHIMATE_CLASS.ACTIVITY,
+        meta: metaBits.join(' · '),
+        x: contentX,
+        y: rowStartY + i * (CHILD_ROW_H + opts.rowGap),
+        width: contentW,
+        height: CHILD_ROW_H,
+      });
+    });
+    cursorY =
+      rowStartY + card.childActivities.length * (CHILD_ROW_H + opts.rowGap) - opts.rowGap + SECTION_GAP;
+  }
+
+  const totalHeight = cursorY - SECTION_GAP + PAD;
+
+  return {
+    bounds: { x: 0, y: 0, width: opts.cardWidth, height: Math.max(totalHeight, PAD * 2 + TITLE_H) },
+    title,
+    dateFields,
+    sectionHeaders,
+    milestones,
+    chainColumns: { factors: factorsCol, goals: goalsCol, changes: changesCol },
+    chainEdges,
+    childActivities,
+  };
+}

--- a/packages/diagrams/src/activity-card/resolver.ts
+++ b/packages/diagrams/src/activity-card/resolver.ts
@@ -1,0 +1,321 @@
+// Activity Card — cross-document resolver (the novel piece of this notation).
+//
+// Unlike every other Studio preview, the Activity Card is assembled from
+// MULTIPLE documents. The card YAML names a project Activity; the resolver
+// pulls the rest of the card's content by reference from sibling documents
+// in the same view directory:
+//
+//   *.activities.transitrix.yaml  → the project Activity (name, lifecycle +
+//                                    schedule dates, goals[], delivers_changes[])
+//                                    and child activities (parent = project id)
+//   *.fgca.transitrix.yaml        → expand the project's goals[] /
+//                                    delivers_changes[] into Factor / Goal /
+//                                    Change definitions and the F→G→C edges
+//
+// Resolution scope is the SINGLE view directory (exact-dir, non-recursive):
+// the extension globs the card file's own directory and hands the parsed
+// sibling docs in here. This resolver is filesystem-free and pure so it stays
+// unit-testable.
+//
+// Cross-document validation lives here (the rules that need the sibling docs):
+//   PC-001   project does not resolve to an admitted Activity
+//   PC-002   resolved Activity has activity_type other than "Project"
+//   PC-003   milestone.delivers_changes[] entry not in the project's own
+//            delivers_changes[]
+//   PC-004   (warning) milestone.date outside [valid_from, valid_to]
+//   LIFECYCLE-001  project valid_from missing / not a parseable ISO date
+//   LIFECYCLE-002  project valid_to present, not null, not a parseable date
+//   LIFECYCLE-003  project valid_to earlier than valid_from
+//
+// LIFECYCLE-* are scoped to the RESOLVED PROJECT Activity only — the card is
+// built around the project's initiation date, so a missing valid_from there is
+// a hard error. Child activities and FGCA elements are not lifecycle-checked
+// here (out of this notation's scope; today's Studio activities docs may
+// legitimately omit lifecycle fields).
+
+import type {
+  ActivityCardDoc,
+  ActivityCardSources,
+  ResolvedActivityCard,
+  ResolvedChange,
+  ResolvedChildActivity,
+  ResolvedFactor,
+  ResolvedGoal,
+  ResolvedMilestone,
+  ResolvedProject,
+} from './types.js';
+import type { ValidationError, ValidationWarning, ValidationResult } from '../validation-types.js';
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export interface ActivityCardResolution extends ValidationResult {
+  /** Present only when resolution succeeded (project found + valid_from OK). */
+  resolved?: ResolvedActivityCard;
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === 'object' && !Array.isArray(v);
+}
+
+function str(v: unknown): string | undefined {
+  return typeof v === 'string' && v.trim().length > 0 ? v : undefined;
+}
+
+function strArray(v: unknown): string[] {
+  if (!Array.isArray(v)) return [];
+  return v.filter((x): x is string => typeof x === 'string' && x.trim().length > 0);
+}
+
+/** A parseable quoted ISO 8601 date, calendar-checked (rejects 2026-13-40). */
+function isIsoDate(v: unknown): v is string {
+  if (typeof v !== 'string' || !DATE_RE.test(v)) return false;
+  const t = Date.parse(`${v}T00:00:00Z`);
+  if (Number.isNaN(t)) return false;
+  // Round-trip guard so 2026-02-30 (which Date.parse may roll forward) is rejected.
+  return new Date(t).toISOString().slice(0, 10) === v;
+}
+
+/** Flatten every `activities[]` entry across all sibling activities docs. */
+function collectActivities(docs: unknown[]): Map<string, Record<string, unknown>> {
+  const out = new Map<string, Record<string, unknown>>();
+  for (const doc of docs) {
+    if (!isObject(doc)) continue;
+    const arr = doc['activities'];
+    if (!Array.isArray(arr)) continue;
+    for (const el of arr) {
+      if (!isObject(el)) continue;
+      const id = str(el['id']);
+      if (!id) continue;
+      if (!out.has(id)) out.set(id, el); // first definition wins
+    }
+  }
+  return out;
+}
+
+/** Collect canonical FGCA factors/goals/changes (string-ID form) across docs. */
+function collectFgca(docs: unknown[]): {
+  factors: Map<string, Record<string, unknown>>;
+  goals: Map<string, Record<string, unknown>>;
+  changes: Map<string, Record<string, unknown>>;
+} {
+  const factors = new Map<string, Record<string, unknown>>();
+  const goals = new Map<string, Record<string, unknown>>();
+  const changes = new Map<string, Record<string, unknown>>();
+  const ingest = (arr: unknown, into: Map<string, Record<string, unknown>>) => {
+    if (!Array.isArray(arr)) return;
+    for (const el of arr) {
+      if (!isObject(el)) continue;
+      const id = str(el['id']);
+      if (id && !into.has(id)) into.set(id, el);
+    }
+  };
+  for (const doc of docs) {
+    if (!isObject(doc)) continue;
+    ingest(doc['factors'], factors);
+    ingest(doc['goals'], goals);
+    ingest(doc['changes'], changes);
+  }
+  return { factors, goals, changes };
+}
+
+export function resolveActivityCard(
+  doc: ActivityCardDoc,
+  sources: ActivityCardSources,
+): ActivityCardResolution {
+  const errors: ValidationError[] = [];
+  const warnings: ValidationWarning[] = [];
+
+  const card = doc?.activity_card;
+  const projectId = str(card?.project);
+  if (!projectId) {
+    // Structural validator already flags this; nothing to resolve.
+    errors.push({ code: 'PC-001', message: 'activity_card.project is missing' });
+    return { valid: false, errors, warnings };
+  }
+
+  const activities = collectActivities(sources.activitiesDocs);
+  const projectRec = activities.get(projectId);
+
+  // PC-001 — project must resolve to an admitted Activity.
+  if (!projectRec) {
+    errors.push({
+      code: 'PC-001',
+      message: `activity_card.project "${projectId}" does not resolve to an Activity in any sibling *.activities.* document`,
+    });
+    return { valid: false, errors, warnings };
+  }
+
+  // PC-002 — resolved Activity must be a Project.
+  const activityType = str(projectRec['activity_type']);
+  if (activityType !== 'Project') {
+    errors.push({
+      code: 'PC-002',
+      message: `Activity "${projectId}" has activity_type "${activityType ?? '(unset)'}", expected "Project"`,
+    });
+  }
+
+  // LIFECYCLE-001..003 on the project Activity.
+  const validFrom = projectRec['valid_from'];
+  const validToRaw = projectRec['valid_to'];
+  let validFromOk = false;
+  if (validFrom === undefined || validFrom === null) {
+    errors.push({ code: 'LIFECYCLE-001', message: `Activity "${projectId}" valid_from is required` });
+  } else if (!isIsoDate(validFrom)) {
+    errors.push({
+      code: 'LIFECYCLE-001',
+      message: `Activity "${projectId}" valid_from "${String(validFrom)}" is not a parseable ISO 8601 date`,
+    });
+  } else {
+    validFromOk = true;
+  }
+
+  let validToOk = false;
+  const validToPresent = validToRaw !== undefined && validToRaw !== null;
+  if (validToPresent) {
+    if (!isIsoDate(validToRaw)) {
+      errors.push({
+        code: 'LIFECYCLE-002',
+        message: `Activity "${projectId}" valid_to "${String(validToRaw)}" is not a parseable ISO 8601 date`,
+      });
+    } else {
+      validToOk = true;
+      if (validFromOk && (validToRaw as string) < (validFrom as string)) {
+        errors.push({
+          code: 'LIFECYCLE-003',
+          message: `Activity "${projectId}" valid_to "${String(validToRaw)}" is earlier than valid_from "${String(validFrom)}"`,
+        });
+      }
+    }
+  }
+
+  // A failed lifecycle/PC-001 stops us producing a card view-model, but we still
+  // return every error collected so the panel lists them all at once.
+  const projectChanges = new Set(strArray(projectRec['delivers_changes']));
+  const projectGoalIds = strArray(projectRec['goals']);
+
+  // PC-003 — each milestone change must be a subset of the project's changes.
+  const rawMilestones = Array.isArray(card.milestones) ? card.milestones : [];
+  const milestones: ResolvedMilestone[] = [];
+  for (const m of rawMilestones) {
+    if (!isObject(m)) continue;
+    const mid = str(m['id']);
+    const mname = str(m['name']);
+    const mdate = str(m['date']);
+    if (!mid || !mname || !mdate) continue; // structural validator already flagged
+    const deliversChanges = strArray(m['delivers_changes']);
+    for (const c of deliversChanges) {
+      if (!projectChanges.has(c)) {
+        errors.push({
+          code: 'PC-003',
+          message: `Milestone "${mid}" delivers_changes "${c}" is not in project "${projectId}" delivers_changes`,
+        });
+      }
+    }
+    // PC-004 — milestone date should fall within the project lifecycle window.
+    if (validFromOk && mdate < (validFrom as string)) {
+      warnings.push({
+        code: 'PC-004',
+        message: `Milestone "${mid}" date "${mdate}" is before project valid_from "${String(validFrom)}"`,
+      });
+    }
+    if (validToOk && mdate > (validToRaw as string)) {
+      warnings.push({
+        code: 'PC-004',
+        message: `Milestone "${mid}" date "${mdate}" is after project valid_to "${String(validToRaw)}"`,
+      });
+    }
+    milestones.push({
+      id: mid,
+      name: mname,
+      date: mdate,
+      description: str(m['description']),
+      deliversChanges,
+    });
+  }
+  milestones.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
+
+  // If we have hard errors, surface them without an assembled card.
+  if (errors.length > 0) {
+    return { valid: false, errors, warnings };
+  }
+
+  // ── Motivation chain — expand against sibling FGCA docs ─────────────────────
+  const fgca = collectFgca(sources.fgcaDocs);
+
+  const changes: ResolvedChange[] = [];
+  for (const cid of projectChanges) {
+    const rec = fgca.changes.get(cid);
+    if (!rec) {
+      warnings.push({
+        code: 'PC-001',
+        message: `Project change "${cid}" not found in any sibling *.fgca.* document; omitted from the motivation chain`,
+      });
+      continue;
+    }
+    changes.push({ id: cid, name: str(rec['name']) ?? cid, goalIds: strArray(rec['goals']) });
+  }
+
+  // Goals shown = the project's declared goals ∪ goals referenced by in-scope
+  // changes (so the F→G→C chain stays connected).
+  const goalIdSet = new Set<string>(projectGoalIds);
+  for (const ch of changes) for (const g of ch.goalIds) goalIdSet.add(g);
+
+  const goals: ResolvedGoal[] = [];
+  for (const gid of goalIdSet) {
+    const rec = fgca.goals.get(gid);
+    if (!rec) {
+      warnings.push({
+        code: 'PC-001',
+        message: `Goal "${gid}" not found in any sibling *.fgca.* document; omitted from the motivation chain`,
+      });
+      continue;
+    }
+    goals.push({ id: gid, name: str(rec['name']) ?? gid, factorIds: strArray(rec['factors']) });
+  }
+
+  // Factors shown = those referenced by the in-scope goals.
+  const factorIdSet = new Set<string>();
+  for (const g of goals) for (const f of g.factorIds) factorIdSet.add(f);
+
+  const factors: ResolvedFactor[] = [];
+  for (const fid of factorIdSet) {
+    const rec = fgca.factors.get(fid);
+    factors.push({ id: fid, name: rec ? str(rec['name']) ?? fid : fid });
+  }
+
+  // ── Child activities — parent = project id ──────────────────────────────────
+  const childActivities: ResolvedChildActivity[] = [];
+  for (const [id, rec] of activities) {
+    if (str(rec['parent']) !== projectId) continue;
+    childActivities.push({
+      id,
+      name: str(rec['name']) ?? id,
+      activity_type: str(rec['activity_type']),
+      start_date: str(rec['start_date']),
+      end_date: str(rec['end_date']),
+      owner: str(rec['owner']),
+    });
+  }
+  childActivities.sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+
+  const project: ResolvedProject = {
+    id: projectId,
+    name: str(projectRec['name']) ?? projectId,
+    description: str(projectRec['description']),
+    valid_from: validFromOk ? (validFrom as string) : undefined,
+    valid_to: validToOk ? (validToRaw as string) : undefined,
+    start_date: str(projectRec['start_date']),
+    end_date: str(projectRec['end_date']),
+  };
+
+  const resolved: ResolvedActivityCard = {
+    cardId: str(card.id) ?? '',
+    cardDescription: str(card.description),
+    project,
+    milestones,
+    motivation: { factors, goals, changes },
+    childActivities,
+  };
+
+  return { valid: true, errors, warnings, resolved };
+}

--- a/packages/diagrams/src/activity-card/types.ts
+++ b/packages/diagrams/src/activity-card/types.ts
@@ -1,0 +1,230 @@
+// Activity Card notation — single-project narrative view.
+//
+// Spec: transitrix/methodology `notations/views/18-activity-card.md` (v0.1).
+// Epic vkgeorgia/strategy#97, Studio track #134.
+//
+// The Activity Card is the first MULTI-DOCUMENT Studio notation. The card
+// YAML itself holds only `id`, `project` (an Activity ID), `description`,
+// and `milestones[]`. Everything painted on the card — the project name,
+// dates, motivation chain (Factors → Goals → Changes), and child activities
+// — is pulled BY REFERENCE at view time from sibling `*.activities.*` and
+// `*.fgca.*` documents in the same view directory. See `resolver.ts`.
+//
+// This file declares two model layers:
+//   1. the RAW card document (what the YAML parses into), and
+//   2. the ASSEMBLED card view-model (what the resolver produces and the
+//      layout consumes).
+
+import type {
+  ValidationError as SharedValidationError,
+  ValidationWarning as SharedValidationWarning,
+  ValidationResult as SharedValidationResult,
+} from '../validation-types.js';
+
+// Keep PREFIXED aliases consistent with the other notation modules so
+// external consumers can name the activity-card result types directly.
+export type ActivityCardValidationError = SharedValidationError;
+export type ActivityCardValidationWarning = SharedValidationWarning;
+export type ActivityCardValidationResult = SharedValidationResult;
+
+// ── Raw card document (the `*.activity-card.transitrix.yaml` shape) ──────────
+
+export interface RawMilestone {
+  id: string;
+  name: string;
+  /** Quoted ISO 8601 date (YYYY-MM-DD) when the milestone is reached. */
+  date: string;
+  description?: string;
+  /** CHANGE-… IDs; each must be a subset of the project Activity's delivers_changes. */
+  delivers_changes?: string[];
+}
+
+export interface ActivityCardBlock {
+  id: string;
+  /** Canonical ID of the referenced project Activity (ACTIVITY-…). */
+  project: string;
+  description?: string;
+  milestones?: RawMilestone[];
+}
+
+export interface ActivityCardDoc {
+  notation: string;
+  spec_version?: string;
+  activity_card: ActivityCardBlock;
+}
+
+// ── Sibling documents consumed by the resolver ──────────────────────────────
+//
+// The resolver is filesystem-free: the extension reads + parses the sibling
+// `*.activities.*` / `*.fgca.*` files and hands the parsed objects in. We
+// model them as `unknown[]` at the boundary and narrow defensively inside the
+// resolver, so a malformed sibling degrades to a resolution error rather than
+// a crash.
+
+export interface ActivityCardSources {
+  /** Parsed `*.activities.transitrix.yaml` documents from the view directory. */
+  activitiesDocs: unknown[];
+  /** Parsed `*.fgca.transitrix.yaml` documents from the view directory. */
+  fgcaDocs: unknown[];
+}
+
+// ── Assembled card view-model (resolver output → layout input) ───────────────
+
+export interface ResolvedProject {
+  id: string;
+  name: string;
+  /** Full description from the Activity (the card's own `description` is separate). */
+  description?: string;
+  /** Lifecycle: decision-to-initiate date (CONTRACT.md §7). */
+  valid_from?: string;
+  /** Lifecycle: when the project ceased effect, or undefined if active. */
+  valid_to?: string;
+  /** Planned work range. */
+  start_date?: string;
+  end_date?: string;
+}
+
+export interface ResolvedMilestone {
+  id: string;
+  name: string;
+  date: string;
+  description?: string;
+  /** CHANGE-… IDs this milestone delivers (subset of the project's). */
+  deliversChanges: string[];
+}
+
+export interface ResolvedFactor {
+  id: string;
+  name: string;
+}
+
+export interface ResolvedGoal {
+  id: string;
+  name: string;
+  /** FACTOR-… IDs that motivate this goal (canonical `goal.factors`). */
+  factorIds: string[];
+}
+
+export interface ResolvedChange {
+  id: string;
+  name: string;
+  /** GOAL-… IDs this change advances (canonical `change.goals`). */
+  goalIds: string[];
+}
+
+/** Motivation chain: Factors → Goals → Changes, scoped to the project. */
+export interface ResolvedMotivation {
+  factors: ResolvedFactor[];
+  goals: ResolvedGoal[];
+  changes: ResolvedChange[];
+}
+
+export interface ResolvedChildActivity {
+  id: string;
+  name: string;
+  activity_type?: string;
+  start_date?: string;
+  end_date?: string;
+  owner?: string;
+}
+
+export interface ResolvedActivityCard {
+  cardId: string;
+  /** The card's own executive-summary description (distinct from the project's). */
+  cardDescription?: string;
+  project: ResolvedProject;
+  /** Sorted ascending by `date`. */
+  milestones: ResolvedMilestone[];
+  motivation: ResolvedMotivation;
+  /** Activities whose `parent` = the project Activity id. */
+  childActivities: ResolvedChildActivity[];
+}
+
+// ── Layout geometry (pure; the preview turns this into SVG) ───────────────────
+
+export interface LayoutBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** A boxed value-pair shown in the dates band. */
+export interface DateField {
+  label: string;
+  value: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** One milestone marker on the timeline. */
+export interface MilestoneMarker {
+  id: string;
+  name: string;
+  date: string;
+  /** ArchiMate class label appended by the renderer (§5.1). */
+  archimateClass: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** One node in a motivation-chain column. */
+export interface ChainNode {
+  id: string;
+  name: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** An edge between two chain nodes (factor→goal or goal→change). */
+export interface ChainEdge {
+  sourceId: string;
+  targetId: string;
+}
+
+export interface ChildActivityRow {
+  id: string;
+  name: string;
+  /** ArchiMate class label appended by the renderer (§5.1). */
+  archimateClass: string;
+  meta: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface SectionHeader {
+  label: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface ActivityCardLayoutOptions {
+  /** Outer card width (px). */
+  cardWidth?: number;
+  /** Horizontal gap (px) between the three motivation-chain columns. */
+  columnGap?: number;
+  /** Vertical gap (px) between stacked rows within a section. */
+  rowGap?: number;
+}
+
+export interface ActivityCardLayout {
+  bounds: LayoutBounds;
+  title: { name: string; x: number; y: number };
+  dateFields: DateField[];
+  sectionHeaders: SectionHeader[];
+  milestones: MilestoneMarker[];
+  /** Three columns of the motivation chain, in F→G→C order. */
+  chainColumns: { factors: ChainNode[]; goals: ChainNode[]; changes: ChainNode[] };
+  chainEdges: ChainEdge[];
+  childActivities: ChildActivityRow[];
+}

--- a/packages/diagrams/src/activity-card/validate.ts
+++ b/packages/diagrams/src/activity-card/validate.ts
@@ -1,0 +1,158 @@
+// Activity Card — document-local structural validation.
+//
+// This validator checks only what can be known from the card document ALONE:
+// the header, the `activity_card` block shape, the project-reference grammar
+// (PC-001's "missing or malformed" half), and each milestone's shape.
+//
+// The cross-document rules — PC-001 "does not resolve", PC-002
+// (activity_type), PC-003 (milestone changes ⊆ project changes), PC-004
+// (milestone date within the project lifecycle window) and the LIFECYCLE-*
+// checks — require the sibling `*.activities.*` / `*.fgca.*` documents and so
+// live in `resolver.ts`. The preview merges both result sets.
+//
+// Codes:
+//   AC-001   document structure (root object, `activity_card` block)
+//   AC-002   `activity_card.id` grammar
+//   AC-003   milestone structure (missing id / name / date)
+//   AC-004   milestone id grammar / duplicate
+//   AC-005   milestone date format
+//   AC-006   milestone `delivers_changes` shape / grammar
+//   HDR-001  missing `notation`           (CONTRACT.md §2)
+//   HDR-002  wrong `notation`             (CONTRACT.md §2)
+//   PC-001   `project` missing or malformed (the document-local half; the
+//            "does not resolve" half is emitted by the resolver)
+
+import type { ValidationError, ValidationWarning, ValidationResult } from '../validation-types.js';
+
+export type { ValidationError, ValidationWarning, ValidationResult };
+
+const ACTIVITY_CARD_ID_RE = /^ACTIVITY_CARD(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
+const ACTIVITY_ID_RE = /^ACTIVITY(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
+const MILESTONE_ID_RE = /^MILESTONE(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
+const CHANGE_ID_RE = /^CHANGE(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function isNonEmptyString(v: unknown): v is string {
+  return typeof v === 'string' && v.trim().length > 0;
+}
+
+export function validateActivityCard(input: unknown): ValidationResult {
+  const errors: ValidationError[] = [];
+  const warnings: ValidationWarning[] = [];
+
+  if (!input || typeof input !== 'object') {
+    return { valid: false, errors: [{ code: 'AC-001', message: 'document root is not an object' }], warnings };
+  }
+
+  const raw = input as Record<string, unknown>;
+
+  // ── Header (CONTRACT.md §2) ────────────────────────────────────────────────
+  if (!('notation' in raw)) {
+    errors.push({ code: 'HDR-001', message: 'notation field is required' });
+  } else if (raw['notation'] !== 'activity-card') {
+    errors.push({
+      code: 'HDR-002',
+      message: `notation must be "activity-card", got "${String(raw['notation'])}"`,
+    });
+  }
+
+  // ── activity_card block ─────────────────────────────────────────────────────
+  const block = raw['activity_card'];
+  if (!block || typeof block !== 'object' || Array.isArray(block)) {
+    errors.push({ code: 'AC-001', message: 'Missing required root key: activity_card (object)' });
+    return { valid: false, errors, warnings };
+  }
+  const card = block as Record<string, unknown>;
+
+  if (!isNonEmptyString(card['id'])) {
+    errors.push({ code: 'AC-002', message: 'activity_card.id is required' });
+  } else if (!ACTIVITY_CARD_ID_RE.test(card['id'])) {
+    errors.push({
+      code: 'AC-002',
+      message: `activity_card.id "${card['id']}" must match ACTIVITY_CARD-[<middle>-]<INTEGER>`,
+    });
+  }
+
+  // PC-001 (document-local half): project present + well-formed.
+  if (!isNonEmptyString(card['project'])) {
+    errors.push({ code: 'PC-001', message: 'activity_card.project is required (an ACTIVITY-… id)' });
+  } else if (!ACTIVITY_ID_RE.test(card['project'])) {
+    errors.push({
+      code: 'PC-001',
+      message: `activity_card.project "${card['project']}" is malformed; must match ACTIVITY-[<middle>-]<INTEGER>`,
+    });
+  }
+
+  if (card['description'] !== undefined && typeof card['description'] !== 'string') {
+    errors.push({ code: 'AC-001', message: 'activity_card.description must be a string' });
+  }
+
+  // ── milestones[] (optional) ─────────────────────────────────────────────────
+  const milestonesRaw = card['milestones'];
+  if (milestonesRaw !== undefined) {
+    if (!Array.isArray(milestonesRaw)) {
+      errors.push({ code: 'AC-003', message: 'activity_card.milestones must be an array', path: 'milestones' });
+    } else {
+      const seenIds = new Set<string>();
+      milestonesRaw.forEach((el, i) => {
+        const p = `milestones[${i}]`;
+        if (!el || typeof el !== 'object' || Array.isArray(el)) {
+          errors.push({ code: 'AC-003', message: `${p} must be an object`, path: p });
+          return;
+        }
+        const m = el as Record<string, unknown>;
+
+        if (!isNonEmptyString(m['id'])) {
+          errors.push({ code: 'AC-003', message: `${p}.id is required`, path: p });
+        } else {
+          const mid = m['id'].trim();
+          if (!MILESTONE_ID_RE.test(mid)) {
+            errors.push({ code: 'AC-004', message: `${p}.id "${mid}" must match MILESTONE-[<middle>-]<INTEGER>`, path: p });
+          }
+          if (seenIds.has(mid)) {
+            errors.push({ code: 'AC-004', message: `Duplicate milestone id "${mid}"`, path: p });
+          } else {
+            seenIds.add(mid);
+          }
+        }
+
+        if (!isNonEmptyString(m['name'])) {
+          errors.push({ code: 'AC-003', message: `${p}.name is required`, path: p });
+        }
+
+        if (!isNonEmptyString(m['date'])) {
+          errors.push({ code: 'AC-003', message: `${p}.date is required`, path: p });
+        } else if (!DATE_RE.test(m['date'])) {
+          errors.push({
+            code: 'AC-005',
+            message: `${p}.date "${m['date']}" must be a quoted ISO 8601 date (YYYY-MM-DD)`,
+            path: p,
+          });
+        }
+
+        if (m['description'] !== undefined && typeof m['description'] !== 'string') {
+          errors.push({ code: 'AC-003', message: `${p}.description must be a string`, path: p });
+        }
+
+        const dc = m['delivers_changes'];
+        if (dc !== undefined) {
+          if (!Array.isArray(dc)) {
+            errors.push({ code: 'AC-006', message: `${p}.delivers_changes must be an array of CHANGE-… ids`, path: p });
+          } else {
+            dc.forEach((c) => {
+              if (typeof c !== 'string' || !CHANGE_ID_RE.test(c)) {
+                errors.push({
+                  code: 'AC-006',
+                  message: `${p}.delivers_changes[] entry "${String(c)}" must match CHANGE-[<middle>-]<INTEGER>`,
+                  path: p,
+                });
+              }
+            });
+          }
+        }
+      });
+    }
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}

--- a/packages/diagrams/src/index.ts
+++ b/packages/diagrams/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./activities/index";
+export * from "./activity-card/index";
 export * from "./applications/index";
 export * from "./blocks/index";
 export * from "./capability-map/index";


### PR DESCRIPTION
## What

PR1 of the **Activity Card** renderer (Studio track of epic vkgeorgia/strategy#97, task #134) — the `@transitrix/diagrams` half. The extension preview + wiring + example land in PR2.

The Activity Card is the **first multi-document Studio notation**. The card YAML holds only `id` / `project` (an Activity ID) / `description` / `milestones[]`; everything painted on the card is pulled **by reference** at view time from sibling `*.activities.*` and `*.fgca.*` documents in the same view directory.

## Contents

- **`types.ts`** — raw card doc model + assembled view-model (`ResolvedActivityCard`) + pure layout geometry.
- **`validate.ts`** — document-local structural validation only: `HDR-001/002` (header), `AC-001..006` (card + milestone shape, id grammars, date format), and the document-local half of `PC-001` (project field present + well-formed).
- **`resolver.ts`** — the novel piece. Filesystem-free, directory-scoped (exact-dir) cross-document resolver. Resolves the project Activity, child activities (`parent` = project id), and expands the project's `goals[]` / `delivers_changes[]` into the Factors→Goals→Changes chain against sibling FGCA docs. Emits the cross-document rules:
  - `PC-001` (project does not resolve), `PC-002` (`activity_type` ≠ `Project`), `PC-003` (milestone changes ⊄ project changes), `PC-004` warning (milestone date outside `[valid_from, valid_to]`)
  - `LIFECYCLE-001..003` scoped to the resolved **project Activity** (initiation = `valid_from`).
- **`layout.ts`** — single-page card geometry (title · dates band · milestone timeline · F→G→C columns + edges · child-activity rows). Applies the spec **§5.1 ArchiMate-class convention** (`ACTIVITY` → "Work Package", `MILESTONE` → "Implementation Event") renderer-side, derived from TYPE — no `archimate_class` data field.

## Design decisions

- **Resolution scope = single view directory, exact-dir (non-recursive).** The extension (PR2) globs the card's own directory and hands parsed siblings in.
- **String-ID canonical FGCA.** The card expands the project's canonical `GOAL-…` / `CHANGE-…` references, so the resolver reads the canonical string-ID FGCA form directly rather than reusing `parseCanonicalFGCA` (which collapses IDs to the internal numeric model).
- **LIFECYCLE scoped to the project only.** Child activities / FGCA elements are not lifecycle-checked — today's Studio docs may legitimately omit those fields.
- Resolver narrows every sibling defensively → a malformed sibling degrades to an error/warning, never a crash.

## Tests

27 new unit tests (`validate` / `resolver` / `layout`). Full diagrams suite green (**503 passed**); `tsc --noEmit` clean.

## Out of scope (PR2)

`extension/src/activity-card-preview.ts`, preview-router / command / activation-event / language wiring in `extension/package.json`, the worked example under `examples/`, and the hand-test of the success signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)