### PR TITLE
feat(intellij): Phase 2 — browser-safe webview bundle (#135)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "compile:extension": "tsc -p extension/tsconfig.json --noEmit",
     "build": "tsc -p tsconfig.build.json",
     "build:webview": "node scripts/build-webview.mjs",
+    "build:webview-bundle": "node scripts/build-webview-bundle.mjs",
     "extension:bundle": "node scripts/build-extension-bundle.mjs",
     "extension:prep": "npm run build:webview && node scripts/build-compiler-bundle.mjs && npm run extension:bundle",
     "pretest": "npm run build",

--- a/packages/diagrams/src/goals/index.ts
+++ b/packages/diagrams/src/goals/index.ts
@@ -15,5 +15,7 @@ export type {
 } from './types.js';
 
 export { validateGoalTree } from './validate.js';
+export { parseCanonicalGoals } from './parse-canonical.js';
+export type { CanonicalGoalsResult } from './parse-canonical.js';
 export { layoutGoalTree, selectScopedGoals } from './layout.js';
 export { reparent, addChild, deleteWithDescendants, moveToBacklog, restoreFromBacklog } from './mutations.js';

--- a/packages/diagrams/src/webview/__tests__/entry.test.ts
+++ b/packages/diagrams/src/webview/__tests__/entry.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import { api, render } from '../entry.js';
+
+const VALID_GOALS_DOC = `
+notation: goals
+id: GOALS-WEBVIEW-1
+name: "Webview entry smoke test"
+goal_types:
+  - { name: "Strategy", level: 0 }
+goals:
+  - id: GOAL-MOON-1
+    name: "Reach the moon"
+    type: "Strategy"
+    level: 0
+`;
+
+describe('webview/entry — Step 2 host API', () => {
+  it('exposes a version + supportedKinds + render() trio', () => {
+    expect(api.version).toMatch(/^\d+\.\d+\.\d+/);
+    expect(api.supportedKinds).toContain('goals');
+    expect(typeof api.render).toBe('function');
+  });
+
+  it('parses + validates a well-formed goals document', () => {
+    const r = render('goals', VALID_GOALS_DOC);
+    expect(r.notation).toBe('goals');
+    expect(r.status).toBe('ok');
+    expect(r.errors).toEqual([]);
+    // Step 2 leaves SVG empty; Step 3 wires the goals renderer.
+    expect(r.svg).toBe('');
+  });
+
+  it('returns YAML-PARSE on malformed input — no exception escapes to the host', () => {
+    const r = render('goals', 'goals:\n  - id: g1\n    name: [unterminated');
+    expect(r.status).toBe('error');
+    expect(r.errors[0].code).toBe('YAML-PARSE');
+  });
+
+  it('returns KIND-UNKNOWN for a non-Transitrix notation kind', () => {
+    const r = render('plantuml', VALID_GOALS_DOC);
+    expect(r.status).toBe('error');
+    expect(r.errors[0].code).toBe('KIND-UNKNOWN');
+  });
+
+  it('returns NOTATION-NOT-WIRED for kinds that parse but have no Step 2 renderer', () => {
+    // fgca is a supported kind but Step 4 wires its validator into the bundle.
+    const r = render('fgca', 'changes: []\n');
+    expect(r.status).toBe('error');
+    expect(r.errors[0].code).toBe('NOTATION-NOT-WIRED');
+  });
+
+  it('surfaces goals validation errors structurally (e.g. missing notation header)', () => {
+    const r = render('goals', 'goals: []\n');
+    expect(r.status).toBe('error');
+    // parseCanonicalGoals emits GOALS-* codes for canonical-shape violations.
+    expect(r.errors.some((e) => e.code.startsWith('GOALS-'))).toBe(true);
+  });
+});

--- a/packages/diagrams/src/webview/entry.ts
+++ b/packages/diagrams/src/webview/entry.ts
@@ -1,0 +1,157 @@
+/**
+ * Browser-bundle entry point for the IntelliJ JCEF preview surface (and any
+ * other host that wants the same in-browser API).
+ *
+ * Why: ADR 0001 picks JCEF + a bundled `@transitrix/diagrams` over a JVM-side
+ * re-implementation. This module is the API contract between the JVM host
+ * (which posts raw document text + the notation kind) and the rendering JS
+ * (which parses, validates, and — Step 3+ — renders SVG). Centralising the
+ * surface in one file means the JVM side only has to know about
+ * `window.transitrix.render(kind, source)` regardless of which notation the
+ * user opened.
+ *
+ * Step 2 scope (this PR): wire YAML parsing, dispatch to the right validator,
+ * surface validation/parse errors in a structured JSON shape. SVG output is
+ * intentionally left empty for every notation; Step 3 swaps `goals` in first,
+ * Step 4 fills the remaining ten.
+ */
+import yaml from 'js-yaml';
+
+import { parseCanonicalGoals } from '../goals/parse-canonical.js';
+
+export interface RenderError {
+  code: string;
+  message: string;
+  path?: string;
+}
+
+export interface RenderWarning {
+  code: string;
+  message: string;
+  path?: string;
+}
+
+export type RenderStatus = 'ok' | 'error';
+
+export interface RenderResult {
+  status: RenderStatus;
+  notation: string;
+  /** SVG markup once the renderer for `notation` is wired (Step 3+). Empty until then. */
+  svg: string;
+  errors: RenderError[];
+  warnings: RenderWarning[];
+}
+
+/**
+ * Notation kinds the host can request. Mirrors the `*.<kind>.<…>` suffix
+ * convention used by the VS Code extension's `activationEvents`. Step 4 fills
+ * the remaining ten; Step 2 only wires `goals` to its validator.
+ */
+export type NotationKind =
+  | 'goals'
+  | 'fgca'
+  | 'fga'
+  | 'activities'
+  | 'activity-card'
+  | 'applications'
+  | 'products'
+  | 'process-map'
+  | 'process-blueprint'
+  | 'scenarios'
+  | 'capability-map'
+  | 'blocks';
+
+const SUPPORTED_KINDS: readonly NotationKind[] = [
+  'goals',
+  'fgca',
+  'fga',
+  'activities',
+  'activity-card',
+  'applications',
+  'products',
+  'process-map',
+  'process-blueprint',
+  'scenarios',
+  'capability-map',
+  'blocks',
+];
+
+const VERSION = '0.1.0';
+
+function emptyResult(notation: string, status: RenderStatus): RenderResult {
+  return { status, notation, svg: '', errors: [], warnings: [] };
+}
+
+function errorResult(notation: string, code: string, message: string, path?: string): RenderResult {
+  const r = emptyResult(notation, 'error');
+  r.errors.push(path !== undefined ? { code, message, path } : { code, message });
+  return r;
+}
+
+function parseYaml(source: string): { doc?: unknown; error?: string } {
+  try {
+    return { doc: yaml.load(source) };
+  } catch (e: unknown) {
+    return { error: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+function dispatchValidate(kind: NotationKind, doc: unknown): RenderResult {
+  switch (kind) {
+    case 'goals': {
+      const v = parseCanonicalGoals(doc);
+      const r = emptyResult('goals', v.valid ? 'ok' : 'error');
+      r.errors.push(...v.errors);
+      r.warnings.push(...v.warnings);
+      return r;
+    }
+    // Step 4 wires the remaining notations. Until then they parse successfully
+    // and surface a clear "not wired" error rather than crashing — the JVM
+    // host can show the user a meaningful message instead of an empty panel.
+    default:
+      return errorResult(
+        kind,
+        'NOTATION-NOT-WIRED',
+        `Notation '${kind}' is not wired into the IntelliJ bundle yet.`,
+      );
+  }
+}
+
+export function render(notationKind: string, source: string): RenderResult {
+  if (typeof notationKind !== 'string' || notationKind.length === 0) {
+    return errorResult('', 'KIND-MISSING', 'notationKind is required');
+  }
+  if (typeof source !== 'string') {
+    return errorResult(notationKind, 'SOURCE-INVALID', 'source must be a string');
+  }
+  if (!SUPPORTED_KINDS.includes(notationKind as NotationKind)) {
+    return errorResult(
+      notationKind,
+      'KIND-UNKNOWN',
+      `Unknown notation kind: '${notationKind}'. Expected one of: ${SUPPORTED_KINDS.join(', ')}.`,
+    );
+  }
+  const parsed = parseYaml(source);
+  if (parsed.error !== undefined) {
+    return errorResult(notationKind, 'YAML-PARSE', parsed.error);
+  }
+  return dispatchValidate(notationKind as NotationKind, parsed.doc);
+}
+
+export const api = {
+  version: VERSION,
+  supportedKinds: SUPPORTED_KINDS,
+  render,
+};
+
+export type TransitrixWebviewApi = typeof api;
+
+// Install the API on `window.transitrix` when running in a browser-ish host
+// (JCEF qualifies). In a Node/Vitest context `window` is undefined and the
+// install is a no-op — the named exports remain available for unit tests.
+declare const window: { transitrix?: TransitrixWebviewApi } | undefined;
+if (typeof window !== 'undefined') {
+  (window as { transitrix?: TransitrixWebviewApi }).transitrix = api;
+}
+
+export default api;

--- a/packages/diagrams/src/webview/styles.css
+++ b/packages/diagrams/src/webview/styles.css
@@ -1,0 +1,76 @@
+/*
+ * Base styles for the IntelliJ JCEF preview surface.
+ *
+ * Step 2 (this PR) ships the minimum needed to host the preview frame and
+ * render the validation error panel — Step 3+ extends with per-notation
+ * styling as each renderer is wired. Keeping this small for now means there's
+ * less to keep aligned with the VS Code preview theme until the SVG paths
+ * actually land.
+ */
+
+:root {
+  --tx-bg: #1e1f22;
+  --tx-fg: #d4d4d4;
+  --tx-muted: #888;
+  --tx-error-bg: #3d2222;
+  --tx-error-fg: #f3a3a3;
+  --tx-error-border: #6d3030;
+  --tx-warning-bg: #3d3322;
+  --tx-warning-fg: #f3d3a3;
+  --tx-warning-border: #6d5530;
+  --tx-mono: ui-monospace, "JetBrains Mono", "SF Mono", Menlo, Consolas, monospace;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--tx-bg);
+  color: var(--tx-fg);
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+#transitrix-root {
+  padding: 12px 16px;
+  box-sizing: border-box;
+  min-height: 100vh;
+}
+
+.tx-error-panel,
+.tx-warning-panel {
+  border-radius: 4px;
+  padding: 10px 12px;
+  margin-bottom: 10px;
+  font-family: var(--tx-mono);
+  font-size: 12px;
+  white-space: pre-wrap;
+}
+
+.tx-error-panel {
+  background: var(--tx-error-bg);
+  color: var(--tx-error-fg);
+  border: 1px solid var(--tx-error-border);
+}
+
+.tx-warning-panel {
+  background: var(--tx-warning-bg);
+  color: var(--tx-warning-fg);
+  border: 1px solid var(--tx-warning-border);
+}
+
+.tx-issue-code {
+  font-weight: 600;
+  margin-right: 6px;
+}
+
+.tx-issue-path {
+  color: var(--tx-muted);
+  margin-left: 6px;
+}
+
+.tx-svg-host svg {
+  max-width: 100%;
+  height: auto;
+}

--- a/scripts/build-webview-bundle.mjs
+++ b/scripts/build-webview-bundle.mjs
@@ -1,0 +1,84 @@
+/**
+ * Bundles `@transitrix/diagrams` into a browser-ready ESM-IIFE for the
+ * IntelliJ JCEF preview surface (ADR 0001 step 2).
+ *
+ * Inputs:
+ *   - packages/diagrams/src/webview/entry.ts (the host-facing API)
+ *   - packages/diagrams/src/webview/styles.css (base + error-panel theme)
+ *
+ * Outputs (under packages/diagrams/dist/webview/):
+ *   - transitrix-render.js   — IIFE; installs `window.transitrix.render(...)`
+ *   - transitrix-render.css  — base styles
+ *
+ * Step 3+ of the IntelliJ epic copies these into the plugin `.zip` under
+ * `resources/webview/` so JCEF can load them at runtime. The bundle is fully
+ * self-contained (js-yaml is inlined), so there is no runtime dependency on a
+ * node_modules tree on the JVM side.
+ *
+ * `platform: 'browser'` + `external: []` makes esbuild fail loudly if any
+ * Node-only API (fs, path, child_process, etc.) sneaks into the diagrams
+ * library — that's the "is @transitrix/diagrams browser-safe?" check the ADR
+ * called for.
+ */
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as esbuild from 'esbuild';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const entry = path.join(root, 'packages', 'diagrams', 'src', 'webview', 'entry.ts');
+const cssSrc = path.join(root, 'packages', 'diagrams', 'src', 'webview', 'styles.css');
+const outDir = path.join(root, 'packages', 'diagrams', 'dist', 'webview');
+const outJs = path.join(outDir, 'transitrix-render.js');
+const outCss = path.join(outDir, 'transitrix-render.css');
+
+await fs.rm(outDir, { recursive: true, force: true });
+await fs.mkdir(outDir, { recursive: true });
+
+const result = await esbuild.build({
+  entryPoints: [entry],
+  bundle: true,
+  outfile: outJs,
+  platform: 'browser',
+  format: 'iife',
+  globalName: '__transitrixWebview',
+  target: ['es2020'],
+  sourcemap: true,
+  // Keep the bundle self-contained for JCEF. We expressly do NOT mark anything
+  // external — if a Node-only import slips into @transitrix/diagrams, esbuild
+  // raises here, which is what we want for the browser-safety guard.
+  external: [],
+  metafile: true,
+  logLevel: 'info',
+});
+
+await fs.copyFile(cssSrc, outCss);
+
+// Manual safety net for Node-only globals that esbuild would otherwise
+// substitute via shims rather than reject. None of @transitrix/diagrams should
+// touch these — if it ever does, fail the build instead of shipping a bundle
+// that explodes inside JCEF.
+const bundled = await fs.readFile(outJs, 'utf8');
+const banned = ['__dirname', '__filename', 'require(', 'process.env'];
+const hits = banned.filter((tok) => bundled.includes(tok));
+if (hits.length > 0) {
+  throw new Error(
+    `Browser-bundle leaked Node-only token(s): ${hits.join(', ')}. ` +
+      `The diagrams library must stay browser-safe (ADR 0001 step 2).`,
+  );
+}
+
+const sizeKb = (Buffer.byteLength(bundled, 'utf8') / 1024).toFixed(1);
+console.log(`Webview bundle → ${path.relative(root, outJs)} (${sizeKb} KB)`);
+console.log(`Webview styles → ${path.relative(root, outCss)}`);
+
+// Surface esbuild's metafile size summary so PR reviews can spot drift.
+if (result.metafile) {
+  const inputs = Object.entries(result.metafile.inputs)
+    .sort((a, b) => b[1].bytes - a[1].bytes)
+    .slice(0, 5);
+  console.log('Top 5 inputs by size:');
+  for (const [name, info] of inputs) {
+    console.log(`  ${(info.bytes / 1024).toFixed(1).padStart(7)} KB  ${name}`);
+  }
+}


### PR DESCRIPTION
## Summary

ADR 0001 step 2 of the IntelliJ epic (#135 in `vkgeorgia/strategy`): produce a self-contained, browser-ready bundle of `@transitrix/diagrams` that JCEF can load, plus the host-facing API the JVM side will call. Builds directly on the merged ADR (#93) and Gradle scaffold (#97).

Do not merge — Valerii gates.

## What's in this PR

- **`scripts/build-webview-bundle.mjs`** — new `npm run build:webview-bundle`. esbuild → `packages/diagrams/dist/webview/transitrix-render.{js,css}`. Browser-safety guard: `platform: 'browser'`, `external: []`, plus a post-build banned-token check (`__dirname`, `__filename`, `require(`, `process.env`) that **fails the build if a Node-only import sneaks into the diagrams library**. This is the "is `@transitrix/diagrams` browser-safe?" check the ADR called for — confirmed clean on the current source (no production-path `readFileSync`; all `node:fs` use is test-only and isn't reached from the bundle entry).
- **`packages/diagrams/src/webview/entry.ts`** — the host-facing API: `window.transitrix.render(kind, source)` returning a structured `{ status, notation, svg, errors, warnings }` for every supported notation kind. Wires `goals` to `parseCanonicalGoals` (Step 2 scope). The other ten kinds return `NOTATION-NOT-WIRED` until Step 4 fills them in. Catches `KIND-MISSING`, `KIND-UNKNOWN`, `SOURCE-INVALID`, `YAML-PARSE` **before** reaching a validator so the JVM host never sees an exception.
- **`packages/diagrams/src/webview/styles.css`** — base + error/warning panel theme for the JCEF surface (minimum needed for the validation error panel; Step 3+ extends with per-notation styling as renderers land).
- **`packages/diagrams/src/goals/index.ts`** — re-export `parseCanonicalGoals` from the public barrel so the webview entry (and any other consumer) doesn't deep-import.
- **Tests**: `packages/diagrams/src/webview/__tests__/entry.test.ts` (6 cases — version/API surface, well-formed parse, YAML-PARSE, KIND-UNKNOWN, NOTATION-NOT-WIRED, structured GOALS-* error).

## Bundle stats

```
packages/diagrams/dist/webview/transitrix-render.js      102.4 KB
packages/diagrams/dist/webview/transitrix-render.js.map  192.8 KB
```

Top inputs: js-yaml (105 KB), `goals/parse-canonical.ts` (9.8 KB), `webview/entry.ts` (4.7 KB). Fully self-contained — no runtime `node_modules` dependency on the JVM side.

## Verification

- `npm test` — **592 passed** (43 files), incl. the 6 new webview entry tests.
- `npm run build` — clean.
- `npm run compile` — clean.
- `npm run compile:extension` — clean.
- `npm run build:webview-bundle` — clean, banned-token guard passes.

## Test plan

- [ ] On a JCEF-capable IDEA, load the produced `transitrix-render.js` + `.css` (this is the Step 3 follow-on PR's job — Step 2 only produces the bundle).
- [ ] Confirm goals YAML produces a structured validation result via `window.transitrix.render('goals', source)`.
- [ ] Confirm malformed YAML returns `YAML-PARSE` instead of throwing.
- [ ] Confirm unknown kinds return `KIND-UNKNOWN` (no exception).

## Next PR (Step 3)

JCEF wiring (`JBCefBrowser`) inside the Gradle plugin from #97, loading this bundle, ship `goals` end-to-end as the first notation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)