### PR TITLE
feat(controls): live in-preview spacing/curvature/scope controls (#75/#76/#77 PR2)

### DIFF
--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -18,7 +18,8 @@ import {
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 import { horizontalCubicEdgePath, DEFAULT_EDGE_CURVATURE } from '../../packages/diagrams/src/edge-path.js';
 import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
-import { readSpacing, readCurvature, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND } from './spacing-config.js';
+import { readSpacing, readCurvature, applyControlMessage, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND } from './spacing-config.js';
+import { genNonce, buildControlsPanel, buildControlsScript } from './preview-controls.js';
 
 // Default network (PSND) gaps — must match the layoutActivities defaults
 // (H_GAP / V_GAP) so an unconfigured preview is visually unchanged.
@@ -553,6 +554,8 @@ export class ActivitiesPreview {
   private lastNetworkSvg = '';
   private lastGanttSvg = '';
 
+  constructor(private readonly extensionUri: vscode.Uri) {}
+
   isShowingDocument(uri: vscode.Uri): boolean {
     return this.panel != null && this.trackedUri === uri.toString();
   }
@@ -567,8 +570,18 @@ export class ActivitiesPreview {
         'activitiesPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveActivitiesAsSvg', 'transitrixStudio.saveActivitiesAsPng', 'transitrixStudio.copyActivitiesAsPng', OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND] },
+        {
+          // Scripts enabled for the in-preview spacing/curvature controls under
+          // the strict nonce CSP (#75/#76 PR2). The CSS-only Network/Gantt tab
+          // switcher and zoom control continue to work unchanged. Activities
+          // has no scope control (#77 excludes it).
+          enableScripts: true,
+          retainContextWhenHidden: true,
+          localResourceRoots: [vscode.Uri.joinPath(this.extensionUri, 'media')],
+          enableCommandUris: ['transitrixStudio.saveActivitiesAsSvg', 'transitrixStudio.saveActivitiesAsPng', 'transitrixStudio.copyActivitiesAsPng', OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND],
+        },
       );
+      this.panel.webview.onDidReceiveMessage((m) => { void applyControlMessage('activities', m); });
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
     }
     await this.pushDocument(doc);
@@ -596,6 +609,10 @@ export class ActivitiesPreview {
     let errorMsg = '';
     let warnings: string[] = [];
 
+    const spacingDefaults = { horizontalGap: ACTIVITIES_DEFAULT_H_GAP, verticalGap: ACTIVITIES_DEFAULT_V_GAP };
+    const spacing = readSpacing('activities', spacingDefaults);
+    const curvature = readCurvature('activities');
+
     try {
       const parsed = coerceDatesToIsoStrings(yaml.load(yamlText) as unknown);
       // Document version/date for the title block. `version` is optional;
@@ -610,8 +627,7 @@ export class ActivitiesPreview {
       if (!v.valid) {
         errorMsg = v.errors.map(e => `${e.code}: ${e.message}`).join('\n');
       } else {
-        const spacing = readSpacing('activities', { horizontalGap: ACTIVITIES_DEFAULT_H_GAP, verticalGap: ACTIVITIES_DEFAULT_V_GAP });
-        const views = buildActivityViews(parsed as ActivityDoc, { horizontalGap: spacing.horizontalGap, verticalGap: spacing.verticalGap }, readCurvature('activities'), filename, docDate, docVersion);
+        const views = buildActivityViews(parsed as ActivityDoc, { horizontalGap: spacing.horizontalGap, verticalGap: spacing.verticalGap }, curvature, filename, docDate, docVersion);
         bodyContent = buildCanvasContent(views);
         this.lastNetworkSvg = views.networkSvg;
         this.lastGanttSvg = views.ganttSvg;
@@ -629,6 +645,14 @@ export class ActivitiesPreview {
       .getConfiguration('transitrix')
       .get<ThemeId>('theme', 'transitrix');
 
+    const nonce = genNonce();
+    // Activities has spacing + curvature controls but no scope filter (#77
+    // excludes it — its multi-row CPM layout isn't a uniform tree).
+    const controlsPanel = buildControlsPanel({
+      spacing: { ...spacing, defaults: spacingDefaults },
+      curvature: { value: curvature, default: 1 },
+    });
+
     return buildDiagramFrame({
       filename,
       notation: 'Activities (PSND + Gantt)',
@@ -642,6 +666,7 @@ export class ActivitiesPreview {
       copyPngCommand: 'transitrixStudio.copyActivitiesAsPng',
       spacingCommand: OPEN_SPACING_SETTINGS_COMMAND,
       curvatureCommand: OPEN_CURVATURE_SETTINGS_COMMAND,
+      interactive: { nonce, controlsPanel, controlsScript: buildControlsScript(nonce) },
     });
   }
 

--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -1,5 +1,6 @@
 import type { ThemeId } from '../../packages/diagrams/src/theme/index.js';
 import { generateWebviewCss, generateSvgEmbedCss } from '../../packages/diagrams/src/theme/index.js';
+import { CONTROLS_PANEL_CSS } from './preview-controls.js';
 
 export type { ThemeId };
 
@@ -90,6 +91,23 @@ export interface DiagramFrameOpts {
    * opt-in contract as `spacingCommand`.
    */
   scopeCommand?: string;
+  /**
+   * Opt-in to in-preview interactive controls (vkgeorgia/strategy#75/#76/#77 —
+   * PR2). When present, the frame switches from the script-less static CSP to a
+   * strict nonce-based CSP (`default-src 'none'; style-src 'unsafe-inline';
+   * script-src 'nonce-…'`), injects the control panel below the toolbar, and
+   * appends the nonce'd wiring script. The preview's webview MUST be created
+   * with `enableScripts: true` for this to function. Omitted on every static
+   * (script-less) preview — those keep the script-less CSP byte-for-byte.
+   *
+   * `controlsPanel` / `controlsScript` come from `preview-controls.ts`
+   * (`buildControlsPanel` / `buildControlsScript`); `nonce` from `genNonce()`.
+   */
+  interactive?: {
+    nonce: string;
+    controlsPanel: string;
+    controlsScript: string;
+  };
 }
 
 function escXml(s: string): string {
@@ -283,6 +301,7 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
     themeId = 'transitrix', extraStyles = '', fixPrompt = '',
     title, subtitle, version, date,
     saveSvgCommand, savePngCommand, copyPngCommand, spacingCommand, curvatureCommand, scopeCommand,
+    interactive,
   } = opts;
 
   const canvasContent = bodyContent ?? svgContent;
@@ -374,17 +393,28 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
     ? `<div class="toolbar-actions">${actionParts.join('')}</div>`
     : '';
 
+  // Interactive previews (vkgeorgia/strategy#75/#76/#77 PR2) opt into a strict
+  // nonce-based CSP and the in-preview control panel. Static previews keep the
+  // script-less CSP unchanged — the only diff in their output is none.
+  const csp = interactive
+    ? `default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${interactive.nonce}';`
+    : `default-src 'none'; style-src 'unsafe-inline';`;
+  const controlsCss = interactive ? CONTROLS_PANEL_CSS : '';
+  const controlsPanel = interactive ? interactive.controlsPanel : '';
+  const controlsScript = interactive ? interactive.controlsScript : '';
+
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8"/>
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline';">
+  <meta http-equiv="Content-Security-Policy" content="${csp}">
   <style>
 ${generateWebviewCss(themeId)}
 ${FIX_PROMPT_CSS}
 ${FRAME_HEADER_CSS}
 ${TITLE_TOGGLE_CSS}
 ${ZOOM_CONTROL_CSS}
+${controlsCss}
 ${extraStyles}
   </style>
 </head>
@@ -392,11 +422,13 @@ ${extraStyles}
   ${toggleInput}
   ${zoomInputs}
   <div id="toolbar"><span class="toolbar-label">${escXml(notation)}: ${escXml(filename)}</span>${toolbarRight}</div>
+  ${controlsPanel}
   ${errBlock}${fixPromptBlock}${warnBlock}
   ${headerBlock}
   <div id="canvas">
     ${canvasContent}
   </div>
+  ${controlsScript}
 </body>
 </html>`;
 }

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -133,10 +133,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   const preview = new CervinPreview(context.extensionUri, (yaml: string) =>
     compiler().then((c) => c(yaml)),
   );
-  const goalsPreview = new GoalsPreview();
-  const fgcaPreview = new FGCAPreview();
-  const fgaPreview = new FGAPreview();
-  const activitiesPreview = new ActivitiesPreview();
+  const goalsPreview = new GoalsPreview(context.extensionUri);
+  const fgcaPreview = new FGCAPreview(context.extensionUri);
+  const fgaPreview = new FGAPreview(context.extensionUri);
+  const activitiesPreview = new ActivitiesPreview(context.extensionUri);
   const blocksPreview = new BlocksPreview();
   const applicationsPreview = new ApplicationsPreview();
   const productsPreview = new ProductsPreview();
@@ -305,9 +305,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     ),
     // Re-render the spacing/curvature/scope-aware previews when a gap, curvature
     // or scope setting changes — the settings-driven persistence mechanism
-    // (vkgeorgia/strategy#75, #76, #77). Previews keep `enableScripts: false`;
-    // the change is applied host-side by rebuilding the webview HTML from the
-    // tracked document.
+    // (vkgeorgia/strategy#75, #76, #77). Config is the single source of truth:
+    // both the in-preview controls (PR2) and the "…" Settings links write here,
+    // and this handler rebuilds the webview HTML from the tracked document.
     vscode.workspace.onDidChangeConfiguration((e) => {
       if (
         !e.affectsConfiguration(SPACING_CONFIG_SECTION) &&

--- a/extension/src/fgca-preview.ts
+++ b/extension/src/fgca-preview.ts
@@ -17,7 +17,8 @@ import { horizontalCubicEdgePath, DEFAULT_EDGE_CURVATURE } from '../../packages/
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 import { checkScopeRoot, type Scope } from '../../packages/diagrams/src/scope.js';
 import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
-import { readSpacing, readCurvature, readScope, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND } from './spacing-config.js';
+import { readSpacing, readCurvature, readScope, applyControlMessage, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND } from './spacing-config.js';
+import { genNonce, buildControlsPanel, buildControlsScript, type ControlsModel, type ScopeGoalOption } from './preview-controls.js';
 
 // ── Inline render types ─────────────────────────────────────────────────────
 //
@@ -60,6 +61,36 @@ const COL_LABELS: Record<string, string> = {
 
 function escXml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+/** Goal options + deepest level for the scope control, from a parsed doc. FGCA
+ *  and FGA goals are flat, so a `root` scope is the single matching goal. */
+function scopeInputsFromDoc(doc: FGCADoc): { goals: ScopeGoalOption[]; maxLevelPresent: number } {
+  return {
+    goals: doc.goals.map(g => ({ id: String(g.id), name: g.name ?? '' })),
+    maxLevelPresent: doc.goals.reduce((m, g) => Math.max(m, typeof g.level === 'number' ? g.level : 0), 0),
+  };
+}
+
+/** Assembles the interactive control-panel model shared by FGCA and FGA. */
+function fgcaControlsModel(
+  gaps: { horizontalGap: number; verticalGap: number },
+  defaults: { horizontalGap: number; verticalGap: number },
+  curvature: number,
+  scope: Scope,
+  goals: ScopeGoalOption[],
+  maxLevelPresent: number,
+): ControlsModel {
+  return {
+    spacing: { ...gaps, defaults },
+    curvature: { value: curvature, default: 1 },
+    scope: {
+      rootId: scope.mode === 'root' ? scope.rootGoalId : '',
+      maxLevel: scope.mode === 'level' ? scope.maxLevel : -1,
+      maxLevelPresent,
+      goals,
+    },
+  };
 }
 
 function buildSvg(
@@ -146,6 +177,8 @@ export class FGCAPreview {
   private trackedUri: string | undefined;
   private lastSvg = '';
 
+  constructor(private readonly extensionUri: vscode.Uri) {}
+
   isShowingDocument(uri: vscode.Uri): boolean {
     return this.panel != null && this.trackedUri === uri.toString();
   }
@@ -160,8 +193,16 @@ export class FGCAPreview {
         'fgcaPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveFGCAAsSvg', 'transitrixStudio.saveFGCAAsPng', 'transitrixStudio.copyFGCAAsPng', OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND] },
+        {
+          // Scripts enabled for the in-preview controls under the strict nonce
+          // CSP (see goals-preview.ts for the full rationale; #75/#76/#77 PR2).
+          enableScripts: true,
+          retainContextWhenHidden: true,
+          localResourceRoots: [vscode.Uri.joinPath(this.extensionUri, 'media')],
+          enableCommandUris: ['transitrixStudio.saveFGCAAsSvg', 'transitrixStudio.saveFGCAAsPng', 'transitrixStudio.copyFGCAAsPng', OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND],
+        },
       );
+      this.panel.webview.onDidReceiveMessage((m) => { void applyControlMessage('fgca', m); });
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
     }
     await this.pushDocument(doc);
@@ -189,6 +230,13 @@ export class FGCAPreview {
     let errorMsg = '';
     let warnings: string[] = [];
 
+    const spacingDefaults = { horizontalGap: FGCA_DEFAULT_COL_GAP, verticalGap: FGCA_DEFAULT_ROW_GAP };
+    const gaps = readSpacing('fgca', spacingDefaults);
+    const scope = readScope('fgca');
+    const curvature = readCurvature('fgca');
+    let goalOptions: ScopeGoalOption[] = [];
+    let maxLevelPresent = 0;
+
     try {
       const parsed = coerceDatesToIsoStrings(yaml.load(yamlText) as unknown);
       const meta = (parsed && typeof parsed === 'object' ? parsed : {}) as { version?: unknown; date?: unknown };
@@ -203,12 +251,11 @@ export class FGCAPreview {
         // IDs and singular `change.goal_id` / `change.activity_ids`. The
         // inline FGCADoc / buildSvg here accept both forms (number | string
         // unions) — pass through.
-        const gaps = readSpacing('fgca', { horizontalGap: FGCA_DEFAULT_COL_GAP, verticalGap: FGCA_DEFAULT_ROW_GAP });
-        const scope = readScope('fgca');
         const fgcaDoc = v.parsed as unknown as FGCADoc;
+        ({ goals: goalOptions, maxLevelPresent } = scopeInputsFromDoc(fgcaDoc));
         const scopeWarning = checkScopeRoot(scope, fgcaDoc.goals.map(g => g.id));
         if (scopeWarning) warnings.push(`${scopeWarning.code}: ${scopeWarning.message}`);
-        svgContent = buildSvg(fgcaDoc, false, { colGap: gaps.horizontalGap, rowGap: gaps.verticalGap, curvature: readCurvature('fgca'), scope }, 'FGCA — Factor → Goal → Change → Activity', filename, docDate, docVersion);
+        svgContent = buildSvg(fgcaDoc, false, { colGap: gaps.horizontalGap, rowGap: gaps.verticalGap, curvature, scope }, 'FGCA — Factor → Goal → Change → Activity', filename, docDate, docVersion);
       }
     } catch (e) {
       errorMsg = (e as Error).message ?? 'Parse error';
@@ -220,6 +267,9 @@ export class FGCAPreview {
       .getConfiguration('transitrix')
       .get<ThemeId>('theme', 'transitrix');
 
+    const nonce = genNonce();
+    const model = fgcaControlsModel(gaps, spacingDefaults, curvature, scope, goalOptions, maxLevelPresent);
+
     return buildDiagramFrame({
       filename, notation: 'FGCA', svgContent, errorMsg, warnings, themeId,
       saveSvgCommand: 'transitrixStudio.saveFGCAAsSvg',
@@ -228,6 +278,7 @@ export class FGCAPreview {
       spacingCommand: OPEN_SPACING_SETTINGS_COMMAND,
       curvatureCommand: OPEN_CURVATURE_SETTINGS_COMMAND,
       scopeCommand: OPEN_SCOPE_SETTINGS_COMMAND,
+      interactive: { nonce, controlsPanel: buildControlsPanel(model), controlsScript: buildControlsScript(nonce) },
     });
   }
 
@@ -277,6 +328,8 @@ export class FGAPreview {
   private trackedUri: string | undefined;
   private lastSvg = '';
 
+  constructor(private readonly extensionUri: vscode.Uri) {}
+
   isShowingDocument(uri: vscode.Uri): boolean {
     return this.panel != null && this.trackedUri === uri.toString();
   }
@@ -291,8 +344,16 @@ export class FGAPreview {
         'fgaPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveFGAAsSvg', 'transitrixStudio.saveFGAAsPng', 'transitrixStudio.copyFGAAsPng', OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND] },
+        {
+          // Scripts enabled for the in-preview controls under the strict nonce
+          // CSP (#75/#76/#77 PR2).
+          enableScripts: true,
+          retainContextWhenHidden: true,
+          localResourceRoots: [vscode.Uri.joinPath(this.extensionUri, 'media')],
+          enableCommandUris: ['transitrixStudio.saveFGAAsSvg', 'transitrixStudio.saveFGAAsPng', 'transitrixStudio.copyFGAAsPng', OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND],
+        },
       );
+      this.panel.webview.onDidReceiveMessage((m) => { void applyControlMessage('fga', m); });
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
     }
     await this.pushDocument(doc);
@@ -320,6 +381,13 @@ export class FGAPreview {
     let errorMsg = '';
     let warnings: string[] = [];
 
+    const spacingDefaults = { horizontalGap: FGCA_DEFAULT_COL_GAP, verticalGap: FGCA_DEFAULT_ROW_GAP };
+    const gaps = readSpacing('fga', spacingDefaults);
+    const scope = readScope('fga');
+    const curvature = readCurvature('fga');
+    let goalOptions: ScopeGoalOption[] = [];
+    let maxLevelPresent = 0;
+
     try {
       const parsed = coerceDatesToIsoStrings(yaml.load(yamlText) as unknown);
       const meta = (parsed && typeof parsed === 'object' ? parsed : {}) as { version?: unknown; date?: unknown };
@@ -331,12 +399,11 @@ export class FGAPreview {
         errorMsg = v.errors.map(e => `${e.code}: ${e.message}`).join('\n');
       } else {
         // FGA shares FGCA's FLAT shape; just hide the (absent) Changes column.
-        const gaps = readSpacing('fga', { horizontalGap: FGCA_DEFAULT_COL_GAP, verticalGap: FGCA_DEFAULT_ROW_GAP });
-        const scope = readScope('fga');
         const fgaDoc = v.parsed as unknown as FGCADoc;
+        ({ goals: goalOptions, maxLevelPresent } = scopeInputsFromDoc(fgaDoc));
         const scopeWarning = checkScopeRoot(scope, fgaDoc.goals.map(g => g.id));
         if (scopeWarning) warnings.push(`${scopeWarning.code}: ${scopeWarning.message}`);
-        svgContent = buildSvg(fgaDoc, true, { colGap: gaps.horizontalGap, rowGap: gaps.verticalGap, curvature: readCurvature('fga'), scope }, 'FGA — Factor → Goal → Activity', filename, docDate, docVersion);
+        svgContent = buildSvg(fgaDoc, true, { colGap: gaps.horizontalGap, rowGap: gaps.verticalGap, curvature, scope }, 'FGA — Factor → Goal → Activity', filename, docDate, docVersion);
       }
     } catch (e) {
       errorMsg = (e as Error).message ?? 'Parse error';
@@ -348,6 +415,9 @@ export class FGAPreview {
       .getConfiguration('transitrix')
       .get<ThemeId>('theme', 'transitrix');
 
+    const nonce = genNonce();
+    const model = fgcaControlsModel(gaps, spacingDefaults, curvature, scope, goalOptions, maxLevelPresent);
+
     return buildDiagramFrame({
       filename, notation: 'FGA', svgContent, errorMsg, warnings, themeId,
       saveSvgCommand: 'transitrixStudio.saveFGAAsSvg',
@@ -356,6 +426,7 @@ export class FGAPreview {
       spacingCommand: OPEN_SPACING_SETTINGS_COMMAND,
       curvatureCommand: OPEN_CURVATURE_SETTINGS_COMMAND,
       scopeCommand: OPEN_SCOPE_SETTINGS_COMMAND,
+      interactive: { nonce, controlsPanel: buildControlsPanel(model), controlsScript: buildControlsScript(nonce) },
     });
   }
 

--- a/extension/src/goals-preview.ts
+++ b/extension/src/goals-preview.ts
@@ -13,7 +13,8 @@ import { parseCanonicalGoals } from '../../packages/diagrams/src/goals/parse-can
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 import { horizontalCubicEdgePath, DEFAULT_EDGE_CURVATURE } from '../../packages/diagrams/src/edge-path.js';
 import { checkScopeRoot } from '../../packages/diagrams/src/scope.js';
-import { readSpacing, readCurvature, readScope, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND } from './spacing-config.js';
+import { readSpacing, readCurvature, readScope, applyControlMessage, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND } from './spacing-config.js';
+import { genNonce, buildControlsPanel, buildControlsScript, type ControlsModel, type ScopeGoalOption } from './preview-controls.js';
 
 // ── SVG renderer ─────────────────────────────────────────────────────────────
 //
@@ -95,6 +96,8 @@ export class GoalsPreview {
   private trackedUri: string | undefined;
   private lastSvg = '';
 
+  constructor(private readonly extensionUri: vscode.Uri) {}
+
   isShowingDocument(uri: vscode.Uri): boolean {
     return this.panel != null && this.trackedUri === uri.toString();
   }
@@ -109,8 +112,19 @@ export class GoalsPreview {
         'goalsPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveGoalsAsSvg', 'transitrixStudio.saveGoalsAsPng', 'transitrixStudio.copyGoalsAsPng', OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND] },
+        {
+          // Scripts enabled for the in-preview spacing/curvature/scope controls
+          // (vkgeorgia/strategy#75/#76/#77 PR2) under the strict nonce CSP set
+          // in buildDiagramFrame. localResourceRoots is pinned to the
+          // extension's own media even though the inline-nonce'd controls load
+          // no resources — defence in depth per Valerii's posture call.
+          enableScripts: true,
+          retainContextWhenHidden: true,
+          localResourceRoots: [vscode.Uri.joinPath(this.extensionUri, 'media')],
+          enableCommandUris: ['transitrixStudio.saveGoalsAsSvg', 'transitrixStudio.saveGoalsAsPng', 'transitrixStudio.copyGoalsAsPng', OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND],
+        },
       );
+      this.panel.webview.onDidReceiveMessage((m) => { void applyControlMessage('goals', m); });
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
     }
     await this.pushDocument(doc);
@@ -138,6 +152,15 @@ export class GoalsPreview {
     let errorMsg = '';
     let warnings: string[] = [];
 
+    const spacingDefaults = { horizontalGap: RANK_SEP, verticalGap: NODE_SEP };
+    const gaps = readSpacing('goals', spacingDefaults);
+    const scope = readScope('goals');
+    const curvature = readCurvature('goals');
+    // Populated on a successful parse — feeds the scope root-picker dropdown
+    // and the level-cap upper bound in the interactive control panel.
+    let goalOptions: ScopeGoalOption[] = [];
+    let maxLevelPresent = 0;
+
     try {
       const parsedYaml = coerceDatesToIsoStrings(yaml.load(yamlText) as unknown);
       const v = parseCanonicalGoals(parsedYaml);
@@ -149,8 +172,8 @@ export class GoalsPreview {
         const treeName = typeof meta.name === 'string' ? meta.name : '';
         const docVersion = typeof meta.version === 'string' ? meta.version : undefined;
         const docDate = typeof meta.date === 'string' ? meta.date : todayIso();
-        const gaps = readSpacing('goals', { horizontalGap: RANK_SEP, verticalGap: NODE_SEP });
-        const scope = readScope('goals');
+        goalOptions = v.parsed.goals.map(g => ({ id: String(g.id), name: g.name ?? '' }));
+        maxLevelPresent = v.parsed.goals.reduce((m, g) => Math.max(m, typeof g.level === 'number' ? g.level : 0), 0);
         const scopeWarning = checkScopeRoot(scope, v.parsed.goals.map(g => g.id));
         if (scopeWarning) warnings.push(`${scopeWarning.code}: ${scopeWarning.message}`);
         const layout = layoutGoalTree(v.parsed, {
@@ -160,7 +183,7 @@ export class GoalsPreview {
           nodeSep: gaps.verticalGap,
           scope,
         });
-        svgContent = layoutToSvg(layout, treeName, filename, docDate, docVersion, readCurvature('goals'));
+        svgContent = layoutToSvg(layout, treeName, filename, docDate, docVersion, curvature);
       }
     } catch (e) {
       errorMsg = (e as Error).message ?? 'Parse error';
@@ -172,6 +195,18 @@ export class GoalsPreview {
       .getConfiguration('transitrix')
       .get<ThemeId>('theme', 'transitrix');
 
+    const nonce = genNonce();
+    const model: ControlsModel = {
+      spacing: { ...gaps, defaults: spacingDefaults },
+      curvature: { value: curvature, default: 1 },
+      scope: {
+        rootId: scope.mode === 'root' ? scope.rootGoalId : '',
+        maxLevel: scope.mode === 'level' ? scope.maxLevel : -1,
+        maxLevelPresent,
+        goals: goalOptions,
+      },
+    };
+
     return buildDiagramFrame({
       filename, notation: 'Goal tree', svgContent, errorMsg, warnings, themeId,
       saveSvgCommand: 'transitrixStudio.saveGoalsAsSvg',
@@ -180,6 +215,7 @@ export class GoalsPreview {
       spacingCommand: OPEN_SPACING_SETTINGS_COMMAND,
       curvatureCommand: OPEN_CURVATURE_SETTINGS_COMMAND,
       scopeCommand: OPEN_SCOPE_SETTINGS_COMMAND,
+      interactive: { nonce, controlsPanel: buildControlsPanel(model), controlsScript: buildControlsScript(nonce) },
     });
   }
 

--- a/extension/src/preview-controls.ts
+++ b/extension/src/preview-controls.ts
@@ -1,0 +1,245 @@
+import { randomBytes } from 'node:crypto';
+
+// In-preview interactive control panel for the spacing / curvature / scope
+// previews (vkgeorgia/strategy#75 / #76 / #77 — PR2).
+//
+// PR1 shipped the same controls as VS Code settings + a "…" toolbar link that
+// opens Settings. PR2 adds live, in-preview controls. Per Valerii's joint
+// `enableScripts` posture call (2026-06-02), the four interactive previews
+// (goals / fgca / fga / activities) now run with scripts enabled under a strict
+// nonce-based CSP. This module is the *pure* string-building half of that work
+// — it never imports `vscode`, so it is unit-testable:
+//
+//   - `buildControlsPanel(model)` → the `<details>` panel markup (inputs carry
+//     `data-tx-control` / `data-tx-field` attributes).
+//   - `buildControlsScript(nonce)` → the nonce'd `<script>` that wires those
+//     inputs to `postMessage`. The host (each preview class) receives the
+//     message and writes the matching `transitrix.*` setting; the existing
+//     `onDidChangeConfiguration` handler then re-renders. Config stays the
+//     single source of truth, shared with the "…" Settings links.
+//
+// Source-of-truth note: the `data-tx-*` attribute contract between the panel
+// markup and the wiring script lives entirely in this file, so the two never
+// drift.
+
+/** A goal option for the scope root-picker dropdown. */
+export interface ScopeGoalOption {
+  /** Goal id, stringified — used as the `<option>` value. */
+  id: string;
+  /** Goal name, shown to the user. Falls back to the id when unnamed. */
+  name: string;
+}
+
+export interface SpacingControlModel {
+  horizontalGap: number;
+  verticalGap: number;
+  /** Layout defaults — used to decide whether the panel opens by default. */
+  defaults: { horizontalGap: number; verticalGap: number };
+}
+
+export interface CurvatureControlModel {
+  value: number;
+  /** Historical default (1) — the no-visual-change baseline. */
+  default: number;
+}
+
+export interface ScopeControlModel {
+  /** Current root id ('' when no root scope is active). */
+  rootId: string;
+  /** Current level cap (-1 when no level scope is active). */
+  maxLevel: number;
+  /** The document's actual deepest level — the upper bound for the level input. */
+  maxLevelPresent: number;
+  /** All goals in the document, for the root-picker dropdown. */
+  goals: ScopeGoalOption[];
+}
+
+export interface ControlsModel {
+  spacing: SpacingControlModel;
+  curvature: CurvatureControlModel;
+  /** Omitted for notations without a scope filter (Activities). */
+  scope?: ScopeControlModel;
+}
+
+/** Message posted from the webview to the host on every control change. */
+export interface ControlMessage {
+  type: 'transitrix:control';
+  control: 'spacing' | 'curvature' | 'scope';
+  /** 'horizontalGap' | 'verticalGap' for spacing; 'rootId' | 'maxLevel' | 'reset' for scope; absent for curvature. */
+  field?: 'horizontalGap' | 'verticalGap' | 'rootId' | 'maxLevel' | 'reset';
+  /** Numeric for spacing/curvature/maxLevel; string for rootId; absent for reset. */
+  value?: number | string;
+}
+
+// Spacing bounds mirror the package.json `transitrix.spacing.*` schema (20–300).
+export const SPACING_MIN = 20;
+export const SPACING_MAX = 300;
+// Curvature bounds mirror `transitrix.curvature.*` (0–3).
+export const CURVATURE_MIN = 0;
+export const CURVATURE_MAX = 3;
+export const CURVATURE_STEP = 0.1;
+
+/** A CSP nonce: 128 bits of base64. Generated host-side, embedded in both the
+ *  CSP `script-src` and the `<script nonce>` so the inline wiring script runs
+ *  while everything else is blocked. */
+export function genNonce(): string {
+  return randomBytes(16).toString('base64');
+}
+
+function escXml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+/** CSS for the control panel — injected into the frame's <style> only when interactive. */
+export const CONTROLS_PANEL_CSS = `
+.tx-ctl { margin: 0 16px 8px; font-size: 11px; color: var(--ts-text-muted, #64748b); border: 1px solid var(--ts-border, #cbd5e1); border-radius: 6px; }
+.tx-ctl > summary { cursor: pointer; user-select: none; padding: 5px 10px; font-weight: 600; list-style: none; }
+.tx-ctl > summary::-webkit-details-marker { display: none; }
+.tx-ctl > summary::before { content: "\\25B8\\00a0"; }
+.tx-ctl[open] > summary::before { content: "\\25BE\\00a0"; }
+.tx-ctl-body { display: flex; flex-direction: column; gap: 8px; padding: 4px 12px 10px; }
+.tx-ctl-row { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.tx-ctl-row > .tx-ctl-label { flex: 0 0 70px; font-weight: 600; color: var(--ts-text, #0f172a); }
+.tx-ctl-row label { display: inline-flex; align-items: center; gap: 4px; }
+.tx-ctl input[type="number"] { width: 56px; }
+.tx-ctl input[type="range"] { vertical-align: middle; }
+.tx-ctl select { max-width: 220px; }
+.tx-ctl input, .tx-ctl select, .tx-ctl button {
+  font-size: 11px;
+  font-family: var(--vscode-font-family, sans-serif);
+  color: var(--vscode-input-foreground, #333);
+  background: var(--vscode-input-background, #fff);
+  border: 1px solid var(--vscode-input-border, var(--ts-border, #cbd5e1));
+  border-radius: 3px;
+  padding: 1px 4px;
+}
+.tx-ctl button { cursor: pointer; }
+.tx-ctl output { min-width: 22px; font-variant-numeric: tabular-nums; }
+`;
+
+/** True when any control differs from its no-visual-change default. */
+function hasNonDefault(model: ControlsModel): boolean {
+  const s = model.spacing;
+  if (s.horizontalGap !== s.defaults.horizontalGap || s.verticalGap !== s.defaults.verticalGap) return true;
+  if (model.curvature.value !== model.curvature.default) return true;
+  if (model.scope && (model.scope.rootId !== '' || model.scope.maxLevel >= 0)) return true;
+  return false;
+}
+
+function spacingRow(s: SpacingControlModel): string {
+  return `<div class="tx-ctl-row">
+    <span class="tx-ctl-label">Spacing</span>
+    <label title="Horizontal gap between columns (px)">H
+      <input type="number" data-tx-control="spacing" data-tx-field="horizontalGap"
+        min="${SPACING_MIN}" max="${SPACING_MAX}" step="1" value="${s.horizontalGap}"></label>
+    <label title="Vertical gap between stacked nodes (px)">V
+      <input type="number" data-tx-control="spacing" data-tx-field="verticalGap"
+        min="${SPACING_MIN}" max="${SPACING_MAX}" step="1" value="${s.verticalGap}"></label>
+  </div>`;
+}
+
+function curvatureRow(c: CurvatureControlModel): string {
+  return `<div class="tx-ctl-row">
+    <span class="tx-ctl-label">Curvature</span>
+    <input type="range" data-tx-control="curvature" data-tx-output="tx-curv-out"
+      min="${CURVATURE_MIN}" max="${CURVATURE_MAX}" step="${CURVATURE_STEP}" value="${c.value}">
+    <output id="tx-curv-out">${c.value}</output>
+  </div>`;
+}
+
+function scopeRow(sc: ScopeControlModel): string {
+  const options = [`<option value="">— All goals —</option>`]
+    .concat(sc.goals.map(g => {
+      const selected = g.id === sc.rootId ? ' selected' : '';
+      const label = g.name && g.name.trim() ? `${g.name} (${g.id})` : g.id;
+      return `<option value="${escXml(g.id)}"${selected}>${escXml(label)}</option>`;
+    }))
+    .join('');
+  // Level input is bounded to the document's deepest level. When the document
+  // has no level information (maxLevelPresent <= 0) the cap can't trim anything,
+  // so the input is disabled with a hint.
+  const levelDisabled = sc.maxLevelPresent <= 0 ? ' disabled' : '';
+  const levelValue = sc.maxLevel >= 0 ? String(sc.maxLevel) : '';
+  return `<div class="tx-ctl-row">
+    <span class="tx-ctl-label">Scope</span>
+    <label title="Show only this goal's subtree (descendants), plus the factors / changes / activities that touch it">Root
+      <select data-tx-control="scope" data-tx-field="rootId">${options}</select></label>
+    <label title="Show only goals at or below this level${sc.maxLevelPresent > 0 ? ` (0–${sc.maxLevelPresent})` : ''}">Level
+      <input type="number" data-tx-control="scope" data-tx-field="maxLevel"
+        min="0" max="${Math.max(0, sc.maxLevelPresent)}" step="1" placeholder="off" value="${levelValue}"${levelDisabled}></label>
+    <button type="button" data-tx-control="scope" data-tx-field="reset" title="Clear scope — show everything">Reset</button>
+  </div>`;
+}
+
+/** Builds the `<details>` control-panel markup for a notation's interactive preview. */
+export function buildControlsPanel(model: ControlsModel): string {
+  const open = hasNonDefault(model) ? ' open' : '';
+  const rows = [spacingRow(model.spacing), curvatureRow(model.curvature)];
+  if (model.scope) rows.push(scopeRow(model.scope));
+  return `<details id="tx-ctl" class="tx-ctl"${open}>
+  <summary>Controls</summary>
+  <div class="tx-ctl-body">
+    ${rows.join('\n    ')}
+  </div>
+</details>`;
+}
+
+/** Builds the nonce'd wiring `<script>`. Reads `data-tx-*` inputs, posts a
+ *  ControlMessage to the host on change, and persists the panel's open/closed
+ *  state in webview state so a host-driven re-render doesn't collapse it. */
+export function buildControlsScript(nonce: string): string {
+  // Plain ES5-ish DOM script; runs inside the webview, not the Node host.
+  return `<script nonce="${nonce}">
+(function () {
+  var vscode = acquireVsCodeApi();
+  function num(v) { var n = Number(v); return isFinite(n) ? n : 0; }
+  function post(control, field, value) {
+    vscode.postMessage({ type: 'transitrix:control', control: control, field: field, value: value });
+  }
+  function sel(control, field) {
+    return document.querySelector('[data-tx-control="' + control + '"][data-tx-field="' + field + '"]');
+  }
+  var nodes = document.querySelectorAll('[data-tx-control]');
+  for (var i = 0; i < nodes.length; i++) {
+    (function (el) {
+      var control = el.getAttribute('data-tx-control');
+      var field = el.getAttribute('data-tx-field');
+      if (el.tagName === 'BUTTON') {
+        el.addEventListener('click', function () { post(control, field); });
+        return;
+      }
+      var outId = el.getAttribute('data-tx-output');
+      if (outId) {
+        var out = document.getElementById(outId);
+        if (out) el.addEventListener('input', function () { out.value = el.value; });
+      }
+      el.addEventListener('change', function () {
+        if (control === 'scope' && field === 'rootId') {
+          var v = el.value;
+          if (v) { var lvl = sel('scope', 'maxLevel'); if (lvl) lvl.value = ''; }
+          post(control, field, v);
+        } else if (control === 'scope' && field === 'maxLevel') {
+          if (el.value === '') { post(control, 'reset'); return; }
+          var root = sel('scope', 'rootId'); if (root) root.value = '';
+          post(control, field, num(el.value));
+        } else if (control === 'curvature') {
+          post(control, undefined, num(el.value));
+        } else {
+          post(control, field, num(el.value));
+        }
+      });
+    })(nodes[i]);
+  }
+  var det = document.getElementById('tx-ctl');
+  if (det) {
+    var st = vscode.getState() || {};
+    if (st.txCtlOpen) det.open = true;
+    det.addEventListener('toggle', function () {
+      var s = vscode.getState() || {};
+      s.txCtlOpen = det.open;
+      vscode.setState(s);
+    });
+  }
+}());
+</script>`;
+}

--- a/extension/src/spacing-config.ts
+++ b/extension/src/spacing-config.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import type { Scope } from '../../packages/diagrams/src/scope.js';
+import type { ControlMessage } from './preview-controls.js';
 
 // Per-notation spacing controls (vkgeorgia/strategy#75). PR1 persists the
 // chosen gaps in VS Code configuration (`transitrix.spacing.<notation>.*`),
@@ -80,3 +81,52 @@ export const SCOPE_CONFIG_SECTION = 'transitrix.scope';
 
 /** Command that opens Settings filtered to the scope controls. */
 export const OPEN_SCOPE_SETTINGS_COMMAND = 'transitrixStudio.openScopeSettings';
+
+// ── In-preview control messages (PR2) ───────────────────────────────────────
+//
+// The interactive control panel (preview-controls.ts) posts a `ControlMessage`
+// on every change. The host writes the matching `transitrix.*` setting here, so
+// VS Code configuration stays the single source of truth — the in-preview
+// controls and the "…" Settings links edit the same store, and the existing
+// `onDidChangeConfiguration` handler re-renders. Writes go to the Global (User)
+// target, mirroring how the "…" links land users on User settings.
+
+function clamp(n: number, min: number, max: number): number {
+  if (!Number.isFinite(n)) return min;
+  return Math.min(max, Math.max(min, n));
+}
+
+/**
+ * Applies one in-preview control change to VS Code configuration for `notation`.
+ * Spacing/curvature apply to all four notations; scope only to goals/fgca/fga
+ * (the Activities panel never renders a scope row). Scope is mutually exclusive
+ * — setting a root clears the level cap and vice-versa, matching `readScope`'s
+ * "one mode at a time" precedence and #77's AC.
+ */
+export async function applyControlMessage(notation: SpacingNotation, msg: ControlMessage): Promise<void> {
+  if (!msg || msg.type !== 'transitrix:control') return;
+  const cfg = vscode.workspace.getConfiguration('transitrix');
+  const target = vscode.ConfigurationTarget.Global;
+
+  if (msg.control === 'spacing' && (msg.field === 'horizontalGap' || msg.field === 'verticalGap')) {
+    await cfg.update(`spacing.${notation}.${msg.field}`, clamp(Number(msg.value), 20, 300), target);
+    return;
+  }
+  if (msg.control === 'curvature') {
+    await cfg.update(`curvature.${notation}`, clamp(Number(msg.value), 0, 3), target);
+    return;
+  }
+  if (msg.control === 'scope' && notation !== 'activities') {
+    if (msg.field === 'reset') {
+      await cfg.update(`scope.${notation}.rootId`, '', target);
+      await cfg.update(`scope.${notation}.maxLevel`, -1, target);
+    } else if (msg.field === 'rootId') {
+      await cfg.update(`scope.${notation}.rootId`, String(msg.value ?? ''), target);
+      await cfg.update(`scope.${notation}.maxLevel`, -1, target);
+    } else if (msg.field === 'maxLevel') {
+      const lv = Number(msg.value);
+      await cfg.update(`scope.${notation}.maxLevel`, Number.isFinite(lv) && lv >= 0 ? Math.floor(lv) : -1, target);
+      await cfg.update(`scope.${notation}.rootId`, '', target);
+    }
+  }
+}

--- a/tests/preview-controls.test.ts
+++ b/tests/preview-controls.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildControlsPanel,
+  buildControlsScript,
+  genNonce,
+  type ControlsModel,
+} from '../extension/src/preview-controls.js';
+
+// Unit coverage for the in-preview control panel (vkgeorgia/strategy#75/#76/#77
+// PR2). The panel + wiring script are pure string builders (no `vscode`), so
+// the data-attribute contract between markup and script is testable here.
+
+const spacingDefaults = { horizontalGap: 100, verticalGap: 24 };
+
+function baseModel(overrides: Partial<ControlsModel> = {}): ControlsModel {
+  return {
+    spacing: { horizontalGap: 100, verticalGap: 24, defaults: spacingDefaults },
+    curvature: { value: 1, default: 1 },
+    ...overrides,
+  };
+}
+
+describe('buildControlsPanel', () => {
+  it('renders spacing and curvature rows with data-tx-control attributes', () => {
+    const html = buildControlsPanel(baseModel());
+    expect(html).toContain('data-tx-control="spacing" data-tx-field="horizontalGap"');
+    expect(html).toContain('data-tx-control="spacing" data-tx-field="verticalGap"');
+    expect(html).toContain('data-tx-control="curvature"');
+    // Bounds mirror the package.json settings schema.
+    expect(html).toContain('min="20"');
+    expect(html).toContain('max="300"');
+  });
+
+  it('reflects current values into the inputs', () => {
+    const html = buildControlsPanel(baseModel({
+      spacing: { horizontalGap: 180, verticalGap: 40, defaults: spacingDefaults },
+      curvature: { value: 2.5, default: 1 },
+    }));
+    expect(html).toContain('data-tx-field="horizontalGap"\n        min="20" max="300" step="1" value="180"');
+    expect(html).toContain('value="2.5"');
+  });
+
+  it('omits the scope row when no scope model is given (Activities)', () => {
+    const html = buildControlsPanel(baseModel());
+    expect(html).not.toContain('data-tx-control="scope"');
+  });
+
+  it('renders the scope dropdown, level input and reset when scope is present', () => {
+    const html = buildControlsPanel(baseModel({
+      scope: { rootId: '', maxLevel: -1, maxLevelPresent: 3, goals: [
+        { id: '1', name: 'Grow revenue' },
+        { id: '2', name: 'Cut cost' },
+      ] },
+    }));
+    expect(html).toContain('data-tx-control="scope" data-tx-field="rootId"');
+    expect(html).toContain('data-tx-control="scope" data-tx-field="maxLevel"');
+    expect(html).toContain('data-tx-field="reset"');
+    expect(html).toContain('<option value="">— All goals —</option>');
+    expect(html).toContain('Grow revenue (1)');
+    // Level input is bounded to the document's deepest level.
+    expect(html).toContain('max="3"');
+  });
+
+  it('escapes goal names in dropdown options', () => {
+    const html = buildControlsPanel(baseModel({
+      scope: { rootId: '', maxLevel: -1, maxLevelPresent: 1, goals: [
+        { id: 'x"1', name: '<b>A & B</b>' },
+      ] },
+    }));
+    expect(html).toContain('&lt;b&gt;A &amp; B&lt;/b&gt;');
+    expect(html).not.toContain('<b>A & B</b>');
+    expect(html).toContain('value="x&quot;1"');
+  });
+
+  it('marks the selected root option', () => {
+    const html = buildControlsPanel(baseModel({
+      scope: { rootId: '2', maxLevel: -1, maxLevelPresent: 2, goals: [
+        { id: '1', name: 'A' },
+        { id: '2', name: 'B' },
+      ] },
+    }));
+    expect(html).toMatch(/<option value="2" selected>/);
+  });
+
+  it('disables the level input when the document has no level info', () => {
+    const html = buildControlsPanel(baseModel({
+      scope: { rootId: '', maxLevel: -1, maxLevelPresent: 0, goals: [] },
+    }));
+    expect(html).toMatch(/data-tx-field="maxLevel"[^>]*disabled/);
+  });
+
+  it('opens by default only when a control is non-default', () => {
+    expect(buildControlsPanel(baseModel())).toContain('<details id="tx-ctl" class="tx-ctl">');
+    const nonDefault = buildControlsPanel(baseModel({ curvature: { value: 0, default: 1 } }));
+    expect(nonDefault).toContain('<details id="tx-ctl" class="tx-ctl" open>');
+    const scopedNonDefault = buildControlsPanel(baseModel({
+      scope: { rootId: '5', maxLevel: -1, maxLevelPresent: 2, goals: [] },
+    }));
+    expect(scopedNonDefault).toContain(' open>');
+  });
+});
+
+describe('buildControlsScript', () => {
+  it('embeds the nonce and posts transitrix:control messages', () => {
+    const script = buildControlsScript('NONCE123');
+    expect(script).toContain('<script nonce="NONCE123">');
+    expect(script).toContain("type: 'transitrix:control'");
+    expect(script).toContain('acquireVsCodeApi');
+    // Persists panel open/closed state across host-driven re-renders.
+    expect(script).toContain('setState');
+  });
+});
+
+describe('genNonce', () => {
+  it('returns distinct base64 nonces', () => {
+    const a = genNonce();
+    const b = genNonce();
+    expect(a).not.toEqual(b);
+    expect(a.length).toBeGreaterThanOrEqual(20);
+  });
+});


### PR DESCRIPTION
@
**Do not merge — Valerii gates.**

Combined PR2 for the three companion preview-config tasks. PR1 (#80/#81/#82, all merged) shipped these controls as VS Code **settings** + a `…` toolbar link that opens Settings. PR2 adds the **live, in-preview controls**, now that the joint `enableScripts` posture call (2026-06-02, decided on #75/#76/#77) unblocked interactive previews under a strict nonce CSP.

One combined PR (Valerii allowed shared) because the interactive infrastructure — scripts + nonce CSP + control panel + message handler — is identical across all four previews; splitting it would triplicate the boilerplate.

### What you get
A collapsible **Controls** panel inside each preview:
- **Spacing** — H / V number inputs (20–300 px) — #75
- **Curvature** — slider 0–3 with live readout — #76
- **Scope** — root-picker dropdown (goal name → id) + level-cap input (bounded to the documents deepest level) + Reset; the two modes are mutually exclusive — #77

Scope set: spacing + curvature on **goals / fgca / fga / activities**; scope on **goals / fgca / fga** only (Activities excluded per #77).

### Design — config is the single source of truth
- The four interactive previews now open with `enableScripts: true` + `localResourceRoots` pinned to `extension/media`.
- `diagram-frame.ts` switches to a nonce CSP **only** when the new `interactive` opt is passed; every static preview keeps the script-less CSP byte-for-byte.
- `preview-controls.ts` (pure, no `vscode` import → unit-testable) builds the `<details>` panel + the nonced wiring `<script>`. The `data-tx-*` attribute contract between markup and script lives in one file.
- On change the script `postMessage`s the value; `applyControlMessage()` writes the matching `transitrix.*` setting (Global). The existing `onDidChangeConfiguration` handler re-renders. **The in-preview controls and the `…` Settings links edit the same store** — persistence + per-notation independence inherited from PR1, no second source of truth.
- Defaults unchanged → no visual change until the user touches a control. Panel auto-opens only when a control is non-default.

### Security note (the enableScripts exception)
Per Valeriis conditions:
- Scripts enabled **only** in the 4 interactive previews — not a blanket flip; the other static previews (applications, products, process-map, scenarios, capability-map, process-blueprint, issues, blocks) keep `enableScripts: false`.
- **Strict nonce CSP** in `diagram-frame.ts`: `default-src none; style-src unsafe-inline; script-src nonce-…` — no inline script without the per-render nonce, no external/remote resources, `localResourceRoots` = `extension/media` only.
- The only script is the inline nonced wiring (`buildControlsScript`), which solely reads the control inputs and posts values to the host. All user content stays `escXml`-escaped.
- The studio `CLAUDE.md` security note was updated locally — but **`CLAUDE.md` is git-ignored** in this repo (`.gitignore` lines 48–49), so it cant ride in the PR diff. The record is instead captured in committed code comments (`diagram-frame.ts`, `goals-preview.ts`, `preview-controls.ts`) and in this description. Flagging in case you want a tracked SECURITY doc instead.

### Tests
- `tests/preview-controls.test.ts` (10 cases): panel markup + `data-tx-*` contract, escaping, selected-option, level-bound, disabled-when-no-levels, default-open, nonced script.
- Core **235** + diagrams **476** green; `tsc` (root + extension) clean; extension bundles (esbuild) clean.
- The PR2 deliverable is webview UX — the layout/scope library logic was already covered by PR1s fixtures (unchanged here). Final verification is your hand-test of the four previews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@