### PR TITLE
feat(compliance): export-compliance PDF format via WeasyPrint (#84)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- **`transitrix export-compliance --format pdf`** — PDF export of the compliance views (matrix / single-law / single-product / gap) via WeasyPrint. The HTML half (`renderComplianceHtml` in `@transitrix/diagrams/compliance`) builds a self-contained A4-portrait branded document; the CLI hands it to a `weasyprint` subprocess on PATH and surfaces a clear install hint when the binary is missing.
+
 ## [1.3.0] — 2026-06-02
 
 ### Added

--- a/packages/diagrams/src/compliance/__tests__/html.test.ts
+++ b/packages/diagrams/src/compliance/__tests__/html.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { renderComplianceHtml } from '../html.js';
+import { emptyCanon, ingestComplianceDoc, type ComplianceCanon } from '../classify.js';
+
+function synthetic(): ComplianceCanon {
+  const canon = emptyCanon();
+  ingestComplianceDoc(canon, { notation: 'product', id: 'PRODUCT-M-1', name: 'Mobile App' });
+  ingestComplianceDoc(canon, { notation: 'requirement', id: 'REQUIREMENT-ERASURE-1', name: 'Erasure', severity: 'high', derived_from: ['LAW-X-1'] });
+  ingestComplianceDoc(canon, { notation: 'requirement', id: 'REQUIREMENT-LOG-1', name: 'Logs', severity: 'low' });
+  ingestComplianceDoc(canon, {
+    notation: 'assertion',
+    id: 'ASSERTION-1',
+    about: 'REQUIREMENT-ERASURE-1',
+    subject: 'PRODUCT-M-1',
+    status: 'compliant',
+    evidence: [{ kind: 'note', text: 'x' }],
+    next_review_at: '2026-09-01',
+  });
+  ingestComplianceDoc(canon, { id: 'LAW-X-1', name: 'Privacy Law', zone: 'codex', type: 'LAW' });
+  return canon;
+}
+
+describe('renderComplianceHtml — document shell', () => {
+  it('produces a complete HTML document with branded header and stamp', () => {
+    const html = renderComplianceHtml(synthetic(), { mode: 'matrix' }, { today: '2026-06-03' });
+    expect(html.startsWith('<!doctype html>')).toBe(true);
+    expect(html).toContain('<title>Compliance Matrix</title>');
+    expect(html).toContain('<div class="cmp-eyebrow">Transitrix · Compliance</div>');
+    expect(html).toContain('<h1>Compliance Matrix</h1>');
+    expect(html).toContain('Generated 2026-06-03');
+    expect(html).toContain('@page');
+    expect(html).toContain('size: A4 portrait');
+  });
+
+  it('escapes HTML in product and requirement names', () => {
+    const canon = emptyCanon();
+    ingestComplianceDoc(canon, { notation: 'product', id: 'PRODUCT-X-1', name: '<Mobile> & "Web"' });
+    ingestComplianceDoc(canon, { notation: 'requirement', id: 'REQUIREMENT-X-1', name: 'A & B' });
+    const html = renderComplianceHtml(canon, { mode: 'matrix' });
+    expect(html).not.toMatch(/<Mobile>/);
+    expect(html).toContain('&lt;Mobile&gt; &amp; &quot;Web&quot;');
+    expect(html).toContain('A &amp; B');
+  });
+});
+
+describe('renderComplianceHtml — matrix', () => {
+  it('renders a table with status badges and gap cells', () => {
+    const html = renderComplianceHtml(synthetic(), { mode: 'matrix' });
+    expect(html).toContain('<table class="cmp-matrix">');
+    expect(html).toContain('<th>Erasure</th>');
+    expect(html).toContain('<th>Logs</th>');
+    expect(html).toContain('<span class="cmp-badge cmp-compliant">Compliant</span>');
+    expect(html).toMatch(/cmp-cell-gap/);
+    expect(html).toContain('1 products × 2 requirements');
+  });
+
+  it('shows an empty-state message when nothing was scanned', () => {
+    const html = renderComplianceHtml(emptyCanon(), { mode: 'matrix' });
+    expect(html).toContain('No products or requirements found');
+  });
+});
+
+describe('renderComplianceHtml — law', () => {
+  it('renders the law name, requirement block, and assertion bullet with badge', () => {
+    const html = renderComplianceHtml(synthetic(), { mode: 'law', id: 'LAW-X-1' });
+    expect(html).toContain('<h1>Compliance — Privacy Law</h1>');
+    expect(html).toContain('class="cmp-req-name">Erasure');
+    expect(html).toContain('class="cmp-req-id">REQUIREMENT-ERASURE-1');
+    expect(html).toContain('cmp-sev cmp-sev-high');
+    expect(html).toContain('cmp-badge cmp-compliant');
+    expect(html).toContain('review by 2026-09-01');
+  });
+
+  it('handles an unknown law id with an empty-state message', () => {
+    const html = renderComplianceHtml(synthetic(), { mode: 'law', id: 'LAW-NONE' });
+    expect(html).toContain('<h1>Compliance — LAW-NONE</h1>');
+    expect(html).toContain('No requirements derive from');
+  });
+});
+
+describe('renderComplianceHtml — product', () => {
+  it('renders the product table of asserted requirements', () => {
+    const html = renderComplianceHtml(synthetic(), { mode: 'product', id: 'PRODUCT-M-1' });
+    expect(html).toContain('<h1>Compliance — Mobile App</h1>');
+    expect(html).toContain('<th>Requirement</th>');
+    expect(html).toContain('<th>Status</th>');
+    expect(html).toContain('cmp-badge cmp-compliant');
+    expect(html).toContain('2026-09-01');
+  });
+});
+
+describe('renderComplianceHtml — gap', () => {
+  it('lists the un-asserted requirement and shows ✓ none for clean sections', () => {
+    const html = renderComplianceHtml(synthetic(), { mode: 'gap' }, { today: '2026-06-02' });
+    expect(html).toContain('Requirements without assertions');
+    expect(html).toContain('REQUIREMENT-LOG-1');
+    expect(html).toContain('severity low');
+    expect(html).toContain('Assertions without evidence — ASSERT-007');
+    expect(html).toContain('Stale assertions — ASSERT-008');
+    expect(html).toContain('class="cmp-ok">✓ none');
+  });
+
+  it('counts gaps in the summary line', () => {
+    const html = renderComplianceHtml(synthetic(), { mode: 'gap' });
+    expect(html).toMatch(/1 gap\(s\)/);
+  });
+});

--- a/packages/diagrams/src/compliance/html.ts
+++ b/packages/diagrams/src/compliance/html.ts
@@ -1,0 +1,219 @@
+// HTML renderers for the compliance views (vkgeorgia/strategy#84 Phase 5,
+// PDF follow-on). Pure string builders — fed to WeasyPrint by the
+// `transitrix export-compliance --format pdf` path in src/export-compliance.ts.
+//
+// Each entry point returns a complete, self-contained HTML document (no
+// external assets) so WeasyPrint reads the whole brief on stdin. CSS is
+// inlined; the page rules target A4 portrait with branded header and footer.
+// Status colours mirror the Studio preview palette (see compliance-render.ts)
+// so the export and the in-editor view stay visually consistent.
+
+import { buildComplianceMatrix } from '../compliance-matrix/index.js';
+import { buildComplianceIndex } from './reverse-index.js';
+import { buildLawTree, buildProductView } from './views.js';
+import { buildGapReport } from './gap-report.js';
+import type { ComplianceCanon } from './classify.js';
+import type { ReportScope } from './markdown.js';
+import type { AssertionStatus } from '../assertion/types.js';
+
+const STATUS_LABELS: Record<AssertionStatus, string> = {
+  compliant: 'Compliant',
+  partial: 'Partial',
+  non_compliant: 'Non-compliant',
+  under_review: 'Under review',
+  n_a: 'N/A',
+};
+
+export interface HtmlOptions {
+  /** Today as ISO YYYY-MM-DD — enables the gap dashboard's stale-assertion list and is stamped in the footer. */
+  today?: string;
+  /** Title override; defaults to the per-scope title. */
+  title?: string;
+}
+
+function escHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function badge(status: AssertionStatus): string {
+  return `<span class="cmp-badge cmp-${status}">${escHtml(STATUS_LABELS[status])}</span>`;
+}
+
+// A4 portrait with 18mm margins — matches the WeasyPrint one-pager template
+// the site uses. Brand colour `#004d67` mirrors `--ts-brand-primary` from
+// extension/src/compliance-render.ts so the PDF and the Studio preview agree.
+const CSS = `
+@page {
+  size: A4 portrait;
+  margin: 18mm 16mm 22mm;
+  @bottom-left { content: "Transitrix — compliance report"; font: 9pt "Helvetica", "Arial", sans-serif; color: #475569; }
+  @bottom-right { content: "Page " counter(page) " / " counter(pages); font: 9pt "Helvetica", "Arial", sans-serif; color: #475569; }
+}
+html, body { margin: 0; padding: 0; }
+body { font-family: "Helvetica", "Arial", sans-serif; font-size: 10pt; color: #0f172a; line-height: 1.4; }
+.cmp-header { border-bottom: 2px solid #004d67; padding-bottom: 6pt; margin-bottom: 14pt; }
+.cmp-header .cmp-eyebrow { font-size: 8.5pt; letter-spacing: 0.08em; text-transform: uppercase; color: #004d67; font-weight: 700; }
+.cmp-header h1 { font-size: 17pt; margin: 2pt 0 4pt; color: #0f172a; }
+.cmp-header .cmp-stamp { font-size: 9pt; color: #475569; }
+h2 { font-size: 12pt; margin: 16pt 0 6pt; color: #0f172a; page-break-after: avoid; }
+h2 .cmp-count { color: #64748b; font-weight: 400; font-size: 10pt; }
+p.cmp-empty { color: #64748b; font-style: italic; }
+table { border-collapse: collapse; width: 100%; font-size: 9.5pt; margin-bottom: 10pt; }
+th, td { border: 0.5pt solid #cbd5e1; padding: 4pt 6pt; text-align: left; vertical-align: top; }
+th { background: #f1f5f9; font-weight: 700; color: #0f172a; }
+table.cmp-matrix th:first-child, table.cmp-matrix td:first-child { background: #f8fafc; font-weight: 600; }
+code, .cmp-id { font-family: "Menlo", "Consolas", monospace; font-size: 9pt; color: #475569; }
+.cmp-badge { display: inline-block; padding: 1pt 6pt; border-radius: 8pt; font-size: 8.5pt; font-weight: 700; }
+.cmp-compliant { background: #d1fae5; color: #065f46; }
+.cmp-partial { background: #fef9c3; color: #854d0e; }
+.cmp-non_compliant { background: #fee2e2; color: #991b1b; }
+.cmp-under_review { background: #e0f2fe; color: #0c4a6e; }
+.cmp-n_a { background: #f1f5f9; color: #64748b; }
+.cmp-cell-gap { color: #94a3b8; text-align: center; }
+.cmp-req { border: 0.5pt solid #cbd5e1; border-radius: 3pt; margin-bottom: 8pt; page-break-inside: avoid; }
+.cmp-req-head { background: #f1f5f9; padding: 5pt 8pt; }
+.cmp-req-head .cmp-req-name { font-weight: 700; color: #0f172a; }
+.cmp-req-head .cmp-req-id { margin-left: 6pt; color: #475569; font-size: 9pt; font-family: "Menlo", "Consolas", monospace; }
+.cmp-sev { font-size: 8pt; text-transform: uppercase; letter-spacing: 0.06em; margin-left: 8pt; }
+.cmp-sev-high { color: #b91c1c; }
+.cmp-sev-medium { color: #b45309; }
+.cmp-sev-low { color: #2563eb; }
+.cmp-assertions { list-style: none; margin: 0; padding: 0; }
+.cmp-assertions li { padding: 4pt 8pt 4pt 16pt; border-top: 0.5pt solid #e2e8f0; }
+.cmp-assertions li .cmp-meta { color: #475569; font-size: 8.5pt; margin-left: 6pt; }
+.cmp-section { margin-bottom: 12pt; }
+.cmp-rows { list-style: none; margin: 0; padding: 0; }
+.cmp-rows li { padding: 3pt 0 3pt 14pt; border-bottom: 0.5pt solid #e2e8f0; text-indent: -10pt; }
+.cmp-rows li::before { content: "☐"; color: #94a3b8; margin-right: 6pt; }
+.cmp-ok { color: #065f46; font-weight: 600; }
+.cmp-summary { font-size: 9pt; color: #475569; }
+`;
+
+function htmlDoc(title: string, today: string | undefined, body: string): string {
+  const stamp = today ? `Generated ${escHtml(today)}` : '';
+  return [
+    '<!doctype html>',
+    '<html lang="en">',
+    '<head>',
+    '<meta charset="utf-8"/>',
+    `<title>${escHtml(title)}</title>`,
+    `<style>${CSS}</style>`,
+    '</head>',
+    '<body>',
+    '<header class="cmp-header">',
+    '<div class="cmp-eyebrow">Transitrix · Compliance</div>',
+    `<h1>${escHtml(title)}</h1>`,
+    stamp ? `<div class="cmp-stamp">${stamp}</div>` : '',
+    '</header>',
+    body,
+    '</body>',
+    '</html>',
+    '',
+  ].join('\n');
+}
+
+/** Renders the requested compliance view from a scanned canon to a complete HTML document. */
+export function renderComplianceHtml(canon: ComplianceCanon, scope: ReportScope, options: HtmlOptions = {}): string {
+  switch (scope.mode) {
+    case 'matrix': {
+      const m = buildComplianceMatrix({ products: canon.products, requirements: canon.requirements, assertions: canon.assertions });
+      const title = options.title ?? 'Compliance Matrix';
+      const summary = `<p class="cmp-summary">${m.summary.products} products × ${m.summary.requirements} requirements · ${m.summary.gaps} gaps · ${m.summary.assertions} assertions</p>`;
+      if (m.products.length === 0 || m.requirements.length === 0) {
+        return htmlDoc(title, options.today, `${summary}<p class="cmp-empty">No products or requirements found in the scanned canon.</p>`);
+      }
+      const head = `<tr><th>Product \\ Requirement</th>${m.requirements.map(r => `<th>${escHtml(r.name)}</th>`).join('')}</tr>`;
+      const rows = m.products.map((p, ri) => {
+        const cells = m.requirements.map((_r, ci) => {
+          const c = m.cells[ri][ci];
+          return c.status ? `<td>${badge(c.status)}</td>` : '<td class="cmp-cell-gap">—</td>';
+        }).join('');
+        const name = escHtml(p.name) + (p.unresolved ? ' <span class="cmp-sev cmp-sev-high">unresolved</span>' : '');
+        return `<tr><td>${name}</td>${cells}</tr>`;
+      }).join('');
+      return htmlDoc(title, options.today, `${summary}<table class="cmp-matrix"><thead>${head}</thead><tbody>${rows}</tbody></table>`);
+    }
+
+    case 'law': {
+      const index = buildComplianceIndex({ requirements: canon.requirements, assertions: canon.assertions });
+      const tree = buildLawTree(scope.id, index);
+      const law = canon.codex.find(c => c.id === scope.id);
+      const title = options.title ?? `Compliance — ${law ? law.name : scope.id}`;
+      const summary = `<p class="cmp-summary"><code>${escHtml(scope.id)}</code> · ${tree.requirements.length} requirement(s)</p>`;
+      if (tree.requirements.length === 0) {
+        return htmlDoc(title, options.today, `${summary}<p class="cmp-empty">No requirements derive from <code>${escHtml(scope.id)}</code>.</p>`);
+      }
+      const blocks = tree.requirements.map(node => {
+        const sev = node.requirement.severity ? ` <span class="cmp-sev cmp-sev-${escHtml(node.requirement.severity)}">${escHtml(node.requirement.severity)}</span>` : '';
+        const head = `<div class="cmp-req-head"><span class="cmp-req-name">${escHtml(node.requirement.name)}</span><span class="cmp-req-id">${escHtml(node.requirement.id)}</span>${sev}</div>`;
+        if (node.assertions.length === 0) {
+          return `<section class="cmp-req">${head}<ul class="cmp-assertions"><li><em>No assertion — compliance gap.</em></li></ul></section>`;
+        }
+        const items = node.assertions.map(a => {
+          const metaParts: string[] = [];
+          if (a.assessed_at) metaParts.push(`assessed ${escHtml(a.assessed_at)}`);
+          if (a.next_review_at) metaParts.push(`review by ${escHtml(a.next_review_at)}`);
+          const meta = metaParts.length > 0 ? `<span class="cmp-meta">${metaParts.join(' · ')}</span>` : '';
+          return `<li>${badge(a.status)} <code>${escHtml(a.id)}</code> <span class="cmp-meta">subject <code>${escHtml(a.subject)}</code></span> ${meta}</li>`;
+        }).join('');
+        return `<section class="cmp-req">${head}<ul class="cmp-assertions">${items}</ul></section>`;
+      }).join('');
+      return htmlDoc(title, options.today, `${summary}${blocks}`);
+    }
+
+    case 'product': {
+      const index = buildComplianceIndex({ requirements: canon.requirements, assertions: canon.assertions });
+      const view = buildProductView(scope.id, index);
+      const product = canon.products.find(p => p.id === scope.id);
+      const title = options.title ?? `Compliance — ${product ? product.name : scope.id}`;
+      const summary = `<p class="cmp-summary"><code>${escHtml(scope.id)}</code> · ${view.requirements.length} requirement(s) asserted</p>`;
+      if (view.requirements.length === 0) {
+        return htmlDoc(title, options.today, `${summary}<p class="cmp-empty">No assertion names this product as its subject.</p>`);
+      }
+      const rows = view.requirements.map(({ requirement, assertion }) => (
+        `<tr>` +
+        `<td>${escHtml(requirement.name)} <code>${escHtml(requirement.id)}</code></td>` +
+        `<td>${badge(assertion.status)}</td>` +
+        `<td><code>${escHtml(assertion.id)}</code></td>` +
+        `<td>${assertion.next_review_at ? escHtml(assertion.next_review_at) : '—'}</td>` +
+        `</tr>`
+      )).join('');
+      const head = '<tr><th>Requirement</th><th>Status</th><th>Assertion</th><th>Next review</th></tr>';
+      return htmlDoc(title, options.today, `${summary}<table><thead>${head}</thead><tbody>${rows}</tbody></table>`);
+    }
+
+    case 'gap': {
+      const index = buildComplianceIndex({ requirements: canon.requirements, assertions: canon.assertions });
+      const report = buildGapReport(index, { today: options.today });
+      const title = options.title ?? 'Compliance Gap Dashboard';
+      const total = report.requirementsWithoutAssertions.length + report.assertionsWithoutEvidence.length + report.staleAssertions.length;
+      const summary = `<p class="cmp-summary">${total} gap(s)</p>`;
+      const section = (heading: string, count: number, items: string[]): string => {
+        const body = items.length === 0
+          ? '<p class="cmp-ok">✓ none</p>'
+          : `<ul class="cmp-rows">${items.join('')}</ul>`;
+        return `<section class="cmp-section"><h2>${escHtml(heading)} <span class="cmp-count">(${count})</span></h2>${body}</section>`;
+      };
+      const reqs = report.requirementsWithoutAssertions.map(r => (
+        `<li><code>${escHtml(r.id)}</code> ${escHtml(r.name)}${r.severity ? ` <span class="cmp-meta">severity ${escHtml(r.severity)}</span>` : ''}</li>`
+      ));
+      const noEvidence = report.assertionsWithoutEvidence.map(a => (
+        `<li><code>${escHtml(a.id)}</code> <span class="cmp-meta">about <code>${escHtml(a.about)}</code>, subject <code>${escHtml(a.subject)}</code>, status ${escHtml(a.status)}</span></li>`
+      ));
+      const stale = report.staleAssertions.map(a => (
+        `<li><code>${escHtml(a.id)}</code> <span class="cmp-meta">review due ${a.next_review_at ? escHtml(a.next_review_at) : '—'}, subject <code>${escHtml(a.subject)}</code></span></li>`
+      ));
+      const body = [
+        summary,
+        section('Requirements without assertions', report.requirementsWithoutAssertions.length, reqs),
+        section('Assertions without evidence — ASSERT-007', report.assertionsWithoutEvidence.length, noEvidence),
+        section('Stale assertions — ASSERT-008', report.staleAssertions.length, stale),
+      ].join('');
+      return htmlDoc(title, options.today, body);
+    }
+  }
+}

--- a/packages/diagrams/src/compliance/index.ts
+++ b/packages/diagrams/src/compliance/index.ts
@@ -6,6 +6,8 @@ export { emptyCanon, ingestComplianceDoc } from './classify.js';
 export type { ComplianceCanon, ComplianceProduct, ComplianceCodexDoc } from './classify.js';
 export { renderComplianceMarkdown } from './markdown.js';
 export type { ReportScope, MarkdownOptions } from './markdown.js';
+export { renderComplianceHtml } from './html.js';
+export type { HtmlOptions } from './html.js';
 export type {
   ComplianceIndex,
   ComplianceIndexInput,

--- a/packages/diagrams/src/compliance/markdown.ts
+++ b/packages/diagrams/src/compliance/markdown.ts
@@ -1,6 +1,6 @@
 // Markdown renderers for the compliance views (vkgeorgia/strategy#84 Phase 5).
 // Pure string builders consumed by the `transitrix export-compliance` CLI.
-// PDF (WeasyPrint) is the planned follow-on; this module is the Markdown half.
+// PDF rendering lives in `html.ts` (HTML doc fed to WeasyPrint by the CLI).
 
 import { buildComplianceMatrix } from '../compliance-matrix/index.js';
 import { buildComplianceIndex } from './reverse-index.js';

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,15 +23,16 @@ function printUsage(): void {
        cervin metrics [--ext=.cervin.yaml,.bpmn.transitrix.yaml] <input.yaml> [--json]
        cervin validate <input.yaml> [--json]
        cervin validate [--ext=.cervin.yaml,.bpmn.transitrix.yaml] <input.yaml> [--json]
-       cervin export-compliance [--format md] [--scope law:<ID>|product:<ID>|gap] [--output <path>] [--root <dir>]
+       cervin export-compliance [--format md|pdf] [--scope law:<ID>|product:<ID>|gap] [--output <path>] [--root <dir>]
 
   serve     — local web UI (run npm run ui:build once beforehand).
   <compile> — YAML → BPMN 2.0 XML with layout metrics.
   metrics   — layout quality metrics (with --json for CI).
   validate  — BPMN validation only (no XML output; exit 1 on errors).
-  export-compliance — Markdown report of the compliance views (matrix by
+  export-compliance — Markdown or PDF report of the compliance views (matrix by
               default; law:/product:/gap scopes). Scans --root (default cwd) for
-              requirement/assertion/product/codex canon. PDF is a follow-on.
+              requirement/assertion/product/codex canon. PDF rendering requires
+              WeasyPrint on PATH (pipx install weasyprint).
 
   --no-metrics  suppress quality metrics report on compile.
   --no-validate suppress validation warnings (errors always run).

--- a/src/export-compliance.ts
+++ b/src/export-compliance.ts
@@ -1,4 +1,4 @@
-// `cervin export-compliance` handler (vkgeorgia/strategy#84 Phase 5).
+// `cervin export-compliance` handler (vkgeorgia/strategy#84 Phase 5 + PDF follow-on).
 //
 // Lives in its own module — separate from cli.ts — because it imports the
 // compliance library from `@transitrix/diagrams` *source*. The root emit build
@@ -8,13 +8,16 @@
 // It is still type-checked by `npm run compile` (the root program has no
 // rootDir restriction).
 
-import { writeFileSync, readFileSync, readdirSync } from 'node:fs';
+import { writeFileSync, readFileSync, readdirSync, mkdtempSync, rmSync } from 'node:fs';
 import * as path from 'node:path';
+import * as os from 'node:os';
+import { spawnSync } from 'node:child_process';
 import yaml from 'js-yaml';
 import {
   emptyCanon,
   ingestComplianceDoc,
   renderComplianceMarkdown,
+  renderComplianceHtml,
   type ComplianceCanon,
   type ReportScope,
 } from '../packages/diagrams/src/compliance/index.js';
@@ -56,6 +59,51 @@ function parseScope(scopeArg: string | undefined): ReportScope | null {
   return null;
 }
 
+/** Invoke `weasyprint <html> <pdf>`. WeasyPrint is a Python tool; we shell out
+ *  rather than re-implement PDF generation in JS, matching the engine the
+ *  Transitrix site uses for one-pager renders so the styling stays consistent.
+ *  Surfaces ENOENT as an installable-prereq message rather than a stack trace. */
+function runWeasyPrint(htmlPath: string, pdfPath: string): { ok: true } | { ok: false; message: string } {
+  const candidates = process.platform === 'win32'
+    ? ['weasyprint.exe', 'weasyprint']
+    : ['weasyprint'];
+  let lastErr: NodeJS.ErrnoException | null = null;
+  for (const cmd of candidates) {
+    const res = spawnSync(cmd, [htmlPath, pdfPath], { encoding: 'utf-8' });
+    if (res.error && (res.error as NodeJS.ErrnoException).code === 'ENOENT') {
+      lastErr = res.error as NodeJS.ErrnoException;
+      continue;
+    }
+    if (res.error) {
+      return { ok: false, message: `weasyprint failed to launch: ${res.error.message}` };
+    }
+    if (res.status !== 0) {
+      const stderr = (res.stderr || '').trim();
+      return {
+        ok: false,
+        message: `weasyprint exited with code ${res.status}${stderr ? `:\n${stderr}` : ''}`,
+      };
+    }
+    return { ok: true };
+  }
+  return {
+    ok: false,
+    message:
+      'weasyprint executable not found on PATH. ' +
+      'PDF export requires WeasyPrint (https://weasyprint.org/) — install it (e.g. `pipx install weasyprint`) and re-run.' +
+      (lastErr ? ` Last error: ${lastErr.message}` : ''),
+  };
+}
+
+function defaultPdfFilename(scope: ReportScope): string {
+  switch (scope.mode) {
+    case 'matrix': return 'compliance-matrix.pdf';
+    case 'gap': return 'compliance-gap.pdf';
+    case 'law': return `compliance-${scope.id}.pdf`;
+    case 'product': return `compliance-${scope.id}.pdf`;
+  }
+}
+
 export async function handleExportComplianceCommand(argv: string[]): Promise<void> {
   const format = (flagValue(argv, '--format') ?? 'md').toLowerCase();
   const output = flagValue(argv, '--output');
@@ -66,23 +114,39 @@ export async function handleExportComplianceCommand(argv: string[]): Promise<voi
     console.error('export-compliance: unknown --scope (expected law:<LAW-ID>, product:<PRODUCT-ID>, gap, or omit for the full matrix).');
     process.exit(1);
   }
-  if (format === 'pdf') {
-    console.error('export-compliance: PDF export is the Phase 5 follow-on (WeasyPrint, A4 branded). Use --format md for now.');
-    process.exit(1);
-  }
-  if (format !== 'md') {
+  if (format !== 'md' && format !== 'pdf') {
     console.error(`export-compliance: unknown --format '${format}' (expected md or pdf).`);
     process.exit(1);
   }
 
   const canon = scanCanonFs(root);
   const today = new Date().toISOString().slice(0, 10);
-  const markdown = renderComplianceMarkdown(canon, scope, { today });
 
-  if (output) {
-    writeFileSync(output, markdown, 'utf-8');
-    console.error(`Wrote ${output}`);
-  } else {
-    process.stdout.write(markdown);
+  if (format === 'md') {
+    const markdown = renderComplianceMarkdown(canon, scope, { today });
+    if (output) {
+      writeFileSync(output, markdown, 'utf-8');
+      console.error(`Wrote ${output}`);
+    } else {
+      process.stdout.write(markdown);
+    }
+    return;
+  }
+
+  // format === 'pdf'
+  const html = renderComplianceHtml(canon, scope, { today });
+  const pdfPath = output ?? defaultPdfFilename(scope);
+  const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'cervin-export-'));
+  const htmlPath = path.join(tmpDir, 'report.html');
+  try {
+    writeFileSync(htmlPath, html, 'utf-8');
+    const result = runWeasyPrint(htmlPath, pdfPath);
+    if (!result.ok) {
+      console.error(`export-compliance: ${result.message}`);
+      process.exit(1);
+    }
+    console.error(`Wrote ${pdfPath}`);
+  } finally {
+    try { rmSync(tmpDir, { recursive: true, force: true }); } catch { /* best-effort cleanup */ }
   }
 }


### PR DESCRIPTION
## Summary

- Adds the **PDF format** to `cervin export-compliance` — completes the last unmet acceptance criterion of Phase 5 in epic [vkgeorgia/strategy#84](https://github.com/vkgeorgia/strategy/issues/84) ("a readable, branded PDF" for `--format pdf`).
- New `renderComplianceHtml` in `@transitrix/diagrams/compliance/html.ts` builds a self-contained A4-portrait branded document (CSS inlined, page rules, status badges that mirror the Studio preview palette).
- The CLI writes the HTML to a temp file and shells out to `weasyprint` (matching the engine the Transitrix site uses for one-pagers, so styling stays consistent). Missing binary → clear `pipx install weasyprint` hint instead of a stack trace.

## What changed

- `packages/diagrams/src/compliance/html.ts` (new) — `renderComplianceHtml(canon, scope, options)`. Covers matrix / law / product / gap. Pure string builder; no DOM, no fs.
- `packages/diagrams/src/compliance/__tests__/html.test.ts` (new) — 9 cases: document shell + page rules, XML/HTML escaping, matrix with badges + empty state, law tree with severity + badges + unknown-id empty state, product table, gap dashboard sections + summary count.
- `packages/diagrams/src/compliance/index.ts` — exports `renderComplianceHtml` + `HtmlOptions`.
- `src/export-compliance.ts` — replaces the "PDF is a follow-on" placeholder with the real path: render HTML → temp file → spawn `weasyprint <html> <pdf>` → clean up. Cross-platform candidate list, ENOENT surfaced as a clear install hint, non-zero exit captured with stderr. Default output filename derived from scope when `--output` is omitted.
- `src/cli.ts` — usage line now lists `--format md|pdf` and the WeasyPrint prereq.
- `packages/diagrams/src/compliance/markdown.ts` — header comment no longer calls PDF "planned".
- `CHANGELOG.md` — `Unreleased` entry.

## Scope discipline

- One concern (PDF export). No refactors. Markdown path unchanged.
- WeasyPrint is invoked as a binary on PATH; no new npm deps, no JS-side PDF engine, no Python in the repo.
- `--format html` was considered but **not** added (out of Phase 5 scope; the library-level `renderComplianceHtml` is the seam if anyone wants it later).

## Test plan

- [x] `npm test` — 235 core + 601 diagrams = 836 passed (incl. 9 new `html.test.ts` cases).
- [x] `npm run compile` + `npm run compile:extension` — clean.
- [x] `npm run build:webview-bundle` — clean.
- [x] CLI smoke: `cervin export-compliance --format md --scope gap --root examples` still renders the acme gap dashboard unchanged.
- [x] CLI smoke: `cervin export-compliance --format pdf --scope law:LAW-PERSONAL-DATA-2017-1 --output report.pdf --root examples` on a host without WeasyPrint installed surfaces the clean `pipx install weasyprint` hint and exits 1 (the agent host can't render an actual PDF — manual end-to-end PDF render is for a host with WeasyPrint installed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)