### PR TITLE
fix(build): build-extension.bat — accept --target <platform>

### DIFF
--- a/build-extension.bat
+++ b/build-extension.bat
@@ -3,15 +3,52 @@ REM ============================================================================
 REM Build the Transitrix Studio VS Code extension and place the .vsix in output\
 REM
 REM Usage:
-REM   build-extension.bat           Build without bumping the version
-REM   build-extension.bat --bump    Bump patch version, then build
+REM   build-extension.bat                                Build a universal VSIX
+REM                                                      (local install only - see warning below)
+REM   build-extension.bat --bump                         Patch bump, then universal build
+REM   build-extension.bat --target win32-x64             Build a targeted VSIX
+REM   build-extension.bat --bump --target win32-x64      Patch bump + targeted build
+REM
+REM Supported targets (per docs/packaging.md): win32-x64, win32-arm64,
+REM   darwin-x64, darwin-arm64, linux-x64, linux-arm64.
+REM   Each must be built on a matching OS/arch (the @resvg/resvg-js native
+REM   binary is fetched per platform on npm install).
+REM
+REM WARNING - universal build (no --target):
+REM   `vsce package` without --target produces a VSIX claiming universal
+REM   compatibility but carrying only the build machine's resvg binary.
+REM   PNG export will fail on any other OS/arch. Use ONLY for local install
+REM   testing on the build machine - NEVER publish to the Marketplace
+REM   without --target. See docs/packaging.md.
 REM ============================================================================
 
 setlocal EnableExtensions
 cd /d "%~dp0"
 
 set "BUMP=0"
-if /I "%~1"=="--bump" set "BUMP=1"
+set "TARGET="
+
+:parse_args
+if "%~1"=="" goto args_done
+if /I "%~1"=="--bump" (
+  set "BUMP=1"
+  shift
+  goto parse_args
+)
+if /I "%~1"=="--target" (
+  if "%~2"=="" (
+    echo build-extension: --target requires a value ^(e.g. win32-x64^).
+    exit /b 2
+  )
+  set "TARGET=%~2"
+  shift
+  shift
+  goto parse_args
+)
+echo build-extension: unknown argument "%~1".
+echo Usage: build-extension.bat [--bump] [--target ^<target^>]
+exit /b 2
+:args_done
 
 if not exist output mkdir output
 
@@ -37,9 +74,19 @@ if "%BUMP%"=="1" (
 )
 
 echo.
-echo === [3/3] vsce package -^> output\
+if defined TARGET (
+  echo === [3/3] vsce package --target %TARGET% -^> output\
+) else (
+  echo === [3/3] vsce package -^> output\
+  echo build-extension: WARNING - no --target given; VSIX is local-install only.
+  echo build-extension: see docs\packaging.md before publishing to the Marketplace.
+)
 pushd extension
-call npx --no-install vsce package -o ..\output
+if defined TARGET (
+  call npx --no-install vsce package --target %TARGET% -o ..\output
+) else (
+  call npx --no-install vsce package -o ..\output
+)
 set "RC=%errorlevel%"
 popd
 if not "%RC%"=="0" (


### PR DESCRIPTION
## Summary

`build-extension.bat` ran `vsce package` without `--target`, producing a
"universal" VSIX that actually carries only the build machine's
`@resvg/resvg-js` native binary. Per `docs/packaging.md`, that VSIX is
**not safe to publish** — PNG export fails on any other OS/arch.

The script now accepts an optional `--target <platform>` flag and
passes it through to `vsce package`. Args can come in any order; the
parser also catches a missing value or unknown flag and exits 2 with a
usage hint.

## Usage

```
build-extension.bat                                # universal, with warning
build-extension.bat --bump                         # patch bump + universal
build-extension.bat --target win32-x64             # targeted
build-extension.bat --bump --target win32-x64      # both
```

Supported targets per `docs/packaging.md`:
`win32-x64`, `win32-arm64`, `darwin-x64`, `darwin-arm64`, `linux-x64`, `linux-arm64`.
Each must be built on a matching OS/arch.

## Behaviour preserved

- Default (no flags) still works for local install testing — but now
  prints an explicit warning that the VSIX is local-only.
- `--bump` semantics unchanged (calls `npm run bump-extension-version`,
  which defaults to patch).

## Test plan

- [ ] `build-extension.bat` (no args) — universal VSIX in `output\`, warning shown.
- [ ] `build-extension.bat --target win32-x64` — targeted VSIX with `win32-x64` in the filename.
- [ ] `build-extension.bat --target` (no value) — exits 2 with hint.
- [ ] `build-extension.bat --foo` — exits 2 with hint.

Do not auto-merge — Valerii gates.