### PR TITLE
feat(compliance): Phase 1 — Requirement & Assertion library (#84)

### DIFF
--- a/examples/assertion/ASSERTION-CRM-DATA-ERASURE-1.yaml
+++ b/examples/assertion/ASSERTION-CRM-DATA-ERASURE-1.yaml
@@ -1,0 +1,37 @@
+# Worked example — under-review assertion with empty evidence.
+# Schema: notations/elements/16-assertion.md §2.
+# Demonstrates: subject = CAPABILITY, status = under_review, evidence empty.
+# Status `under_review` deliberately has no evidence yet — the prior judgement
+# no longer holds and the new one has not been determined. The planned
+# ASSERT-007 warning ("positive status with empty evidence") does NOT fire
+# here because under_review is not a positive status.
+
+notation: assertion
+id: ASSERTION-CRM-DATA-ERASURE-1
+about: REQUIREMENT-DATA-ERASURE-1                      # same requirement as the other two
+subject: CAPABILITY-V2                                  # CAPABILITY TYPE; Customer Relationship Management
+
+# realised_via is empty during the review — the team is auditing whether the
+# existing realisation set still holds after a CRM platform change.
+realised_via: []
+
+status: under_review
+
+evidence: []
+
+assessed_at: "2026-05-20"
+assessed_by: ROLE-DPO-1
+next_review_at: "2026-06-30"                            # review scheduled within ~6 weeks
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-28"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-05-20"
+valid_to: null

--- a/examples/assertion/ASSERTION-MOBILE-DATA-ERASURE-1.yaml
+++ b/examples/assertion/ASSERTION-MOBILE-DATA-ERASURE-1.yaml
@@ -1,0 +1,45 @@
+# Worked example — full-evidence compliant assertion.
+# Schema: notations/elements/16-assertion.md §2.
+# Demonstrates: subject = PRODUCT, status = compliant, evidence with all three
+# kinds (canonical_ref + external_doc + note).
+
+notation: assertion
+id: ASSERTION-MOBILE-DATA-ERASURE-1
+about: REQUIREMENT-DATA-ERASURE-1                      # → canon/elements/01_motivation/requirements/
+subject: PRODUCT-MOBILE-1                              # PRODUCT TYPE; resolves to a product element
+
+realised_via:
+  - CAPABILITY-V2                                       # Customer Relationship Management capability
+  - PROCESS-USER-DATA-PURGE-1                           # operational purge workflow
+  - INTERNAL_STANDARD-coding-conventions-1              # development discipline that bakes erasure into the codebase
+
+status: compliant
+
+evidence:
+  - kind: canonical_ref
+    ref: PROCESS-USER-DATA-PURGE-1                      # the documented purge process is itself the artefact-of-record
+  - kind: external_doc
+    title: "Q1 2026 data-erasure SLA report — Acme Mobile"
+    url: "https://internal.acme.example/reports/2026-Q1-mobile-erasure-sla.pdf"
+  - kind: note
+    text: >
+      DPO review on 2026-03-15 confirmed 100% of in-period erasure requests
+      were completed within the 30-day window. Sample audit of 50 requests
+      across Q1 showed median completion of 4.2 days. No exceptions raised.
+
+assessed_at: "2026-03-15"
+assessed_by: ROLE-DPO-1
+next_review_at: "2026-09-15"                            # twice-yearly cadence
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-28"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-03-15"
+valid_to: null

--- a/examples/assertion/ASSERTION-ONBOARD-DATA-ERASURE-1.yaml
+++ b/examples/assertion/ASSERTION-ONBOARD-DATA-ERASURE-1.yaml
@@ -1,0 +1,46 @@
+# Worked example — partial-status assertion with mixed evidence.
+# Schema: notations/elements/16-assertion.md §2.
+# Demonstrates: subject = PROCESS, status = partial, evidence with two kinds
+# (external_doc + note) and a documented gap.
+
+notation: assertion
+id: ASSERTION-ONBOARD-DATA-ERASURE-1
+about: REQUIREMENT-DATA-ERASURE-1                      # same requirement as the mobile assertion
+subject: PROCESS-CUST-ONBOARD-1                        # PROCESS TYPE; the customer-onboarding process
+
+realised_via:
+  - CAPABILITY-V2                                       # Customer Relationship Management
+  - PROCESS-USER-DATA-PURGE-1                           # same downstream purge — but not yet wired into onboarding rollback
+
+status: partial
+
+evidence:
+  - kind: external_doc
+    title: "Onboarding-system DPIA addendum — erasure paths"
+    url: "https://internal.acme.example/dpia/onboarding-erasure-2026-04.pdf"
+  - kind: note
+    text: >
+      Onboarding correctly forwards verified erasure requests to the central
+      purge workflow within the 30-day window for the happy path. KNOWN GAP:
+      requests received during onboarding ROLLBACK (account creation aborted
+      mid-flow before activation) are not yet routed to purge — the data is
+      retained in the transient onboarding store until the 7-day TTL clears
+      it. Remediation tracked as ISSUE-ONBOARD-ROLLBACK-ERASURE-1; target
+      close 2026-Q3. Status will be re-evaluated at next review.
+
+assessed_at: "2026-04-20"
+assessed_by: ROLE-DPO-1
+next_review_at: "2026-07-20"                            # quarterly cadence until partial is closed
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-28"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-04-20"
+valid_to: null

--- a/examples/assertion/README.md
+++ b/examples/assertion/README.md
@@ -1,0 +1,13 @@
+# Assertion — worked examples
+
+Compliance claims that a subject (PRODUCT / PROCESS / CAPABILITY) satisfies a
+REQUIREMENT (`notation: assertion`). Schema: methodology
+`notations/elements/16-assertion.md`.
+
+These files are mirrored from the methodology canon
+(`organizations/acme_corp/canon/assertions/`) and are consumed by the
+conformance test in `packages/diagrams/src/assertion/__tests__/example.test.ts`.
+
+- `ASSERTION-MOBILE-DATA-ERASURE-1.yaml` — subject = PRODUCT, status = compliant, all three evidence kinds.
+- `ASSERTION-CRM-DATA-ERASURE-1.yaml` — subject = CAPABILITY, status = under_review, empty evidence (ASSERT-007 correctly does not fire).
+- `ASSERTION-ONBOARD-DATA-ERASURE-1.yaml` — subject = PROCESS, status = partial, mixed evidence with a documented gap.

--- a/examples/requirement/README.md
+++ b/examples/requirement/README.md
@@ -1,0 +1,12 @@
+# Requirement — worked examples
+
+Motivation-layer positive obligations (`notation: requirement`). Schema:
+methodology `notations/elements/15-requirement.md`.
+
+These files are mirrored from the methodology canon
+(`organizations/acme_corp/canon/elements/01_motivation/requirements/`) and are
+consumed by the conformance test in
+`packages/diagrams/src/requirement/__tests__/example.test.ts`.
+
+- `REQUIREMENT-DATA-ERASURE-1.yaml` — derived from an external codex source (a LAW).
+- `REQUIREMENT-AUDIT-LOG-RETENTION-1.yaml` — internal-only, no `derived_from`.

--- a/examples/requirement/REQUIREMENT-AUDIT-LOG-RETENTION-1.yaml
+++ b/examples/requirement/REQUIREMENT-AUDIT-LOG-RETENTION-1.yaml
@@ -1,0 +1,32 @@
+# Worked example — internal-only REQUIREMENT with no codex source.
+# Schema: notations/elements/15-requirement.md §2.
+#
+# This requirement intentionally has no assertion targeting it, to demonstrate
+# the planned REQ-COVERAGE-001 cross-cutting warning (a REQUIREMENT with no
+# ASSERTION about it). See notations/elements/16-assertion.md §7 Evolution.
+
+notation: requirement
+id: REQUIREMENT-AUDIT-LOG-RETENTION-1
+name: "Retain operational audit logs for at least 12 months"
+description: >
+  All systems producing operational audit logs must retain those logs for
+  at least 12 months from creation. The obligation is an internal Acme
+  practice; no external codex source binds it. If a future internal
+  standard formalises it, this requirement should be updated to cite that
+  standard via derived_from.
+
+severity: medium
+# derived_from: absent — purely internal obligation
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-28"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-01-01"
+valid_to: null

--- a/examples/requirement/REQUIREMENT-DATA-ERASURE-1.yaml
+++ b/examples/requirement/REQUIREMENT-DATA-ERASURE-1.yaml
@@ -1,0 +1,29 @@
+# Worked example — REQUIREMENT derived from an external codex source.
+# Schema: notations/elements/15-requirement.md §2.
+# Assertion(s) about this requirement live in canon/assertions/.
+
+notation: requirement
+id: REQUIREMENT-DATA-ERASURE-1
+name: "Personal-data erasure on request within 30 days"
+description: >
+  On a verified request from a data subject, the controller must erase the
+  subject's personal data within 30 days. The window starts at the time the
+  request is received and verified. Applies across every system that stores
+  personal data of natural persons resident in Georgia.
+
+severity: high
+derived_from:
+  - LAW-PERSONAL-DATA-2017-1     # codex/external/ge/
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-05-28"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2017-05-01"           # date the source law took effect
+valid_to: null

--- a/extension/package.json
+++ b/extension/package.json
@@ -217,6 +217,18 @@
           "minimum": -1,
           "default": -1,
           "description": "FGA preview: scope to a goal-level cap. Show only goals at this level and above, plus their connected factors/activities. -1 = no cap. Ignored when a scope root id is set."
+        },
+        "transitrix.view.fgca": {
+          "type": "string",
+          "enum": ["tree", "table"],
+          "default": "tree",
+          "description": "FGCA preview: 'tree' renders the Factor→Goal→Change→Activity chain diagram; 'table' renders the chain flattened into a table with merged cells. Toggle live from the preview toolbar."
+        },
+        "transitrix.view.fga": {
+          "type": "string",
+          "enum": ["tree", "table"],
+          "default": "tree",
+          "description": "FGA preview: 'tree' renders the Factor→Goal→Activity chain diagram; 'table' renders the chain flattened into a table with merged cells. Toggle live from the preview toolbar."
         }
       }
     },

--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -107,6 +107,12 @@ export interface DiagramFrameOpts {
     nonce: string;
     controlsPanel: string;
     controlsScript: string;
+    /**
+     * Optional toolbar segmented control (e.g. the tree↔table view toggle,
+     * vkgeorgia/strategy#137). Injected as the first item in the toolbar
+     * actions. Pass '' / omit when the preview has no toolbar control.
+     */
+    viewToggleHtml?: string;
   };
 }
 
@@ -365,6 +371,9 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
   <input type="radio" name="ts-zoom" id="z-200" class="zoom-radio">`
     : '';
   const actionParts: string[] = [];
+  if (interactive?.viewToggleHtml) {
+    actionParts.push(interactive.viewToggleHtml);
+  }
   if (showToggle) {
     actionParts.push(`<label for="ts-title-toggle" class="title-toggle" title="Show or hide the diagram title">Title</label>`);
   }

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -29,6 +29,7 @@ import {
   CURVATURE_CONFIG_SECTION,
   OPEN_SCOPE_SETTINGS_COMMAND,
   SCOPE_CONFIG_SECTION,
+  VIEW_CONFIG_SECTION,
 } from './spacing-config.js';
 
 function isGoalsFile(doc: vscode.TextDocument): boolean {
@@ -331,7 +332,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       if (
         !e.affectsConfiguration(SPACING_CONFIG_SECTION) &&
         !e.affectsConfiguration(CURVATURE_CONFIG_SECTION) &&
-        !e.affectsConfiguration(SCOPE_CONFIG_SECTION)
+        !e.affectsConfiguration(SCOPE_CONFIG_SECTION) &&
+        !e.affectsConfiguration(VIEW_CONFIG_SECTION)
       ) return;
       void goalsPreview.refreshConfig();
       void fgcaPreview.refreshConfig();

--- a/extension/src/fgca-preview.ts
+++ b/extension/src/fgca-preview.ts
@@ -14,11 +14,12 @@ import {
   FGCA_DEFAULT_ROW_GAP,
 } from '../../packages/diagrams/src/fgca/preview-layout.js';
 import { horizontalCubicEdgePath, DEFAULT_EDGE_CURVATURE } from '../../packages/diagrams/src/edge-path.js';
+import { buildChainTable, type ChainTable, type ChainColumn } from '../../packages/diagrams/src/fgca/chain-table.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 import { checkScopeRoot, type Scope } from '../../packages/diagrams/src/scope.js';
 import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
-import { readSpacing, readCurvature, readScope, applyControlMessage, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND } from './spacing-config.js';
-import { genNonce, buildControlsPanel, buildControlsScript, type ControlsModel, type ScopeGoalOption } from './preview-controls.js';
+import { readSpacing, readCurvature, readScope, readView, applyControlMessage, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND } from './spacing-config.js';
+import { genNonce, buildControlsPanel, buildControlsScript, buildViewToggle, type ControlsModel, type ScopeGoalOption } from './preview-controls.js';
 
 // ── Inline render types ─────────────────────────────────────────────────────
 //
@@ -72,6 +73,43 @@ function scopeInputsFromDoc(doc: FGCADoc): { goals: ScopeGoalOption[]; maxLevelP
   };
 }
 
+// ── Chain table (vkgeorgia/strategy#137) ────────────────────────────────────
+//
+// The flattening + rowspan derivation lives in @transitrix/diagrams
+// (`buildChainTable`). Here we render that model as an HTML <table>. Scope
+// is a no-op in table view (per #137) — the table always shows the full doc.
+
+const CHAIN_COLUMN_HEADERS: Record<ChainColumn, string> = {
+  factor: 'Factor', goal: 'Goal', change: 'Change', activity: 'Activity',
+};
+
+const CHAIN_TABLE_CSS = `
+.chain-table-wrap { padding: 0 16px 16px; overflow-x: auto; }
+.chain-table { border-collapse: collapse; font-size: 12px; }
+.chain-table th, .chain-table td { border: 1px solid var(--ts-border, #cbd5e1); padding: 6px 12px; text-align: left; vertical-align: top; }
+.chain-table th { background: var(--ts-bg-subtle, #f1f5f9); color: var(--ts-text, #0f172a); font-weight: 600; }
+.chain-table td { color: var(--ts-text, #0f172a); }
+.chain-table td.chain-empty { background: var(--ts-bg-subtle, #f8fafc); }
+.chain-empty-table { padding: 24px 16px; color: var(--ts-text-muted, #64748b); font-style: italic; }
+`;
+
+function chainTableHtml(table: ChainTable): string {
+  if (table.rows.length === 0) {
+    return `<div class="chain-empty-table">Nothing to tabulate — the document has no factors, goals or activities.</div>`;
+  }
+  const head = `<tr>${table.columns.map(c => `<th>${CHAIN_COLUMN_HEADERS[c]}</th>`).join('')}</tr>`;
+  const body = table.rows.map(row => {
+    const cells = row.map(c => {
+      if (c === null) return ''; // covered by a rowspan above — emit no <td>
+      const span = c.rowSpan > 1 ? ` rowspan="${c.rowSpan}"` : '';
+      if (c.cell === null) return `<td${span} class="chain-empty"></td>`;
+      return `<td${span}>${escXml(c.cell.label)}</td>`;
+    }).join('');
+    return `<tr>${cells}</tr>`;
+  }).join('\n');
+  return `<div class="chain-table-wrap"><table class="chain-table"><thead>${head}</thead><tbody>${body}</tbody></table></div>`;
+}
+
 /** Assembles the interactive control-panel model shared by FGCA and FGA. */
 function fgcaControlsModel(
   gaps: { horizontalGap: number; verticalGap: number },
@@ -91,6 +129,89 @@ function fgcaControlsModel(
       goals,
     },
   };
+}
+
+interface ChainPreviewParams {
+  /** Toolbar / frame notation label. */
+  notation: 'FGCA' | 'FGA';
+  /** Settings namespace + view key (`transitrix.{spacing,curvature,scope,view}.<this>`). */
+  viewNotation: 'fgca' | 'fga';
+  /** FGA hides the Change column. */
+  hideChanges: boolean;
+  /** SVG title-block heading (tree view). */
+  heading: string;
+  saveSvgCommand: string;
+  savePngCommand: string;
+  copyPngCommand: string;
+}
+
+/**
+ * Shared render path for the FGCA and FGA previews. Branches on the persisted
+ * tree↔table view (vkgeorgia/strategy#137):
+ *  - **tree** — the chain SVG, with the spacing/curvature/scope control panel +
+ *    Save/Zoom toolbar (the PR #86 interactive surface) plus the view toggle.
+ *  - **table** — the flattened chain table; the spacing/curvature/scope controls
+ *    are hidden and scope is a no-op (the table always shows the full doc), so
+ *    only the view toggle + Title toggle remain in the toolbar.
+ * Returns the frame HTML and the tree SVG (for Save-as-SVG; empty in table view).
+ */
+function renderChainPreview(
+  p: ChainPreviewParams,
+  parsedDoc: FGCADoc | null,
+  baseWarnings: string[],
+  errorMsg: string,
+  docVersion: string | undefined,
+  docDate: string,
+  filename: string,
+  themeId: ThemeId,
+): { html: string; svg: string } {
+  const view = readView(p.viewNotation);
+  const nonce = genNonce();
+  const script = buildControlsScript(nonce);
+  const viewToggleHtml = buildViewToggle(view);
+
+  if (view === 'table') {
+    // Scope is a no-op in table view, so no scope-warning is added here.
+    const body = parsedDoc ? chainTableHtml(buildChainTable(parsedDoc, { hideChanges: p.hideChanges })) : '';
+    const showHeader = !errorMsg && parsedDoc != null;
+    const html = buildDiagramFrame({
+      filename, notation: p.notation, bodyContent: body, errorMsg, warnings: baseWarnings, themeId,
+      extraStyles: CHAIN_TABLE_CSS,
+      title: showHeader ? p.heading : undefined,
+      version: docVersion,
+      date: showHeader ? docDate : undefined,
+      interactive: { nonce, controlsPanel: '', controlsScript: script, viewToggleHtml },
+    });
+    return { html, svg: '' };
+  }
+
+  // Tree view (default) — the PR #86 interactive control surface.
+  const spacingDefaults = { horizontalGap: FGCA_DEFAULT_COL_GAP, verticalGap: FGCA_DEFAULT_ROW_GAP };
+  const gaps = readSpacing(p.viewNotation, spacingDefaults);
+  const scope = readScope(p.viewNotation);
+  const curvature = readCurvature(p.viewNotation);
+  const warnings = [...baseWarnings];
+  let svg = '';
+  let goalOptions: ScopeGoalOption[] = [];
+  let maxLevelPresent = 0;
+  if (parsedDoc) {
+    ({ goals: goalOptions, maxLevelPresent } = scopeInputsFromDoc(parsedDoc));
+    const scopeWarning = checkScopeRoot(scope, parsedDoc.goals.map(g => g.id));
+    if (scopeWarning) warnings.push(`${scopeWarning.code}: ${scopeWarning.message}`);
+    svg = buildSvg(parsedDoc, p.hideChanges, { colGap: gaps.horizontalGap, rowGap: gaps.verticalGap, curvature, scope }, p.heading, filename, docDate, docVersion);
+  }
+  const model = fgcaControlsModel(gaps, spacingDefaults, curvature, scope, goalOptions, maxLevelPresent);
+  const html = buildDiagramFrame({
+    filename, notation: p.notation, svgContent: svg, errorMsg, warnings, themeId,
+    saveSvgCommand: p.saveSvgCommand,
+    savePngCommand: p.savePngCommand,
+    copyPngCommand: p.copyPngCommand,
+    spacingCommand: OPEN_SPACING_SETTINGS_COMMAND,
+    curvatureCommand: OPEN_CURVATURE_SETTINGS_COMMAND,
+    scopeCommand: OPEN_SCOPE_SETTINGS_COMMAND,
+    interactive: { nonce, controlsPanel: buildControlsPanel(model), controlsScript: script, viewToggleHtml },
+  });
+  return { html, svg };
 }
 
 function buildSvg(
@@ -226,22 +347,17 @@ export class FGCAPreview {
   }
 
   private buildHtml(yamlText: string, filename: string): string {
-    let svgContent = '';
+    let parsedDoc: FGCADoc | null = null;
     let errorMsg = '';
     let warnings: string[] = [];
-
-    const spacingDefaults = { horizontalGap: FGCA_DEFAULT_COL_GAP, verticalGap: FGCA_DEFAULT_ROW_GAP };
-    const gaps = readSpacing('fgca', spacingDefaults);
-    const scope = readScope('fgca');
-    const curvature = readCurvature('fgca');
-    let goalOptions: ScopeGoalOption[] = [];
-    let maxLevelPresent = 0;
+    let docVersion: string | undefined;
+    let docDate = todayIso();
 
     try {
       const parsed = coerceDatesToIsoStrings(yaml.load(yamlText) as unknown);
       const meta = (parsed && typeof parsed === 'object' ? parsed : {}) as { version?: unknown; date?: unknown };
-      const docVersion = typeof meta.version === 'string' ? meta.version : undefined;
-      const docDate = typeof meta.date === 'string' ? meta.date : todayIso();
+      docVersion = typeof meta.version === 'string' ? meta.version : undefined;
+      docDate = typeof meta.date === 'string' ? meta.date : todayIso();
       const v = parseCanonicalFGCA(parsed);
       warnings = v.warnings.map(w => `${w.code}: ${w.message}`);
       if (!v.valid || !v.parsed) {
@@ -251,35 +367,28 @@ export class FGCAPreview {
         // IDs and singular `change.goal_id` / `change.activity_ids`. The
         // inline FGCADoc / buildSvg here accept both forms (number | string
         // unions) — pass through.
-        const fgcaDoc = v.parsed as unknown as FGCADoc;
-        ({ goals: goalOptions, maxLevelPresent } = scopeInputsFromDoc(fgcaDoc));
-        const scopeWarning = checkScopeRoot(scope, fgcaDoc.goals.map(g => g.id));
-        if (scopeWarning) warnings.push(`${scopeWarning.code}: ${scopeWarning.message}`);
-        svgContent = buildSvg(fgcaDoc, false, { colGap: gaps.horizontalGap, rowGap: gaps.verticalGap, curvature, scope }, 'FGCA — Factor → Goal → Change → Activity', filename, docDate, docVersion);
+        parsedDoc = v.parsed as unknown as FGCADoc;
       }
     } catch (e) {
       errorMsg = (e as Error).message ?? 'Parse error';
     }
 
-    this.lastSvg = svgContent;
-
     const themeId = vscode.workspace
       .getConfiguration('transitrix')
       .get<ThemeId>('theme', 'transitrix');
 
-    const nonce = genNonce();
-    const model = fgcaControlsModel(gaps, spacingDefaults, curvature, scope, goalOptions, maxLevelPresent);
-
-    return buildDiagramFrame({
-      filename, notation: 'FGCA', svgContent, errorMsg, warnings, themeId,
-      saveSvgCommand: 'transitrixStudio.saveFGCAAsSvg',
-      savePngCommand: 'transitrixStudio.saveFGCAAsPng',
-      copyPngCommand: 'transitrixStudio.copyFGCAAsPng',
-      spacingCommand: OPEN_SPACING_SETTINGS_COMMAND,
-      curvatureCommand: OPEN_CURVATURE_SETTINGS_COMMAND,
-      scopeCommand: OPEN_SCOPE_SETTINGS_COMMAND,
-      interactive: { nonce, controlsPanel: buildControlsPanel(model), controlsScript: buildControlsScript(nonce) },
-    });
+    const { html, svg } = renderChainPreview(
+      {
+        notation: 'FGCA', viewNotation: 'fgca', hideChanges: false,
+        heading: 'FGCA — Factor → Goal → Change → Activity',
+        saveSvgCommand: 'transitrixStudio.saveFGCAAsSvg',
+        savePngCommand: 'transitrixStudio.saveFGCAAsPng',
+        copyPngCommand: 'transitrixStudio.copyFGCAAsPng',
+      },
+      parsedDoc, warnings, errorMsg, docVersion, docDate, filename, themeId,
+    );
+    this.lastSvg = svg;
+    return html;
   }
 
   private pngTarget() {
@@ -377,57 +486,45 @@ export class FGAPreview {
   }
 
   private buildHtml(yamlText: string, filename: string): string {
-    let svgContent = '';
+    let parsedDoc: FGCADoc | null = null;
     let errorMsg = '';
     let warnings: string[] = [];
-
-    const spacingDefaults = { horizontalGap: FGCA_DEFAULT_COL_GAP, verticalGap: FGCA_DEFAULT_ROW_GAP };
-    const gaps = readSpacing('fga', spacingDefaults);
-    const scope = readScope('fga');
-    const curvature = readCurvature('fga');
-    let goalOptions: ScopeGoalOption[] = [];
-    let maxLevelPresent = 0;
+    let docVersion: string | undefined;
+    let docDate = todayIso();
 
     try {
       const parsed = coerceDatesToIsoStrings(yaml.load(yamlText) as unknown);
       const meta = (parsed && typeof parsed === 'object' ? parsed : {}) as { version?: unknown; date?: unknown };
-      const docVersion = typeof meta.version === 'string' ? meta.version : undefined;
-      const docDate = typeof meta.date === 'string' ? meta.date : todayIso();
+      docVersion = typeof meta.version === 'string' ? meta.version : undefined;
+      docDate = typeof meta.date === 'string' ? meta.date : todayIso();
       const v = parseCanonicalFGA(parsed);
       warnings = v.warnings.map(w => `${w.code}: ${w.message}`);
       if (!v.valid || !v.parsed) {
         errorMsg = v.errors.map(e => `${e.code}: ${e.message}`).join('\n');
       } else {
         // FGA shares FGCA's FLAT shape; just hide the (absent) Changes column.
-        const fgaDoc = v.parsed as unknown as FGCADoc;
-        ({ goals: goalOptions, maxLevelPresent } = scopeInputsFromDoc(fgaDoc));
-        const scopeWarning = checkScopeRoot(scope, fgaDoc.goals.map(g => g.id));
-        if (scopeWarning) warnings.push(`${scopeWarning.code}: ${scopeWarning.message}`);
-        svgContent = buildSvg(fgaDoc, true, { colGap: gaps.horizontalGap, rowGap: gaps.verticalGap, curvature, scope }, 'FGA — Factor → Goal → Activity', filename, docDate, docVersion);
+        parsedDoc = v.parsed as unknown as FGCADoc;
       }
     } catch (e) {
       errorMsg = (e as Error).message ?? 'Parse error';
     }
 
-    this.lastSvg = svgContent;
-
     const themeId = vscode.workspace
       .getConfiguration('transitrix')
       .get<ThemeId>('theme', 'transitrix');
 
-    const nonce = genNonce();
-    const model = fgcaControlsModel(gaps, spacingDefaults, curvature, scope, goalOptions, maxLevelPresent);
-
-    return buildDiagramFrame({
-      filename, notation: 'FGA', svgContent, errorMsg, warnings, themeId,
-      saveSvgCommand: 'transitrixStudio.saveFGAAsSvg',
-      savePngCommand: 'transitrixStudio.saveFGAAsPng',
-      copyPngCommand: 'transitrixStudio.copyFGAAsPng',
-      spacingCommand: OPEN_SPACING_SETTINGS_COMMAND,
-      curvatureCommand: OPEN_CURVATURE_SETTINGS_COMMAND,
-      scopeCommand: OPEN_SCOPE_SETTINGS_COMMAND,
-      interactive: { nonce, controlsPanel: buildControlsPanel(model), controlsScript: buildControlsScript(nonce) },
-    });
+    const { html, svg } = renderChainPreview(
+      {
+        notation: 'FGA', viewNotation: 'fga', hideChanges: true,
+        heading: 'FGA — Factor → Goal → Activity',
+        saveSvgCommand: 'transitrixStudio.saveFGAAsSvg',
+        savePngCommand: 'transitrixStudio.saveFGAAsPng',
+        copyPngCommand: 'transitrixStudio.copyFGAAsPng',
+      },
+      parsedDoc, warnings, errorMsg, docVersion, docDate, filename, themeId,
+    );
+    this.lastSvg = svg;
+    return html;
   }
 
   private pngTarget() {

--- a/extension/src/preview-controls.ts
+++ b/extension/src/preview-controls.ts
@@ -64,12 +64,15 @@ export interface ControlsModel {
 /** Message posted from the webview to the host on every control change. */
 export interface ControlMessage {
   type: 'transitrix:control';
-  control: 'spacing' | 'curvature' | 'scope';
-  /** 'horizontalGap' | 'verticalGap' for spacing; 'rootId' | 'maxLevel' | 'reset' for scope; absent for curvature. */
-  field?: 'horizontalGap' | 'verticalGap' | 'rootId' | 'maxLevel' | 'reset';
-  /** Numeric for spacing/curvature/maxLevel; string for rootId; absent for reset. */
+  control: 'spacing' | 'curvature' | 'scope' | 'view';
+  /** spacing: 'horizontalGap'|'verticalGap'; scope: 'rootId'|'maxLevel'|'reset'; view: 'tree'|'table'; absent for curvature. */
+  field?: 'horizontalGap' | 'verticalGap' | 'rootId' | 'maxLevel' | 'reset' | 'tree' | 'table';
+  /** Numeric for spacing/curvature/maxLevel; string for rootId; absent for reset/view. */
   value?: number | string;
 }
+
+/** Tree ↔ table view, persisted per notation (vkgeorgia/strategy#137). */
+export type PreviewView = 'tree' | 'table';
 
 // Spacing bounds mirror the package.json `transitrix.spacing.*` schema (20–300).
 export const SPACING_MIN = 20;
@@ -115,6 +118,24 @@ export const CONTROLS_PANEL_CSS = `
 }
 .tx-ctl button { cursor: pointer; }
 .tx-ctl output { min-width: 22px; font-variant-numeric: tabular-nums; }
+
+/* View toggle (tree ↔ table) — a segmented control in the toolbar (#137).
+   Mirrors the zoom control's look so the toolbar reads consistently. */
+.tx-view { display: inline-flex; border: 1px solid var(--ts-border, #cbd5e1); border-radius: 4px; overflow: hidden; }
+.tx-view-btn {
+  cursor: pointer;
+  user-select: none;
+  font-size: 11px;
+  padding: 1px 8px;
+  color: var(--ts-text-muted, #64748b);
+  background: transparent;
+  border: none;
+  border-right: 1px solid var(--ts-border, #cbd5e1);
+  font-family: var(--vscode-font-family, sans-serif);
+}
+.tx-view-btn:last-child { border-right: none; }
+.tx-view-btn:hover { color: var(--ts-text, #0f172a); background: var(--ts-bg-elevated, #f1f5f9); }
+.tx-view-btn.active { color: var(--ts-text, #0f172a); background: var(--ts-bg-elevated, #f1f5f9); font-weight: 600; }
 `;
 
 /** True when any control differs from its no-visual-change default. */
@@ -182,6 +203,15 @@ export function buildControlsPanel(model: ControlsModel): string {
     ${rows.join('\n    ')}
   </div>
 </details>`;
+}
+
+/** Builds the toolbar segmented control that switches the tree ↔ table view
+ *  (#137). Wired by the same `data-tx-control` mechanism as the panel inputs —
+ *  the buttons post `{control:'view', field:'tree'|'table'}` to the host. */
+export function buildViewToggle(current: PreviewView): string {
+  const btn = (view: PreviewView, label: string): string =>
+    `<button type="button" class="tx-view-btn${current === view ? ' active' : ''}" data-tx-control="view" data-tx-field="${view}">${label}</button>`;
+  return `<span class="tx-view" title="Switch between the tree and table view">${btn('tree', 'Tree')}${btn('table', 'Table')}</span>`;
 }
 
 /** Builds the nonce'd wiring `<script>`. Reads `data-tx-*` inputs, posts a

--- a/extension/src/spacing-config.ts
+++ b/extension/src/spacing-config.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import type { Scope } from '../../packages/diagrams/src/scope.js';
-import type { ControlMessage } from './preview-controls.js';
+import type { ControlMessage, PreviewView } from './preview-controls.js';
 
 // Per-notation spacing controls (vkgeorgia/strategy#75). PR1 persists the
 // chosen gaps in VS Code configuration (`transitrix.spacing.<notation>.*`),
@@ -82,6 +82,24 @@ export const SCOPE_CONFIG_SECTION = 'transitrix.scope';
 /** Command that opens Settings filtered to the scope controls. */
 export const OPEN_SCOPE_SETTINGS_COMMAND = 'transitrixStudio.openScopeSettings';
 
+// ── Tree ↔ table view (vkgeorgia/strategy#137) ──────────────────────────────
+//
+// FGCA/FGA previews can render as the tree/chain diagram (default) or as a
+// flattened chain table. Same settings-backed persistence as the controls
+// above: the in-preview toolbar toggle writes `transitrix.view.<notation>` and
+// the preview re-renders.
+
+export type ViewNotation = 'fgca' | 'fga';
+
+/** Reads the persisted view for a notation. Defaults to 'tree' (no change). */
+export function readView(notation: ViewNotation): PreviewView {
+  const v = vscode.workspace.getConfiguration('transitrix').get<string>(`view.${notation}`, 'tree');
+  return v === 'table' ? 'table' : 'tree';
+}
+
+/** Config section that, when changed, re-renders view-aware previews. */
+export const VIEW_CONFIG_SECTION = 'transitrix.view';
+
 // ── In-preview control messages (PR2) ───────────────────────────────────────
 //
 // The interactive control panel (preview-controls.ts) posts a `ControlMessage`
@@ -114,6 +132,10 @@ export async function applyControlMessage(notation: SpacingNotation, msg: Contro
   }
   if (msg.control === 'curvature') {
     await cfg.update(`curvature.${notation}`, clamp(Number(msg.value), 0, 3), target);
+    return;
+  }
+  if (msg.control === 'view' && (notation === 'fgca' || notation === 'fga')) {
+    await cfg.update(`view.${notation}`, msg.field === 'table' ? 'table' : 'tree', target);
     return;
   }
   if (msg.control === 'scope' && notation !== 'activities') {

--- a/packages/diagrams/src/assertion/__tests__/example.test.ts
+++ b/packages/diagrams/src/assertion/__tests__/example.test.ts
@@ -1,0 +1,37 @@
+// Conformance test for the shipped ASSERTION worked examples — the acme_corp
+// canon files mirrored under `examples/assertion/`. Pins the success signal of
+// vkgeorgia/strategy#84 Phase 1: the library consumes the canonical example
+// files without error.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import yaml from 'js-yaml';
+import { validateAssertion } from '../validate.js';
+
+const dir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../examples/assertion');
+const load = (f: string): unknown => yaml.load(readFileSync(path.join(dir, f), 'utf-8'));
+
+// Fixed reference date so the ASSERT-008 staleness check is deterministic; all
+// three examples have a future review date relative to it.
+const today = '2026-06-02';
+
+describe('assertion worked examples (acme_corp)', () => {
+  for (const f of [
+    'ASSERTION-MOBILE-DATA-ERASURE-1.yaml',
+    'ASSERTION-CRM-DATA-ERASURE-1.yaml',
+    'ASSERTION-ONBOARD-DATA-ERASURE-1.yaml',
+  ]) {
+    it(`validates ${f} without error`, () => {
+      const v = validateAssertion(load(f), { today });
+      expect(v.valid, JSON.stringify(v.errors)).toBe(true);
+      expect(v.errors).toHaveLength(0);
+    });
+  }
+
+  it('does not raise ASSERT-007 for the under_review assertion with empty evidence', () => {
+    const v = validateAssertion(load('ASSERTION-CRM-DATA-ERASURE-1.yaml'), { today });
+    expect(v.warnings.map(w => w.code)).not.toContain('ASSERT-007');
+  });
+});

--- a/packages/diagrams/src/assertion/__tests__/validate.test.ts
+++ b/packages/diagrams/src/assertion/__tests__/validate.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest';
+import { validateAssertion } from '../validate.js';
+import type { CanonCatalog } from '../../typed-id.js';
+
+function valid(): Record<string, unknown> {
+  return {
+    notation: 'assertion',
+    id: 'ASSERTION-MOBILE-DATA-ERASURE-1',
+    about: 'REQUIREMENT-DATA-ERASURE-1',
+    subject: 'PRODUCT-MOBILE-1',
+    realised_via: ['CAPABILITY-V2', 'PROCESS-USER-DATA-PURGE-1'],
+    status: 'compliant',
+    evidence: [{ kind: 'note', text: 'DPO review confirmed compliance.' }],
+    assessed_at: '2026-03-15',
+    next_review_at: '2026-09-15',
+    zone: 'canon',
+    admitted_at: '2026-05-28',
+    admitted_by: 'v.korobeinikov',
+    gate_checks: { uniqueness: 'pass' },
+    valid_from: '2026-03-15',
+    valid_to: null,
+  };
+}
+
+const codes = (input: unknown, opts?: Parameters<typeof validateAssertion>[1]): string[] =>
+  validateAssertion(input, opts).errors.map(e => e.code);
+const warnCodes = (input: unknown, opts?: Parameters<typeof validateAssertion>[1]): string[] =>
+  validateAssertion(input, opts).warnings.map(w => w.code);
+
+describe('validateAssertion — positive', () => {
+  it('accepts a well-formed assertion', () => {
+    const r = validateAssertion(valid());
+    expect(r.valid, JSON.stringify(r.errors)).toBe(true);
+    expect(r.errors).toHaveLength(0);
+  });
+});
+
+describe('validateAssertion — ASSERT-001 (shape / id grammar)', () => {
+  it('flags id grammar, wrong notation, missing admission/lifecycle fields', () => {
+    expect(codes({ ...valid(), id: 'ASSERT-1' })).toContain('ASSERT-001');
+    expect(codes({ ...valid(), notation: 'claim' })).toContain('ASSERT-001');
+    const noAdmit = valid(); delete noAdmit.admitted_at;
+    expect(codes(noAdmit)).toContain('ASSERT-001');
+    const noValidTo = valid(); delete noValidTo.valid_to;
+    expect(codes(noValidTo)).toContain('ASSERT-001');
+  });
+
+  it('flags a missing status as ASSERT-001 (required field)', () => {
+    const r = valid(); delete r.status;
+    expect(codes(r)).toContain('ASSERT-001');
+  });
+
+  it('rejects a non-object', () => {
+    expect(codes(null)).toEqual(['ASSERT-001']);
+  });
+});
+
+describe('validateAssertion — ASSERT-002 (about → REQUIREMENT)', () => {
+  it('flags a missing about', () => {
+    const r = valid(); delete r.about;
+    expect(codes(r)).toContain('ASSERT-002');
+  });
+  it('flags an about that is not a REQUIREMENT typed id', () => {
+    expect(codes({ ...valid(), about: 'PRODUCT-MOBILE-1' })).toContain('ASSERT-002');
+  });
+  it('with a catalog, flags an unresolved about and a wrong-type about', () => {
+    expect(codes({ ...valid() }, { catalog: { typeOf: () => undefined } })).toContain('ASSERT-002');
+    const catalog: CanonCatalog = { typeOf: (id) => (id === 'REQUIREMENT-DATA-ERASURE-1' ? 'GOAL' : 'PRODUCT') };
+    expect(codes(valid(), { catalog })).toContain('ASSERT-002');
+  });
+});
+
+describe('validateAssertion — ASSERT-003 (subject TYPE)', () => {
+  it('flags a subject whose TYPE is not PRODUCT/PROCESS/CAPABILITY', () => {
+    expect(codes({ ...valid(), subject: 'GOAL-1' })).toContain('ASSERT-003');
+  });
+  it('accepts PRODUCT, PROCESS and CAPABILITY subjects', () => {
+    for (const s of ['PRODUCT-1', 'PROCESS-1', 'CAPABILITY-V2']) {
+      expect(codes({ ...valid(), subject: s })).not.toContain('ASSERT-003');
+    }
+  });
+  it('with a catalog, flags an unresolved subject', () => {
+    const catalog: CanonCatalog = { typeOf: (id) => (id === 'PRODUCT-MOBILE-1' ? undefined : 'REQUIREMENT') };
+    expect(codes(valid(), { catalog })).toContain('ASSERT-003');
+  });
+});
+
+describe('validateAssertion — ASSERT-004 (realised_via resolves)', () => {
+  it('flags a malformed realised_via entry', () => {
+    expect(codes({ ...valid(), realised_via: ['nope'] })).toContain('ASSERT-004');
+  });
+  it('with a catalog, flags an unresolved realised_via entry', () => {
+    const catalog: CanonCatalog = { typeOf: (id) => (id.startsWith('CAPABILITY') ? undefined : 'X') };
+    expect(codes(valid(), { catalog })).toContain('ASSERT-004');
+  });
+});
+
+describe('validateAssertion — ASSERT-005 (canonical_ref evidence resolves)', () => {
+  it('flags a malformed canonical_ref', () => {
+    expect(codes({ ...valid(), evidence: [{ kind: 'canonical_ref', ref: 'nope' }] })).toContain('ASSERT-005');
+  });
+  it('with a catalog, flags an unresolved canonical_ref', () => {
+    const catalog: CanonCatalog = { typeOf: () => undefined };
+    expect(codes({ ...valid(), evidence: [{ kind: 'canonical_ref', ref: 'PROCESS-X-1' }] }, { catalog })).toContain('ASSERT-005');
+  });
+  it('ignores external_doc and note evidence kinds for resolution', () => {
+    const ev = [{ kind: 'external_doc', title: 't', url: 'u' }, { kind: 'note', text: 'n' }];
+    expect(codes({ ...valid(), evidence: ev })).not.toContain('ASSERT-005');
+  });
+});
+
+describe('validateAssertion — ASSERT-006 (status enum)', () => {
+  it('flags an out-of-enum status', () => {
+    expect(codes({ ...valid(), status: 'maybe' })).toContain('ASSERT-006');
+  });
+  it('accepts every status value', () => {
+    for (const s of ['compliant', 'partial', 'non_compliant', 'under_review', 'n_a']) {
+      expect(codes({ ...valid(), status: s, evidence: [{ kind: 'note', text: 'x' }] })).not.toContain('ASSERT-006');
+    }
+  });
+});
+
+describe('validateAssertion — ASSERT-007 (positive status without evidence)', () => {
+  it('warns when evidence is empty and status is compliant or partial', () => {
+    expect(warnCodes({ ...valid(), evidence: [], status: 'compliant' })).toContain('ASSERT-007');
+    expect(warnCodes({ ...valid(), evidence: [], status: 'partial' })).toContain('ASSERT-007');
+  });
+  it('does not warn for under_review / non_compliant / n_a with empty evidence', () => {
+    for (const s of ['under_review', 'non_compliant', 'n_a']) {
+      expect(warnCodes({ ...valid(), evidence: [], status: s })).not.toContain('ASSERT-007');
+    }
+  });
+});
+
+describe('validateAssertion — ASSERT-008 (stale review)', () => {
+  it('warns only when today is supplied and next_review_at is in the past', () => {
+    expect(warnCodes({ ...valid(), next_review_at: '2026-01-01' }, { today: '2026-06-02' })).toContain('ASSERT-008');
+    expect(warnCodes({ ...valid(), next_review_at: '2026-12-01' }, { today: '2026-06-02' })).not.toContain('ASSERT-008');
+    // No `today` → clock-free, never warns.
+    expect(warnCodes({ ...valid(), next_review_at: '2000-01-01' })).not.toContain('ASSERT-008');
+  });
+});

--- a/packages/diagrams/src/assertion/index.ts
+++ b/packages/diagrams/src/assertion/index.ts
@@ -1,0 +1,12 @@
+export type {
+  Assertion,
+  AssertionStatus,
+  Evidence,
+  EvidenceKind,
+  CanonicalRefEvidence,
+  ExternalDocEvidence,
+  NoteEvidence,
+} from './types.js';
+export { ASSERTION_STATUSES, ASSERTION_SUBJECT_TYPES } from './types.js';
+export { validateAssertion } from './validate.js';
+export type { AssertionValidateOptions } from './validate.js';

--- a/packages/diagrams/src/assertion/types.ts
+++ b/packages/diagrams/src/assertion/types.ts
@@ -1,0 +1,58 @@
+// ASSERTION — REQUIREMENT realisation claim.
+// Schema: methodology notations/elements/16-assertion.md §2.
+
+import type { GateChecks } from '../requirement/types.js';
+
+/** Compliance status vocabulary (16-assertion.md §3). */
+export type AssertionStatus = 'compliant' | 'partial' | 'non_compliant' | 'under_review' | 'n_a';
+
+export const ASSERTION_STATUSES: readonly AssertionStatus[] = [
+  'compliant', 'partial', 'non_compliant', 'under_review', 'n_a',
+];
+
+/** TYPEs a `subject` may resolve to (16-assertion.md §2, ASSERT-003). */
+export const ASSERTION_SUBJECT_TYPES = ['PRODUCT', 'PROCESS', 'CAPABILITY'] as const;
+
+/** Evidence entry kinds (16-assertion.md §4). */
+export type EvidenceKind = 'canonical_ref' | 'external_doc' | 'note';
+
+export interface CanonicalRefEvidence {
+  kind: 'canonical_ref';
+  ref: string;
+}
+export interface ExternalDocEvidence {
+  kind: 'external_doc';
+  title: string;
+  url: string;
+}
+export interface NoteEvidence {
+  kind: 'note';
+  text: string;
+}
+export type Evidence = CanonicalRefEvidence | ExternalDocEvidence | NoteEvidence;
+
+export interface Assertion {
+  notation: 'assertion';
+  id: string;
+  /** Typed ID of the REQUIREMENT this assertion is about. */
+  about: string;
+  /** Exactly one typed ID; TYPE ∈ {PRODUCT, PROCESS, CAPABILITY}. */
+  subject: string;
+  /** Typed IDs of elements that realise the requirement for the subject. */
+  realised_via?: string[];
+  status: AssertionStatus;
+  evidence?: Evidence[];
+  assessed_at?: string;
+  assessed_by?: string;
+  next_review_at?: string;
+
+  // Admission record (CONTRACT.md §6).
+  zone: 'canon';
+  admitted_at: string;
+  admitted_by: string;
+  gate_checks: GateChecks;
+
+  // Primitive lifecycle (CONTRACT.md §7).
+  valid_from: string;
+  valid_to: string | null;
+}

--- a/packages/diagrams/src/assertion/validate.ts
+++ b/packages/diagrams/src/assertion/validate.ts
@@ -1,0 +1,145 @@
+// ASSERTION validator — methodology notations/elements/16-assertion.md §5.
+//
+// Implements ASSERT-001..008. The shared HDR-/LIFECYCLE- rules and the
+// cross-cutting ASSERT-DEAD-LINK-001 are owned elsewhere (CONTRACT.md §8) and
+// are out of scope for this single-artefact validator.
+//
+// Resolution rules (ASSERT-002/003/004/005) that need artefact *existence*
+// run only when a `CanonCatalog` is supplied; the TYPE checks they also carry
+// are derivable from the id prefix and run either way. ASSERT-008 (staleness)
+// runs only when `today` is supplied, keeping the validator clock-free.
+
+import type { ValidationError, ValidationWarning, ValidationResult } from '../validation-types.js';
+import { typeOfId, isCanonicalIdOfType, type CanonCatalog } from '../typed-id.js';
+import { ASSERTION_STATUSES, ASSERTION_SUBJECT_TYPES } from './types.js';
+
+export interface AssertionValidateOptions {
+  /** When provided, the resolution rules enforce artefact existence. */
+  catalog?: CanonCatalog;
+  /** Today as an ISO `YYYY-MM-DD` string; enables the ASSERT-008 staleness check. */
+  today?: string;
+}
+
+const SUBJECT_TYPES: readonly string[] = ASSERTION_SUBJECT_TYPES;
+
+export function validateAssertion(input: unknown, options: AssertionValidateOptions = {}): ValidationResult {
+  const errors: ValidationError[] = [];
+  const warnings: ValidationWarning[] = [];
+  const { catalog, today } = options;
+
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    errors.push({ code: 'ASSERT-001', message: 'Assertion must be a YAML mapping.' });
+    return { valid: false, errors, warnings };
+  }
+  const a = input as Record<string, unknown>;
+
+  // ── ASSERT-001 — id grammar + plain required fields ──────────────────────
+  if (!isCanonicalIdOfType(a.id, 'ASSERTION')) {
+    errors.push({ code: 'ASSERT-001', message: `id "${String(a.id)}" must match ASSERTION-[<middle>-]<INTEGER>.`, path: 'id' });
+  }
+  if (a.notation !== 'assertion') {
+    errors.push({ code: 'ASSERT-001', message: 'notation must be the fixed value "assertion".', path: 'notation' });
+  }
+  if (a.zone !== 'canon') {
+    errors.push({ code: 'ASSERT-001', message: 'zone is required and must be "canon".', path: 'zone' });
+  }
+  for (const f of ['admitted_at', 'admitted_by', 'valid_from'] as const) {
+    if (typeof a[f] !== 'string' || (a[f] as string).trim() === '') {
+      errors.push({ code: 'ASSERT-001', message: `${f} is required.`, path: f });
+    }
+  }
+  if (a.gate_checks === null || typeof a.gate_checks !== 'object') {
+    errors.push({ code: 'ASSERT-001', message: 'gate_checks is required and must be a mapping.', path: 'gate_checks' });
+  }
+  if (!('valid_to' in a) || !(typeof a.valid_to === 'string' || a.valid_to === null)) {
+    errors.push({ code: 'ASSERT-001', message: 'valid_to is required (an ISO date string or null).', path: 'valid_to' });
+  }
+
+  // ── ASSERT-002 — about → REQUIREMENT ─────────────────────────────────────
+  const about = a.about;
+  if (typeof about !== 'string' || about.trim() === '') {
+    errors.push({ code: 'ASSERT-002', message: 'about is required and must be a typed REQUIREMENT id.', path: 'about' });
+  } else if (catalog) {
+    const t = catalog.typeOf(about);
+    if (t === undefined) {
+      errors.push({ code: 'ASSERT-002', message: `about "${about}" does not resolve to an admitted artefact.`, path: 'about' });
+    } else if (t !== 'REQUIREMENT') {
+      errors.push({ code: 'ASSERT-002', message: `about "${about}" resolves to a ${t}, not a REQUIREMENT.`, path: 'about' });
+    }
+  } else if (typeOfId(about) !== 'REQUIREMENT') {
+    errors.push({ code: 'ASSERT-002', message: `about "${about}" must be a REQUIREMENT typed id.`, path: 'about' });
+  }
+
+  // ── ASSERT-003 — subject ∈ {PRODUCT, PROCESS, CAPABILITY} ────────────────
+  const subject = a.subject;
+  if (typeof subject !== 'string' || subject.trim() === '') {
+    errors.push({ code: 'ASSERT-003', message: 'subject is required and must be a typed PRODUCT/PROCESS/CAPABILITY id.', path: 'subject' });
+  } else if (catalog) {
+    const t = catalog.typeOf(subject);
+    if (t === undefined) {
+      errors.push({ code: 'ASSERT-003', message: `subject "${subject}" does not resolve to an admitted artefact.`, path: 'subject' });
+    } else if (!SUBJECT_TYPES.includes(t)) {
+      errors.push({ code: 'ASSERT-003', message: `subject "${subject}" resolves to a ${t}; must be PRODUCT, PROCESS or CAPABILITY.`, path: 'subject' });
+    }
+  } else {
+    const t = typeOfId(subject);
+    if (!t || !SUBJECT_TYPES.includes(t)) {
+      errors.push({ code: 'ASSERT-003', message: `subject "${subject}" TYPE must be PRODUCT, PROCESS or CAPABILITY.`, path: 'subject' });
+    }
+  }
+
+  // ── ASSERT-004 — realised_via resolves ───────────────────────────────────
+  if (a.realised_via !== undefined) {
+    if (!Array.isArray(a.realised_via)) {
+      errors.push({ code: 'ASSERT-001', message: 'realised_via must be a list of typed IDs.', path: 'realised_via' });
+    } else {
+      a.realised_via.forEach((ref, i) => {
+        if (!typeOfId(ref)) {
+          errors.push({ code: 'ASSERT-004', message: `realised_via[${i}] "${String(ref)}" is not a resolvable typed ID.`, path: `realised_via[${i}]` });
+        } else if (catalog && catalog.typeOf(ref as string) === undefined) {
+          errors.push({ code: 'ASSERT-004', message: `realised_via[${i}] "${String(ref)}" does not resolve to an admitted element.`, path: `realised_via[${i}]` });
+        }
+      });
+    }
+  }
+
+  // ── ASSERT-005 — canonical_ref evidence resolves ─────────────────────────
+  if (a.evidence !== undefined) {
+    if (!Array.isArray(a.evidence)) {
+      errors.push({ code: 'ASSERT-001', message: 'evidence must be a list.', path: 'evidence' });
+    } else {
+      a.evidence.forEach((e, i) => {
+        if (e === null || typeof e !== 'object') return;
+        const entry = e as Record<string, unknown>;
+        if (entry.kind !== 'canonical_ref') return;
+        const ref = entry.ref;
+        if (!typeOfId(ref)) {
+          errors.push({ code: 'ASSERT-005', message: `evidence[${i}] canonical_ref "${String(ref)}" is not a resolvable typed ID.`, path: `evidence[${i}].ref` });
+        } else if (catalog && catalog.typeOf(ref as string) === undefined) {
+          errors.push({ code: 'ASSERT-005', message: `evidence[${i}] canonical_ref "${String(ref)}" does not resolve.`, path: `evidence[${i}].ref` });
+        }
+      });
+    }
+  }
+
+  // ── ASSERT-006 / ASSERT-001 — status ─────────────────────────────────────
+  const status = a.status;
+  if (status === undefined || status === null) {
+    errors.push({ code: 'ASSERT-001', message: 'status is required.', path: 'status' });
+  } else if (!ASSERTION_STATUSES.includes(status as never)) {
+    errors.push({ code: 'ASSERT-006', message: `status "${String(status)}" must be one of ${ASSERTION_STATUSES.join(', ')}.`, path: 'status' });
+  }
+
+  // ── ASSERT-007 (warning) — positive status with no evidence ──────────────
+  const evidenceEmpty = !Array.isArray(a.evidence) || a.evidence.length === 0;
+  if (evidenceEmpty && (status === 'compliant' || status === 'partial')) {
+    warnings.push({ code: 'ASSERT-007', message: `status "${status}" has no evidence — a positive status without evidence is undefended.`, path: 'evidence' });
+  }
+
+  // ── ASSERT-008 (warning) — stale review (only when `today` is known) ──────
+  if (today && typeof a.next_review_at === 'string' && a.next_review_at < today) {
+    warnings.push({ code: 'ASSERT-008', message: `next_review_at ${a.next_review_at} is in the past — the assertion is stale and due for re-review.`, path: 'next_review_at' });
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}

--- a/packages/diagrams/src/fgca/__tests__/chain-table.test.ts
+++ b/packages/diagrams/src/fgca/__tests__/chain-table.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest';
+import { buildChainTable, type ChainTable, type ChainColumn } from '../chain-table.js';
+import type { FGCAPreviewDoc } from '../preview-layout.js';
+
+// Renders a ChainTable to a compact text grid for readable assertions. Each
+// cell shows "label×rowSpan" (×1 omitted); a position covered by a span above
+// shows "·".
+function asGrid(t: ChainTable): string[][] {
+  return t.rows.map(row =>
+    row.map(c => {
+      if (c === null) return '·';
+      const label = c.cell ? c.cell.label : '∅';
+      return c.rowSpan > 1 ? `${label}×${c.rowSpan}` : label;
+    }),
+  );
+}
+
+describe('buildChainTable — worked example (FGCA)', () => {
+  // F1 → G1, G2 ; G1 → C1 → A1 ; G2 → C2 → A2, A3
+  const doc: FGCAPreviewDoc = {
+    factors: [{ id: 1, name: 'F1' }],
+    goals: [
+      { id: 10, name: 'G1', factor: [{ id: 1 }] },
+      { id: 11, name: 'G2', factor: [{ id: 1 }] },
+    ],
+    changes: [
+      { id: 20, name: 'C1', goal_id: 10, activity_ids: [30] },
+      { id: 21, name: 'C2', goal_id: 11, activity_ids: [31, 32] },
+    ],
+    activities: [
+      { id: 30, name: 'A1', goal_id: 10 },
+      { id: 31, name: 'A2', goal_id: 11 },
+      { id: 32, name: 'A3', goal_id: 11 },
+    ],
+  };
+
+  it('produces the spec grid with F1 spanning 3 and G2/C2 spanning 2', () => {
+    const t = buildChainTable(doc);
+    expect(t.columns).toEqual<ChainColumn[]>(['factor', 'goal', 'change', 'activity']);
+    expect(asGrid(t)).toEqual([
+      ['F1×3', 'G1', 'C1', 'A1'],
+      ['·', 'G2×2', 'C2×2', 'A2'],
+      ['·', '·', '·', 'A3'],
+    ]);
+  });
+
+  it('orders the merged cells with correct rowSpans on the model', () => {
+    const t = buildChainTable(doc);
+    // Factor cell spans all three rows.
+    expect(t.rows[0][0]).toMatchObject({ rowSpan: 3, cell: { label: 'F1' } });
+    // Covered positions are null (no <td> emitted).
+    expect(t.rows[1][0]).toBeNull();
+    expect(t.rows[2][1]).toBeNull();
+  });
+});
+
+describe('buildChainTable — FGA (no Change column)', () => {
+  // FGA links Goal → Activity directly via activity.goal_id; no changes.
+  const doc: FGCAPreviewDoc = {
+    factors: [{ id: 1, name: 'F1' }],
+    goals: [{ id: 10, name: 'G1', factor: [{ id: 1 }] }],
+    activities: [
+      { id: 30, name: 'A1', goal_id: 10 },
+      { id: 31, name: 'A2', goal_id: 10 },
+    ],
+  };
+
+  it('emits three columns and merges Factor/Goal across the two activities', () => {
+    const t = buildChainTable(doc, { hideChanges: true });
+    expect(t.columns).toEqual<ChainColumn[]>(['factor', 'goal', 'activity']);
+    expect(asGrid(t)).toEqual([
+      ['F1×2', 'G1×2', 'A1'],
+      ['·', '·', 'A2'],
+    ]);
+  });
+});
+
+describe('buildChainTable — missing downstream links (gaps stay visible)', () => {
+  it('shows a factor with no goal, a goal with no change, and a change with no activity', () => {
+    const doc: FGCAPreviewDoc = {
+      factors: [
+        { id: 1, name: 'F1' },
+        { id: 2, name: 'F2' }, // no goals
+      ],
+      goals: [
+        { id: 10, name: 'G1', factor: [{ id: 1 }] }, // no change, no activity
+        { id: 11, name: 'G2', factor: [{ id: 1 }] }, // has a change with no activity
+      ],
+      changes: [{ id: 20, name: 'C1', goal_id: 11, activity_ids: [] }],
+      activities: [],
+    };
+    const t = buildChainTable(doc);
+    expect(asGrid(t)).toEqual([
+      ['F1×2', 'G1', '∅', '∅'],
+      ['·', 'G2', 'C1', '∅'],
+      ['F2', '∅', '∅', '∅'],
+    ]);
+  });
+
+  it('renders a change-less direct goal→activity path with an empty Change cell', () => {
+    const doc: FGCAPreviewDoc = {
+      factors: [{ id: 1, name: 'F1' }],
+      goals: [{ id: 10, name: 'G1', factor: [{ id: 1 }] }],
+      // activity bound straight to the goal, not covered by any change
+      changes: [],
+      activities: [{ id: 30, name: 'A1', goal_id: 10 }],
+    };
+    const t = buildChainTable(doc);
+    expect(asGrid(t)).toEqual([['F1', 'G1', '∅', 'A1']]);
+  });
+});
+
+describe('buildChainTable — orphans (broken refs are warnings, not errors)', () => {
+  it('places a goal with a missing factor in a trailing empty-Factor row', () => {
+    const doc: FGCAPreviewDoc = {
+      factors: [{ id: 1, name: 'F1' }],
+      goals: [
+        { id: 10, name: 'G1', factor: [{ id: 1 }] },
+        { id: 11, name: 'Gx', factor: [{ id: 99 }] }, // factor 99 does not exist
+        { id: 12, name: 'Gy' }, // no factor at all
+      ],
+      changes: [{ id: 20, name: 'C1', goal_id: 10, activity_ids: [30] }],
+      activities: [{ id: 30, name: 'A1', goal_id: 10 }],
+    };
+    const t = buildChainTable(doc);
+    expect(asGrid(t)).toEqual([
+      ['F1', 'G1', 'C1', 'A1'],
+      ['∅×2', 'Gx', '∅', '∅'],
+      ['·', 'Gy', '∅', '∅'],
+    ]);
+  });
+
+  it('surfaces an unlinked activity as a trailing row with empty cells to its left', () => {
+    const doc: FGCAPreviewDoc = {
+      factors: [{ id: 1, name: 'F1' }],
+      goals: [{ id: 10, name: 'G1', factor: [{ id: 1 }] }],
+      changes: [{ id: 20, name: 'C1', goal_id: 10, activity_ids: [30] }],
+      activities: [
+        { id: 30, name: 'A1', goal_id: 10 },
+        { id: 99, name: 'Aorphan' }, // no goal, no change
+      ],
+    };
+    const t = buildChainTable(doc);
+    expect(asGrid(t)).toEqual([
+      ['F1', 'G1', 'C1', 'A1'],
+      ['∅', '∅', '∅', 'Aorphan'],
+    ]);
+  });
+
+  it('surfaces a change whose goal is missing as an empty Factor+Goal row', () => {
+    const doc: FGCAPreviewDoc = {
+      factors: [],
+      goals: [],
+      changes: [{ id: 20, name: 'Cx', goal_id: 999, activity_ids: [30] }],
+      activities: [{ id: 30, name: 'A1' }],
+    };
+    const t = buildChainTable(doc);
+    expect(asGrid(t)).toEqual([['∅', '∅', 'Cx', 'A1']]);
+  });
+});
+
+describe('buildChainTable — name fallback', () => {
+  it('falls back to the id when an element has an empty name', () => {
+    const doc: FGCAPreviewDoc = {
+      factors: [{ id: 7, name: '' }],
+      goals: [],
+      activities: [],
+    };
+    const t = buildChainTable(doc);
+    expect(t.rows[0][0]?.cell?.label).toBe('7');
+  });
+});

--- a/packages/diagrams/src/fgca/chain-table.ts
+++ b/packages/diagrams/src/fgca/chain-table.ts
@@ -1,0 +1,225 @@
+// Chain-table model for the FGCA / FGA previews (vkgeorgia/strategy#137).
+//
+// The tree/chain preview (`layoutFGCAPreview`) shows Factor → Goal → Change →
+// Activity as columns of nodes joined by edges. This module produces the
+// *tabular* alternative: the same chain flattened into rows, with shared
+// parents collapsed into vertically-merged (rowspan) cells.
+//
+// It is the pure, unit-testable half of the feature — no DOM, no vscode. The
+// Studio preview renders the returned model as an HTML `<table>`.
+//
+// Link semantics mirror `layoutFGCAPreview` exactly (the authoritative source):
+//   - F → G via `goal.factor[]`
+//   - G → C via `change.goal_id`            (FGCA only)
+//   - C → A via `change.activity_ids[]`     (FGCA only)
+//   - G → A directly via `activity.goal_id` for activities not covered by any
+//     change (FGCA) / for every activity (FGA, no Change column)
+//
+// Broken references are validation *warnings*, not errors, so a rendered doc
+// can contain a goal with a missing factor, a change with a missing goal, or an
+// unlinked activity. Every element still appears in the table — rooted where it
+// links, or as a trailing orphan row with empty cells to its left — so the
+// table mirrors the document the same way the tree does.
+
+import type { FGCAPreviewDoc } from './preview-layout.js';
+
+export type ChainColumn = 'factor' | 'goal' | 'change' | 'activity';
+
+export interface ChainCell {
+  /** Column-qualified identity (e.g. "goal:3") — stable, unique across columns. */
+  key: string;
+  /** Display text — the element name, falling back to its id. */
+  label: string;
+}
+
+export interface ChainTableCell {
+  /** The element to render, or null for a gap in the chain (empty cell). */
+  cell: ChainCell | null;
+  /** Vertical span — how many rows this cell covers. */
+  rowSpan: number;
+}
+
+export interface ChainTable {
+  /** Columns left→right: FGA omits 'change'. */
+  columns: ChainColumn[];
+  /**
+   * Grid of rendered cells. `rows[r][c]` is the cell to emit at (r, c), or null
+   * when that position is covered by a `rowSpan` from a row above (emit no
+   * `<td>`). Each row corresponds to one path through the chain.
+   */
+  rows: Array<Array<ChainTableCell | null>>;
+}
+
+export interface ChainTableOptions {
+  /** FGA hides the Change column (Goal links straight to Activity). */
+  hideChanges?: boolean;
+}
+
+function cellOf(col: ChainColumn, id: number | string, name: string): ChainCell {
+  const label = name && name.trim() ? name : String(id);
+  return { key: `${col}:${id}`, label };
+}
+
+/** Identity comparison for the rowspan grouping; both-null counts as equal. */
+function sameCell(a: ChainCell | null, b: ChainCell | null): boolean {
+  if (a === null || b === null) return a === b;
+  return a.key === b.key;
+}
+
+/**
+ * Flattens an FGCA/FGA doc into a chain table with rowspan-merged parent cells.
+ *
+ * Rows are enumerated in document order (deterministic). A parent that links to
+ * several children spans those children's rows; an element with no downstream
+ * link still appears, with empty cells to its right.
+ */
+export function buildChainTable(doc: FGCAPreviewDoc, options: ChainTableOptions = {}): ChainTable {
+  const { hideChanges = false } = options;
+  const columns: ChainColumn[] = hideChanges
+    ? ['factor', 'goal', 'activity']
+    : ['factor', 'goal', 'change', 'activity'];
+
+  const changes = doc.changes ?? [];
+  const factorIds = new Set(doc.factors.map(f => f.id));
+  const activityById = new Map(doc.activities.map(a => [a.id, a] as const));
+  // An activity is "covered" by a change when any change lists it — those render
+  // under their change, not directly under the goal (mirrors the tree).
+  const coveredActivityIds = new Set(changes.flatMap(c => c.activity_ids));
+
+  const emittedGoals = new Set<number | string>();
+  const emittedChanges = new Set<number | string>();
+  const emittedActivities = new Set<number | string>();
+
+  // Each path is an array (length = columns.length) of ChainCell | null.
+  const paths: Array<Array<ChainCell | null>> = [];
+  const pad = (cells: Array<ChainCell | null>): Array<ChainCell | null> => {
+    // Defensive: ensure every path matches the column count.
+    while (cells.length < columns.length) cells.push(null);
+    return cells;
+  };
+
+  const emitGoal = (factorCell: ChainCell | null, goal: FGCAPreviewDoc['goals'][number]): void => {
+    emittedGoals.add(goal.id);
+    const goalCell = cellOf('goal', goal.id, goal.name);
+
+    if (hideChanges) {
+      const acts = doc.activities.filter(a => a.goal_id != null && a.goal_id === goal.id);
+      if (acts.length === 0) {
+        paths.push(pad([factorCell, goalCell]));
+        return;
+      }
+      for (const a of acts) {
+        emittedActivities.add(a.id);
+        paths.push([factorCell, goalCell, cellOf('activity', a.id, a.name)]);
+      }
+      return;
+    }
+
+    const goalChanges = changes.filter(c => c.goal_id === goal.id);
+    const directActs = doc.activities.filter(
+      a => a.goal_id != null && a.goal_id === goal.id && !coveredActivityIds.has(a.id),
+    );
+
+    if (goalChanges.length === 0 && directActs.length === 0) {
+      paths.push([factorCell, goalCell, null, null]);
+      return;
+    }
+    for (const c of goalChanges) {
+      emittedChanges.add(c.id);
+      const changeCell = cellOf('change', c.id, c.name);
+      const acts = c.activity_ids.map(id => activityById.get(id)).filter((a): a is NonNullable<typeof a> => a != null);
+      if (acts.length === 0) {
+        paths.push([factorCell, goalCell, changeCell, null]);
+        continue;
+      }
+      for (const a of acts) {
+        emittedActivities.add(a.id);
+        paths.push([factorCell, goalCell, changeCell, cellOf('activity', a.id, a.name)]);
+      }
+    }
+    // Change-less paths: activities bound straight to the goal (gap in Change).
+    for (const a of directActs) {
+      emittedActivities.add(a.id);
+      paths.push([factorCell, goalCell, null, cellOf('activity', a.id, a.name)]);
+    }
+  };
+
+  // Phase 1 — factor-rooted paths.
+  for (const f of doc.factors) {
+    const factorCell = cellOf('factor', f.id, f.name);
+    const goalsOfFactor = doc.goals.filter(g => (g.factor ?? []).some(ref => ref.id === f.id));
+    if (goalsOfFactor.length === 0) {
+      paths.push(pad([factorCell]));
+      continue;
+    }
+    for (const g of goalsOfFactor) emitGoal(factorCell, g);
+  }
+
+  // Phase 2 — goals with no existing factor (orphan or broken-ref): empty Factor.
+  for (const g of doc.goals) {
+    if (emittedGoals.has(g.id)) continue;
+    const hasExistingFactor = (g.factor ?? []).some(ref => factorIds.has(ref.id));
+    if (hasExistingFactor) continue; // emitted under its factor in phase 1
+    emitGoal(null, g);
+  }
+
+  // Phase 3 — changes whose goal is missing (FGCA only): empty Factor + Goal.
+  if (!hideChanges) {
+    for (const c of changes) {
+      if (emittedChanges.has(c.id)) continue;
+      emittedChanges.add(c.id);
+      const changeCell = cellOf('change', c.id, c.name);
+      const acts = c.activity_ids.map(id => activityById.get(id)).filter((a): a is NonNullable<typeof a> => a != null);
+      if (acts.length === 0) {
+        paths.push([null, null, changeCell, null]);
+        continue;
+      }
+      for (const a of acts) {
+        emittedActivities.add(a.id);
+        paths.push([null, null, changeCell, cellOf('activity', a.id, a.name)]);
+      }
+    }
+  }
+
+  // Phase 4 — activities linked to nothing: empty cells to their left.
+  for (const a of doc.activities) {
+    if (emittedActivities.has(a.id)) continue;
+    const row: Array<ChainCell | null> = columns.map(() => null);
+    row[columns.length - 1] = cellOf('activity', a.id, a.name);
+    paths.push(row);
+  }
+
+  return { columns, rows: computeRowSpans(paths, columns.length) };
+}
+
+/**
+ * Turns a flat list of equal-length paths into a render grid. For each column,
+ * a cell spans the run of consecutive rows that share identical values in every
+ * column from 0 through that column (so a child only merges within one parent).
+ */
+function computeRowSpans(
+  paths: Array<Array<ChainCell | null>>,
+  colCount: number,
+): Array<Array<ChainTableCell | null>> {
+  const n = paths.length;
+  const grid: Array<Array<ChainTableCell | null>> = paths.map(() => new Array(colCount).fill(null));
+
+  for (let c = 0; c < colCount; c++) {
+    let r = 0;
+    while (r < n) {
+      let end = r + 1;
+      while (end < n && prefixEqual(paths[end], paths[r], c)) end++;
+      grid[r][c] = { cell: paths[r][c], rowSpan: end - r };
+      r = end;
+    }
+  }
+  return grid;
+}
+
+/** True when two paths agree on every column 0..c (inclusive). */
+function prefixEqual(a: Array<ChainCell | null>, b: Array<ChainCell | null>, c: number): boolean {
+  for (let i = 0; i <= c; i++) {
+    if (!sameCell(a[i], b[i])) return false;
+  }
+  return true;
+}

--- a/packages/diagrams/src/fgca/index.ts
+++ b/packages/diagrams/src/fgca/index.ts
@@ -19,6 +19,8 @@ export type {
   FGCAPreviewEdge,
   FGCAPreviewColumnPos,
 } from "./preview-layout";
+export { buildChainTable } from "./chain-table";
+export type { ChainTable, ChainTableCell, ChainColumn, ChainCell, ChainTableOptions } from "./chain-table";
 export { validateFGCADoc } from "./validate";
 export type { FGCADoc, FGCAValidationResult, FGCAValidationError, FGCAValidationWarning } from "./validate";
 export {

--- a/packages/diagrams/src/index.ts
+++ b/packages/diagrams/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./activities/index";
 export * from "./activity-card/index";
 export * from "./applications/index";
+export * from "./assertion/index";
 export * from "./blocks/index";
 export * from "./capability-map/index";
 export * from "./fgca/index";
@@ -9,7 +10,9 @@ export * from "./issues/index";
 export * from "./process-blueprint/index";
 export * from "./process-map/index";
 export * from "./products/index";
+export * from "./requirement/index";
 export * from "./scenarios/index";
 export * from "./theme/index";
+export * from "./typed-id";
 export * from "./validation-types";
 export { coerceDatesToIsoStrings } from "./yaml-normalize";

--- a/packages/diagrams/src/requirement/__tests__/example.test.ts
+++ b/packages/diagrams/src/requirement/__tests__/example.test.ts
@@ -1,0 +1,24 @@
+// Conformance test for the shipped REQUIREMENT worked examples — the
+// acme_corp canon files mirrored under `examples/requirement/`. Pins the
+// success signal of vkgeorgia/strategy#84 Phase 1: the library consumes the
+// canonical example files without error.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import yaml from 'js-yaml';
+import { validateRequirement } from '../validate.js';
+
+const dir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../examples/requirement');
+const load = (f: string): unknown => yaml.load(readFileSync(path.join(dir, f), 'utf-8'));
+
+describe('requirement worked examples (acme_corp)', () => {
+  for (const f of ['REQUIREMENT-DATA-ERASURE-1.yaml', 'REQUIREMENT-AUDIT-LOG-RETENTION-1.yaml']) {
+    it(`validates ${f} without error`, () => {
+      const v = validateRequirement(load(f));
+      expect(v.valid, JSON.stringify(v.errors)).toBe(true);
+      expect(v.errors).toHaveLength(0);
+    });
+  }
+});

--- a/packages/diagrams/src/requirement/__tests__/validate.test.ts
+++ b/packages/diagrams/src/requirement/__tests__/validate.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { validateRequirement } from '../validate.js';
+import type { CanonCatalog } from '../../typed-id.js';
+
+function valid(): Record<string, unknown> {
+  return {
+    notation: 'requirement',
+    id: 'REQUIREMENT-DATA-ERASURE-1',
+    name: 'Personal-data erasure within 30 days',
+    description: 'The controller must erase personal data within 30 days of a verified request.',
+    severity: 'high',
+    zone: 'canon',
+    admitted_at: '2026-05-28',
+    admitted_by: 'v.korobeinikov',
+    gate_checks: { uniqueness: 'pass', consistency: 'pass', completeness: 'pass' },
+    valid_from: '2017-05-01',
+    valid_to: null,
+  };
+}
+
+const codes = (input: unknown, opts?: Parameters<typeof validateRequirement>[1]): string[] =>
+  validateRequirement(input, opts).errors.map(e => e.code);
+
+describe('validateRequirement — positive', () => {
+  it('accepts a well-formed requirement', () => {
+    const r = validateRequirement(valid());
+    expect(r.valid, JSON.stringify(r.errors)).toBe(true);
+    expect(r.errors).toHaveLength(0);
+  });
+
+  it('accepts an internal-only requirement with no derived_from', () => {
+    const r = valid();
+    delete r.derived_from;
+    r.severity = 'medium';
+    expect(validateRequirement(r).valid).toBe(true);
+  });
+});
+
+describe('validateRequirement — REQ-001 (shape / id grammar)', () => {
+  it('flags a missing required field', () => {
+    const r = valid();
+    delete r.name;
+    expect(codes(r)).toContain('REQ-001');
+  });
+
+  it('flags an id that violates the grammar', () => {
+    expect(codes({ ...valid(), id: 'REQUIREMENT-DATA-ERASURE-001' })).toContain('REQ-001'); // leading zero
+    expect(codes({ ...valid(), id: 'REQ-1' })).toContain('REQ-001'); // wrong TYPE
+    expect(codes({ ...valid(), id: 'requirement-data-1' })).toContain('REQ-001'); // lowercase TYPE
+  });
+
+  it('flags a wrong notation tag and a non-canon zone', () => {
+    expect(codes({ ...valid(), notation: 'req' })).toContain('REQ-001');
+    expect(codes({ ...valid(), zone: 'sandbox' })).toContain('REQ-001');
+  });
+
+  it('flags a missing valid_to key (distinct from a null value)', () => {
+    const r = valid();
+    delete r.valid_to;
+    expect(codes(r)).toContain('REQ-001');
+    expect(validateRequirement({ ...valid(), valid_to: null }).valid).toBe(true);
+  });
+
+  it('rejects a non-object', () => {
+    expect(codes(null)).toEqual(['REQ-001']);
+    expect(codes('x')).toEqual(['REQ-001']);
+    expect(codes(['a'])).toEqual(['REQ-001']);
+  });
+});
+
+describe('validateRequirement — REQ-002 (derived_from resolution)', () => {
+  it('flags a well-formed allowed-type ref that does not resolve in the catalog', () => {
+    const catalog: CanonCatalog = { typeOf: () => undefined };
+    expect(codes({ ...valid(), derived_from: ['LAW-PERSONAL-DATA-2017-1'] }, { catalog })).toContain('REQ-002');
+  });
+
+  it('flags a malformed derived_from entry (cannot resolve)', () => {
+    expect(codes({ ...valid(), derived_from: ['not an id'] })).toContain('REQ-002');
+  });
+
+  it('does not flag REQ-002 without a catalog for a well-formed allowed-type ref', () => {
+    expect(codes({ ...valid(), derived_from: ['LAW-PERSONAL-DATA-2017-1'] })).not.toContain('REQ-002');
+  });
+});
+
+describe('validateRequirement — REQ-003 (derived_from TYPE)', () => {
+  it('flags a derived_from TYPE outside LAW/REGULATION/POLICY/INTERNAL_STANDARD', () => {
+    expect(codes({ ...valid(), derived_from: ['PRODUCT-MOBILE-1'] })).toContain('REQ-003');
+  });
+
+  it('accepts each permitted derived_from TYPE', () => {
+    for (const id of ['LAW-X-1', 'REGULATION-X-1', 'POLICY-X-1', 'INTERNAL_STANDARD-X-1']) {
+      expect(codes({ ...valid(), derived_from: [id] })).not.toContain('REQ-003');
+    }
+  });
+});

--- a/packages/diagrams/src/requirement/index.ts
+++ b/packages/diagrams/src/requirement/index.ts
@@ -1,0 +1,4 @@
+export type { Requirement, RequirementSeverity, GateChecks } from './types.js';
+export { REQUIREMENT_DERIVED_FROM_TYPES } from './types.js';
+export { validateRequirement } from './validate.js';
+export type { RequirementValidateOptions } from './validate.js';

--- a/packages/diagrams/src/requirement/types.ts
+++ b/packages/diagrams/src/requirement/types.ts
@@ -1,0 +1,35 @@
+// REQUIREMENT — motivation-layer positive obligation.
+// Schema: methodology notations/elements/15-requirement.md §2.
+
+export type RequirementSeverity = 'high' | 'medium' | 'low';
+
+/** Standard canon admission gate checks (CONTRACT.md §6). */
+export interface GateChecks {
+  uniqueness?: string;
+  consistency?: string;
+  completeness?: string;
+}
+
+/** TYPEs a requirement may be derived from (15-requirement.md §2, REQ-003). */
+export const REQUIREMENT_DERIVED_FROM_TYPES = ['LAW', 'REGULATION', 'POLICY', 'INTERNAL_STANDARD'] as const;
+
+export interface Requirement {
+  notation: 'requirement';
+  id: string;
+  name: string;
+  description: string;
+  /** Organisation-defined priority. */
+  severity?: RequirementSeverity;
+  /** Typed IDs of the codex source documents this requirement is drawn from. */
+  derived_from?: string[];
+
+  // Admission record (CONTRACT.md §6).
+  zone: 'canon';
+  admitted_at: string;
+  admitted_by: string;
+  gate_checks: GateChecks;
+
+  // Primitive lifecycle (CONTRACT.md §7).
+  valid_from: string;
+  valid_to: string | null;
+}

--- a/packages/diagrams/src/requirement/validate.ts
+++ b/packages/diagrams/src/requirement/validate.ts
@@ -1,0 +1,92 @@
+// REQUIREMENT validator — methodology notations/elements/15-requirement.md §4.
+//
+// Implements REQ-001..003. The shared HDR-/LIFECYCLE-/REQ-COVERAGE rules are
+// cross-cutting concerns owned elsewhere (CONTRACT.md §8) and are out of scope
+// for this single-artefact validator.
+//
+// REQ-002/003 resolve `derived_from` against the codex zone. Resolution that
+// needs artefact *existence* (REQ-002) only runs when a `CanonCatalog` is
+// supplied; the TYPE check (REQ-003) is derivable from the id prefix and runs
+// either way.
+
+import type { ValidationError, ValidationWarning, ValidationResult } from '../validation-types.js';
+import { typeOfId, isCanonicalIdOfType, type CanonCatalog } from '../typed-id.js';
+import { REQUIREMENT_DERIVED_FROM_TYPES } from './types.js';
+
+export interface RequirementValidateOptions {
+  /** When provided, REQ-002 enforces that each `derived_from` id is admitted. */
+  catalog?: CanonCatalog;
+}
+
+const REQUIRED_FIELDS = [
+  'notation', 'name', 'description', 'zone', 'admitted_at', 'admitted_by', 'gate_checks', 'valid_from',
+] as const;
+
+export function validateRequirement(input: unknown, options: RequirementValidateOptions = {}): ValidationResult {
+  const errors: ValidationError[] = [];
+  const warnings: ValidationWarning[] = [];
+
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    errors.push({ code: 'REQ-001', message: 'Requirement must be a YAML mapping.' });
+    return { valid: false, errors, warnings };
+  }
+  const r = input as Record<string, unknown>;
+
+  // REQ-001 — id grammar.
+  if (!isCanonicalIdOfType(r.id, 'REQUIREMENT')) {
+    errors.push({ code: 'REQ-001', message: `id "${String(r.id)}" must match REQUIREMENT-[<middle>-]<INTEGER>.`, path: 'id' });
+  }
+  // REQ-001 — fixed notation tag.
+  if (r.notation !== 'requirement') {
+    errors.push({ code: 'REQ-001', message: 'notation must be the fixed value "requirement".', path: 'notation' });
+  }
+  // REQ-001 — required fields present and non-empty (notation handled above).
+  for (const f of REQUIRED_FIELDS) {
+    if (f === 'notation') continue;
+    if (f === 'gate_checks') {
+      if (r.gate_checks === null || typeof r.gate_checks !== 'object') {
+        errors.push({ code: 'REQ-001', message: 'gate_checks is required and must be a mapping.', path: 'gate_checks' });
+      }
+      continue;
+    }
+    const v = r[f];
+    if (typeof v !== 'string' || v.trim() === '') {
+      errors.push({ code: 'REQ-001', message: `${f} is required.`, path: f });
+    }
+  }
+  // REQ-001 — zone fixed value.
+  if (r.zone !== undefined && r.zone !== 'canon') {
+    errors.push({ code: 'REQ-001', message: 'zone must be "canon" for a REQUIREMENT.', path: 'zone' });
+  }
+  // REQ-001 — valid_to key must exist (string or null).
+  if (!('valid_to' in r) || !(typeof r.valid_to === 'string' || r.valid_to === null)) {
+    errors.push({ code: 'REQ-001', message: 'valid_to is required (an ISO date string or null).', path: 'valid_to' });
+  }
+
+  // REQ-002 / REQ-003 — derived_from references.
+  if (r.derived_from !== undefined) {
+    if (!Array.isArray(r.derived_from)) {
+      errors.push({ code: 'REQ-001', message: 'derived_from must be a list of typed IDs.', path: 'derived_from' });
+    } else {
+      r.derived_from.forEach((ref, i) => {
+        const type = typeOfId(ref);
+        if (!type) {
+          // A malformed ref cannot resolve — REQ-002.
+          errors.push({ code: 'REQ-002', message: `derived_from[${i}] "${String(ref)}" is not a resolvable typed ID.`, path: `derived_from[${i}]` });
+          return;
+        }
+        if (!REQUIREMENT_DERIVED_FROM_TYPES.includes(type as typeof REQUIREMENT_DERIVED_FROM_TYPES[number])) {
+          // REQ-003 — TYPE not a permitted codex source type (prefix-derivable).
+          errors.push({ code: 'REQ-003', message: `derived_from[${i}] TYPE "${type}" is not one of ${REQUIREMENT_DERIVED_FROM_TYPES.join(', ')}.`, path: `derived_from[${i}]` });
+          return;
+        }
+        if (options.catalog && options.catalog.typeOf(ref as string) === undefined) {
+          // REQ-002 — well-formed but not admitted in the codex zone.
+          errors.push({ code: 'REQ-002', message: `derived_from[${i}] "${String(ref)}" does not resolve to an admitted codex artefact.`, path: `derived_from[${i}]` });
+        }
+      });
+    }
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}

--- a/packages/diagrams/src/typed-id.ts
+++ b/packages/diagrams/src/typed-id.ts
@@ -1,0 +1,56 @@
+// Canonical typed-ID grammar + cross-reference resolution catalogue.
+//
+// Every element ID and cross-reference in the Transitrix canon follows the
+// grammar in methodology `notations/IDS_AND_REFERENCES.md` §1:
+//
+//     <TYPE>-[<middle segment(s)>-]<INTEGER>
+//
+//   - TYPE: uppercase, starts with a letter, may contain digits and `_`
+//     (multi-word TYPEs like INTERNAL_STANDARD / PROCESS_BLUEPRINT).
+//   - middle: optional, notation-specific segments.
+//   - INTEGER: terminal positive integer, no leading zeros.
+//
+// CAPABILITY is the one exception (§2): its terminal is a V/H diagram address
+// (CAPABILITY-V1.2) rather than a plain integer. Compliance artefacts only
+// *resolve* capability ids (they never own one), so the catalogue handles
+// them; the strict integer-terminal grammar below is used only for an
+// artefact's own id (REQUIREMENT-… / ASSERTION-…).
+
+/** TYPE prefix of a typed id — the segment before the first hyphen. */
+const TYPE_PREFIX_RE = /^([A-Z][A-Z0-9_]*)-/;
+
+/** Full integer-terminal canonical id. Middle segments may be mixed-case
+ *  (real canon ids such as INTERNAL_STANDARD-coding-conventions-1 exist). */
+const CANONICAL_ID_RE = /^[A-Z][A-Z0-9_]*(?:-[A-Za-z0-9]+)*-[1-9][0-9]*$/;
+
+/** Extracts the TYPE prefix of a typed id, or null when `id` is not a typed
+ *  reference (`PRODUCT-MOBILE-1` → `PRODUCT`, `CAPABILITY-V2` → `CAPABILITY`). */
+export function typeOfId(id: unknown): string | null {
+  if (typeof id !== 'string') return null;
+  const m = TYPE_PREFIX_RE.exec(id);
+  return m ? m[1] : null;
+}
+
+/** True when `id` is a well-formed integer-terminal canonical id. */
+export function isCanonicalId(id: unknown): id is string {
+  return typeof id === 'string' && CANONICAL_ID_RE.test(id);
+}
+
+/** True when `id` is a well-formed canonical id whose TYPE is exactly `type`. */
+export function isCanonicalIdOfType(id: unknown, type: string): boolean {
+  return isCanonicalId(id) && typeOfId(id) === type;
+}
+
+/**
+ * A read-only view of an organisation's admitted canon, used to resolve typed
+ * cross-references during validation. Phase 1 validators accept it optionally:
+ * with no catalogue they perform shape + prefix-TYPE checks only; given one,
+ * they additionally enforce the resolution rules (REQ-002, ASSERT-002/004/005…)
+ * that depend on whether a referenced artefact actually exists.
+ *
+ * The compliance previews (Phase 2+) build a catalogue by scanning the repo.
+ */
+export interface CanonCatalog {
+  /** TYPE of an admitted artefact with this id, or undefined if not admitted. */
+  typeOf(id: string): string | undefined;
+}


### PR DESCRIPTION
@
**Do not merge — Valerii gates.** First phase of the compliance epic (#84).

Teaches `@transitrix/diagrams` to recognise the two new canonical artefact types from the methodology canon (`notations/elements/15-requirement.md`, `16-assertion.md`). Library-only — the previews + CLI export come in later phases.

### New modules
- **`typed-id.ts`** — the shared canonical ID grammar (`<TYPE>-[<middle>-]<INTEGER>`, per `IDS_AND_REFERENCES.md` §1) and a `CanonCatalog` resolution interface for cross-references.
- **`requirement/`** — `types.ts` (schema) + `validate.ts` implementing **REQ-001..003**.
- **`assertion/`** — `types.ts` (schema, status enum, three evidence kinds) + `validate.ts` implementing **ASSERT-001..008**.
- Both exported from `packages/diagrams/src/index.ts`.

### Resolution design (the one judgement call)
REQ-002/003 and ASSERT-002/003/004/005 carry cross-reference checks that need the organisation catalogue. The validators take an **optional `CanonCatalog`**:
- **Without** a catalogue → shape + prefix-derivable TYPE checks (REQ-003, ASSERT-002/003 TYPE, malformed refs). Enough for single-file validation.
- **With** a catalogue → additionally enforce artefact *existence* (REQ-002, ASSERT-002/003 resolve, ASSERT-004, ASSERT-005). The compliance previews (Phase 2+) build the catalogue by scanning the repo.

ASSERT-008 (staleness) runs only when a `today` is supplied — the validator stays clock-free and deterministic. The cross-cutting rules (`REQ-COVERAGE-001`, `ASSERT-DEAD-LINK-001`, `HDR-*`, `LIFECYCLE-*`) are explicitly out of scope for these single-artefact validators per `CONTRACT.md` §8.

### Tests (AC)
- **Unit fixtures** (32 cases): positive parse + every REQ-/ASSERT- code triggered, including the catalogue-dependent and `today`-dependent paths.
- **Conformance** (AC): the acme_corp worked examples — mirrored into `examples/requirement/` and `examples/assertion/` from the methodology canon — validate **without error**. Confirms ASSERT-007 correctly does *not* fire on the `under_review` empty-evidence assertion.
- diagrams **551** + core **235** green; `tsc` (root + extension) + package build clean.

### Methodology dependency — satisfied
The paired methodology epic (Requirements/Assertions canon) is **merged**: the `15-requirement.md` / `16-assertion.md` specs and the acme_corp example files are present in the methodology repo and are consumed here (mirrored into `examples/`). Nothing in this PR was built blind against an unfinalised spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@