### PR TITLE
feat(compliance): Phase 3 — single-law tree + single-product view (#84)

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -622,6 +622,30 @@
         "icon": "$(refresh)"
       },
       {
+        "command": "transitrixStudio.previewSingleLaw",
+        "title": "Transitrix: Preview compliance — single law",
+        "category": "Transitrix",
+        "icon": "$(law)"
+      },
+      {
+        "command": "transitrixStudio.refreshSingleLaw",
+        "title": "Transitrix: Refresh single-law compliance view",
+        "category": "Transitrix",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "transitrixStudio.previewSingleProduct",
+        "title": "Transitrix: Preview compliance — single product",
+        "category": "Transitrix",
+        "icon": "$(package)"
+      },
+      {
+        "command": "transitrixStudio.refreshSingleProduct",
+        "title": "Transitrix: Refresh single-product compliance view",
+        "category": "Transitrix",
+        "icon": "$(refresh)"
+      },
+      {
         "command": "transitrixStudio.openSpacingSettings",
         "title": "Transitrix: Open diagram spacing settings",
         "category": "Transitrix",
@@ -786,6 +810,16 @@
           "when": "resourceFilename =~ /\\.issues\\.transitrix\\.yaml$/",
           "command": "transitrixStudio.saveIssuesAsSvg",
           "group": "navigation@-9"
+        },
+        {
+          "when": "resourceFilename =~ /^(LAW|REGULATION|POLICY|INTERNAL_STANDARD)-.*\\.yaml$/",
+          "command": "transitrixStudio.previewSingleLaw",
+          "group": "navigation@-10"
+        },
+        {
+          "when": "resourceFilename =~ /^PRODUCT-.*\\.yaml$/",
+          "command": "transitrixStudio.previewSingleProduct",
+          "group": "navigation@-10"
         },
         {
           "when": "activeWebviewPanelId == issuesPreview",

--- a/extension/src/compliance-matrix-preview.ts
+++ b/extension/src/compliance-matrix-preview.ts
@@ -1,17 +1,14 @@
 import * as vscode from 'vscode';
-import yaml from 'js-yaml';
 import { generateWebviewCss, type ThemeId } from '../../packages/diagrams/src/theme/index.js';
 import {
   buildComplianceMatrix,
   filterComplianceMatrix,
   type ComplianceMatrix,
-  type MatrixAssertionRef,
   type MatrixFilter,
-  type MatrixProduct,
-  type MatrixRequirement,
 } from '../../packages/diagrams/src/compliance-matrix/index.js';
 import type { AssertionStatus } from '../../packages/diagrams/src/assertion/types.js';
 import { genNonce } from './preview-controls.js';
+import { scanComplianceCanon } from './compliance-scan.js';
 
 // Compliance matrix preview (vkgeorgia/strategy#84 Phase 2).
 //
@@ -39,14 +36,6 @@ const REFRESH_COMMAND = 'transitrixStudio.refreshComplianceMatrix';
 
 function escXml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-}
-
-interface ScanResult {
-  products: MatrixProduct[];
-  requirements: MatrixRequirement[];
-  assertions: MatrixAssertionRef[];
-  /** assertion id → workspace file path, for cell click-to-open. */
-  assertionPaths: Map<string, string>;
 }
 
 export class ComplianceMatrixPreview {
@@ -82,21 +71,14 @@ export class ComplianceMatrixPreview {
   /** Re-scan the workspace and re-render. */
   async refresh(): Promise<void> {
     if (!this.panel) return;
-    const scan = await this.scanWorkspace();
-    this.assertionPaths = scan.assertionPaths;
+    const scan = await scanComplianceCanon();
+    this.assertionPaths = scan.pathById;
     this.fullMatrix = buildComplianceMatrix({
       products: scan.products,
       requirements: scan.requirements,
       assertions: scan.assertions,
     });
     this.render();
-  }
-
-  /** Open the file backing an assertion cell. */
-  async openFile(fsPath: string): Promise<void> {
-    if (!fsPath) return;
-    const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(fsPath));
-    await vscode.window.showTextDocument(doc, { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false });
   }
 
   private async onMessage(m: { type?: string; statuses?: string[]; severities?: string[] }): Promise<void> {
@@ -106,49 +88,6 @@ export class ComplianceMatrixPreview {
       severities: (m.severities ?? []).filter(s => ALL_SEVERITIES.includes(s)),
     };
     this.render();
-  }
-
-  private async scanWorkspace(): Promise<ScanResult> {
-    const products: MatrixProduct[] = [];
-    const requirements: MatrixRequirement[] = [];
-    const assertions: MatrixAssertionRef[] = [];
-    const assertionPaths = new Map<string, string>();
-
-    const uris = await vscode.workspace.findFiles('**/*.{yaml,yml}', '**/node_modules/**', 5000);
-    for (const uri of uris) {
-      let doc: Record<string, unknown> | undefined;
-      try {
-        const bytes = await vscode.workspace.fs.readFile(uri);
-        const parsed = yaml.load(Buffer.from(bytes).toString('utf-8'));
-        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) doc = parsed as Record<string, unknown>;
-      } catch {
-        continue; // unparseable / unreadable — skip
-      }
-      if (!doc || typeof doc.id !== 'string') continue;
-
-      if (doc.notation === 'product') {
-        products.push({ id: doc.id, name: typeof doc.name === 'string' ? doc.name : doc.id });
-      } else if (doc.notation === 'requirement') {
-        requirements.push({
-          id: doc.id,
-          name: typeof doc.name === 'string' ? doc.name : doc.id,
-          severity: typeof doc.severity === 'string' ? doc.severity : undefined,
-        });
-      } else if (doc.notation === 'assertion') {
-        if (typeof doc.about === 'string' && typeof doc.subject === 'string' && typeof doc.status === 'string') {
-          assertions.push({
-            id: doc.id,
-            about: doc.about,
-            subject: doc.subject,
-            status: doc.status as AssertionStatus,
-            assessed_at: typeof doc.assessed_at === 'string' ? doc.assessed_at : undefined,
-            next_review_at: typeof doc.next_review_at === 'string' ? doc.next_review_at : undefined,
-          });
-          assertionPaths.set(doc.id, uri.fsPath);
-        }
-      }
-    }
-    return { products, requirements, assertions, assertionPaths };
   }
 
   private render(): void {

--- a/extension/src/compliance-render.ts
+++ b/extension/src/compliance-render.ts
@@ -1,0 +1,107 @@
+import { generateWebviewCss, type ThemeId } from '../../packages/diagrams/src/theme/index.js';
+import type { AssertionStatus } from '../../packages/diagrams/src/assertion/types.js';
+
+// Shared HTML rendering for the script-less compliance views — the single-law
+// tree and single-product view (vkgeorgia/strategy#84 Phase 3). These previews
+// are read-only and need no scripts: click-to-open uses command URIs and status
+// is shown with inline badges, so they keep `enableScripts: false` and the
+// script-less CSP (smallest security surface).
+
+export const STATUS_LABELS: Record<AssertionStatus, string> = {
+  compliant: 'Compliant',
+  partial: 'Partial',
+  non_compliant: 'Non-compliant',
+  under_review: 'Under review',
+  n_a: 'N/A',
+};
+
+export function escXml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+/** A coloured status pill. */
+export function statusBadge(status: AssertionStatus): string {
+  return `<span class="cmp-badge cmp-${status}">${escXml(STATUS_LABELS[status])}</span>`;
+}
+
+/**
+ * A click-to-open link via a command URI, or a plain span when the artefact has
+ * no resolved file path (e.g. a dangling reference). `command` is the registered
+ * open-file command; `inner` is already-escaped HTML.
+ */
+export function openLink(command: string, fsPath: string | undefined, inner: string, title: string): string {
+  if (!fsPath) return `<span title="${escXml(title)}">${inner}</span>`;
+  const href = `command:${command}?${encodeURIComponent(JSON.stringify([fsPath]))}`;
+  return `<a class="cmp-link" href="${href}" title="${escXml(title)}">${inner}</a>`;
+}
+
+const COMPLIANCE_CSS = `
+body { padding: 0; }
+#cmp-toolbar { display: flex; align-items: baseline; gap: 12px; padding: 12px 16px; border-bottom: 1px solid var(--ts-border, #cbd5e1); flex-wrap: wrap; }
+.cmp-title { font-size: 15px; font-weight: 700; color: var(--ts-text, #0f172a); }
+.cmp-subtitle { font-size: 12px; color: var(--ts-text-muted, #64748b); }
+.cmp-btn { font-size: 11px; padding: 2px 10px; border-radius: 4px; color: var(--ts-text-muted, #64748b); text-decoration: none; border: 1px solid var(--ts-border, #cbd5e1); margin-left: auto; }
+.cmp-btn:hover { color: var(--ts-text, #0f172a); background: var(--ts-bg-elevated, #f1f5f9); }
+#cmp-body { padding: 12px 16px 28px; }
+.cmp-link { color: var(--ts-brand-primary, #004d67); text-decoration: none; }
+.cmp-link:hover { text-decoration: underline; }
+.cmp-badge { display: inline-block; padding: 1px 8px; border-radius: 10px; font-size: 11px; font-weight: 600; }
+.cmp-compliant { background: var(--ts-status-success-bg, #d1fae5); color: var(--ts-status-success-fg, #065f46); }
+.cmp-partial { background: var(--ts-status-warning-bg, #fef9c3); color: var(--ts-status-warning-fg, #854d0e); }
+.cmp-non_compliant { background: var(--ts-status-error-bg, #fee2e2); color: var(--ts-status-error-fg, #991b1b); }
+.cmp-under_review { background: var(--ts-status-info-bg, #e0f2fe); color: var(--ts-status-info-fg, #0c4a6e); }
+.cmp-n_a { background: var(--ts-bg-subtle, #f1f5f9); color: var(--ts-text-muted, #64748b); }
+
+/* Tree (single-law) */
+.cmp-req { margin: 0 0 14px; border: 1px solid var(--ts-border, #cbd5e1); border-radius: 6px; overflow: hidden; }
+.cmp-req-head { display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--ts-bg-subtle, #f1f5f9); }
+.cmp-req-name { font-weight: 600; color: var(--ts-text, #0f172a); }
+.cmp-req-id { font-size: 11px; color: var(--ts-text-muted, #64748b); font-family: var(--vscode-editor-font-family, monospace); }
+.cmp-sev { font-size: 10px; text-transform: uppercase; letter-spacing: 0.04em; }
+.cmp-sev-high { color: #b91c1c; } .cmp-sev-medium { color: #b45309; } .cmp-sev-low { color: #2563eb; }
+.cmp-assertions { list-style: none; margin: 0; padding: 0; }
+.cmp-assertions li { display: flex; align-items: center; gap: 8px; padding: 6px 12px 6px 24px; border-top: 1px solid var(--ts-border, #e2e8f0); font-size: 12px; }
+.cmp-assertions li .cmp-meta { color: var(--ts-text-muted, #64748b); font-size: 11px; }
+.cmp-none { color: var(--ts-text-muted, #64748b); font-style: italic; padding: 6px 12px 6px 24px; border-top: 1px solid var(--ts-border, #e2e8f0); }
+
+/* List (single-product) */
+.cmp-list { border-collapse: collapse; font-size: 12px; width: 100%; max-width: 760px; }
+.cmp-list th, .cmp-list td { border: 1px solid var(--ts-border, #cbd5e1); padding: 6px 12px; text-align: left; }
+.cmp-list th { background: var(--ts-bg-subtle, #f1f5f9); color: var(--ts-text, #0f172a); }
+.cmp-empty { color: var(--ts-text-muted, #64748b); padding: 24px 0; max-width: 640px; }
+`;
+
+export interface ComplianceShellOptions {
+  title: string;
+  subtitle?: string;
+  themeId: ThemeId;
+  /** Command id for the Refresh button (re-scan). */
+  refreshCommand: string;
+  /** Already-built body HTML (caller is responsible for escaping). */
+  bodyHtml: string;
+}
+
+/** Full webview document for a script-less compliance view (static CSP). */
+export function complianceShell(opts: ComplianceShellOptions): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline';">
+  <style>
+${generateWebviewCss(opts.themeId)}
+${COMPLIANCE_CSS}
+  </style>
+</head>
+<body data-theme="${escXml(opts.themeId)}">
+  <div id="cmp-toolbar">
+    <span class="cmp-title">${escXml(opts.title)}</span>
+    ${opts.subtitle ? `<span class="cmp-subtitle">${escXml(opts.subtitle)}</span>` : ''}
+    <a href="command:${opts.refreshCommand}" class="cmp-btn" title="Re-scan the workspace">Refresh</a>
+  </div>
+  <div id="cmp-body">
+    ${opts.bodyHtml}
+  </div>
+</body>
+</html>`;
+}

--- a/extension/src/compliance-scan.ts
+++ b/extension/src/compliance-scan.ts
@@ -1,0 +1,100 @@
+import * as vscode from 'vscode';
+import yaml from 'js-yaml';
+import type { AssertionStatus } from '../../packages/diagrams/src/assertion/types.js';
+
+// Shared workspace scanner for the compliance views (vkgeorgia/strategy#84).
+// The compliance matrix (Phase 2), the single-law / single-product views
+// (Phase 3) and the gap dashboard (Phase 4) all need the same repo-wide sweep
+// of the canon artefacts, so it lives here once.
+
+export interface ScannedProduct { id: string; name: string; }
+export interface ScannedRequirement { id: string; name: string; severity?: string; derived_from?: string[]; }
+export interface ScannedAssertion {
+  id: string;
+  about: string;
+  subject: string;
+  status: AssertionStatus;
+  assessed_at?: string;
+  next_review_at?: string;
+  evidenceCount: number;
+}
+export interface ScannedCodex { id: string; name: string; type?: string; jurisdiction?: string; }
+
+export interface ScannedCanon {
+  products: ScannedProduct[];
+  requirements: ScannedRequirement[];
+  assertions: ScannedAssertion[];
+  /** Codex source documents (zone: codex) — laws, regulations, policies, standards. */
+  codex: ScannedCodex[];
+  /** Any artefact id → its workspace file path, for click-to-open. */
+  pathById: Map<string, string>;
+}
+
+const str = (v: unknown): string | undefined => (typeof v === 'string' ? v : undefined);
+
+/**
+ * Scans the workspace for the compliance canon artefacts: products,
+ * requirements and assertions (identified by their `notation` tag) and codex
+ * source documents (identified by `zone: codex`). Unreadable/unparseable files
+ * and entries without an `id` are skipped. node_modules is excluded.
+ */
+export async function scanComplianceCanon(): Promise<ScannedCanon> {
+  const products: ScannedProduct[] = [];
+  const requirements: ScannedRequirement[] = [];
+  const assertions: ScannedAssertion[] = [];
+  const codex: ScannedCodex[] = [];
+  const pathById = new Map<string, string>();
+
+  const uris = await vscode.workspace.findFiles('**/*.{yaml,yml}', '**/node_modules/**', 5000);
+  for (const uri of uris) {
+    let doc: Record<string, unknown> | undefined;
+    try {
+      const bytes = await vscode.workspace.fs.readFile(uri);
+      const parsed = yaml.load(Buffer.from(bytes).toString('utf-8'));
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) doc = parsed as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    const id = str(doc?.id);
+    if (!doc || !id) continue;
+
+    if (doc.notation === 'product') {
+      products.push({ id, name: str(doc.name) ?? id });
+      pathById.set(id, uri.fsPath);
+    } else if (doc.notation === 'requirement') {
+      requirements.push({
+        id,
+        name: str(doc.name) ?? id,
+        severity: str(doc.severity),
+        derived_from: Array.isArray(doc.derived_from) ? (doc.derived_from as unknown[]).filter((d): d is string => typeof d === 'string') : undefined,
+      });
+      pathById.set(id, uri.fsPath);
+    } else if (doc.notation === 'assertion') {
+      const about = str(doc.about);
+      const subject = str(doc.subject);
+      const status = str(doc.status) as AssertionStatus | undefined;
+      if (about && subject && status) {
+        assertions.push({
+          id, about, subject, status,
+          assessed_at: str(doc.assessed_at),
+          next_review_at: str(doc.next_review_at),
+          evidenceCount: Array.isArray(doc.evidence) ? doc.evidence.length : 0,
+        });
+        pathById.set(id, uri.fsPath);
+      }
+    } else if (doc.zone === 'codex') {
+      codex.push({ id, name: str(doc.name) ?? id, type: str(doc.type), jurisdiction: str(doc.jurisdiction) });
+      pathById.set(id, uri.fsPath);
+    }
+  }
+
+  return { products, requirements, assertions, codex, pathById };
+}
+
+/** Opens a canon artefact file beside the active editor — the click-to-open
+ *  target shared by every compliance view's command-URI cells/links. */
+export async function openComplianceFile(fsPath: string): Promise<void> {
+  if (!fsPath) return;
+  const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(fsPath));
+  await vscode.window.showTextDocument(doc, { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false });
+}

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -17,6 +17,9 @@ import { ProcessBlueprintPreview } from './process-blueprint-preview.js';
 import { ActivityCardPreview } from './activity-card-preview.js';
 import { IssuesPreview } from './issues-preview.js';
 import { ComplianceMatrixPreview } from './compliance-matrix-preview.js';
+import { SingleLawPreview } from './single-law-preview.js';
+import { SingleProductPreview } from './single-product-preview.js';
+import { openComplianceFile } from './compliance-scan.js';
 import type { LayoutMetrics, ValidationReport } from './types.js';
 import {
   documentMatchesCervinSource,
@@ -154,6 +157,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   const activityCardPreview = new ActivityCardPreview();
   const issuesPreview = new IssuesPreview();
   const complianceMatrixPreview = new ComplianceMatrixPreview(context.extensionUri);
+  const singleLawPreview = new SingleLawPreview(context.extensionUri);
+  const singleProductPreview = new SingleProductPreview(context.extensionUri);
 
   context.subscriptions.push(
     vscode.commands.registerCommand('cervin.openPreview', async () => {
@@ -320,7 +325,21 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     // bound to a file. `openComplianceFile` is invoked from cell command URIs.
     vscode.commands.registerCommand('transitrixStudio.previewComplianceMatrix', () => complianceMatrixPreview.showOrReveal()),
     vscode.commands.registerCommand('transitrixStudio.refreshComplianceMatrix', () => complianceMatrixPreview.refresh()),
-    vscode.commands.registerCommand('transitrixStudio.openComplianceFile', (fsPath: string) => complianceMatrixPreview.openFile(fsPath)),
+    vscode.commands.registerCommand('transitrixStudio.openComplianceFile', (fsPath: string) => openComplianceFile(fsPath)),
+    // Single-law tree + single-product view (vkgeorgia/strategy#84 Phase 3) —
+    // triggered from a codex / product file's editor-title bar; repo-wide scan.
+    vscode.commands.registerCommand('transitrixStudio.previewSingleLaw', async () => {
+      const doc = vscode.window.activeTextEditor?.document;
+      if (!doc) { vscode.window.showWarningMessage('Open a codex file (LAW / REGULATION / POLICY / INTERNAL_STANDARD) first.'); return; }
+      await singleLawPreview.showOrReveal(doc);
+    }),
+    vscode.commands.registerCommand('transitrixStudio.refreshSingleLaw', () => singleLawPreview.refresh()),
+    vscode.commands.registerCommand('transitrixStudio.previewSingleProduct', async () => {
+      const doc = vscode.window.activeTextEditor?.document;
+      if (!doc) { vscode.window.showWarningMessage('Open a product file (notation: product) first.'); return; }
+      await singleProductPreview.showOrReveal(doc);
+    }),
+    vscode.commands.registerCommand('transitrixStudio.refreshSingleProduct', () => singleProductPreview.refresh()),
     vscode.commands.registerCommand(OPEN_SPACING_SETTINGS_COMMAND, () =>
       vscode.commands.executeCommand('workbench.action.openSettings', SPACING_CONFIG_SECTION),
     ),
@@ -352,6 +371,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       // sibling *.activities.* / *.fgca.* documents is saved. Runs before the
       // per-type routing below (which early-returns on a match).
       void activityCardPreview.refreshIfSiblingSaved(doc);
+      // Compliance views are repo-wide: re-scan the open ones whenever a canon
+      // artefact (by filename convention) is saved. No-op when no panel is open.
+      if (/^(PRODUCT|REQUIREMENT|ASSERTION|LAW|REGULATION|POLICY|INTERNAL_STANDARD)-.*\.ya?ml$/.test(path.basename(doc.fileName))) {
+        void complianceMatrixPreview.refresh();
+        void singleLawPreview.refresh();
+        void singleProductPreview.refresh();
+      }
       if (isGoalsFile(doc)) { void goalsPreview.refreshSaved(doc); return; }
       if (isFGCAFile(doc)) { void fgcaPreview.refreshSaved(doc); return; }
       if (isFGAFile(doc)) { void fgaPreview.refreshSaved(doc); return; }

--- a/extension/src/single-law-preview.ts
+++ b/extension/src/single-law-preview.ts
@@ -1,0 +1,119 @@
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+import yaml from 'js-yaml';
+import { type ThemeId } from '../../packages/diagrams/src/theme/index.js';
+import { buildComplianceIndex, buildLawTree, type LawTree } from '../../packages/diagrams/src/compliance/index.js';
+import { scanComplianceCanon } from './compliance-scan.js';
+import { complianceShell, escXml, openLink, statusBadge } from './compliance-render.js';
+
+// Single-law tree (vkgeorgia/strategy#84 Phase 3). Triggered from a codex file
+// (LAW / REGULATION / POLICY / INTERNAL_STANDARD) in the editor-title bar.
+// Shows the law → the requirements that derive from it → the assertions
+// targeting each, with status badges. Read-only, script-less; click-to-open via
+// command URIs.
+
+const OPEN_FILE_COMMAND = 'transitrixStudio.openComplianceFile';
+const REFRESH_COMMAND = 'transitrixStudio.refreshSingleLaw';
+
+export class SingleLawPreview {
+  readonly panelTitle = 'Compliance — Law';
+  private panel: vscode.WebviewPanel | undefined;
+  private trackedUri: string | undefined;
+
+  constructor(private readonly extensionUri: vscode.Uri) {}
+
+  isShowingDocument(uri: vscode.Uri): boolean {
+    return this.panel != null && this.trackedUri === uri.toString();
+  }
+
+  async showOrReveal(doc: vscode.TextDocument): Promise<void> {
+    this.trackedUri = doc.uri.toString();
+    if (!this.panel) {
+      this.panel = vscode.window.createWebviewPanel(
+        'singleLawPreview',
+        `${this.panelTitle} — ${path.basename(doc.fileName)}`,
+        { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
+        {
+          enableScripts: false,
+          retainContextWhenHidden: true,
+          enableCommandUris: [OPEN_FILE_COMMAND, REFRESH_COMMAND],
+        },
+      );
+      this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
+    } else {
+      this.panel.title = `${this.panelTitle} — ${path.basename(doc.fileName)}`;
+      this.panel.reveal(vscode.ViewColumn.Beside, true);
+    }
+    await this.push(doc);
+  }
+
+  async refreshSaved(doc: vscode.TextDocument): Promise<void> {
+    if (this.isShowingDocument(doc.uri)) await this.push(doc);
+  }
+
+  /** Re-scan + re-render the tracked law. */
+  async refresh(): Promise<void> {
+    if (!this.panel || !this.trackedUri) return;
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.parse(this.trackedUri));
+    await this.push(doc);
+  }
+
+  private async push(doc: vscode.TextDocument): Promise<void> {
+    if (!this.panel) return;
+    const themeId = vscode.workspace.getConfiguration('transitrix').get<ThemeId>('theme', 'transitrix');
+
+    let lawId = '';
+    let lawName = '';
+    try {
+      const parsed = yaml.load(doc.getText());
+      if (parsed && typeof parsed === 'object') {
+        const r = parsed as Record<string, unknown>;
+        lawId = typeof r.id === 'string' ? r.id : '';
+        lawName = typeof r.name === 'string' ? r.name : lawId;
+      }
+    } catch { /* fall through to the no-id message */ }
+
+    if (!lawId) {
+      this.panel.webview.html = complianceShell({
+        title: 'Single-law tree',
+        themeId, refreshCommand: REFRESH_COMMAND,
+        bodyHtml: `<div class="cmp-empty">This file has no <code>id</code> — open a codex artefact (LAW / REGULATION / POLICY / INTERNAL_STANDARD).</div>`,
+      });
+      return;
+    }
+
+    const scan = await scanComplianceCanon();
+    const index = buildComplianceIndex({ requirements: scan.requirements, assertions: scan.assertions });
+    const tree = buildLawTree(lawId, index);
+
+    this.panel.webview.html = complianceShell({
+      title: lawName,
+      subtitle: `${lawId} · ${tree.requirements.length} requirement(s)`,
+      themeId,
+      refreshCommand: REFRESH_COMMAND,
+      bodyHtml: this.treeHtml(tree, scan.pathById),
+    });
+  }
+
+  private treeHtml(tree: LawTree, pathById: Map<string, string>): string {
+    if (tree.requirements.length === 0) {
+      return `<div class="cmp-empty">No requirements derive from <strong>${escXml(tree.lawId)}</strong>. Add <code>derived_from: [${escXml(tree.lawId)}]</code> to a requirement to bind it.</div>`;
+    }
+    return tree.requirements.map(node => {
+      const r = node.requirement;
+      const sev = r.severity ? `<span class="cmp-sev cmp-sev-${escXml(r.severity)}">${escXml(r.severity)}</span>` : '';
+      const reqLink = openLink(OPEN_FILE_COMMAND, pathById.get(r.id), escXml(r.name), `Open ${r.id}`);
+      const assertions = node.assertions.length === 0
+        ? `<div class="cmp-none">No assertion targets this requirement — compliance gap.</div>`
+        : `<ul class="cmp-assertions">${node.assertions.map(a => {
+            const meta = [a.assessed_at ? `assessed ${a.assessed_at}` : null, a.next_review_at ? `review by ${a.next_review_at}` : null].filter(Boolean).join(' · ');
+            const link = openLink(OPEN_FILE_COMMAND, pathById.get(a.id), escXml(a.id), `Open ${a.id}`);
+            return `<li>${statusBadge(a.status)} ${link}${meta ? ` <span class="cmp-meta">${escXml(meta)}</span>` : ''}</li>`;
+          }).join('')}</ul>`;
+      return `<div class="cmp-req">
+        <div class="cmp-req-head">${sev}<span class="cmp-req-name">${reqLink}</span><span class="cmp-req-id">${escXml(r.id)}</span></div>
+        ${assertions}
+      </div>`;
+    }).join('');
+  }
+}

--- a/extension/src/single-product-preview.ts
+++ b/extension/src/single-product-preview.ts
@@ -1,0 +1,116 @@
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+import yaml from 'js-yaml';
+import { type ThemeId } from '../../packages/diagrams/src/theme/index.js';
+import { buildComplianceIndex, buildProductView, type ProductView } from '../../packages/diagrams/src/compliance/index.js';
+import { scanComplianceCanon } from './compliance-scan.js';
+import { complianceShell, escXml, openLink, statusBadge } from './compliance-render.js';
+
+// Single-product view (vkgeorgia/strategy#84 Phase 3). Triggered from a PRODUCT
+// file in the editor-title bar. Shows the product → every requirement an
+// assertion binds it to → the status of each. Read-only, script-less;
+// click-to-open via command URIs.
+
+const OPEN_FILE_COMMAND = 'transitrixStudio.openComplianceFile';
+const REFRESH_COMMAND = 'transitrixStudio.refreshSingleProduct';
+
+export class SingleProductPreview {
+  readonly panelTitle = 'Compliance — Product';
+  private panel: vscode.WebviewPanel | undefined;
+  private trackedUri: string | undefined;
+
+  constructor(private readonly extensionUri: vscode.Uri) {}
+
+  isShowingDocument(uri: vscode.Uri): boolean {
+    return this.panel != null && this.trackedUri === uri.toString();
+  }
+
+  async showOrReveal(doc: vscode.TextDocument): Promise<void> {
+    this.trackedUri = doc.uri.toString();
+    if (!this.panel) {
+      this.panel = vscode.window.createWebviewPanel(
+        'singleProductPreview',
+        `${this.panelTitle} — ${path.basename(doc.fileName)}`,
+        { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
+        {
+          enableScripts: false,
+          retainContextWhenHidden: true,
+          enableCommandUris: [OPEN_FILE_COMMAND, REFRESH_COMMAND],
+        },
+      );
+      this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
+    } else {
+      this.panel.title = `${this.panelTitle} — ${path.basename(doc.fileName)}`;
+      this.panel.reveal(vscode.ViewColumn.Beside, true);
+    }
+    await this.push(doc);
+  }
+
+  async refreshSaved(doc: vscode.TextDocument): Promise<void> {
+    if (this.isShowingDocument(doc.uri)) await this.push(doc);
+  }
+
+  async refresh(): Promise<void> {
+    if (!this.panel || !this.trackedUri) return;
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.parse(this.trackedUri));
+    await this.push(doc);
+  }
+
+  private async push(doc: vscode.TextDocument): Promise<void> {
+    if (!this.panel) return;
+    const themeId = vscode.workspace.getConfiguration('transitrix').get<ThemeId>('theme', 'transitrix');
+
+    let productId = '';
+    let productName = '';
+    try {
+      const parsed = yaml.load(doc.getText());
+      if (parsed && typeof parsed === 'object') {
+        const r = parsed as Record<string, unknown>;
+        productId = typeof r.id === 'string' ? r.id : '';
+        productName = typeof r.name === 'string' ? r.name : productId;
+      }
+    } catch { /* fall through */ }
+
+    if (!productId) {
+      this.panel.webview.html = complianceShell({
+        title: 'Single-product view',
+        themeId, refreshCommand: REFRESH_COMMAND,
+        bodyHtml: `<div class="cmp-empty">This file has no <code>id</code> — open a <code>notation: product</code> file.</div>`,
+      });
+      return;
+    }
+
+    const scan = await scanComplianceCanon();
+    const index = buildComplianceIndex({ requirements: scan.requirements, assertions: scan.assertions });
+    const view = buildProductView(productId, index);
+
+    this.panel.webview.html = complianceShell({
+      title: productName,
+      subtitle: `${productId} · ${view.requirements.length} requirement(s) asserted`,
+      themeId,
+      refreshCommand: REFRESH_COMMAND,
+      bodyHtml: this.viewHtml(view, scan.pathById),
+    });
+  }
+
+  private viewHtml(view: ProductView, pathById: Map<string, string>): string {
+    if (view.requirements.length === 0) {
+      return `<div class="cmp-empty">No assertion names <strong>${escXml(view.productId)}</strong> as its subject yet — this product has no recorded compliance claims.</div>`;
+    }
+    const rows = view.requirements.map(({ requirement, assertion }) => {
+      const reqLink = openLink(OPEN_FILE_COMMAND, pathById.get(requirement.id), escXml(requirement.name), `Open ${requirement.id}`);
+      const aLink = openLink(OPEN_FILE_COMMAND, pathById.get(assertion.id), escXml(assertion.id), `Open ${assertion.id}`);
+      const review = assertion.next_review_at ? escXml(assertion.next_review_at) : '—';
+      return `<tr>
+        <td>${reqLink}<div class="cmp-req-id">${escXml(requirement.id)}</div></td>
+        <td>${statusBadge(assertion.status)}</td>
+        <td>${aLink}</td>
+        <td>${review}</td>
+      </tr>`;
+    }).join('');
+    return `<table class="cmp-list">
+      <thead><tr><th>Requirement</th><th>Status</th><th>Assertion</th><th>Next review</th></tr></thead>
+      <tbody>${rows}</tbody>
+    </table>`;
+  }
+}

--- a/packages/diagrams/src/compliance/__tests__/example.test.ts
+++ b/packages/diagrams/src/compliance/__tests__/example.test.ts
@@ -1,0 +1,57 @@
+// Conformance — single-law tree + single-product view on the acme_corp worked
+// examples (mirrored under examples/requirement, examples/assertion). Pins the
+// #84 Phase 3 acceptance.
+
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import yaml from 'js-yaml';
+import { buildComplianceIndex } from '../reverse-index.js';
+import { buildLawTree, buildProductView } from '../views.js';
+import type { IndexAssertion, IndexRequirement } from '../types.js';
+
+const examples = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../examples');
+function loadAll(dir: string): Record<string, unknown>[] {
+  const full = path.join(examples, dir);
+  return readdirSync(full).filter(f => f.endsWith('.yaml')).map(f => yaml.load(readFileSync(path.join(full, f), 'utf-8')) as Record<string, unknown>);
+}
+
+const requirements: IndexRequirement[] = loadAll('requirement').map(r => ({
+  id: String(r.id), name: String(r.name),
+  severity: r.severity as string | undefined,
+  derived_from: Array.isArray(r.derived_from) ? (r.derived_from as string[]) : undefined,
+}));
+const assertions: IndexAssertion[] = loadAll('assertion').map(a => ({
+  id: String(a.id), about: String(a.about), subject: String(a.subject),
+  status: a.status as IndexAssertion['status'],
+  evidenceCount: Array.isArray(a.evidence) ? a.evidence.length : 0,
+}));
+const index = buildComplianceIndex({ requirements, assertions });
+
+describe('single-law tree — LAW-PERSONAL-DATA-2017-1', () => {
+  const tree = buildLawTree('LAW-PERSONAL-DATA-2017-1', index);
+  it('derives the data-erasure requirement with its three assertions', () => {
+    expect(tree.requirements.map(r => r.requirement.id)).toEqual(['REQUIREMENT-DATA-ERASURE-1']);
+    const node = tree.requirements[0];
+    expect(node.assertions.map(a => a.id)).toEqual([
+      'ASSERTION-CRM-DATA-ERASURE-1',
+      'ASSERTION-MOBILE-DATA-ERASURE-1',
+      'ASSERTION-ONBOARD-DATA-ERASURE-1',
+    ]);
+    expect(node.assertions.map(a => a.status).sort()).toEqual(['compliant', 'partial', 'under_review']);
+  });
+  it('the internal-only audit-log requirement is not under any law', () => {
+    expect(index.requirementsByLaw.has('LAW-PERSONAL-DATA-2017-1')).toBe(true);
+    expect(tree.requirements.some(r => r.requirement.id === 'REQUIREMENT-AUDIT-LOG-RETENTION-1')).toBe(false);
+  });
+});
+
+describe('single-product view — PRODUCT-MOBILE-1', () => {
+  it('shows the data-erasure requirement as compliant', () => {
+    const view = buildProductView('PRODUCT-MOBILE-1', index);
+    expect(view.requirements.map(r => r.requirement.id)).toEqual(['REQUIREMENT-DATA-ERASURE-1']);
+    expect(view.requirements[0].assertion.status).toBe('compliant');
+    expect(view.requirements[0].requirement.name).toBe('Personal-data erasure on request within 30 days');
+  });
+});

--- a/packages/diagrams/src/compliance/__tests__/views.test.ts
+++ b/packages/diagrams/src/compliance/__tests__/views.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { buildComplianceIndex } from '../reverse-index.js';
+import { buildLawTree, buildProductView } from '../views.js';
+import type { ComplianceIndexInput } from '../types.js';
+
+const input: ComplianceIndexInput = {
+  requirements: [
+    { id: 'REQUIREMENT-A-1', name: 'A', severity: 'high', derived_from: ['LAW-X-1'] },
+    { id: 'REQUIREMENT-B-1', name: 'B', severity: 'low', derived_from: ['LAW-X-1', 'REGULATION-Y-1'] },
+    { id: 'REQUIREMENT-C-1', name: 'C' }, // internal-only, no law
+  ],
+  assertions: [
+    { id: 'ASSERTION-2', about: 'REQUIREMENT-A-1', subject: 'PRODUCT-M-1', status: 'compliant' },
+    { id: 'ASSERTION-1', about: 'REQUIREMENT-A-1', subject: 'CAPABILITY-V2', status: 'under_review' },
+    { id: 'ASSERTION-3', about: 'REQUIREMENT-B-1', subject: 'PRODUCT-M-1', status: 'partial' },
+  ],
+};
+
+describe('buildComplianceIndex', () => {
+  const idx = buildComplianceIndex(input);
+  it('indexes requirements by the laws they derive from', () => {
+    expect(idx.requirementsByLaw.get('LAW-X-1')?.map(r => r.id)).toEqual(['REQUIREMENT-A-1', 'REQUIREMENT-B-1']);
+    expect(idx.requirementsByLaw.get('REGULATION-Y-1')?.map(r => r.id)).toEqual(['REQUIREMENT-B-1']);
+    expect(idx.requirementsByLaw.has('LAW-NONE-1')).toBe(false);
+  });
+  it('indexes assertions by requirement and by subject', () => {
+    expect(idx.assertionsByRequirement.get('REQUIREMENT-A-1')?.map(a => a.id).sort()).toEqual(['ASSERTION-1', 'ASSERTION-2']);
+    expect(idx.assertionsBySubject.get('PRODUCT-M-1')?.map(a => a.id).sort()).toEqual(['ASSERTION-2', 'ASSERTION-3']);
+  });
+});
+
+describe('buildLawTree', () => {
+  const idx = buildComplianceIndex(input);
+  it('lists requirements derived from the law, each with its id-sorted assertions', () => {
+    const tree = buildLawTree('LAW-X-1', idx);
+    expect(tree.requirements.map(r => r.requirement.id)).toEqual(['REQUIREMENT-A-1', 'REQUIREMENT-B-1']);
+    expect(tree.requirements[0].assertions.map(a => a.id)).toEqual(['ASSERTION-1', 'ASSERTION-2']);
+    expect(tree.requirements[0].assertions.map(a => a.status)).toEqual(['under_review', 'compliant']);
+  });
+  it('returns an empty tree for an unknown law', () => {
+    expect(buildLawTree('LAW-NONE-1', idx).requirements).toEqual([]);
+  });
+});
+
+describe('buildProductView', () => {
+  const idx = buildComplianceIndex(input);
+  it('lists the requirements the product is asserted against, with status, requirement-id-sorted', () => {
+    const view = buildProductView('PRODUCT-M-1', idx);
+    expect(view.requirements.map(r => r.requirement.id)).toEqual(['REQUIREMENT-A-1', 'REQUIREMENT-B-1']);
+    expect(view.requirements.map(r => r.assertion.status)).toEqual(['compliant', 'partial']);
+    expect(view.requirements[0].requirement.name).toBe('A');
+  });
+  it('falls back to the id as name when the requirement is not in the scan (dangling about)', () => {
+    const idx2 = buildComplianceIndex({
+      requirements: [],
+      assertions: [{ id: 'ASSERTION-9', about: 'REQUIREMENT-GONE-1', subject: 'PRODUCT-M-1', status: 'n_a' }],
+    });
+    const view = buildProductView('PRODUCT-M-1', idx2);
+    expect(view.requirements[0].requirement).toEqual({ id: 'REQUIREMENT-GONE-1', name: 'REQUIREMENT-GONE-1' });
+  });
+  it('returns an empty view for a product with no assertions', () => {
+    expect(buildProductView('PRODUCT-NONE-1', idx).requirements).toEqual([]);
+  });
+});

--- a/packages/diagrams/src/compliance/index.ts
+++ b/packages/diagrams/src/compliance/index.ts
@@ -1,0 +1,12 @@
+export { buildComplianceIndex } from './reverse-index.js';
+export { buildLawTree, buildProductView } from './views.js';
+export type {
+  ComplianceIndex,
+  ComplianceIndexInput,
+  IndexRequirement,
+  IndexAssertion,
+  LawTree,
+  LawTreeRequirement,
+  ProductView,
+  ProductRequirementStatus,
+} from './types.js';

--- a/packages/diagrams/src/compliance/reverse-index.ts
+++ b/packages/diagrams/src/compliance/reverse-index.ts
@@ -1,0 +1,33 @@
+// Reverse-index builder (vkgeorgia/strategy#84 Phase 3).
+
+import type { ComplianceIndex, ComplianceIndexInput, IndexAssertion, IndexRequirement } from './types.js';
+
+function push<K, V>(map: Map<K, V[]>, key: K, value: V): void {
+  const list = map.get(key);
+  if (list) list.push(value);
+  else map.set(key, [value]);
+}
+
+/**
+ * Builds the reverse indexes used by every compliance view. Pure; the input
+ * arrays are read, not mutated. Requirements with no `derived_from` simply do
+ * not appear under any law; assertions are indexed by both their requirement
+ * (`about`) and their subject.
+ */
+export function buildComplianceIndex(input: ComplianceIndexInput): ComplianceIndex {
+  const requirementById = new Map<string, IndexRequirement>();
+  const requirementsByLaw = new Map<string, IndexRequirement[]>();
+  const assertionsByRequirement = new Map<string, IndexAssertion[]>();
+  const assertionsBySubject = new Map<string, IndexAssertion[]>();
+
+  for (const r of input.requirements) {
+    requirementById.set(r.id, r);
+    for (const law of r.derived_from ?? []) push(requirementsByLaw, law, r);
+  }
+  for (const a of input.assertions) {
+    push(assertionsByRequirement, a.about, a);
+    push(assertionsBySubject, a.subject, a);
+  }
+
+  return { requirementById, requirementsByLaw, assertionsByRequirement, assertionsBySubject };
+}

--- a/packages/diagrams/src/compliance/types.ts
+++ b/packages/diagrams/src/compliance/types.ts
@@ -1,0 +1,70 @@
+// Shared compliance reverse-index + derived views (vkgeorgia/strategy#84
+// Phase 3). The reverse-index pass (Law → Requirements, Requirement →
+// Assertions, Subject → Assertions) backs the single-law tree and the
+// single-product view here, and the gap dashboard in Phase 4.
+
+import type { AssertionStatus } from '../assertion/types.js';
+
+/** Projection of a REQUIREMENT the compliance views need. */
+export interface IndexRequirement {
+  id: string;
+  name: string;
+  severity?: string;
+  /** Typed IDs of the codex sources this requirement derives from. */
+  derived_from?: string[];
+}
+
+/** Projection of an ASSERTION the compliance views need. */
+export interface IndexAssertion {
+  id: string;
+  about: string;
+  subject: string;
+  status: AssertionStatus;
+  assessed_at?: string;
+  next_review_at?: string;
+  /** Number of evidence entries — feeds the Phase 4 "no evidence" gap. */
+  evidenceCount?: number;
+}
+
+export interface ComplianceIndexInput {
+  requirements: IndexRequirement[];
+  assertions: IndexAssertion[];
+}
+
+/** The reverse-index — all maps are keyed by canonical id. */
+export interface ComplianceIndex {
+  requirementById: Map<string, IndexRequirement>;
+  /** Codex artefact id → requirements whose `derived_from` names it. */
+  requirementsByLaw: Map<string, IndexRequirement[]>;
+  /** Requirement id → assertions whose `about` names it. */
+  assertionsByRequirement: Map<string, IndexAssertion[]>;
+  /** Subject id (product / process / capability) → assertions about it. */
+  assertionsBySubject: Map<string, IndexAssertion[]>;
+}
+
+// ── Single-law tree ─────────────────────────────────────────────────────────
+
+export interface LawTreeRequirement {
+  requirement: IndexRequirement;
+  /** Assertions targeting this requirement, id-sorted. */
+  assertions: IndexAssertion[];
+}
+export interface LawTree {
+  lawId: string;
+  /** Requirements derived from the law, id-sorted. */
+  requirements: LawTreeRequirement[];
+}
+
+// ── Single-product view ─────────────────────────────────────────────────────
+
+export interface ProductRequirementStatus {
+  /** The requirement the assertion is about. `name` falls back to the id when
+   *  the requirement is not present in the scan (dangling `about`). */
+  requirement: IndexRequirement;
+  assertion: IndexAssertion;
+}
+export interface ProductView {
+  productId: string;
+  /** Requirements bound to the product via an assertion, requirement-id-sorted. */
+  requirements: ProductRequirementStatus[];
+}

--- a/packages/diagrams/src/compliance/views.ts
+++ b/packages/diagrams/src/compliance/views.ts
@@ -1,0 +1,46 @@
+// Single-law tree + single-product view builders (vkgeorgia/strategy#84 Phase 3).
+
+import type {
+  ComplianceIndex,
+  IndexRequirement,
+  LawTree,
+  ProductView,
+} from './types.js';
+
+function byId<T extends { id: string }>(a: T, b: T): number {
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+}
+
+/**
+ * Law → Requirements → Assertions. Requirements are those whose `derived_from`
+ * names `lawId`; each carries the assertions targeting it. An unknown law (no
+ * requirement derives from it) yields an empty tree.
+ */
+export function buildLawTree(lawId: string, index: ComplianceIndex): LawTree {
+  const requirements = [...(index.requirementsByLaw.get(lawId) ?? [])].sort(byId);
+  return {
+    lawId,
+    requirements: requirements.map(requirement => ({
+      requirement,
+      assertions: [...(index.assertionsByRequirement.get(requirement.id) ?? [])].sort(byId),
+    })),
+  };
+}
+
+/**
+ * Product → the Requirements it has an assertion about, with each assertion's
+ * status. The requirement is resolved from the index; a dangling `about`
+ * (assertion references a requirement not in the scan) falls back to a stub
+ * carrying the id as its name, so the binding still shows.
+ */
+export function buildProductView(productId: string, index: ComplianceIndex): ProductView {
+  const assertions = [...(index.assertionsBySubject.get(productId) ?? [])];
+  const requirements = assertions
+    .map(assertion => {
+      const requirement: IndexRequirement =
+        index.requirementById.get(assertion.about) ?? { id: assertion.about, name: assertion.about };
+      return { requirement, assertion };
+    })
+    .sort((a, b) => byId(a.requirement, b.requirement));
+  return { productId, requirements };
+}

--- a/packages/diagrams/src/index.ts
+++ b/packages/diagrams/src/index.ts
@@ -4,6 +4,7 @@ export * from "./applications/index";
 export * from "./assertion/index";
 export * from "./blocks/index";
 export * from "./capability-map/index";
+export * from "./compliance/index";
 export * from "./compliance-matrix/index";
 export * from "./fgca/index";
 export * from "./goals/index";


### PR DESCRIPTION
@
**Do not merge — Valerii gates.** Phase 3 of the compliance epic (#84), on the merged Phase 1+2.

Two narrower views, plus the shared **reverse-index** pass that the epic calls out as shared with Phase 4.

### Library — `@transitrix/diagrams/compliance`
- **`buildComplianceIndex({requirements, assertions})`** — the reverse-index: `requirementsByLaw` (derived_from), `assertionsByRequirement` (about), `assertionsBySubject` (subject), `requirementById`. The shared primitive (Phase 4s gap dashboard reuses it).
- **`buildLawTree(lawId, index)`** — Law → derived Requirements → Assertions per requirement (id-sorted). **`buildProductView(productId, index)`** — Product → the Requirements an assertion binds it to, with status; a dangling `about` falls back to the id as name.
- **10 vitest cases + conformance**: on the acme_corp examples, the `LAW-PERSONAL-DATA-2017-1` tree yields `REQUIREMENT-DATA-ERASURE-1` with its **three** assertions (compliant / partial / under_review); the `PRODUCT-MOBILE-1` view shows data-erasure compliant.

### Extension
- **Shared `compliance-scan.ts`** — one repo-wide sweep of the canon (product / requirement / assertion by `notation`; codex by `zone: codex`) + an id→path map + `openComplianceFile`. The Phase 2 matrix preview now uses it too (**dropped its private duplicate scan** — net cleanup).
- **Shared `compliance-render.ts`** — status badges, command-URI open links, and the script-less webview shell. These views are read-only, so they keep `enableScripts: false` and the static CSP (smallest surface) — click-to-open via command URIs, status via inline badges.
- **`single-law-preview.ts` / `single-product-preview.ts`** — editor-title-triggered webviews (a codex file → law tree; a `PRODUCT-*` file → product view) with click-to-open and a Refresh re-scan. Wired via `contributes.menus` editor/title `when` regex on the filename + palette commands. Open compliance views re-scan when a canon-named file is saved.

### Notes
- The single-law trigger matches `^(LAW|REGULATION|POLICY|INTERNAL_STANDARD)-*.yaml`; single-product matches `^PRODUCT-*.yaml` (the canon element files, distinct from the `*.products.transitrix.yaml` catalogue notation).
- On the acme data the law tree is the rich view (3 assertions); the product view is richest on `PRODUCT-MOBILE-1` (the only product-subject). `PRODUCT-ECOMM-1` / `-SUPPORT-1` currently have no assertions, so their product view is the empty state — surfaced as a clear "no recorded claims" message.

### Tests
diagrams **571** + core **235** green; `tsc` (root + extension) clean; extension bundles. Library is unit + conformance tested; the two webviews are for your hand-test on a repo with compliance canon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@