### PR TITLE
fix(activity-card): land PR2 (preview + wiring + example) on main (#134)

### DIFF
--- a/examples/activity-card/eu-programme.activities.transitrix.yaml
+++ b/examples/activity-card/eu-programme.activities.transitrix.yaml
@@ -1,0 +1,72 @@
+notation: activities
+spec_version: "0.1"
+
+title: EU MDR Conformity Programme
+description: |
+  Activity breakdown for the EU Medical Device Regulation conformity
+  programme. The top-level Project activity (ACTIVITY-EU-PROGRAMME-1) is the
+  one the sibling activity-card binds to; the remaining activities are its
+  children (parent = the project).
+version: "0.1"
+date: "2026-05-28"
+author: "Valerii Korobeinikov"
+
+activities:
+  # ── The project itself ─────────────────────────────────────────────────────
+  - id: ACTIVITY-EU-PROGRAMME-1
+    name: "EU MDR conformity programme"
+    activity_type: Project
+    valid_from: "2026-04-01"     # decision to initiate (lifecycle)
+    valid_to: null               # still active
+    start_date: "2026-04-15"     # planned work range
+    end_date: "2027-03-15"
+    goals: [GOAL-EU-MARKET-1]
+    delivers_changes: [CHANGE-EU-COMPLIANCE-1]
+    description: |
+      Bring the first product line into MDR compliance, secure notified-body
+      certification, and open EU market access.
+
+  # ── Children (parent = the project) ────────────────────────────────────────
+  - id: ACTIVITY-EU-GAP-ANALYSIS-1
+    name: "MDR gap analysis"
+    activity_type: Task
+    parent: ACTIVITY-EU-PROGRAMME-1
+    duration: 20
+    start_date: "2026-04-15"
+    end_date: "2026-05-13"
+    owner: UNIT-REGULATORY
+    goals: [GOAL-EU-MARKET-1]
+
+  - id: ACTIVITY-EU-TECH-FILE-1
+    name: "Technical file compilation"
+    activity_type: Task
+    parent: ACTIVITY-EU-PROGRAMME-1
+    duration: 60
+    predecessors: [ACTIVITY-EU-GAP-ANALYSIS-1]
+    start_date: "2026-05-14"
+    end_date: "2026-08-06"
+    owner: UNIT-QUALITY
+    goals: [GOAL-EU-MARKET-1]
+
+  - id: ACTIVITY-EU-NB-AUDIT-1
+    name: "Notified-body conformity audit"
+    activity_type: Task
+    parent: ACTIVITY-EU-PROGRAMME-1
+    duration: 90
+    predecessors: [ACTIVITY-EU-TECH-FILE-1]
+    start_date: "2026-08-07"
+    end_date: "2026-12-11"
+    owner: UNIT-REGULATORY
+    goals: [GOAL-EU-MARKET-1]
+    delivers_changes: [CHANGE-EU-COMPLIANCE-1]
+
+  - id: ACTIVITY-EU-MARKET-PREP-1
+    name: "EU market-launch preparation"
+    activity_type: Task
+    parent: ACTIVITY-EU-PROGRAMME-1
+    duration: 30
+    predecessors: [ACTIVITY-EU-NB-AUDIT-1]
+    start_date: "2027-02-01"
+    end_date: "2027-03-15"
+    owner: UNIT-COMMERCIAL
+    goals: [GOAL-EU-MARKET-1]

--- a/examples/activity-card/eu-programme.activity-card.transitrix.yaml
+++ b/examples/activity-card/eu-programme.activity-card.transitrix.yaml
@@ -1,0 +1,45 @@
+notation: activity-card
+spec_version: "0.1"
+
+# Worked example — EU regulatory-conformity programme.
+# Single-project narrative view per the methodology spec
+# (transitrix/methodology notations/views/18-activity-card.md).
+#
+# The card binds to an existing project Activity (ACTIVITY-EU-PROGRAMME-1)
+# and adds two narrative milestones for the certification gate and the
+# market-launch follow-on. The project name, dates, motivation chain, and
+# child activities are pulled BY REFERENCE from the sibling documents in
+# this same directory — they are not duplicated here:
+#   eu-programme.activities.transitrix.yaml  → project + child activities
+#   eu-programme.fgca.transitrix.yaml        → Factors → Goals → Changes
+
+activity_card:
+  id: ACTIVITY_CARD-EU-PROGRAMME-1
+  project: ACTIVITY-EU-PROGRAMME-1
+
+  description: >
+    Programme of work bringing the company's first product line into
+    compliance with the EU Medical Device Regulation, certified by a
+    notified body, and live in EU markets under the new regime.
+    Spans 2026-Q2 through 2027-Q1.
+
+  milestones:
+    - id: MILESTONE-EU-CONFORMITY-CERT-1
+      name: "EU MDR conformity-assessment certification obtained"
+      date: "2027-01-31"
+      description: >
+        First product line certified by a notified body under the EU
+        Medical Device Regulation. The certification is a hard gate
+        for EU market access — no sales until this date clears.
+      delivers_changes:
+        - CHANGE-EU-COMPLIANCE-1
+
+    - id: MILESTONE-EU-MARKET-LAUNCH-1
+      name: "First product line live in EU post-certification"
+      date: "2027-03-15"
+      description: >
+        Sales channel opens to EU customers under the new compliance
+        regime. Marketing, support, and supply-chain handovers are
+        complete by this date.
+      delivers_changes:
+        - CHANGE-EU-COMPLIANCE-1

--- a/examples/activity-card/eu-programme.fgca.transitrix.yaml
+++ b/examples/activity-card/eu-programme.fgca.transitrix.yaml
@@ -1,0 +1,30 @@
+notation: fgca
+spec_version: "0.1"
+
+id: FGCA-EU-PROGRAMME-1
+name: "EU MDR conformity — motivation chain"
+description: "Factor → Goal → Change → Activity decomposition behind the EU MDR programme."
+period: "2026-2027"
+version: "0.1"
+date: "2026-05-28"
+author: Transitrix
+
+factors:
+  - id: FACTOR-EU-MDR-1
+    name: "EU Medical Device Regulation in force"
+    type: external
+
+goals:
+  - id: GOAL-EU-MARKET-1
+    name: "Maintain EU market access under MDR"
+    factors: [FACTOR-EU-MDR-1]
+
+changes:
+  - id: CHANGE-EU-COMPLIANCE-1
+    name: "Achieve & certify MDR compliance"
+    goals: [GOAL-EU-MARKET-1]
+
+activities:
+  - id: ACTIVITY-EU-NB-AUDIT-1
+    name: "Notified-body conformity audit"
+    changes: [CHANGE-EU-COMPLIANCE-1]

--- a/extension/package.json
+++ b/extension/package.json
@@ -32,6 +32,7 @@
     "critical-path",
     "process-map",
     "process-blueprint",
+    "activity-card",
     "capability-map",
     "scenarios",
     "applications",
@@ -62,6 +63,7 @@
     "workspaceContains:**/*.scenarios.transitrix.yaml",
     "workspaceContains:**/*.capability-map.transitrix.yaml",
     "workspaceContains:**/*.process-blueprint.transitrix.yaml",
+    "workspaceContains:**/*.activity-card.transitrix.yaml",
     "workspaceContains:**/*.issues.transitrix.yaml"
   ],
   "contributes": {
@@ -320,6 +322,17 @@
         "configuration": "./language-configuration.json"
       },
       {
+        "id": "transitrix-activity-card",
+        "aliases": [
+          "Transitrix Activity Card",
+          "Activity Card"
+        ],
+        "extensions": [
+          ".activity-card.transitrix.yaml"
+        ],
+        "configuration": "./language-configuration.json"
+      },
+      {
         "id": "transitrix-issues",
         "aliases": [
           "Transitrix Issues",
@@ -479,6 +492,28 @@
         "title": "Transitrix: Save process blueprint as SVG",
         "category": "Transitrix",
         "icon": "$(save)"
+      },
+      {
+        "command": "transitrixStudio.previewActivityCard",
+        "title": "Transitrix: Preview activity card",
+        "category": "Transitrix",
+        "icon": "$(type-hierarchy)"
+      },
+      {
+        "command": "transitrixStudio.saveActivityCardAsSvg",
+        "title": "Transitrix: Save activity card as SVG",
+        "category": "Transitrix",
+        "icon": "$(save)"
+      },
+      {
+        "command": "transitrixStudio.saveActivityCardAsPng",
+        "title": "Transitrix: Save activity card as PNG",
+        "category": "Transitrix"
+      },
+      {
+        "command": "transitrixStudio.copyActivityCardAsPng",
+        "title": "Transitrix: Copy activity card as PNG",
+        "category": "Transitrix"
       },
       {
         "command": "transitrixStudio.previewIssues",
@@ -701,6 +736,21 @@
         {
           "when": "activeWebviewPanelId == processBlueprintPreview",
           "command": "transitrixStudio.saveProcessBlueprintAsSvg",
+          "group": "navigation@-9"
+        },
+        {
+          "when": "resourceFilename =~ /\\.activity-card\\.transitrix\\.yaml$/",
+          "command": "transitrixStudio.previewActivityCard",
+          "group": "navigation@-10"
+        },
+        {
+          "when": "resourceFilename =~ /\\.activity-card\\.transitrix\\.yaml$/",
+          "command": "transitrixStudio.saveActivityCardAsSvg",
+          "group": "navigation@-9"
+        },
+        {
+          "when": "activeWebviewPanelId == activityCardPreview",
+          "command": "transitrixStudio.saveActivityCardAsSvg",
           "group": "navigation@-9"
         },
         {

--- a/extension/src/activity-card-preview.ts
+++ b/extension/src/activity-card-preview.ts
@@ -1,0 +1,336 @@
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+import yaml from 'js-yaml';
+import { buildDiagramFrame, prepareSvgForExport, type ThemeId } from './diagram-frame.js';
+import { TITLE_BLOCK_H, titleBlockSvg, todayIso } from './svg-title-block.js';
+import {
+  validateActivityCard,
+  resolveActivityCard,
+  layoutActivityCard,
+  type ActivityCardDoc,
+  type ActivityCardLayout,
+} from '../../packages/diagrams/src/activity-card/index.js';
+import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
+import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
+
+// The Activity Card is the first MULTI-DOCUMENT Studio preview. The card YAML
+// names a project Activity; the project's name/dates, the motivation chain,
+// and the child activities are pulled by reference from sibling
+// `*.activities.*` / `*.fgca.*` documents in the SAME directory. This preview
+// owns the filesystem half of that resolution (read + parse the siblings); the
+// pure resolver in `@transitrix/diagrams` does the rest.
+
+const ACTIVITIES_SUFFIX = '.activities.transitrix.yaml';
+const FGCA_SUFFIX = '.fgca.transitrix.yaml';
+const CARD_SUFFIX = '.activity-card.transitrix.yaml';
+
+function escXml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+function truncate(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  return text.slice(0, Math.max(0, maxChars - 1)) + '…';
+}
+
+interface SiblingDocs {
+  activitiesDocs: unknown[];
+  fgcaDocs: unknown[];
+  warnings: string[];
+}
+
+/** Read + parse every sibling `*.activities.*` / `*.fgca.*` doc in `dirUri`. */
+async function readSiblingDocs(dirUri: vscode.Uri): Promise<SiblingDocs> {
+  const activitiesDocs: unknown[] = [];
+  const fgcaDocs: unknown[] = [];
+  const warnings: string[] = [];
+
+  let entries: [string, vscode.FileType][];
+  try {
+    entries = await vscode.workspace.fs.readDirectory(dirUri);
+  } catch {
+    return { activitiesDocs, fgcaDocs, warnings: ['Could not read the card directory to resolve sibling documents.'] };
+  }
+
+  for (const [name, type] of entries) {
+    if (type !== vscode.FileType.File) continue;
+    const isActivities = name.endsWith(ACTIVITIES_SUFFIX);
+    const isFgca = name.endsWith(FGCA_SUFFIX);
+    if (!isActivities && !isFgca) continue;
+    try {
+      const bytes = await vscode.workspace.fs.readFile(vscode.Uri.joinPath(dirUri, name));
+      const parsed = coerceDatesToIsoStrings(yaml.load(Buffer.from(bytes).toString('utf-8')) as unknown);
+      if (isActivities) activitiesDocs.push(parsed);
+      else fgcaDocs.push(parsed);
+    } catch (e) {
+      warnings.push(`Skipped sibling ${name}: ${(e as Error).message ?? 'parse error'}`);
+    }
+  }
+
+  if (activitiesDocs.length === 0) {
+    warnings.push(`No sibling ${ACTIVITIES_SUFFIX} document found — project + child activities cannot resolve.`);
+  }
+  return { activitiesDocs, fgcaDocs, warnings };
+}
+
+const ARROW_DEF = `<defs><marker id="ac-arrow" markerWidth="8" markerHeight="8" refX="8" refY="3" orient="auto"><path d="M0,0 L0,6 L8,3 z" class="arrow-fill"/></marker></defs>`;
+
+function layoutToSvg(layout: ActivityCardLayout, filename?: string, date?: string, version?: string): string {
+  const pad = 24;
+  const showTitle = filename != null && date != null;
+  const titleH = showTitle ? TITLE_BLOCK_H : 0;
+  const w = layout.bounds.width + pad * 2;
+  const h = layout.bounds.height + pad * 2 + titleH;
+  const ox = pad;
+  const oy = pad + titleH;
+
+  const parts: string[] = [ARROW_DEF];
+
+  // Outer card.
+  parts.push(
+    `<rect class="diagram-node level-0" x="${ox}" y="${oy}" width="${layout.bounds.width}" height="${layout.bounds.height}" rx="8"/>`,
+  );
+
+  // Title (project name).
+  parts.push(
+    `<text class="text-header" x="${layout.title.x + ox}" y="${layout.title.y + oy}" dominant-baseline="central" font-size="18">${escXml(truncate(layout.title.name, 70))}</text>`,
+  );
+
+  // Dates band.
+  for (const d of layout.dateFields) {
+    parts.push(
+      `<rect class="diagram-node level-2" x="${d.x + ox}" y="${d.y + oy}" width="${d.width}" height="${d.height}" rx="6"/>`,
+    );
+    parts.push(
+      `<text class="text-secondary" x="${d.x + ox + 12}" y="${d.y + oy + 18}" dominant-baseline="central">${escXml(d.label)}</text>`,
+    );
+    parts.push(
+      `<text class="text-primary" x="${d.x + ox + 12}" y="${d.y + oy + 40}" dominant-baseline="central">${escXml(d.value)}</text>`,
+    );
+  }
+
+  // Section headers.
+  for (const s of layout.sectionHeaders) {
+    parts.push(
+      `<text class="text-header" x="${s.x + ox}" y="${s.y + oy + s.height / 2}" dominant-baseline="central">${escXml(s.label)}</text>`,
+    );
+  }
+
+  // Milestones.
+  for (const m of layout.milestones) {
+    parts.push(
+      `<rect class="diagram-node level-3" x="${m.x + ox}" y="${m.y + oy}" width="${m.width}" height="${m.height}" rx="6"/>`,
+    );
+    parts.push(
+      `<text class="text-secondary" x="${m.x + ox + 10}" y="${m.y + oy + 16}" dominant-baseline="central">${escXml(m.date)}</text>`,
+    );
+    parts.push(
+      `<text class="text-primary" x="${m.x + ox + 10}" y="${m.y + oy + 36}" dominant-baseline="central">${escXml(truncate(m.name, 22))}</text>`,
+    );
+    parts.push(
+      `<text class="text-secondary" x="${m.x + ox + 10}" y="${m.y + oy + 52}" dominant-baseline="central" font-style="italic">(${escXml(m.archimateClass)})</text>`,
+    );
+  }
+
+  // Motivation chain — edges first (under nodes).
+  const nodeById = new Map<string, { x: number; y: number; width: number; height: number }>();
+  for (const col of [layout.chainColumns.factors, layout.chainColumns.goals, layout.chainColumns.changes]) {
+    for (const n of col) nodeById.set(n.id, n);
+  }
+  for (const e of layout.chainEdges) {
+    const s = nodeById.get(e.sourceId);
+    const t = nodeById.get(e.targetId);
+    if (!s || !t) continue;
+    const x1 = s.x + s.width + ox;
+    const y1 = s.y + s.height / 2 + oy;
+    const x2 = t.x + ox;
+    const y2 = t.y + t.height / 2 + oy;
+    const mx = (x1 + x2) / 2;
+    parts.push(
+      `<path class="diagram-edge" d="M${x1},${y1} C${mx},${y1} ${mx},${y2} ${x2},${y2}" fill="none" marker-end="url(#ac-arrow)"/>`,
+    );
+  }
+  const chainLevels: Array<[typeof layout.chainColumns.factors, number]> = [
+    [layout.chainColumns.factors, 4],
+    [layout.chainColumns.goals, 5],
+    [layout.chainColumns.changes, 6],
+  ];
+  for (const [col, level] of chainLevels) {
+    for (const n of col) {
+      parts.push(
+        `<rect class="diagram-node level-${level}" x="${n.x + ox}" y="${n.y + oy}" width="${n.width}" height="${n.height}" rx="6"/>`,
+      );
+      parts.push(
+        `<text class="text-pill" x="${n.x + ox + n.width / 2}" y="${n.y + oy + n.height / 2}" text-anchor="middle" dominant-baseline="central">${escXml(truncate(n.name, Math.floor(n.width / 7)))}</text>`,
+      );
+    }
+  }
+
+  // Child activities.
+  for (const a of layout.childActivities) {
+    parts.push(
+      `<rect class="diagram-node level-1" x="${a.x + ox}" y="${a.y + oy}" width="${a.width}" height="${a.height}" rx="6"/>`,
+    );
+    parts.push(
+      `<text class="text-primary" x="${a.x + ox + 12}" y="${a.y + oy + a.height / 2}" dominant-baseline="central">${escXml(truncate(a.name, 48))} <tspan class="text-secondary" font-style="italic">(${escXml(a.archimateClass)})</tspan></text>`,
+    );
+    if (a.meta) {
+      parts.push(
+        `<text class="text-secondary" x="${a.x + a.width + ox - 12}" y="${a.y + oy + a.height / 2}" text-anchor="end" dominant-baseline="central">${escXml(truncate(a.meta, 40))}</text>`,
+      );
+    }
+  }
+
+  const titleSvg = showTitle ? titleBlockSvg('Activity Card', filename!, date!, pad, pad, version) : '';
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">
+${titleSvg}
+${parts.join('\n')}
+</svg>`;
+}
+
+export class ActivityCardPreview {
+  readonly panelTitle = 'Activity Card Preview';
+  private panel: vscode.WebviewPanel | undefined;
+  private trackedUri: string | undefined;
+  private lastSvg = '';
+
+  isShowingDocument(uri: vscode.Uri): boolean {
+    return this.panel != null && this.trackedUri === uri.toString();
+  }
+
+  async showOrReveal(doc: vscode.TextDocument): Promise<void> {
+    this.trackedUri = doc.uri.toString();
+    if (this.panel) {
+      this.panel.title = `${this.panelTitle} — ${path.basename(doc.fileName)}`;
+      this.panel.reveal(vscode.ViewColumn.Beside, true);
+    } else {
+      this.panel = vscode.window.createWebviewPanel(
+        'activityCardPreview',
+        `${this.panelTitle} — ${path.basename(doc.fileName)}`,
+        { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
+        {
+          enableScripts: false,
+          retainContextWhenHidden: true,
+          enableCommandUris: [
+            'transitrixStudio.saveActivityCardAsSvg',
+            'transitrixStudio.saveActivityCardAsPng',
+            'transitrixStudio.copyActivityCardAsPng',
+          ],
+        },
+      );
+      this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
+    }
+    await this.pushDocument(doc);
+  }
+
+  async refreshSaved(doc: vscode.TextDocument): Promise<void> {
+    if (!this.isShowingDocument(doc.uri)) return;
+    await this.pushDocument(doc);
+  }
+
+  /**
+   * Multi-document refresh: when a sibling `*.activities.*` / `*.fgca.*` doc in
+   * the same directory as the tracked card is saved, re-resolve and re-render.
+   */
+  async refreshIfSiblingSaved(doc: vscode.TextDocument): Promise<void> {
+    if (!this.panel || !this.trackedUri) return;
+    const name = path.basename(doc.fileName);
+    if (!name.endsWith(ACTIVITIES_SUFFIX) && !name.endsWith(FGCA_SUFFIX)) return;
+    const cardUri = vscode.Uri.parse(this.trackedUri);
+    if (path.dirname(doc.uri.fsPath) !== path.dirname(cardUri.fsPath)) return;
+    const cardDoc = await vscode.workspace.openTextDocument(cardUri);
+    await this.pushDocument(cardDoc);
+  }
+
+  private async pushDocument(doc: vscode.TextDocument): Promise<void> {
+    if (!this.panel) return;
+    const dirUri = vscode.Uri.file(path.dirname(doc.uri.fsPath));
+    const siblings = await readSiblingDocs(dirUri);
+    this.panel.webview.html = this.buildHtml(doc.getText(), path.basename(doc.fileName), siblings);
+  }
+
+  private buildHtml(yamlText: string, filename: string, siblings: SiblingDocs): string {
+    let svgContent = '';
+    let errorMsg = '';
+    const warnings: string[] = [...siblings.warnings];
+
+    try {
+      const parsed = coerceDatesToIsoStrings(yaml.load(yamlText) as unknown);
+      const v = validateActivityCard(parsed);
+      warnings.push(...v.warnings.map((w) => `${w.code}: ${w.message}`));
+      if (!v.valid) {
+        errorMsg = v.errors.map((e) => `${e.code}: ${e.message}`).join('\n');
+      } else {
+        const cardDoc = parsed as ActivityCardDoc;
+        const r = resolveActivityCard(cardDoc, {
+          activitiesDocs: siblings.activitiesDocs,
+          fgcaDocs: siblings.fgcaDocs,
+        });
+        warnings.push(...r.warnings.map((w) => `${w.code}: ${w.message}`));
+        if (!r.valid || !r.resolved) {
+          errorMsg = r.errors.map((e) => `${e.code}: ${e.message}`).join('\n');
+        } else {
+          const meta = (parsed && typeof parsed === 'object' ? parsed : {}) as Record<string, unknown>;
+          const docVersion = typeof meta['version'] === 'string' ? (meta['version'] as string) : undefined;
+          const docDate = typeof meta['date'] === 'string' ? (meta['date'] as string) : todayIso();
+          const layout = layoutActivityCard(r.resolved);
+          svgContent = layoutToSvg(layout, filename, docDate, docVersion);
+        }
+      }
+    } catch (e) {
+      errorMsg = (e as Error).message ?? 'Parse error';
+    }
+
+    this.lastSvg = svgContent;
+
+    const themeId = vscode.workspace.getConfiguration('transitrix').get<ThemeId>('theme', 'transitrix');
+    return buildDiagramFrame({
+      filename, notation: 'Activity Card', svgContent, errorMsg, warnings, themeId,
+      saveSvgCommand: 'transitrixStudio.saveActivityCardAsSvg',
+      savePngCommand: 'transitrixStudio.saveActivityCardAsPng',
+      copyPngCommand: 'transitrixStudio.copyActivityCardAsPng',
+    });
+  }
+
+  private pngTarget() {
+    return {
+      rawSvg: this.lastSvg || undefined,
+      themeId: vscode.workspace.getConfiguration('transitrix').get<ThemeId>('theme', 'transitrix'),
+      emptyMessage: 'No card rendered yet. Open a *.activity-card.transitrix.yaml file first.',
+    };
+  }
+
+  saveAsPng(): Promise<void> {
+    const sourceUri = this.trackedUri ? vscode.Uri.parse(this.trackedUri) : undefined;
+    return savePngFromSvg({ ...this.pngTarget(), sourceUri, stripExt: /\.activity-card\.transitrix\.yaml$/ });
+  }
+
+  copyAsPng(): Promise<void> {
+    return copyPngFromSvg(this.pngTarget());
+  }
+
+  async saveAsSvg(): Promise<void> {
+    if (!this.lastSvg) {
+      vscode.window.showWarningMessage('No card rendered yet. Open a *.activity-card.transitrix.yaml file first.');
+      return;
+    }
+    const sourceUri = this.trackedUri ? vscode.Uri.parse(this.trackedUri) : undefined;
+    const stem = sourceUri
+      ? path.basename(sourceUri.fsPath).replace(/\.activity-card\.transitrix\.yaml$/, '')
+      : 'diagram';
+    const defaultUri = sourceUri
+      ? vscode.Uri.file(path.join(path.dirname(sourceUri.fsPath), `${stem}.svg`))
+      : vscode.Uri.file(`${stem}.svg`);
+    const target = await vscode.window.showSaveDialog({ defaultUri, filters: { 'SVG Image': ['svg'] } });
+    if (!target) return;
+    const themeId = vscode.workspace.getConfiguration('transitrix').get<ThemeId>('theme', 'transitrix');
+    const svg = prepareSvgForExport(this.lastSvg, themeId);
+    await vscode.workspace.fs.writeFile(target, Buffer.from(svg, 'utf-8'));
+    vscode.window.showInformationMessage(`Saved: ${path.basename(target.fsPath)}`);
+  }
+}
+
+/** Suffix guard used by the extension router. */
+export function isActivityCardFileName(fileName: string): boolean {
+  return fileName.endsWith(CARD_SUFFIX);
+}

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -14,6 +14,7 @@ import { ProcessMapPreview } from './process-map-preview.js';
 import { ScenariosPreview } from './scenarios-preview.js';
 import { CapabilityMapPreview } from './capability-map-preview.js';
 import { ProcessBlueprintPreview } from './process-blueprint-preview.js';
+import { ActivityCardPreview } from './activity-card-preview.js';
 import { IssuesPreview } from './issues-preview.js';
 import type { LayoutMetrics, ValidationReport } from './types.js';
 import {
@@ -76,6 +77,10 @@ function isProcessBlueprintFile(doc: vscode.TextDocument): boolean {
 
 function isIssuesFile(doc: vscode.TextDocument): boolean {
   return doc.fileName.endsWith('.issues.transitrix.yaml');
+}
+
+function isActivityCardFile(doc: vscode.TextDocument): boolean {
+  return doc.fileName.endsWith('.activity-card.transitrix.yaml');
 }
 
 async function loadCompiler(ext: vscode.ExtensionContext): Promise<CompileFn> {
@@ -144,6 +149,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   const scenariosPreview = new ScenariosPreview();
   const capabilityMapPreview = new CapabilityMapPreview();
   const processBlueprintPreview = new ProcessBlueprintPreview();
+  const activityCardPreview = new ActivityCardPreview();
   const issuesPreview = new IssuesPreview();
 
   context.subscriptions.push(
@@ -281,6 +287,19 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     }),
     vscode.commands.registerCommand('transitrixStudio.saveProcessBlueprintAsPng', () => processBlueprintPreview.saveAsPng()),
     vscode.commands.registerCommand('transitrixStudio.copyProcessBlueprintAsPng', () => processBlueprintPreview.copyAsPng()),
+    vscode.commands.registerCommand('transitrixStudio.previewActivityCard', async () => {
+      const doc = vscode.window.activeTextEditor?.document;
+      if (!doc || !isActivityCardFile(doc)) {
+        vscode.window.showWarningMessage('Open a *.activity-card.transitrix.yaml file first.');
+        return;
+      }
+      await activityCardPreview.showOrReveal(doc);
+    }),
+    vscode.commands.registerCommand('transitrixStudio.saveActivityCardAsSvg', async () => {
+      await activityCardPreview.saveAsSvg();
+    }),
+    vscode.commands.registerCommand('transitrixStudio.saveActivityCardAsPng', () => activityCardPreview.saveAsPng()),
+    vscode.commands.registerCommand('transitrixStudio.copyActivityCardAsPng', () => activityCardPreview.copyAsPng()),
     vscode.commands.registerCommand('transitrixStudio.previewIssues', async () => {
       const doc = vscode.window.activeTextEditor?.document;
       if (!doc || !isIssuesFile(doc)) {
@@ -320,6 +339,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       void activitiesPreview.refreshConfig();
     }),
     vscode.workspace.onDidSaveTextDocument((doc) => {
+      // Multi-document: an open Activity Card re-resolves when one of its
+      // sibling *.activities.* / *.fgca.* documents is saved. Runs before the
+      // per-type routing below (which early-returns on a match).
+      void activityCardPreview.refreshIfSiblingSaved(doc);
       if (isGoalsFile(doc)) { void goalsPreview.refreshSaved(doc); return; }
       if (isFGCAFile(doc)) { void fgcaPreview.refreshSaved(doc); return; }
       if (isFGAFile(doc)) { void fgaPreview.refreshSaved(doc); return; }
@@ -331,6 +354,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       if (isScenariosFile(doc)) { void scenariosPreview.refreshSaved(doc); return; }
       if (isCapabilityMapFile(doc)) { void capabilityMapPreview.refreshSaved(doc); return; }
       if (isProcessBlueprintFile(doc)) { void processBlueprintPreview.refreshSaved(doc); return; }
+      if (isActivityCardFile(doc)) { void activityCardPreview.refreshSaved(doc); return; }
       if (isIssuesFile(doc)) { void issuesPreview.refreshSaved(doc); return; }
       if (!documentMatchesCervinSource(doc)) return;
       void preview.refreshSaved(doc);
@@ -347,6 +371,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       if (isScenariosFile(doc)) { await scenariosPreview.showOrReveal(doc); return; }
       if (isCapabilityMapFile(doc)) { await capabilityMapPreview.showOrReveal(doc); return; }
       if (isProcessBlueprintFile(doc)) { await processBlueprintPreview.showOrReveal(doc); return; }
+      if (isActivityCardFile(doc)) { await activityCardPreview.showOrReveal(doc); return; }
       if (isIssuesFile(doc)) { await issuesPreview.showOrReveal(doc); }
     }),
   );

--- a/packages/diagrams/src/activity-card/__tests__/example.test.ts
+++ b/packages/diagrams/src/activity-card/__tests__/example.test.ts
@@ -1,0 +1,54 @@
+// Conformance test for the shipped worked example. Exercises the full
+// validate → resolve → layout pipeline against the real co-located example
+// files under `examples/activity-card/`, so the success signal of #134 is
+// pinned and any drift in the example or the resolver is caught by CI.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import yaml from 'js-yaml';
+import { validateActivityCard } from '../validate.js';
+import { resolveActivityCard } from '../resolver.js';
+import { layoutActivityCard } from '../layout.js';
+import type { ActivityCardDoc } from '../types.js';
+
+const dir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../../../examples/activity-card',
+);
+const load = (f: string): unknown => yaml.load(readFileSync(path.join(dir, f), 'utf-8'));
+
+describe('activity-card worked example (eu-programme)', () => {
+  it('validates, resolves, and lays out the success-signal card', () => {
+    const card = load('eu-programme.activity-card.transitrix.yaml');
+    const activitiesDocs = [load('eu-programme.activities.transitrix.yaml')];
+    const fgcaDocs = [load('eu-programme.fgca.transitrix.yaml')];
+
+    const v = validateActivityCard(card);
+    expect(v.valid, JSON.stringify(v.errors)).toBe(true);
+
+    const r = resolveActivityCard(card as ActivityCardDoc, { activitiesDocs, fgcaDocs });
+    expect(r.valid, JSON.stringify(r.errors)).toBe(true);
+    expect(r.warnings, JSON.stringify(r.warnings)).toHaveLength(0);
+
+    const c = r.resolved!;
+    expect(c.project.name).toBe('EU MDR conformity programme');
+    expect(c.project.valid_from).toBe('2026-04-01');
+    expect(c.project.start_date).toBe('2026-04-15');
+    expect(c.project.end_date).toBe('2027-03-15');
+    expect(c.milestones.map((m) => m.id)).toEqual([
+      'MILESTONE-EU-CONFORMITY-CERT-1',
+      'MILESTONE-EU-MARKET-LAUNCH-1',
+    ]);
+    expect(c.motivation.factors.map((f) => f.id)).toEqual(['FACTOR-EU-MDR-1']);
+    expect(c.motivation.goals.map((g) => g.id)).toEqual(['GOAL-EU-MARKET-1']);
+    expect(c.motivation.changes.map((x) => x.id)).toEqual(['CHANGE-EU-COMPLIANCE-1']);
+    expect(c.childActivities).toHaveLength(4);
+
+    const layout = layoutActivityCard(c);
+    expect(layout.bounds.height).toBeGreaterThan(0);
+    expect(layout.chainEdges).toContainEqual({ sourceId: 'FACTOR-EU-MDR-1', targetId: 'GOAL-EU-MARKET-1' });
+    expect(layout.chainEdges).toContainEqual({ sourceId: 'GOAL-EU-MARKET-1', targetId: 'CHANGE-EU-COMPLIANCE-1' });
+  });
+});


### PR DESCRIPTION
## Why

PR #83 (PR1, `@transitrix/diagrams` half) and PR #84 (PR2, extension half) of the Activity Card (#134) were merged stacked, but the order left PR2 off `main`: #84 merged the extension branch into the **PR1 branch**, while #83 had already merged the PR1 branch into `main` ~12s earlier. Net result on `main`:

- PR1 present — `packages/diagrams/src/activity-card/` (types / resolver / validator / layout).
- PR2 missing — `extension/src/activity-card-preview.ts`, the command/activation/language wiring in `extension/package.json`, the `examples/activity-card/` worked example, and the `example.test.ts` conformance test.

So the notation has its model on `main` but no preview, no wiring, and no example — it won't render in the extension.

## What

Brings the PR2 commits (already reviewed in #84) onto `main`. Diff is PR2-only — same content as #84.

Do not auto-merge — Valerii gates.