### PR TITLE
feat(fgca): tree↔table view toggle for FGCA/FGA previews (#137)

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -217,6 +217,18 @@
           "minimum": -1,
           "default": -1,
           "description": "FGA preview: scope to a goal-level cap. Show only goals at this level and above, plus their connected factors/activities. -1 = no cap. Ignored when a scope root id is set."
+        },
+        "transitrix.view.fgca": {
+          "type": "string",
+          "enum": ["tree", "table"],
+          "default": "tree",
+          "description": "FGCA preview: 'tree' renders the Factor→Goal→Change→Activity chain diagram; 'table' renders the chain flattened into a table with merged cells. Toggle live from the preview toolbar."
+        },
+        "transitrix.view.fga": {
+          "type": "string",
+          "enum": ["tree", "table"],
+          "default": "tree",
+          "description": "FGA preview: 'tree' renders the Factor→Goal→Activity chain diagram; 'table' renders the chain flattened into a table with merged cells. Toggle live from the preview toolbar."
         }
       }
     },

--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -107,6 +107,12 @@ export interface DiagramFrameOpts {
     nonce: string;
     controlsPanel: string;
     controlsScript: string;
+    /**
+     * Optional toolbar segmented control (e.g. the tree↔table view toggle,
+     * vkgeorgia/strategy#137). Injected as the first item in the toolbar
+     * actions. Pass '' / omit when the preview has no toolbar control.
+     */
+    viewToggleHtml?: string;
   };
 }
 
@@ -365,6 +371,9 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
   <input type="radio" name="ts-zoom" id="z-200" class="zoom-radio">`
     : '';
   const actionParts: string[] = [];
+  if (interactive?.viewToggleHtml) {
+    actionParts.push(interactive.viewToggleHtml);
+  }
   if (showToggle) {
     actionParts.push(`<label for="ts-title-toggle" class="title-toggle" title="Show or hide the diagram title">Title</label>`);
   }

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -29,6 +29,7 @@ import {
   CURVATURE_CONFIG_SECTION,
   OPEN_SCOPE_SETTINGS_COMMAND,
   SCOPE_CONFIG_SECTION,
+  VIEW_CONFIG_SECTION,
 } from './spacing-config.js';
 
 function isGoalsFile(doc: vscode.TextDocument): boolean {
@@ -331,7 +332,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       if (
         !e.affectsConfiguration(SPACING_CONFIG_SECTION) &&
         !e.affectsConfiguration(CURVATURE_CONFIG_SECTION) &&
-        !e.affectsConfiguration(SCOPE_CONFIG_SECTION)
+        !e.affectsConfiguration(SCOPE_CONFIG_SECTION) &&
+        !e.affectsConfiguration(VIEW_CONFIG_SECTION)
       ) return;
       void goalsPreview.refreshConfig();
       void fgcaPreview.refreshConfig();

--- a/extension/src/fgca-preview.ts
+++ b/extension/src/fgca-preview.ts
@@ -14,11 +14,12 @@ import {
   FGCA_DEFAULT_ROW_GAP,
 } from '../../packages/diagrams/src/fgca/preview-layout.js';
 import { horizontalCubicEdgePath, DEFAULT_EDGE_CURVATURE } from '../../packages/diagrams/src/edge-path.js';
+import { buildChainTable, type ChainTable, type ChainColumn } from '../../packages/diagrams/src/fgca/chain-table.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 import { checkScopeRoot, type Scope } from '../../packages/diagrams/src/scope.js';
 import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
-import { readSpacing, readCurvature, readScope, applyControlMessage, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND } from './spacing-config.js';
-import { genNonce, buildControlsPanel, buildControlsScript, type ControlsModel, type ScopeGoalOption } from './preview-controls.js';
+import { readSpacing, readCurvature, readScope, readView, applyControlMessage, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND } from './spacing-config.js';
+import { genNonce, buildControlsPanel, buildControlsScript, buildViewToggle, type ControlsModel, type ScopeGoalOption } from './preview-controls.js';
 
 // ── Inline render types ─────────────────────────────────────────────────────
 //
@@ -72,6 +73,43 @@ function scopeInputsFromDoc(doc: FGCADoc): { goals: ScopeGoalOption[]; maxLevelP
   };
 }
 
+// ── Chain table (vkgeorgia/strategy#137) ────────────────────────────────────
+//
+// The flattening + rowspan derivation lives in @transitrix/diagrams
+// (`buildChainTable`). Here we render that model as an HTML <table>. Scope
+// is a no-op in table view (per #137) — the table always shows the full doc.
+
+const CHAIN_COLUMN_HEADERS: Record<ChainColumn, string> = {
+  factor: 'Factor', goal: 'Goal', change: 'Change', activity: 'Activity',
+};
+
+const CHAIN_TABLE_CSS = `
+.chain-table-wrap { padding: 0 16px 16px; overflow-x: auto; }
+.chain-table { border-collapse: collapse; font-size: 12px; }
+.chain-table th, .chain-table td { border: 1px solid var(--ts-border, #cbd5e1); padding: 6px 12px; text-align: left; vertical-align: top; }
+.chain-table th { background: var(--ts-bg-subtle, #f1f5f9); color: var(--ts-text, #0f172a); font-weight: 600; }
+.chain-table td { color: var(--ts-text, #0f172a); }
+.chain-table td.chain-empty { background: var(--ts-bg-subtle, #f8fafc); }
+.chain-empty-table { padding: 24px 16px; color: var(--ts-text-muted, #64748b); font-style: italic; }
+`;
+
+function chainTableHtml(table: ChainTable): string {
+  if (table.rows.length === 0) {
+    return `<div class="chain-empty-table">Nothing to tabulate — the document has no factors, goals or activities.</div>`;
+  }
+  const head = `<tr>${table.columns.map(c => `<th>${CHAIN_COLUMN_HEADERS[c]}</th>`).join('')}</tr>`;
+  const body = table.rows.map(row => {
+    const cells = row.map(c => {
+      if (c === null) return ''; // covered by a rowspan above — emit no <td>
+      const span = c.rowSpan > 1 ? ` rowspan="${c.rowSpan}"` : '';
+      if (c.cell === null) return `<td${span} class="chain-empty"></td>`;
+      return `<td${span}>${escXml(c.cell.label)}</td>`;
+    }).join('');
+    return `<tr>${cells}</tr>`;
+  }).join('\n');
+  return `<div class="chain-table-wrap"><table class="chain-table"><thead>${head}</thead><tbody>${body}</tbody></table></div>`;
+}
+
 /** Assembles the interactive control-panel model shared by FGCA and FGA. */
 function fgcaControlsModel(
   gaps: { horizontalGap: number; verticalGap: number },
@@ -91,6 +129,89 @@ function fgcaControlsModel(
       goals,
     },
   };
+}
+
+interface ChainPreviewParams {
+  /** Toolbar / frame notation label. */
+  notation: 'FGCA' | 'FGA';
+  /** Settings namespace + view key (`transitrix.{spacing,curvature,scope,view}.<this>`). */
+  viewNotation: 'fgca' | 'fga';
+  /** FGA hides the Change column. */
+  hideChanges: boolean;
+  /** SVG title-block heading (tree view). */
+  heading: string;
+  saveSvgCommand: string;
+  savePngCommand: string;
+  copyPngCommand: string;
+}
+
+/**
+ * Shared render path for the FGCA and FGA previews. Branches on the persisted
+ * tree↔table view (vkgeorgia/strategy#137):
+ *  - **tree** — the chain SVG, with the spacing/curvature/scope control panel +
+ *    Save/Zoom toolbar (the PR #86 interactive surface) plus the view toggle.
+ *  - **table** — the flattened chain table; the spacing/curvature/scope controls
+ *    are hidden and scope is a no-op (the table always shows the full doc), so
+ *    only the view toggle + Title toggle remain in the toolbar.
+ * Returns the frame HTML and the tree SVG (for Save-as-SVG; empty in table view).
+ */
+function renderChainPreview(
+  p: ChainPreviewParams,
+  parsedDoc: FGCADoc | null,
+  baseWarnings: string[],
+  errorMsg: string,
+  docVersion: string | undefined,
+  docDate: string,
+  filename: string,
+  themeId: ThemeId,
+): { html: string; svg: string } {
+  const view = readView(p.viewNotation);
+  const nonce = genNonce();
+  const script = buildControlsScript(nonce);
+  const viewToggleHtml = buildViewToggle(view);
+
+  if (view === 'table') {
+    // Scope is a no-op in table view, so no scope-warning is added here.
+    const body = parsedDoc ? chainTableHtml(buildChainTable(parsedDoc, { hideChanges: p.hideChanges })) : '';
+    const showHeader = !errorMsg && parsedDoc != null;
+    const html = buildDiagramFrame({
+      filename, notation: p.notation, bodyContent: body, errorMsg, warnings: baseWarnings, themeId,
+      extraStyles: CHAIN_TABLE_CSS,
+      title: showHeader ? p.heading : undefined,
+      version: docVersion,
+      date: showHeader ? docDate : undefined,
+      interactive: { nonce, controlsPanel: '', controlsScript: script, viewToggleHtml },
+    });
+    return { html, svg: '' };
+  }
+
+  // Tree view (default) — the PR #86 interactive control surface.
+  const spacingDefaults = { horizontalGap: FGCA_DEFAULT_COL_GAP, verticalGap: FGCA_DEFAULT_ROW_GAP };
+  const gaps = readSpacing(p.viewNotation, spacingDefaults);
+  const scope = readScope(p.viewNotation);
+  const curvature = readCurvature(p.viewNotation);
+  const warnings = [...baseWarnings];
+  let svg = '';
+  let goalOptions: ScopeGoalOption[] = [];
+  let maxLevelPresent = 0;
+  if (parsedDoc) {
+    ({ goals: goalOptions, maxLevelPresent } = scopeInputsFromDoc(parsedDoc));
+    const scopeWarning = checkScopeRoot(scope, parsedDoc.goals.map(g => g.id));
+    if (scopeWarning) warnings.push(`${scopeWarning.code}: ${scopeWarning.message}`);
+    svg = buildSvg(parsedDoc, p.hideChanges, { colGap: gaps.horizontalGap, rowGap: gaps.verticalGap, curvature, scope }, p.heading, filename, docDate, docVersion);
+  }
+  const model = fgcaControlsModel(gaps, spacingDefaults, curvature, scope, goalOptions, maxLevelPresent);
+  const html = buildDiagramFrame({
+    filename, notation: p.notation, svgContent: svg, errorMsg, warnings, themeId,
+    saveSvgCommand: p.saveSvgCommand,
+    savePngCommand: p.savePngCommand,
+    copyPngCommand: p.copyPngCommand,
+    spacingCommand: OPEN_SPACING_SETTINGS_COMMAND,
+    curvatureCommand: OPEN_CURVATURE_SETTINGS_COMMAND,
+    scopeCommand: OPEN_SCOPE_SETTINGS_COMMAND,
+    interactive: { nonce, controlsPanel: buildControlsPanel(model), controlsScript: script, viewToggleHtml },
+  });
+  return { html, svg };
 }
 
 function buildSvg(
@@ -226,22 +347,17 @@ export class FGCAPreview {
   }
 
   private buildHtml(yamlText: string, filename: string): string {
-    let svgContent = '';
+    let parsedDoc: FGCADoc | null = null;
     let errorMsg = '';
     let warnings: string[] = [];
-
-    const spacingDefaults = { horizontalGap: FGCA_DEFAULT_COL_GAP, verticalGap: FGCA_DEFAULT_ROW_GAP };
-    const gaps = readSpacing('fgca', spacingDefaults);
-    const scope = readScope('fgca');
-    const curvature = readCurvature('fgca');
-    let goalOptions: ScopeGoalOption[] = [];
-    let maxLevelPresent = 0;
+    let docVersion: string | undefined;
+    let docDate = todayIso();
 
     try {
       const parsed = coerceDatesToIsoStrings(yaml.load(yamlText) as unknown);
       const meta = (parsed && typeof parsed === 'object' ? parsed : {}) as { version?: unknown; date?: unknown };
-      const docVersion = typeof meta.version === 'string' ? meta.version : undefined;
-      const docDate = typeof meta.date === 'string' ? meta.date : todayIso();
+      docVersion = typeof meta.version === 'string' ? meta.version : undefined;
+      docDate = typeof meta.date === 'string' ? meta.date : todayIso();
       const v = parseCanonicalFGCA(parsed);
       warnings = v.warnings.map(w => `${w.code}: ${w.message}`);
       if (!v.valid || !v.parsed) {
@@ -251,35 +367,28 @@ export class FGCAPreview {
         // IDs and singular `change.goal_id` / `change.activity_ids`. The
         // inline FGCADoc / buildSvg here accept both forms (number | string
         // unions) — pass through.
-        const fgcaDoc = v.parsed as unknown as FGCADoc;
-        ({ goals: goalOptions, maxLevelPresent } = scopeInputsFromDoc(fgcaDoc));
-        const scopeWarning = checkScopeRoot(scope, fgcaDoc.goals.map(g => g.id));
-        if (scopeWarning) warnings.push(`${scopeWarning.code}: ${scopeWarning.message}`);
-        svgContent = buildSvg(fgcaDoc, false, { colGap: gaps.horizontalGap, rowGap: gaps.verticalGap, curvature, scope }, 'FGCA — Factor → Goal → Change → Activity', filename, docDate, docVersion);
+        parsedDoc = v.parsed as unknown as FGCADoc;
       }
     } catch (e) {
       errorMsg = (e as Error).message ?? 'Parse error';
     }
 
-    this.lastSvg = svgContent;
-
     const themeId = vscode.workspace
       .getConfiguration('transitrix')
       .get<ThemeId>('theme', 'transitrix');
 
-    const nonce = genNonce();
-    const model = fgcaControlsModel(gaps, spacingDefaults, curvature, scope, goalOptions, maxLevelPresent);
-
-    return buildDiagramFrame({
-      filename, notation: 'FGCA', svgContent, errorMsg, warnings, themeId,
-      saveSvgCommand: 'transitrixStudio.saveFGCAAsSvg',
-      savePngCommand: 'transitrixStudio.saveFGCAAsPng',
-      copyPngCommand: 'transitrixStudio.copyFGCAAsPng',
-      spacingCommand: OPEN_SPACING_SETTINGS_COMMAND,
-      curvatureCommand: OPEN_CURVATURE_SETTINGS_COMMAND,
-      scopeCommand: OPEN_SCOPE_SETTINGS_COMMAND,
-      interactive: { nonce, controlsPanel: buildControlsPanel(model), controlsScript: buildControlsScript(nonce) },
-    });
+    const { html, svg } = renderChainPreview(
+      {
+        notation: 'FGCA', viewNotation: 'fgca', hideChanges: false,
+        heading: 'FGCA — Factor → Goal → Change → Activity',
+        saveSvgCommand: 'transitrixStudio.saveFGCAAsSvg',
+        savePngCommand: 'transitrixStudio.saveFGCAAsPng',
+        copyPngCommand: 'transitrixStudio.copyFGCAAsPng',
+      },
+      parsedDoc, warnings, errorMsg, docVersion, docDate, filename, themeId,
+    );
+    this.lastSvg = svg;
+    return html;
   }
 
   private pngTarget() {
@@ -377,57 +486,45 @@ export class FGAPreview {
   }
 
   private buildHtml(yamlText: string, filename: string): string {
-    let svgContent = '';
+    let parsedDoc: FGCADoc | null = null;
     let errorMsg = '';
     let warnings: string[] = [];
-
-    const spacingDefaults = { horizontalGap: FGCA_DEFAULT_COL_GAP, verticalGap: FGCA_DEFAULT_ROW_GAP };
-    const gaps = readSpacing('fga', spacingDefaults);
-    const scope = readScope('fga');
-    const curvature = readCurvature('fga');
-    let goalOptions: ScopeGoalOption[] = [];
-    let maxLevelPresent = 0;
+    let docVersion: string | undefined;
+    let docDate = todayIso();
 
     try {
       const parsed = coerceDatesToIsoStrings(yaml.load(yamlText) as unknown);
       const meta = (parsed && typeof parsed === 'object' ? parsed : {}) as { version?: unknown; date?: unknown };
-      const docVersion = typeof meta.version === 'string' ? meta.version : undefined;
-      const docDate = typeof meta.date === 'string' ? meta.date : todayIso();
+      docVersion = typeof meta.version === 'string' ? meta.version : undefined;
+      docDate = typeof meta.date === 'string' ? meta.date : todayIso();
       const v = parseCanonicalFGA(parsed);
       warnings = v.warnings.map(w => `${w.code}: ${w.message}`);
       if (!v.valid || !v.parsed) {
         errorMsg = v.errors.map(e => `${e.code}: ${e.message}`).join('\n');
       } else {
         // FGA shares FGCA's FLAT shape; just hide the (absent) Changes column.
-        const fgaDoc = v.parsed as unknown as FGCADoc;
-        ({ goals: goalOptions, maxLevelPresent } = scopeInputsFromDoc(fgaDoc));
-        const scopeWarning = checkScopeRoot(scope, fgaDoc.goals.map(g => g.id));
-        if (scopeWarning) warnings.push(`${scopeWarning.code}: ${scopeWarning.message}`);
-        svgContent = buildSvg(fgaDoc, true, { colGap: gaps.horizontalGap, rowGap: gaps.verticalGap, curvature, scope }, 'FGA — Factor → Goal → Activity', filename, docDate, docVersion);
+        parsedDoc = v.parsed as unknown as FGCADoc;
       }
     } catch (e) {
       errorMsg = (e as Error).message ?? 'Parse error';
     }
 
-    this.lastSvg = svgContent;
-
     const themeId = vscode.workspace
       .getConfiguration('transitrix')
       .get<ThemeId>('theme', 'transitrix');
 
-    const nonce = genNonce();
-    const model = fgcaControlsModel(gaps, spacingDefaults, curvature, scope, goalOptions, maxLevelPresent);
-
-    return buildDiagramFrame({
-      filename, notation: 'FGA', svgContent, errorMsg, warnings, themeId,
-      saveSvgCommand: 'transitrixStudio.saveFGAAsSvg',
-      savePngCommand: 'transitrixStudio.saveFGAAsPng',
-      copyPngCommand: 'transitrixStudio.copyFGAAsPng',
-      spacingCommand: OPEN_SPACING_SETTINGS_COMMAND,
-      curvatureCommand: OPEN_CURVATURE_SETTINGS_COMMAND,
-      scopeCommand: OPEN_SCOPE_SETTINGS_COMMAND,
-      interactive: { nonce, controlsPanel: buildControlsPanel(model), controlsScript: buildControlsScript(nonce) },
-    });
+    const { html, svg } = renderChainPreview(
+      {
+        notation: 'FGA', viewNotation: 'fga', hideChanges: true,
+        heading: 'FGA — Factor → Goal → Activity',
+        saveSvgCommand: 'transitrixStudio.saveFGAAsSvg',
+        savePngCommand: 'transitrixStudio.saveFGAAsPng',
+        copyPngCommand: 'transitrixStudio.copyFGAAsPng',
+      },
+      parsedDoc, warnings, errorMsg, docVersion, docDate, filename, themeId,
+    );
+    this.lastSvg = svg;
+    return html;
   }
 
   private pngTarget() {

--- a/extension/src/preview-controls.ts
+++ b/extension/src/preview-controls.ts
@@ -64,12 +64,15 @@ export interface ControlsModel {
 /** Message posted from the webview to the host on every control change. */
 export interface ControlMessage {
   type: 'transitrix:control';
-  control: 'spacing' | 'curvature' | 'scope';
-  /** 'horizontalGap' | 'verticalGap' for spacing; 'rootId' | 'maxLevel' | 'reset' for scope; absent for curvature. */
-  field?: 'horizontalGap' | 'verticalGap' | 'rootId' | 'maxLevel' | 'reset';
-  /** Numeric for spacing/curvature/maxLevel; string for rootId; absent for reset. */
+  control: 'spacing' | 'curvature' | 'scope' | 'view';
+  /** spacing: 'horizontalGap'|'verticalGap'; scope: 'rootId'|'maxLevel'|'reset'; view: 'tree'|'table'; absent for curvature. */
+  field?: 'horizontalGap' | 'verticalGap' | 'rootId' | 'maxLevel' | 'reset' | 'tree' | 'table';
+  /** Numeric for spacing/curvature/maxLevel; string for rootId; absent for reset/view. */
   value?: number | string;
 }
+
+/** Tree ↔ table view, persisted per notation (vkgeorgia/strategy#137). */
+export type PreviewView = 'tree' | 'table';
 
 // Spacing bounds mirror the package.json `transitrix.spacing.*` schema (20–300).
 export const SPACING_MIN = 20;
@@ -115,6 +118,24 @@ export const CONTROLS_PANEL_CSS = `
 }
 .tx-ctl button { cursor: pointer; }
 .tx-ctl output { min-width: 22px; font-variant-numeric: tabular-nums; }
+
+/* View toggle (tree ↔ table) — a segmented control in the toolbar (#137).
+   Mirrors the zoom control's look so the toolbar reads consistently. */
+.tx-view { display: inline-flex; border: 1px solid var(--ts-border, #cbd5e1); border-radius: 4px; overflow: hidden; }
+.tx-view-btn {
+  cursor: pointer;
+  user-select: none;
+  font-size: 11px;
+  padding: 1px 8px;
+  color: var(--ts-text-muted, #64748b);
+  background: transparent;
+  border: none;
+  border-right: 1px solid var(--ts-border, #cbd5e1);
+  font-family: var(--vscode-font-family, sans-serif);
+}
+.tx-view-btn:last-child { border-right: none; }
+.tx-view-btn:hover { color: var(--ts-text, #0f172a); background: var(--ts-bg-elevated, #f1f5f9); }
+.tx-view-btn.active { color: var(--ts-text, #0f172a); background: var(--ts-bg-elevated, #f1f5f9); font-weight: 600; }
 `;
 
 /** True when any control differs from its no-visual-change default. */
@@ -182,6 +203,15 @@ export function buildControlsPanel(model: ControlsModel): string {
     ${rows.join('\n    ')}
   </div>
 </details>`;
+}
+
+/** Builds the toolbar segmented control that switches the tree ↔ table view
+ *  (#137). Wired by the same `data-tx-control` mechanism as the panel inputs —
+ *  the buttons post `{control:'view', field:'tree'|'table'}` to the host. */
+export function buildViewToggle(current: PreviewView): string {
+  const btn = (view: PreviewView, label: string): string =>
+    `<button type="button" class="tx-view-btn${current === view ? ' active' : ''}" data-tx-control="view" data-tx-field="${view}">${label}</button>`;
+  return `<span class="tx-view" title="Switch between the tree and table view">${btn('tree', 'Tree')}${btn('table', 'Table')}</span>`;
 }
 
 /** Builds the nonce'd wiring `<script>`. Reads `data-tx-*` inputs, posts a

--- a/extension/src/spacing-config.ts
+++ b/extension/src/spacing-config.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import type { Scope } from '../../packages/diagrams/src/scope.js';
-import type { ControlMessage } from './preview-controls.js';
+import type { ControlMessage, PreviewView } from './preview-controls.js';
 
 // Per-notation spacing controls (vkgeorgia/strategy#75). PR1 persists the
 // chosen gaps in VS Code configuration (`transitrix.spacing.<notation>.*`),
@@ -82,6 +82,24 @@ export const SCOPE_CONFIG_SECTION = 'transitrix.scope';
 /** Command that opens Settings filtered to the scope controls. */
 export const OPEN_SCOPE_SETTINGS_COMMAND = 'transitrixStudio.openScopeSettings';
 
+// ── Tree ↔ table view (vkgeorgia/strategy#137) ──────────────────────────────
+//
+// FGCA/FGA previews can render as the tree/chain diagram (default) or as a
+// flattened chain table. Same settings-backed persistence as the controls
+// above: the in-preview toolbar toggle writes `transitrix.view.<notation>` and
+// the preview re-renders.
+
+export type ViewNotation = 'fgca' | 'fga';
+
+/** Reads the persisted view for a notation. Defaults to 'tree' (no change). */
+export function readView(notation: ViewNotation): PreviewView {
+  const v = vscode.workspace.getConfiguration('transitrix').get<string>(`view.${notation}`, 'tree');
+  return v === 'table' ? 'table' : 'tree';
+}
+
+/** Config section that, when changed, re-renders view-aware previews. */
+export const VIEW_CONFIG_SECTION = 'transitrix.view';
+
 // ── In-preview control messages (PR2) ───────────────────────────────────────
 //
 // The interactive control panel (preview-controls.ts) posts a `ControlMessage`
@@ -114,6 +132,10 @@ export async function applyControlMessage(notation: SpacingNotation, msg: Contro
   }
   if (msg.control === 'curvature') {
     await cfg.update(`curvature.${notation}`, clamp(Number(msg.value), 0, 3), target);
+    return;
+  }
+  if (msg.control === 'view' && (notation === 'fgca' || notation === 'fga')) {
+    await cfg.update(`view.${notation}`, msg.field === 'table' ? 'table' : 'tree', target);
     return;
   }
   if (msg.control === 'scope' && notation !== 'activities') {

--- a/packages/diagrams/src/fgca/__tests__/chain-table.test.ts
+++ b/packages/diagrams/src/fgca/__tests__/chain-table.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest';
+import { buildChainTable, type ChainTable, type ChainColumn } from '../chain-table.js';
+import type { FGCAPreviewDoc } from '../preview-layout.js';
+
+// Renders a ChainTable to a compact text grid for readable assertions. Each
+// cell shows "label×rowSpan" (×1 omitted); a position covered by a span above
+// shows "·".
+function asGrid(t: ChainTable): string[][] {
+  return t.rows.map(row =>
+    row.map(c => {
+      if (c === null) return '·';
+      const label = c.cell ? c.cell.label : '∅';
+      return c.rowSpan > 1 ? `${label}×${c.rowSpan}` : label;
+    }),
+  );
+}
+
+describe('buildChainTable — worked example (FGCA)', () => {
+  // F1 → G1, G2 ; G1 → C1 → A1 ; G2 → C2 → A2, A3
+  const doc: FGCAPreviewDoc = {
+    factors: [{ id: 1, name: 'F1' }],
+    goals: [
+      { id: 10, name: 'G1', factor: [{ id: 1 }] },
+      { id: 11, name: 'G2', factor: [{ id: 1 }] },
+    ],
+    changes: [
+      { id: 20, name: 'C1', goal_id: 10, activity_ids: [30] },
+      { id: 21, name: 'C2', goal_id: 11, activity_ids: [31, 32] },
+    ],
+    activities: [
+      { id: 30, name: 'A1', goal_id: 10 },
+      { id: 31, name: 'A2', goal_id: 11 },
+      { id: 32, name: 'A3', goal_id: 11 },
+    ],
+  };
+
+  it('produces the spec grid with F1 spanning 3 and G2/C2 spanning 2', () => {
+    const t = buildChainTable(doc);
+    expect(t.columns).toEqual<ChainColumn[]>(['factor', 'goal', 'change', 'activity']);
+    expect(asGrid(t)).toEqual([
+      ['F1×3', 'G1', 'C1', 'A1'],
+      ['·', 'G2×2', 'C2×2', 'A2'],
+      ['·', '·', '·', 'A3'],
+    ]);
+  });
+
+  it('orders the merged cells with correct rowSpans on the model', () => {
+    const t = buildChainTable(doc);
+    // Factor cell spans all three rows.
+    expect(t.rows[0][0]).toMatchObject({ rowSpan: 3, cell: { label: 'F1' } });
+    // Covered positions are null (no <td> emitted).
+    expect(t.rows[1][0]).toBeNull();
+    expect(t.rows[2][1]).toBeNull();
+  });
+});
+
+describe('buildChainTable — FGA (no Change column)', () => {
+  // FGA links Goal → Activity directly via activity.goal_id; no changes.
+  const doc: FGCAPreviewDoc = {
+    factors: [{ id: 1, name: 'F1' }],
+    goals: [{ id: 10, name: 'G1', factor: [{ id: 1 }] }],
+    activities: [
+      { id: 30, name: 'A1', goal_id: 10 },
+      { id: 31, name: 'A2', goal_id: 10 },
+    ],
+  };
+
+  it('emits three columns and merges Factor/Goal across the two activities', () => {
+    const t = buildChainTable(doc, { hideChanges: true });
+    expect(t.columns).toEqual<ChainColumn[]>(['factor', 'goal', 'activity']);
+    expect(asGrid(t)).toEqual([
+      ['F1×2', 'G1×2', 'A1'],
+      ['·', '·', 'A2'],
+    ]);
+  });
+});
+
+describe('buildChainTable — missing downstream links (gaps stay visible)', () => {
+  it('shows a factor with no goal, a goal with no change, and a change with no activity', () => {
+    const doc: FGCAPreviewDoc = {
+      factors: [
+        { id: 1, name: 'F1' },
+        { id: 2, name: 'F2' }, // no goals
+      ],
+      goals: [
+        { id: 10, name: 'G1', factor: [{ id: 1 }] }, // no change, no activity
+        { id: 11, name: 'G2', factor: [{ id: 1 }] }, // has a change with no activity
+      ],
+      changes: [{ id: 20, name: 'C1', goal_id: 11, activity_ids: [] }],
+      activities: [],
+    };
+    const t = buildChainTable(doc);
+    expect(asGrid(t)).toEqual([
+      ['F1×2', 'G1', '∅', '∅'],
+      ['·', 'G2', 'C1', '∅'],
+      ['F2', '∅', '∅', '∅'],
+    ]);
+  });
+
+  it('renders a change-less direct goal→activity path with an empty Change cell', () => {
+    const doc: FGCAPreviewDoc = {
+      factors: [{ id: 1, name: 'F1' }],
+      goals: [{ id: 10, name: 'G1', factor: [{ id: 1 }] }],
+      // activity bound straight to the goal, not covered by any change
+      changes: [],
+      activities: [{ id: 30, name: 'A1', goal_id: 10 }],
+    };
+    const t = buildChainTable(doc);
+    expect(asGrid(t)).toEqual([['F1', 'G1', '∅', 'A1']]);
+  });
+});
+
+describe('buildChainTable — orphans (broken refs are warnings, not errors)', () => {
+  it('places a goal with a missing factor in a trailing empty-Factor row', () => {
+    const doc: FGCAPreviewDoc = {
+      factors: [{ id: 1, name: 'F1' }],
+      goals: [
+        { id: 10, name: 'G1', factor: [{ id: 1 }] },
+        { id: 11, name: 'Gx', factor: [{ id: 99 }] }, // factor 99 does not exist
+        { id: 12, name: 'Gy' }, // no factor at all
+      ],
+      changes: [{ id: 20, name: 'C1', goal_id: 10, activity_ids: [30] }],
+      activities: [{ id: 30, name: 'A1', goal_id: 10 }],
+    };
+    const t = buildChainTable(doc);
+    expect(asGrid(t)).toEqual([
+      ['F1', 'G1', 'C1', 'A1'],
+      ['∅×2', 'Gx', '∅', '∅'],
+      ['·', 'Gy', '∅', '∅'],
+    ]);
+  });
+
+  it('surfaces an unlinked activity as a trailing row with empty cells to its left', () => {
+    const doc: FGCAPreviewDoc = {
+      factors: [{ id: 1, name: 'F1' }],
+      goals: [{ id: 10, name: 'G1', factor: [{ id: 1 }] }],
+      changes: [{ id: 20, name: 'C1', goal_id: 10, activity_ids: [30] }],
+      activities: [
+        { id: 30, name: 'A1', goal_id: 10 },
+        { id: 99, name: 'Aorphan' }, // no goal, no change
+      ],
+    };
+    const t = buildChainTable(doc);
+    expect(asGrid(t)).toEqual([
+      ['F1', 'G1', 'C1', 'A1'],
+      ['∅', '∅', '∅', 'Aorphan'],
+    ]);
+  });
+
+  it('surfaces a change whose goal is missing as an empty Factor+Goal row', () => {
+    const doc: FGCAPreviewDoc = {
+      factors: [],
+      goals: [],
+      changes: [{ id: 20, name: 'Cx', goal_id: 999, activity_ids: [30] }],
+      activities: [{ id: 30, name: 'A1' }],
+    };
+    const t = buildChainTable(doc);
+    expect(asGrid(t)).toEqual([['∅', '∅', 'Cx', 'A1']]);
+  });
+});
+
+describe('buildChainTable — name fallback', () => {
+  it('falls back to the id when an element has an empty name', () => {
+    const doc: FGCAPreviewDoc = {
+      factors: [{ id: 7, name: '' }],
+      goals: [],
+      activities: [],
+    };
+    const t = buildChainTable(doc);
+    expect(t.rows[0][0]?.cell?.label).toBe('7');
+  });
+});

--- a/packages/diagrams/src/fgca/chain-table.ts
+++ b/packages/diagrams/src/fgca/chain-table.ts
@@ -1,0 +1,225 @@
+// Chain-table model for the FGCA / FGA previews (vkgeorgia/strategy#137).
+//
+// The tree/chain preview (`layoutFGCAPreview`) shows Factor → Goal → Change →
+// Activity as columns of nodes joined by edges. This module produces the
+// *tabular* alternative: the same chain flattened into rows, with shared
+// parents collapsed into vertically-merged (rowspan) cells.
+//
+// It is the pure, unit-testable half of the feature — no DOM, no vscode. The
+// Studio preview renders the returned model as an HTML `<table>`.
+//
+// Link semantics mirror `layoutFGCAPreview` exactly (the authoritative source):
+//   - F → G via `goal.factor[]`
+//   - G → C via `change.goal_id`            (FGCA only)
+//   - C → A via `change.activity_ids[]`     (FGCA only)
+//   - G → A directly via `activity.goal_id` for activities not covered by any
+//     change (FGCA) / for every activity (FGA, no Change column)
+//
+// Broken references are validation *warnings*, not errors, so a rendered doc
+// can contain a goal with a missing factor, a change with a missing goal, or an
+// unlinked activity. Every element still appears in the table — rooted where it
+// links, or as a trailing orphan row with empty cells to its left — so the
+// table mirrors the document the same way the tree does.
+
+import type { FGCAPreviewDoc } from './preview-layout.js';
+
+export type ChainColumn = 'factor' | 'goal' | 'change' | 'activity';
+
+export interface ChainCell {
+  /** Column-qualified identity (e.g. "goal:3") — stable, unique across columns. */
+  key: string;
+  /** Display text — the element name, falling back to its id. */
+  label: string;
+}
+
+export interface ChainTableCell {
+  /** The element to render, or null for a gap in the chain (empty cell). */
+  cell: ChainCell | null;
+  /** Vertical span — how many rows this cell covers. */
+  rowSpan: number;
+}
+
+export interface ChainTable {
+  /** Columns left→right: FGA omits 'change'. */
+  columns: ChainColumn[];
+  /**
+   * Grid of rendered cells. `rows[r][c]` is the cell to emit at (r, c), or null
+   * when that position is covered by a `rowSpan` from a row above (emit no
+   * `<td>`). Each row corresponds to one path through the chain.
+   */
+  rows: Array<Array<ChainTableCell | null>>;
+}
+
+export interface ChainTableOptions {
+  /** FGA hides the Change column (Goal links straight to Activity). */
+  hideChanges?: boolean;
+}
+
+function cellOf(col: ChainColumn, id: number | string, name: string): ChainCell {
+  const label = name && name.trim() ? name : String(id);
+  return { key: `${col}:${id}`, label };
+}
+
+/** Identity comparison for the rowspan grouping; both-null counts as equal. */
+function sameCell(a: ChainCell | null, b: ChainCell | null): boolean {
+  if (a === null || b === null) return a === b;
+  return a.key === b.key;
+}
+
+/**
+ * Flattens an FGCA/FGA doc into a chain table with rowspan-merged parent cells.
+ *
+ * Rows are enumerated in document order (deterministic). A parent that links to
+ * several children spans those children's rows; an element with no downstream
+ * link still appears, with empty cells to its right.
+ */
+export function buildChainTable(doc: FGCAPreviewDoc, options: ChainTableOptions = {}): ChainTable {
+  const { hideChanges = false } = options;
+  const columns: ChainColumn[] = hideChanges
+    ? ['factor', 'goal', 'activity']
+    : ['factor', 'goal', 'change', 'activity'];
+
+  const changes = doc.changes ?? [];
+  const factorIds = new Set(doc.factors.map(f => f.id));
+  const activityById = new Map(doc.activities.map(a => [a.id, a] as const));
+  // An activity is "covered" by a change when any change lists it — those render
+  // under their change, not directly under the goal (mirrors the tree).
+  const coveredActivityIds = new Set(changes.flatMap(c => c.activity_ids));
+
+  const emittedGoals = new Set<number | string>();
+  const emittedChanges = new Set<number | string>();
+  const emittedActivities = new Set<number | string>();
+
+  // Each path is an array (length = columns.length) of ChainCell | null.
+  const paths: Array<Array<ChainCell | null>> = [];
+  const pad = (cells: Array<ChainCell | null>): Array<ChainCell | null> => {
+    // Defensive: ensure every path matches the column count.
+    while (cells.length < columns.length) cells.push(null);
+    return cells;
+  };
+
+  const emitGoal = (factorCell: ChainCell | null, goal: FGCAPreviewDoc['goals'][number]): void => {
+    emittedGoals.add(goal.id);
+    const goalCell = cellOf('goal', goal.id, goal.name);
+
+    if (hideChanges) {
+      const acts = doc.activities.filter(a => a.goal_id != null && a.goal_id === goal.id);
+      if (acts.length === 0) {
+        paths.push(pad([factorCell, goalCell]));
+        return;
+      }
+      for (const a of acts) {
+        emittedActivities.add(a.id);
+        paths.push([factorCell, goalCell, cellOf('activity', a.id, a.name)]);
+      }
+      return;
+    }
+
+    const goalChanges = changes.filter(c => c.goal_id === goal.id);
+    const directActs = doc.activities.filter(
+      a => a.goal_id != null && a.goal_id === goal.id && !coveredActivityIds.has(a.id),
+    );
+
+    if (goalChanges.length === 0 && directActs.length === 0) {
+      paths.push([factorCell, goalCell, null, null]);
+      return;
+    }
+    for (const c of goalChanges) {
+      emittedChanges.add(c.id);
+      const changeCell = cellOf('change', c.id, c.name);
+      const acts = c.activity_ids.map(id => activityById.get(id)).filter((a): a is NonNullable<typeof a> => a != null);
+      if (acts.length === 0) {
+        paths.push([factorCell, goalCell, changeCell, null]);
+        continue;
+      }
+      for (const a of acts) {
+        emittedActivities.add(a.id);
+        paths.push([factorCell, goalCell, changeCell, cellOf('activity', a.id, a.name)]);
+      }
+    }
+    // Change-less paths: activities bound straight to the goal (gap in Change).
+    for (const a of directActs) {
+      emittedActivities.add(a.id);
+      paths.push([factorCell, goalCell, null, cellOf('activity', a.id, a.name)]);
+    }
+  };
+
+  // Phase 1 — factor-rooted paths.
+  for (const f of doc.factors) {
+    const factorCell = cellOf('factor', f.id, f.name);
+    const goalsOfFactor = doc.goals.filter(g => (g.factor ?? []).some(ref => ref.id === f.id));
+    if (goalsOfFactor.length === 0) {
+      paths.push(pad([factorCell]));
+      continue;
+    }
+    for (const g of goalsOfFactor) emitGoal(factorCell, g);
+  }
+
+  // Phase 2 — goals with no existing factor (orphan or broken-ref): empty Factor.
+  for (const g of doc.goals) {
+    if (emittedGoals.has(g.id)) continue;
+    const hasExistingFactor = (g.factor ?? []).some(ref => factorIds.has(ref.id));
+    if (hasExistingFactor) continue; // emitted under its factor in phase 1
+    emitGoal(null, g);
+  }
+
+  // Phase 3 — changes whose goal is missing (FGCA only): empty Factor + Goal.
+  if (!hideChanges) {
+    for (const c of changes) {
+      if (emittedChanges.has(c.id)) continue;
+      emittedChanges.add(c.id);
+      const changeCell = cellOf('change', c.id, c.name);
+      const acts = c.activity_ids.map(id => activityById.get(id)).filter((a): a is NonNullable<typeof a> => a != null);
+      if (acts.length === 0) {
+        paths.push([null, null, changeCell, null]);
+        continue;
+      }
+      for (const a of acts) {
+        emittedActivities.add(a.id);
+        paths.push([null, null, changeCell, cellOf('activity', a.id, a.name)]);
+      }
+    }
+  }
+
+  // Phase 4 — activities linked to nothing: empty cells to their left.
+  for (const a of doc.activities) {
+    if (emittedActivities.has(a.id)) continue;
+    const row: Array<ChainCell | null> = columns.map(() => null);
+    row[columns.length - 1] = cellOf('activity', a.id, a.name);
+    paths.push(row);
+  }
+
+  return { columns, rows: computeRowSpans(paths, columns.length) };
+}
+
+/**
+ * Turns a flat list of equal-length paths into a render grid. For each column,
+ * a cell spans the run of consecutive rows that share identical values in every
+ * column from 0 through that column (so a child only merges within one parent).
+ */
+function computeRowSpans(
+  paths: Array<Array<ChainCell | null>>,
+  colCount: number,
+): Array<Array<ChainTableCell | null>> {
+  const n = paths.length;
+  const grid: Array<Array<ChainTableCell | null>> = paths.map(() => new Array(colCount).fill(null));
+
+  for (let c = 0; c < colCount; c++) {
+    let r = 0;
+    while (r < n) {
+      let end = r + 1;
+      while (end < n && prefixEqual(paths[end], paths[r], c)) end++;
+      grid[r][c] = { cell: paths[r][c], rowSpan: end - r };
+      r = end;
+    }
+  }
+  return grid;
+}
+
+/** True when two paths agree on every column 0..c (inclusive). */
+function prefixEqual(a: Array<ChainCell | null>, b: Array<ChainCell | null>, c: number): boolean {
+  for (let i = 0; i <= c; i++) {
+    if (!sameCell(a[i], b[i])) return false;
+  }
+  return true;
+}

--- a/packages/diagrams/src/fgca/index.ts
+++ b/packages/diagrams/src/fgca/index.ts
@@ -19,6 +19,8 @@ export type {
   FGCAPreviewEdge,
   FGCAPreviewColumnPos,
 } from "./preview-layout";
+export { buildChainTable } from "./chain-table";
+export type { ChainTable, ChainTableCell, ChainColumn, ChainCell, ChainTableOptions } from "./chain-table";
 export { validateFGCADoc } from "./validate";
 export type { FGCADoc, FGCAValidationResult, FGCAValidationError, FGCAValidationWarning } from "./validate";
 export {


### PR DESCRIPTION
@
**Do not merge — Valerii gates.**

Adds a tabular alternative to the FGCA/FGA chain diagram. A live **Tree | Table** toggle in the preview toolbar switches between the tree/chain view (default) and a chain table with rowspan-merged parent cells. Builds directly on the interactive preview surface from PR #86.

### Table form
Columns follow the chain left→right: `Factor | Goal | Change | Activity` (FGA drops `Change`). Each row is one path through the chain; a parent that links to several children is merged vertically (`rowspan`). Worked example from the issue (`F1 → G1,G2; G1→C1→A1; G2→C2→A2,A3`) renders exactly as specified — F1 spans 3 rows, G2/C2 span 2.

### Library — `@transitrix/diagrams` (unit-testable, AC#4)
- `buildChainTable()` in `fgca/chain-table.ts` is the pure flattening + rowspan derivation. Link semantics mirror `layoutFGCAPreview` exactly (F→G via `goal.factor[]`; G→C via `change.goal_id`; C→A via `change.activity_ids`; direct G→A for change-less activities / FGA).
- Broken references are validation **warnings, not errors**, so a rendered doc can contain a goal with a missing factor, a change with a missing goal, or an unlinked activity. Every element still appears — rooted where it links, or as a trailing orphan row with empty left cells — so the table mirrors the document the same way the tree does.
- **9 vitest fixtures**: the spec worked example, FGA no-Change, missing downstream links (factor→no goal, goal→no change, change→no activity, change-less direct path), orphan goal / activity / change, and id-fallback.

### Preview — extension
- `fgca-preview.ts` renders the model as an HTML `<table>` (rowspan, all cells `escXml`-escaped). A shared `renderChainPreview` dedups the FGCA + FGA paths and branches on the persisted view.
- The **Tree | Table** segmented control (`buildViewToggle` in `preview-controls.ts`) rides the same nonce-CSP interactive machinery from PR #86 — no new script/CSP code. In table view the spacing/curvature/scope panel is hidden and **scope is a no-op** (the table shows the full doc); Save/Zoom are omitted (table export is out of scope per #137).
- Persisted per notation via new `transitrix.view.{fgca,fga}` settings (default `tree`), re-rendered through the existing `onDidChangeConfiguration` handler. **Config stays the single source of truth**, consistent with #75/#76/#77.

### Scope / out of scope
FGCA and FGA only. No table export (CSV/MD), no editing from the table, no Goals table — all explicitly out of scope per the issue.

### Security
Reuses PR #86s `enableScripts: true` + strict nonce CSP on the FGCA/FGA previews only (no blanket flip; other static previews stay `enableScripts: false`). All user content stays escaped. `CLAUDE.md` is git-ignored in this repo, so the rationale lives in committed code comments + this PR description (the approach accepted on PR #86).

### Tests
diagrams **513** + core **235** green; `tsc` (root + extension) clean; extension bundles. Final verification is your hand-test of both previews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@