### PR TITLE
chore(release): 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,58 @@
 # Changelog
 
+## [1.3.0] — 2026-06-02
+
+### Added
+- **Activity Card notation** (`*.activity-card.transitrix.yaml`) — `@transitrix/diagrams` types, cross-doc resolver, validator, layout, Studio preview, activation/build wiring, worked example. Save-as-SVG / PNG and copy-as-PNG commands.
+- **Configurable preview spacing** — `transitrix.spacing.{goals,fgca,fga,activities}.{horizontalGap,verticalGap}` settings.
+- **Configurable edge curvature** — `transitrix.curvature.{goals,fgca,fga,activities}` settings (0 = straight, 1 = default, higher = stronger arc).
+- **Scope filters for Goals/FGCA/FGA** — `transitrix.scope.{goals,fgca,fga}.{rootId,maxLevel}` settings (scope to a single subtree or to a level cap).
+- **Live in-preview controls** — spacing / curvature / scope adjustable from a toolbar inside the Goals, FGCA, FGA, and Activities previews (interactive webviews backed by a strict nonce-CSP).
+- **FGCA / FGA tree↔table view toggle** — flatten the chain into a table with merged cells (`Factor | Goal | Change | Activity`, FGA: `Factor | Goal | Activity`). Persisted per notation via `transitrix.view.{fgca,fga}`.
+- **Compliance notations** — Requirement and Assertion schemas + validators in `@transitrix/diagrams` (REQ-001..003, ASSERT-001..008).
+- **Compliance matrix preview** — Products × Requirements grid with status colouring; toolbar filters by jurisdiction / severity / status. Command: `transitrixStudio.previewComplianceMatrix`.
+- **Single-law compliance preview** — Law → Requirements → Assertions tree, triggered from any Codex file. Command: `transitrixStudio.previewSingleLaw`.
+- **Single-product compliance preview** — Product → bound Requirements → status. Command: `transitrixStudio.previewSingleProduct`.
+- **Compliance gap dashboard** — Requirements without Assertions, Assertions without evidence, stale Assertions past `next_review_at`; CSV export. Command: `transitrixStudio.previewGapDashboard`.
+- **`transitrix export-compliance` CLI** — exports the compliance matrix as Markdown (`--format md`, `--scope law:<id>|product:<id>`, `--output <path>`).
+
+### Changed
+- Validators across `goals`, `fgca`, `capability-map`, `process-map`, `applications`, `products`, `scenarios`, `process-blueprint` now guard each array element with an "entry must be an object" check before reading fields — malformed YAML (e.g. `goals: [null]`) degrades to a structured error panel instead of crashing the preview.
+
+### Fixed
+- `goals/validate.ts` — `goal.level` is now type-checked numerically; a string or missing `level` produces a SCHEMA_INVALID error instead of silently slipping through.
+- `goals/layout.ts` `placeSubtree` — adds a visited-set guard so a parent cycle / self-parent no longer overflows the stack when `layoutGoalTree` is called without prior validation.
+- `fgca/layout.ts` — `activity_ids` accesses are nullish-guarded so a change with no `activity_ids` renders cleanly instead of throwing.
+- `activities/validate.ts` ACT-008 — `start_date` / `end_date` are now format-checked against `YYYY-MM-DD` before lexicographic comparison.
+- `serve-ui.ts` — `createReadStream` now attaches an `'error'` handler that destroys the socket cleanly instead of crashing the process on a mid-stream disk error.
+- `serve-ui.ts` `isInsideRoot` — uses a direct path-prefix comparison so a candidate on a different Windows drive (`D:\` vs `C:\`) is correctly rejected.
+- `extension/package.json` — `activationEvents` extended to cover all eleven notation suffixes (activities, blocks, applications, products, process-map, scenarios, capability-map, process-blueprint, activity-card, issues) so previews and editor-title buttons activate from a cold VS Code window.
+
+### Docs
+- New ADR `docs/adr/0001-intellij-mvp-tech-choice.md` — records the rendering / validation technology choice for the upcoming IntelliJ IDEA extension MVP (JCEF + bundled `@transitrix/diagrams`). Tracking work only; no plugin code in this release.
+
+## [1.2.1] — 2026-05-29
+
+Marketplace re-package of 1.2.0. No user-facing changes; release-engineering only.
+
+## [1.2.0] — 2026-05-27
+
+### Added
+- PNG export across previews — `Save as .png` and `Copy as PNG` commands for goals, FGCA, FGA, activities, blocks, process-blueprint, issues, activity-card.
+- Refreshed Marketplace README and extension description (legacy "cervin" copy removed; native-binaries claim corrected).
+
+### Changed
+- Stopped tracking generated `extension/media/` assets in git.
+- Locked flat-canon FGCA/FGA rendering; FGA parser consolidated.
+
+## [1.1.0] — earlier 2026-05
+
+Internal release between 1.0.0 and 1.2.0; see git history for details.
+
+## [1.0.0] — earlier 2026-05
+
+First **1.x** Marketplace release after the v0.4.x line. See `0.4.x` entries below for the prior history.
+
 ## [0.4.19] — 2026-05-21
 
 ### Added

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Architecture-as-code for the modern enterprise. Author 13 notations — goals, processes, capabilities, BPMN, applications, more — as plain YAML, get live diagrams in VS Code. Diffable in git. AI-friendly. Open source. Built on ArchiMate 3.2 and BPMN 2.0.",
   "license": "MIT",
   "icon": "icon.png",
@@ -220,13 +220,19 @@
         },
         "transitrix.view.fgca": {
           "type": "string",
-          "enum": ["tree", "table"],
+          "enum": [
+            "tree",
+            "table"
+          ],
           "default": "tree",
           "description": "FGCA preview: 'tree' renders the Factor→Goal→Change→Activity chain diagram; 'table' renders the chain flattened into a table with merged cells. Toggle live from the preview toolbar."
         },
         "transitrix.view.fga": {
           "type": "string",
-          "enum": ["tree", "table"],
+          "enum": [
+            "tree",
+            "table"
+          ],
           "default": "tree",
           "description": "FGA preview: 'tree' renders the Factor→Goal→Activity chain diagram; 'table' renders the chain flattened into a table with merged cells. Toggle live from the preview toolbar."
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
## Summary

- Bumps `extension/package.json` and root `package.json` from **1.2.1 → 1.3.0** (`scripts/bump-extension-version.mjs minor`).
- Adds a comprehensive `CHANGELOG.md` entry for 1.3.0 (the changelog was stale at `0.4.19` — also backfills brief entries for 1.0.0 / 1.1.0 / 1.2.0 / 1.2.1 so the file no longer skips a whole major).

## What's in 1.3.0

Everything merged since 1.2.1 (29 May):

- **Configurable preview controls** — spacing (#75), curvature (#76), scope (#77 PR1), and the live in-preview control panel (#75/#76/#77 PR2).
- **Activity Card notation** end-to-end (#134 PR1+PR2).
- **FGCA/FGA tree↔table view toggle** (#137).
- **Compliance epic phases 1–5** (#84): Requirement & Assertion library, compliance matrix preview, single-law / single-product previews, gap dashboard, `transitrix export-compliance` CLI (Markdown).
- **IntelliJ MVP tech-choice ADR** (#135) — docs only.

Plus the pre-release fixes from the 2026-05-21 review that landed in feature PRs along the way: per-element `null` guards in every validator, `goals/layout.ts` cycle guard, `fgca/layout.ts` `activity_ids` guard, `serve-ui.ts` stream-error + Windows drive-letter checks, ACT-008 date-format validation, full `activationEvents` coverage.

## 2026-05-21 pre-release blocker audit

All eight blockers from the orchestrator review are addressed on `main`:

- ✅ Validator null-element guards (goals, fgca, capability-map, applications, products, scenarios, process-blueprint).
- ✅ `goals/validate.ts` numeric `level` type-check.
- ✅ `goals/layout.ts` `placeSubtree` visited-set cycle guard.
- ✅ `fgca/layout.ts` `activity_ids ?? []` guards on both sites.
- ✅ `extension/src/goals-preview.ts` cycle detection now lives in `validateGoalTree` (library-side), not in the preview (preview no longer calls `checkCycles` on the wrapper).
- ✅ `extension/package.json` `activationEvents` covers all eleven notation suffixes.
- ✅ `src/serve-ui.ts` `createReadStream` `.on('error')` handler in `serveFile`.
- ✅ `src/serve-ui.ts` `isInsideRoot` uses path-prefix comparison (Windows drive-letter safe).

## Verification

- `tsc -p tsconfig.build.json` — clean.
- `npm test` — diagrams suite **586 / 586** passing; core suite green.

## Test plan

- [ ] Valerii runs `npm run package-extension` on each target OS/arch per `docs/packaging.md` (`win32-x64`, `win32-arm64`, `darwin-x64`, `darwin-arm64`, `linux-x64`, `linux-arm64`) to produce per-platform VSIXs.
- [ ] Smoke-install one VSIX, open one of each notation, confirm previews render and the new compliance commands + FGCA/FGA table toggle work.
- [ ] `vsce publish --target <…>` per artifact.

Do not auto-merge — Valerii gates.