### PR TITLE
feat(compliance): Phase 4 — gap dashboard (#84)

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -646,6 +646,24 @@
         "icon": "$(refresh)"
       },
       {
+        "command": "transitrixStudio.previewGapDashboard",
+        "title": "Transitrix: Preview compliance gap dashboard",
+        "category": "Transitrix",
+        "icon": "$(checklist)"
+      },
+      {
+        "command": "transitrixStudio.refreshGapDashboard",
+        "title": "Transitrix: Refresh compliance gap dashboard",
+        "category": "Transitrix",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "transitrixStudio.exportGapDashboardCsv",
+        "title": "Transitrix: Export compliance gaps as CSV",
+        "category": "Transitrix",
+        "icon": "$(export)"
+      },
+      {
         "command": "transitrixStudio.openSpacingSettings",
         "title": "Transitrix: Open diagram spacing settings",
         "category": "Transitrix",

--- a/extension/src/compliance-render.ts
+++ b/extension/src/compliance-render.ts
@@ -40,7 +40,8 @@ body { padding: 0; }
 #cmp-toolbar { display: flex; align-items: baseline; gap: 12px; padding: 12px 16px; border-bottom: 1px solid var(--ts-border, #cbd5e1); flex-wrap: wrap; }
 .cmp-title { font-size: 15px; font-weight: 700; color: var(--ts-text, #0f172a); }
 .cmp-subtitle { font-size: 12px; color: var(--ts-text-muted, #64748b); }
-.cmp-btn { font-size: 11px; padding: 2px 10px; border-radius: 4px; color: var(--ts-text-muted, #64748b); text-decoration: none; border: 1px solid var(--ts-border, #cbd5e1); margin-left: auto; }
+.cmp-toolbar-actions { margin-left: auto; display: inline-flex; gap: 6px; }
+.cmp-btn { font-size: 11px; padding: 2px 10px; border-radius: 4px; color: var(--ts-text-muted, #64748b); text-decoration: none; border: 1px solid var(--ts-border, #cbd5e1); }
 .cmp-btn:hover { color: var(--ts-text, #0f172a); background: var(--ts-bg-elevated, #f1f5f9); }
 #cmp-body { padding: 12px 16px 28px; }
 .cmp-link { color: var(--ts-brand-primary, #004d67); text-decoration: none; }
@@ -69,6 +70,15 @@ body { padding: 0; }
 .cmp-list th, .cmp-list td { border: 1px solid var(--ts-border, #cbd5e1); padding: 6px 12px; text-align: left; }
 .cmp-list th { background: var(--ts-bg-subtle, #f1f5f9); color: var(--ts-text, #0f172a); }
 .cmp-empty { color: var(--ts-text-muted, #64748b); padding: 24px 0; max-width: 640px; }
+
+/* Gap dashboard sections */
+.cmp-section { margin: 0 0 22px; max-width: 860px; }
+.cmp-section h2 { font-size: 13px; margin: 0 0 8px; color: var(--ts-text, #0f172a); }
+.cmp-section h2 .cmp-count { color: var(--ts-text-muted, #64748b); font-weight: 400; }
+.cmp-ok { color: var(--ts-status-success-fg, #065f46); font-size: 12px; }
+.cmp-rows { list-style: none; margin: 0; padding: 0; }
+.cmp-rows li { display: flex; align-items: center; gap: 8px; padding: 5px 2px; border-bottom: 1px solid var(--ts-border, #e2e8f0); font-size: 12px; }
+.cmp-rows .cmp-meta { color: var(--ts-text-muted, #64748b); font-size: 11px; }
 `;
 
 export interface ComplianceShellOptions {
@@ -77,6 +87,8 @@ export interface ComplianceShellOptions {
   themeId: ThemeId;
   /** Command id for the Refresh button (re-scan). */
   refreshCommand: string;
+  /** Extra toolbar buttons (command URIs), rendered before Refresh. */
+  extraButtons?: Array<{ command: string; label: string; title: string }>;
   /** Already-built body HTML (caller is responsible for escaping). */
   bodyHtml: string;
 }
@@ -97,7 +109,7 @@ ${COMPLIANCE_CSS}
   <div id="cmp-toolbar">
     <span class="cmp-title">${escXml(opts.title)}</span>
     ${opts.subtitle ? `<span class="cmp-subtitle">${escXml(opts.subtitle)}</span>` : ''}
-    <a href="command:${opts.refreshCommand}" class="cmp-btn" title="Re-scan the workspace">Refresh</a>
+    <span class="cmp-toolbar-actions">${(opts.extraButtons ?? []).map(b => `<a href="command:${b.command}" class="cmp-btn" title="${escXml(b.title)}">${escXml(b.label)}</a>`).join('')}<a href="command:${opts.refreshCommand}" class="cmp-btn" title="Re-scan the workspace">Refresh</a></span>
   </div>
   <div id="cmp-body">
     ${opts.bodyHtml}

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -19,6 +19,7 @@ import { IssuesPreview } from './issues-preview.js';
 import { ComplianceMatrixPreview } from './compliance-matrix-preview.js';
 import { SingleLawPreview } from './single-law-preview.js';
 import { SingleProductPreview } from './single-product-preview.js';
+import { GapDashboardPreview } from './gap-dashboard-preview.js';
 import { openComplianceFile } from './compliance-scan.js';
 import type { LayoutMetrics, ValidationReport } from './types.js';
 import {
@@ -159,6 +160,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   const complianceMatrixPreview = new ComplianceMatrixPreview(context.extensionUri);
   const singleLawPreview = new SingleLawPreview(context.extensionUri);
   const singleProductPreview = new SingleProductPreview(context.extensionUri);
+  const gapDashboardPreview = new GapDashboardPreview(context.extensionUri);
 
   context.subscriptions.push(
     vscode.commands.registerCommand('cervin.openPreview', async () => {
@@ -340,6 +342,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       await singleProductPreview.showOrReveal(doc);
     }),
     vscode.commands.registerCommand('transitrixStudio.refreshSingleProduct', () => singleProductPreview.refresh()),
+    // Gap dashboard (vkgeorgia/strategy#84 Phase 4) — repo-wide, palette-invoked.
+    vscode.commands.registerCommand('transitrixStudio.previewGapDashboard', () => gapDashboardPreview.showOrReveal()),
+    vscode.commands.registerCommand('transitrixStudio.refreshGapDashboard', () => gapDashboardPreview.refresh()),
+    vscode.commands.registerCommand('transitrixStudio.exportGapDashboardCsv', () => gapDashboardPreview.exportCsv()),
     vscode.commands.registerCommand(OPEN_SPACING_SETTINGS_COMMAND, () =>
       vscode.commands.executeCommand('workbench.action.openSettings', SPACING_CONFIG_SECTION),
     ),
@@ -377,6 +383,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         void complianceMatrixPreview.refresh();
         void singleLawPreview.refresh();
         void singleProductPreview.refresh();
+        void gapDashboardPreview.refresh();
       }
       if (isGoalsFile(doc)) { void goalsPreview.refreshSaved(doc); return; }
       if (isFGCAFile(doc)) { void fgcaPreview.refreshSaved(doc); return; }

--- a/extension/src/gap-dashboard-preview.ts
+++ b/extension/src/gap-dashboard-preview.ts
@@ -1,0 +1,122 @@
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+import { type ThemeId } from '../../packages/diagrams/src/theme/index.js';
+import { buildComplianceIndex, buildGapReport, type GapReport } from '../../packages/diagrams/src/compliance/index.js';
+import { scanComplianceCanon } from './compliance-scan.js';
+import { complianceShell, escXml, openLink, statusBadge } from './compliance-render.js';
+
+// Gap dashboard (vkgeorgia/strategy#84 Phase 4). A repo-wide operational view
+// for compliance owners: requirements with no assertion, assertions with a
+// positive status but no evidence (ASSERT-007), and stale assertions past their
+// review date (ASSERT-008). Read-only, script-less; click-to-open via command
+// URIs. Reuses the shared scan + reverse-index + gap-report.
+
+const OPEN_FILE_COMMAND = 'transitrixStudio.openComplianceFile';
+const REFRESH_COMMAND = 'transitrixStudio.refreshGapDashboard';
+const EXPORT_CSV_COMMAND = 'transitrixStudio.exportGapDashboardCsv';
+
+/** Today as ISO YYYY-MM-DD (extension host clock; the library stays clock-free). */
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export class GapDashboardPreview {
+  readonly panelTitle = 'Compliance Gap Dashboard';
+  private panel: vscode.WebviewPanel | undefined;
+  private lastReport: GapReport | undefined;
+  private pathById = new Map<string, string>();
+
+  constructor(private readonly extensionUri: vscode.Uri) {}
+
+  async showOrReveal(): Promise<void> {
+    if (!this.panel) {
+      this.panel = vscode.window.createWebviewPanel(
+        'gapDashboardPreview',
+        this.panelTitle,
+        { viewColumn: vscode.ViewColumn.Active, preserveFocus: false },
+        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: [OPEN_FILE_COMMAND, REFRESH_COMMAND, EXPORT_CSV_COMMAND] },
+      );
+      this.panel.onDidDispose(() => { this.panel = undefined; this.lastReport = undefined; });
+    } else {
+      this.panel.reveal(vscode.ViewColumn.Active, false);
+    }
+    await this.refresh();
+  }
+
+  async refresh(): Promise<void> {
+    if (!this.panel) return;
+    const scan = await scanComplianceCanon();
+    this.pathById = scan.pathById;
+    const index = buildComplianceIndex({ requirements: scan.requirements, assertions: scan.assertions });
+    this.lastReport = buildGapReport(index, { today: todayIso() });
+    const themeId = vscode.workspace.getConfiguration('transitrix').get<ThemeId>('theme', 'transitrix');
+    this.panel.webview.html = this.buildHtml(this.lastReport, themeId);
+  }
+
+  /** Export the current report to a CSV file (toolbar action). */
+  async exportCsv(): Promise<void> {
+    if (!this.lastReport) {
+      vscode.window.showWarningMessage('Open the compliance gap dashboard first.');
+      return;
+    }
+    const target = await vscode.window.showSaveDialog({
+      defaultUri: vscode.Uri.file('compliance-gaps.csv'),
+      filters: { 'CSV': ['csv'] },
+    });
+    if (!target) return;
+    await vscode.workspace.fs.writeFile(target, Buffer.from(this.toCsv(this.lastReport), 'utf-8'));
+    vscode.window.showInformationMessage(`Saved: ${path.basename(target.fsPath)}`);
+  }
+
+  private toCsv(report: GapReport): string {
+    const esc = (v: string): string => `"${v.replace(/"/g, '""')}"`;
+    const rows: string[][] = [['section', 'id', 'detail', 'status_or_severity', 'next_review_at']];
+    for (const r of report.requirementsWithoutAssertions) {
+      rows.push(['requirement_without_assertion', r.id, r.name, r.severity ?? '', '']);
+    }
+    for (const a of report.assertionsWithoutEvidence) {
+      rows.push(['assertion_without_evidence', a.id, `about=${a.about}|subject=${a.subject}`, a.status, a.next_review_at ?? '']);
+    }
+    for (const a of report.staleAssertions) {
+      rows.push(['stale_assertion', a.id, `about=${a.about}|subject=${a.subject}`, a.status, a.next_review_at ?? '']);
+    }
+    return rows.map(cols => cols.map(esc).join(',')).join('\r\n') + '\r\n';
+  }
+
+  private buildHtml(report: GapReport, themeId: ThemeId): string {
+    const total = report.requirementsWithoutAssertions.length + report.assertionsWithoutEvidence.length + report.staleAssertions.length;
+
+    const reqRows = report.requirementsWithoutAssertions.map(r => {
+      const sev = r.severity ? `<span class="cmp-sev cmp-sev-${escXml(r.severity)}">${escXml(r.severity)}</span>` : '';
+      return `<li>${sev}${openLink(OPEN_FILE_COMMAND, this.pathById.get(r.id), escXml(r.name), `Open ${r.id}`)}<span class="cmp-meta">${escXml(r.id)}</span></li>`;
+    }).join('');
+
+    const noEvRows = report.assertionsWithoutEvidence.map(a =>
+      `<li>${statusBadge(a.status)}${openLink(OPEN_FILE_COMMAND, this.pathById.get(a.id), escXml(a.id), `Open ${a.id}`)}<span class="cmp-meta">${escXml(`about ${a.about} · subject ${a.subject}`)}</span></li>`,
+    ).join('');
+
+    const staleRows = report.staleAssertions.map(a =>
+      `<li>${statusBadge(a.status)}${openLink(OPEN_FILE_COMMAND, this.pathById.get(a.id), escXml(a.id), `Open ${a.id}`)}<span class="cmp-meta">${escXml(`review due ${a.next_review_at ?? '—'} · subject ${a.subject}`)}</span></li>`,
+    ).join('');
+
+    const section = (title: string, count: number, rowsHtml: string, okMessage: string): string =>
+      `<div class="cmp-section">
+        <h2>${escXml(title)} <span class="cmp-count">(${count})</span></h2>
+        ${count === 0 ? `<div class="cmp-ok">✓ ${escXml(okMessage)}</div>` : `<ul class="cmp-rows">${rowsHtml}</ul>`}
+      </div>`;
+
+    const body = `
+      ${section('Requirements without assertions', report.requirementsWithoutAssertions.length, reqRows, 'Every requirement has at least one assertion.')}
+      ${section('Assertions without evidence (ASSERT-007)', report.assertionsWithoutEvidence.length, noEvRows, 'No compliant/partial assertion is missing evidence.')}
+      ${section('Stale assertions — review overdue (ASSERT-008)', report.staleAssertions.length, staleRows, 'No assertion is past its review date.')}`;
+
+    return complianceShell({
+      title: 'Compliance Gap Dashboard',
+      subtitle: total === 0 ? 'No gaps found' : `${total} gap(s) across 3 checks`,
+      themeId,
+      refreshCommand: REFRESH_COMMAND,
+      extraButtons: [{ command: EXPORT_CSV_COMMAND, label: 'Export CSV', title: 'Save the gap report as a CSV file' }],
+      bodyHtml: body,
+    });
+  }
+}

--- a/packages/diagrams/src/compliance/__tests__/gap-report.test.ts
+++ b/packages/diagrams/src/compliance/__tests__/gap-report.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import yaml from 'js-yaml';
+import { buildComplianceIndex } from '../reverse-index.js';
+import { buildGapReport } from '../gap-report.js';
+import type { ComplianceIndexInput, IndexAssertion, IndexRequirement } from '../types.js';
+
+const input: ComplianceIndexInput = {
+  requirements: [
+    { id: 'REQUIREMENT-A-1', name: 'A', severity: 'high' },   // has assertions
+    { id: 'REQUIREMENT-B-1', name: 'B', severity: 'low' },    // orphan
+    { id: 'REQUIREMENT-C-1', name: 'C', severity: 'medium' }, // orphan
+    { id: 'REQUIREMENT-D-1', name: 'D' },                     // orphan, no severity
+  ],
+  assertions: [
+    { id: 'ASSERTION-1', about: 'REQUIREMENT-A-1', subject: 'PRODUCT-1', status: 'compliant', evidenceCount: 0 }, // 007
+    { id: 'ASSERTION-2', about: 'REQUIREMENT-A-1', subject: 'PRODUCT-2', status: 'under_review', evidenceCount: 0 }, // NOT 007
+    { id: 'ASSERTION-3', about: 'REQUIREMENT-A-1', subject: 'PRODUCT-3', status: 'partial', evidenceCount: 2, next_review_at: '2025-01-01' }, // stale
+  ],
+};
+
+describe('buildGapReport', () => {
+  const index = buildComplianceIndex(input);
+  const report = buildGapReport(index, { today: '2026-06-02' });
+
+  it('lists requirements without assertions, severity-sorted (high→medium→low→none)', () => {
+    expect(report.requirementsWithoutAssertions.map(r => r.id)).toEqual([
+      'REQUIREMENT-C-1', // medium
+      'REQUIREMENT-B-1', // low
+      'REQUIREMENT-D-1', // none
+    ]);
+  });
+
+  it('flags only compliant/partial assertions with empty evidence (ASSERT-007)', () => {
+    expect(report.assertionsWithoutEvidence.map(a => a.id)).toEqual(['ASSERTION-1']);
+    // under_review with empty evidence is legitimate — not flagged.
+    expect(report.assertionsWithoutEvidence.map(a => a.id)).not.toContain('ASSERTION-2');
+  });
+
+  it('flags assertions whose next_review_at is past today (ASSERT-008)', () => {
+    expect(report.staleAssertions.map(a => a.id)).toEqual(['ASSERTION-3']);
+  });
+
+  it('produces no stale list when today is not supplied (clock-free)', () => {
+    expect(buildGapReport(index, {}).staleAssertions).toEqual([]);
+  });
+});
+
+// ── Conformance on the acme_corp worked examples ────────────────────────────
+
+const examples = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../examples');
+function loadAll(dir: string): Record<string, unknown>[] {
+  const full = path.join(examples, dir);
+  return readdirSync(full).filter(f => f.endsWith('.yaml')).map(f => yaml.load(readFileSync(path.join(full, f), 'utf-8')) as Record<string, unknown>);
+}
+
+describe('gap report — acme_corp worked examples', () => {
+  const requirements: IndexRequirement[] = loadAll('requirement').map(r => ({
+    id: String(r.id), name: String(r.name), severity: r.severity as string | undefined,
+    derived_from: Array.isArray(r.derived_from) ? (r.derived_from as string[]) : undefined,
+  }));
+  const assertions: IndexAssertion[] = loadAll('assertion').map(a => ({
+    id: String(a.id), about: String(a.about), subject: String(a.subject),
+    status: a.status as IndexAssertion['status'],
+    next_review_at: a.next_review_at as string | undefined,
+    evidenceCount: Array.isArray(a.evidence) ? a.evidence.length : 0,
+  }));
+  const report = buildGapReport(buildComplianceIndex({ requirements, assertions }), { today: '2026-06-02' });
+
+  it('surfaces the internal audit-log requirement as an un-asserted gap', () => {
+    expect(report.requirementsWithoutAssertions.map(r => r.id)).toEqual(['REQUIREMENT-AUDIT-LOG-RETENTION-1']);
+  });
+
+  it('does not flag the under_review empty-evidence assertion under ASSERT-007', () => {
+    expect(report.assertionsWithoutEvidence).toEqual([]);
+  });
+
+  it('has no stale assertions (all acme reviews are in the future)', () => {
+    expect(report.staleAssertions).toEqual([]);
+  });
+});

--- a/packages/diagrams/src/compliance/gap-report.ts
+++ b/packages/diagrams/src/compliance/gap-report.ts
@@ -1,0 +1,67 @@
+// Gap dashboard report (vkgeorgia/strategy#84 Phase 4).
+//
+// Three operational gap lists computed from the shared reverse-index (Phase 3):
+//   1. Requirements with no Assertion targeting them (severity-sorted).
+//   2. Assertions without evidence — the ASSERT-007 case: status ∈
+//      {compliant, partial} AND no evidence. `under_review` / `non_compliant` /
+//      `n_a` are NOT positive statuses, so an empty-evidence assertion in those
+//      states is legitimate and is not flagged (matches 16-assertion.md §5).
+//   3. Stale Assertions — the ASSERT-008 case: `next_review_at` is in the past.
+
+import type { ComplianceIndex, IndexAssertion, IndexRequirement } from './types.js';
+
+export interface GapReport {
+  /** Requirements with no assertion about them, severity-sorted then id. */
+  requirementsWithoutAssertions: IndexRequirement[];
+  /** ASSERT-007: positive status (compliant/partial) with empty evidence. */
+  assertionsWithoutEvidence: IndexAssertion[];
+  /** ASSERT-008: next_review_at in the past (only when `today` is supplied). */
+  staleAssertions: IndexAssertion[];
+}
+
+export interface GapReportOptions {
+  /** Today as ISO `YYYY-MM-DD`; required for the stale-assertion list. */
+  today?: string;
+}
+
+const SEVERITY_RANK: Record<string, number> = { high: 0, medium: 1, low: 2 };
+function severityRank(s?: string): number {
+  return s !== undefined && s in SEVERITY_RANK ? SEVERITY_RANK[s] : 3;
+}
+
+/** Flattens the by-requirement index back to the full assertion set (each
+ *  assertion has exactly one `about`, so it appears once). */
+function allAssertions(index: ComplianceIndex): IndexAssertion[] {
+  const out: IndexAssertion[] = [];
+  for (const list of index.assertionsByRequirement.values()) out.push(...list);
+  return out;
+}
+
+export function buildGapReport(index: ComplianceIndex, options: GapReportOptions = {}): GapReport {
+  const { today } = options;
+
+  const requirementsWithoutAssertions = [...index.requirementById.values()]
+    .filter(r => (index.assertionsByRequirement.get(r.id) ?? []).length === 0)
+    .sort((a, b) => {
+      const d = severityRank(a.severity) - severityRank(b.severity);
+      return d !== 0 ? d : a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+    });
+
+  const assertions = allAssertions(index);
+
+  const assertionsWithoutEvidence = assertions
+    .filter(a => (a.status === 'compliant' || a.status === 'partial') && (a.evidenceCount ?? 0) === 0)
+    .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+
+  const staleAssertions = (today
+    ? assertions.filter(a => typeof a.next_review_at === 'string' && a.next_review_at < today)
+    : []
+  ).sort((a, b) => {
+    // Oldest review first — most overdue at the top.
+    const ra = a.next_review_at ?? '';
+    const rb = b.next_review_at ?? '';
+    return ra < rb ? -1 : ra > rb ? 1 : a.id < b.id ? -1 : 1;
+  });
+
+  return { requirementsWithoutAssertions, assertionsWithoutEvidence, staleAssertions };
+}

--- a/packages/diagrams/src/compliance/index.ts
+++ b/packages/diagrams/src/compliance/index.ts
@@ -1,5 +1,7 @@
 export { buildComplianceIndex } from './reverse-index.js';
 export { buildLawTree, buildProductView } from './views.js';
+export { buildGapReport } from './gap-report.js';
+export type { GapReport, GapReportOptions } from './gap-report.js';
 export type {
   ComplianceIndex,
   ComplianceIndexInput,


### PR DESCRIPTION
@
**Do not merge — Valerii gates.** Phase 4 of the compliance epic (#84), on the merged Phase 1–3.

An operational gap dashboard for compliance owners, computed from the Phase 3 shared reverse-index — no rework.

### Library — `@transitrix/diagrams/compliance`
`buildGapReport(index, {today})` produces three lists:
1. **Requirements without assertions** — severity-sorted (high→medium→low→none), then id.
2. **Assertions without evidence** — the **ASSERT-007** case: `status ∈ {compliant, partial}` with empty evidence. `under_review` / `non_compliant` / `n_a` with empty evidence are legitimate and **not** flagged (per `16-assertion.md` §5).
3. **Stale assertions** — the **ASSERT-008** case: `next_review_at < today`, most-overdue first. Only computed when a `today` is supplied (the library stays clock-free).

**7 vitest cases + conformance**: on acme the audit-log requirement surfaces as an un-asserted gap; the CRM `under_review` empty-evidence assertion is correctly not flagged; no stale assertions (all reviews are future).

### Extension — `gap-dashboard-preview.ts`
- Command **`transitrixStudio.previewGapDashboard`** (palette, repo-wide scan). Three sections with counts; an empty section shows a green ✓ all-clear.
- Per-row **click-to-open** (command URI), **Refresh** re-scan, and an **Export CSV** toolbar button (section / id / detail / status_or_severity / next_review_at). Read-only, **script-less**, static CSP — reuses the shared scan + render helpers + reverse-index. Re-scans when a canon-named file is saved.

### Acceptance note (flagged)
The epics acceptance says *"one example deliberately under_review with empty evidence should appear here."* That predates the CRM examples own comment clarifying **ASSERT-007 does not fire for `under_review`** (only positive statuses). The dashboard follows the rule, so CRM is not in the "no evidence" panel; the real acme gap it does surface is the **un-asserted audit-log requirement**. If youd rather the dashboard also list non-positive empty-evidence assertions as a separate signal, thats a one-line addition — say the word.

### Tests
diagrams **578** + core **235** green; `tsc` (root + extension) clean; extension bundles. Library is unit + conformance tested; the dashboard webview is for your hand-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@