### PR TITLE
feat(intellij): Phase 4 — wire remaining 11 notations into JCEF bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,14 @@ node_modules/
 **/0. archive/
 
 dist/
+# Compiled output must never land beside the TypeScript sources. The diagrams
+# package builds to dist/ (above); these patterns are a backstop so a stray
+# bare `tsc` / `npx tsc <file>.ts` run can't litter the pure-TS src tree with
+# emitted .js/.d.ts and have it show up as untracked churn.
+packages/diagrams/src/**/*.js
+packages/diagrams/src/**/*.js.map
+packages/diagrams/src/**/*.d.ts
+packages/diagrams/src/**/*.d.ts.map
 extension/out/
 extension/compiler/
 # The entire media/ tree is build output: build-webview.mjs wipes and

--- a/intellij/src/main/kotlin/com/transitrix/intellij/TransitrixNotation.kt
+++ b/intellij/src/main/kotlin/com/transitrix/intellij/TransitrixNotation.kt
@@ -7,10 +7,10 @@ package com.transitrix.intellij
  * The suffix list mirrors `extension/package.json` `activationEvents` plus
  * the `*.cervin.yaml` / `*.bpmn.transitrix.yaml` files the VS Code extension
  * handles. The kinds returned here are the same strings the JS-side
- * `entry.ts` whitelists in `SUPPORTED_KINDS`. Phase 3 (ADR 0001 step 3) only
- * ships the `goals` renderer end-to-end; the other supported kinds return
- * `NOTATION-NOT-WIRED` from the bundle, which the host page surfaces as a
- * clear error panel — that's the deliberate Phase 3 / Phase 4 boundary.
+ * `entry.ts` whitelists in `SUPPORTED_KINDS`. As of Phase 4 (ADR 0001 step 4)
+ * every kind below is wired to its validator + renderer in the bundle, so a
+ * valid document renders and a malformed one surfaces the validation error
+ * panel.
  */
 object TransitrixNotation {
 

--- a/packages/diagrams/src/webview/__tests__/entry-notations.test.ts
+++ b/packages/diagrams/src/webview/__tests__/entry-notations.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Step 4 parity check: every supported notation must render through the
+ * webview bundle's `render(kind, source)` API from the same example fixtures
+ * the VS Code previews consume — a valid document yields `status: 'ok'` with
+ * non-empty markup, and a malformed document degrades to the error panel
+ * (structured errors, no thrown exception reaching the JVM host).
+ */
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { api, render, type NotationKind } from '../entry.js';
+
+const EXAMPLES = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../examples');
+
+interface Fixture {
+  kind: NotationKind;
+  file: string;
+  /** The markup wrapper the renderer emits: an <svg> diagram or an HTML <section>. */
+  markup: 'svg' | 'section';
+}
+
+// Mirrors the fixtures used by the VS Code previews. One representative
+// example per notation is enough to prove the dispatch + renderer wiring.
+const FIXTURES: Fixture[] = [
+  { kind: 'goals', file: 'goals/strategy-2026.goals.transitrix.yaml', markup: 'svg' },
+  { kind: 'fgca', file: 'fgca/strategy-2026.fgca.transitrix.yaml', markup: 'svg' },
+  { kind: 'fga', file: 'fga/strategy-2026.fga.transitrix.yaml', markup: 'svg' },
+  { kind: 'activities', file: 'activities/platform-launch.activities.transitrix.yaml', markup: 'svg' },
+  { kind: 'activity-card', file: 'activity-card/eu-programme.activity-card.transitrix.yaml', markup: 'svg' },
+  { kind: 'process-blueprint', file: 'process-blueprint/order-fulfilment.process-blueprint.transitrix.yaml', markup: 'svg' },
+  { kind: 'blocks', file: 'blocks/architecture.blocks.transitrix.yaml', markup: 'svg' },
+  { kind: 'applications', file: 'applications/portfolio-2026.applications.transitrix.yaml', markup: 'section' },
+  { kind: 'products', file: 'products/portfolio-2026.products.transitrix.yaml', markup: 'section' },
+  { kind: 'process-map', file: 'process-map/enterprise.process-map.transitrix.yaml', markup: 'section' },
+  { kind: 'scenarios', file: 'scenarios/omnichannel-2028.scenarios.transitrix.yaml', markup: 'section' },
+  { kind: 'capability-map', file: 'capability-map/business.capability-map.transitrix.yaml', markup: 'section' },
+];
+
+describe('webview/entry — Step 4 notation coverage', () => {
+  it('wires every supported kind (no kind left on NOTATION-NOT-WIRED)', () => {
+    // The fixture table must cover the full supported-kinds surface, so a new
+    // kind added to the bundle without a renderer fails this test loudly.
+    const covered = new Set(FIXTURES.map((f) => f.kind));
+    for (const kind of api.supportedKinds) {
+      expect(covered.has(kind)).toBe(true);
+    }
+  });
+
+  for (const fx of FIXTURES) {
+    it(`renders ${fx.kind} from its example fixture`, () => {
+      const source = readFileSync(path.join(EXAMPLES, fx.file), 'utf8');
+      const r = render(fx.kind, source);
+      expect(r.notation).toBe(fx.kind);
+      expect(r.errors).toEqual([]);
+      expect(r.status).toBe('ok');
+      expect(r.svg.length).toBeGreaterThan(0);
+      expect(r.svg).toContain(fx.markup === 'svg' ? '<svg ' : '<section');
+    });
+  }
+
+  it('degrades malformed input to the error panel for a diagram notation', () => {
+    const r = render('process-blueprint', 'process_blueprint:\n  stages: "not a list"\n');
+    expect(r.status).toBe('error');
+    expect(r.errors.length).toBeGreaterThan(0);
+    expect(r.svg).toBe('');
+  });
+
+  it('degrades malformed input to the error panel for a catalogue notation', () => {
+    const r = render('applications', 'applications_catalogue:\n  applications: "not a list"\n');
+    expect(r.status).toBe('error');
+    expect(r.errors.length).toBeGreaterThan(0);
+    expect(r.svg).toBe('');
+  });
+});

--- a/packages/diagrams/src/webview/__tests__/entry.test.ts
+++ b/packages/diagrams/src/webview/__tests__/entry.test.ts
@@ -45,11 +45,14 @@ describe('webview/entry — Step 2 host API', () => {
     expect(r.errors[0].code).toBe('KIND-UNKNOWN');
   });
 
-  it('returns NOTATION-NOT-WIRED for kinds that parse but have no Step 2 renderer', () => {
-    // fgca is a supported kind but Step 4 wires its validator into the bundle.
+  it('routes non-goals kinds to their validator after Step 4 (no NOTATION-NOT-WIRED)', () => {
+    // Every supported kind is now wired to its validator + renderer. A
+    // malformed fgca document must surface a structured validation error from
+    // the fgca validator — never the Step-2/3 "not wired" placeholder.
     const r = render('fgca', 'changes: []\n');
     expect(r.status).toBe('error');
-    expect(r.errors[0].code).toBe('NOTATION-NOT-WIRED');
+    expect(r.errors.length).toBeGreaterThan(0);
+    expect(r.errors.every((e) => e.code !== 'NOTATION-NOT-WIRED')).toBe(true);
   });
 
   it('surfaces goals validation errors structurally (e.g. missing notation header)', () => {

--- a/packages/diagrams/src/webview/entry.ts
+++ b/packages/diagrams/src/webview/entry.ts
@@ -12,14 +12,49 @@
  *
  * Step 2 scope: wire YAML parsing, dispatch to the right validator, surface
  * validation/parse errors in a structured JSON shape.
- * Step 3 scope (this PR): wire the `goals` SVG renderer so the bundle returns
- * non-empty `svg` for a valid goals document. Step 4 fills the remaining ten
- * notations.
+ * Step 3 scope: wire the `goals` SVG renderer so the bundle returns non-empty
+ * `svg` for a valid goals document.
+ * Step 4 scope (this PR): wire the remaining eleven notations — each one
+ * validates the parsed YAML and, when valid, renders host-neutral markup
+ * (SVG for the diagram notations, an HTML fragment for the catalogue
+ * notations). The JVM host drops whatever `svg` carries into the DOM, so the
+ * field name is historical — it transports any self-contained markup.
  */
 import yaml from 'js-yaml';
 
+import { validateActivities } from '../activities/index.js';
+import type { ActivityDoc } from '../activities/index.js';
+import { validateActivityCard } from '../activity-card/index.js';
+import type { ActivityCardDoc } from '../activity-card/index.js';
+import { validateApplicationsCatalogue } from '../applications/index.js';
+import type { ApplicationsCatalogueFile } from '../applications/index.js';
+import { validateNestedBlocks } from '../blocks/index.js';
+import type { BlocksFile } from '../blocks/index.js';
+import { validateCapabilityMap } from '../capability-map/index.js';
+import type { CapabilityMapFile } from '../capability-map/index.js';
+import { parseCanonicalFGCA, parseCanonicalFGA } from '../fgca/parse-canonical.js';
 import { parseCanonicalGoals } from '../goals/parse-canonical.js';
+import { validateProcessBlueprint } from '../process-blueprint/index.js';
+import type { ProcessBlueprintFile } from '../process-blueprint/index.js';
+import { validateProcessMap } from '../process-map/index.js';
+import type { ProcessMapFile } from '../process-map/index.js';
+import { validateProductsCatalogue } from '../products/index.js';
+import type { ProductsCatalogueFile } from '../products/index.js';
+import { validateScenario } from '../scenarios/index.js';
+import type { ScenarioFile } from '../scenarios/index.js';
+import { coerceDatesToIsoStrings } from '../yaml-normalize.js';
+
+import { renderActivitiesSvg } from './render-activities.js';
+import { renderActivityCardSvg } from './render-activity-card.js';
+import { renderApplicationsHtml } from './render-applications.js';
+import { renderBlocksSvg } from './render-blocks.js';
+import { renderCapabilityMapHtml } from './render-capability-map.js';
+import { renderFgcaSvg } from './render-fgca.js';
 import { renderGoalsSvg } from './render-goals.js';
+import { renderProcessBlueprintSvg } from './render-process-blueprint.js';
+import { renderProcessMapHtml } from './render-process-map.js';
+import { renderProductsHtml } from './render-products.js';
+import { renderScenarioHtml } from './render-scenarios.js';
 
 export interface RenderError {
   code: string;
@@ -38,7 +73,12 @@ export type RenderStatus = 'ok' | 'error';
 export interface RenderResult {
   status: RenderStatus;
   notation: string;
-  /** SVG markup once the renderer for `notation` is wired (Step 3+). Empty until then. */
+  /**
+   * Self-contained markup for the rendered notation — an `<svg>` for the
+   * diagram notations, an HTML `<section>` for the catalogue notations. Empty
+   * on validation failure (the host shows the error panel instead). The field
+   * name is historical; the JVM host injects whatever it carries into the DOM.
+   */
   svg: string;
   errors: RenderError[];
   warnings: RenderWarning[];
@@ -46,8 +86,8 @@ export interface RenderResult {
 
 /**
  * Notation kinds the host can request. Mirrors the `*.<kind>.<…>` suffix
- * convention used by the VS Code extension's `activationEvents`. Step 4 fills
- * the remaining ten; Step 2 only wires `goals` to its validator.
+ * convention used by the VS Code extension's `activationEvents`. All twelve
+ * are wired to their validator + renderer as of Step 4.
  */
 export type NotationKind =
   | 'goals'
@@ -92,10 +132,40 @@ function errorResult(notation: string, code: string, message: string, path?: str
 
 function parseYaml(source: string): { doc?: unknown; error?: string } {
   try {
-    return { doc: yaml.load(source) };
+    // Coerce native `Date`s (bare `2026-06-01` per YAML 1.1) back to ISO
+    // strings before validation — every notation validator expects string
+    // dates, and the VS Code previews apply the same normalisation. Without
+    // it the canonical-minus-quotes form would falsely fail shape checks.
+    return { doc: coerceDatesToIsoStrings(yaml.load(source)) };
   } catch (e: unknown) {
     return { error: e instanceof Error ? e.message : String(e) };
   }
+}
+
+interface ValidationLike {
+  valid: boolean;
+  errors: RenderError[];
+  warnings: RenderWarning[];
+}
+
+/**
+ * Shared shape for the validate-then-render notations: copy the validator's
+ * errors/warnings into the result, and render markup only once the document is
+ * valid. `renderMarkup` is a thunk so the (type-asserted) render call never
+ * runs against a document the validator rejected.
+ */
+function renderFromValidation(
+  kind: NotationKind,
+  result: ValidationLike,
+  renderMarkup: () => string,
+): RenderResult {
+  const r = emptyResult(kind, result.valid ? 'ok' : 'error');
+  r.errors.push(...result.errors);
+  r.warnings.push(...result.warnings);
+  if (result.valid) {
+    r.svg = renderMarkup();
+  }
+  return r;
 }
 
 function dispatchValidate(kind: NotationKind, doc: unknown): RenderResult {
@@ -112,9 +182,67 @@ function dispatchValidate(kind: NotationKind, doc: unknown): RenderResult {
       }
       return r;
     }
-    // Step 4 wires the remaining notations. Until then they parse successfully
-    // and surface a clear "not wired" error rather than crashing — the JVM
-    // host can show the user a meaningful message instead of an empty panel.
+    // FGCA and FGA share the canonical parse + renderer; only the layer
+    // visibility differs (FGA collapses the Change column). Both carry the
+    // parsed `FGCADoc` on the result's `parsed` field when valid.
+    case 'fgca': {
+      const v = parseCanonicalFGCA(doc);
+      const r = emptyResult('fgca', v.valid ? 'ok' : 'error');
+      r.errors.push(...v.errors);
+      r.warnings.push(...v.warnings);
+      if (v.valid && v.parsed) {
+        r.svg = renderFgcaSvg(v.parsed, { variant: 'fgca' });
+      }
+      return r;
+    }
+    case 'fga': {
+      const v = parseCanonicalFGA(doc);
+      const r = emptyResult('fga', v.valid ? 'ok' : 'error');
+      r.errors.push(...v.errors);
+      r.warnings.push(...v.warnings);
+      if (v.valid && v.parsed) {
+        r.svg = renderFgcaSvg(v.parsed, { variant: 'fga' });
+      }
+      return r;
+    }
+    case 'activities':
+      return renderFromValidation('activities', validateActivities(doc), () =>
+        renderActivitiesSvg(doc as ActivityDoc),
+      );
+    case 'activity-card':
+      return renderFromValidation('activity-card', validateActivityCard(doc), () =>
+        renderActivityCardSvg(doc as ActivityCardDoc),
+      );
+    case 'process-blueprint':
+      return renderFromValidation('process-blueprint', validateProcessBlueprint(doc), () =>
+        renderProcessBlueprintSvg(doc as ProcessBlueprintFile),
+      );
+    case 'blocks':
+      return renderFromValidation('blocks', validateNestedBlocks(doc), () =>
+        renderBlocksSvg(doc as BlocksFile),
+      );
+    // Catalogue notations render an HTML fragment from the header nested under
+    // their top-level wrapper key (`<thing>_catalogue` / `scenario` / …).
+    case 'applications':
+      return renderFromValidation('applications', validateApplicationsCatalogue(doc), () =>
+        renderApplicationsHtml((doc as ApplicationsCatalogueFile).applications_catalogue),
+      );
+    case 'products':
+      return renderFromValidation('products', validateProductsCatalogue(doc), () =>
+        renderProductsHtml((doc as ProductsCatalogueFile).products_catalogue),
+      );
+    case 'process-map':
+      return renderFromValidation('process-map', validateProcessMap(doc), () =>
+        renderProcessMapHtml((doc as ProcessMapFile).process_map),
+      );
+    case 'scenarios':
+      return renderFromValidation('scenarios', validateScenario(doc), () =>
+        renderScenarioHtml((doc as ScenarioFile).scenario),
+      );
+    case 'capability-map':
+      return renderFromValidation('capability-map', validateCapabilityMap(doc), () =>
+        renderCapabilityMapHtml((doc as CapabilityMapFile).capability_map),
+      );
     default:
       return errorResult(
         kind,

--- a/packages/diagrams/src/webview/render-activities.ts
+++ b/packages/diagrams/src/webview/render-activities.ts
@@ -1,0 +1,156 @@
+/**
+ * Browser-safe SVG renderer for the Activities notation (network / PSND view).
+ *
+ * Step 4 of the IntelliJ epic (ADR 0001): the webview bundle must turn a
+ * validated ActivityDoc into renderable SVG so JCEF can drop it into the
+ * preview panel. The VS Code path lives in `extension/src/activities-preview.ts`
+ * and pulls in VS Code-specific concerns (themes, title block, Gantt tab
+ * switcher, save dialogs); this module is the host-neutral subset — pure
+ * layout → SVG with no VS Code APIs, no `node:fs`, no `node:path`.
+ *
+ * Only the DEFAULT network view (Project Schedule Network Diagram) is ported.
+ * The Gantt view, the CSS-only tab switcher and the interactive spacing /
+ * curvature controls stay in the VS Code preview.
+ */
+import { layoutActivities } from '../activities/layout.js';
+import { computeCpm } from '../activities/cpm.js';
+import type {
+  ActivityDoc,
+  ActivitiesLayout,
+  ActivitiesLayoutOptions,
+} from '../activities/types.js';
+import { horizontalCubicEdgePath, DEFAULT_EDGE_CURVATURE } from '../edge-path.js';
+import { generateSvgEmbedCss } from '../theme/index.js';
+import { escXml } from './render-util.js';
+
+const N_NODE_W = 200;
+const N_NODE_H = 80;
+const N_PAD = 24;
+
+// Activities-specific diagram CSS. Mirrors `ACTIVITIES_DIAGRAM_CSS` from the
+// VS Code preview — the rules that shape the network diagram itself (critical
+// path, milestones, edge colours). Embedded alongside the shared theme CSS so
+// the SVG is self-contained for the JCEF host.
+const ACTIVITIES_DIAGRAM_CSS = `
+  .act-node { fill: var(--ts-bg-surface, #f8fafc); stroke: var(--ts-border, #94a3b8); stroke-width: 1.5; }
+  .critical-node { fill: #fff7ed; stroke: var(--ts-brand-orange, #ff4d00); stroke-width: 2.5; }
+  .milestone-node { fill: #ecfeff; stroke: var(--ts-text-muted, #64748b); stroke-dasharray: 4 2; }
+  .critical-edge { stroke: var(--ts-brand-orange, #ff4d00); stroke-width: 2; }
+  .arrow-fill-critical { fill: var(--ts-brand-orange, #ff4d00); }
+`;
+
+function truncate(s: string, maxLen: number): string {
+  return s.length > maxLen ? s.slice(0, maxLen - 1) + '…' : s;
+}
+
+export interface RenderActivitiesOptions {
+  /** Optional heading rendered as a `text-header` above the diagram. */
+  title?: string;
+  /** Network column / row gaps. Defaults match `layoutActivities`. */
+  gaps?: ActivitiesLayoutOptions;
+  /** Edge curvature; 1 = default, 0 = straight, higher = stronger arc. */
+  curvature?: number;
+}
+
+/**
+ * Render the network (PSND) view of an already-validated ActivityDoc to a
+ * self-contained SVG string.
+ *
+ * The caller passes a doc cast from the yaml-parsed `unknown` after
+ * `validateActivities` returns valid (the activities module has no parsed
+ * field, so the dispatcher does `doc as ActivityDoc`).
+ *
+ * Cyclic graphs degrade gracefully: `layoutActivities` / `computeCpm` defend
+ * against cycles internally (Kahn's topo-order omits cyclic nodes from the
+ * critical-path computation, which `computeCpm` backfills with neutral CPM
+ * values), so this renderer simply renders whatever the layout returns rather
+ * than short-circuiting.
+ */
+export function renderActivitiesSvg(doc: ActivityDoc, options: RenderActivitiesOptions = {}): string {
+  const { title = '', gaps = {}, curvature = DEFAULT_EDGE_CURVATURE } = options;
+
+  const layout: ActivitiesLayout = layoutActivities(doc, gaps);
+
+  if (layout.nodes.length === 0) {
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="0" height="0" viewBox="0 0 0 0"></svg>`;
+  }
+
+  const cpm = computeCpm(doc.activities ?? []);
+  const titleH = title ? 24 : 0;
+  const w = layout.bounds.width + N_PAD * 2;
+  const h = layout.bounds.height + N_PAD * 2 + titleH;
+  const ox = -layout.bounds.x + N_PAD;
+  const oy = -layout.bounds.y + N_PAD + titleH;
+
+  const nodeMap = new Map(layout.nodes.map((n) => [n.id, n]));
+
+  // SVG paints later siblings over earlier ones. Sort non-critical first so the
+  // bright orange critical-path edges land on top — a gray edge crossing an
+  // orange one shouldn't bury the critical signal.
+  const orderedEdges = [...layout.edges].sort(
+    (a, b) => Number(Boolean(a.isCritical)) - Number(Boolean(b.isCritical)),
+  );
+
+  // Edge path = a single cubic Bézier with horizontal control handles (shared
+  // geometry in `edge-path.js`), so the curve meets the vertical node edge at a
+  // right angle and the marker-end arrow reads as perpendicular.
+  const edgeSvg = orderedEdges
+    .map((e) => {
+      const s = nodeMap.get(e.sourceId);
+      const t = nodeMap.get(e.targetId);
+      if (!s || !t) return '';
+      const sx = s.x + ox + s.width;
+      const sy = s.y + oy + s.height / 2;
+      const tx = t.x + ox;
+      const ty = t.y + oy + t.height / 2;
+      const cls = e.isCritical ? 'diagram-edge critical-edge' : 'diagram-edge';
+      const marker = `url(#${e.isCritical ? 'arrow-crit' : 'arrow'})`;
+      return `<path d="${horizontalCubicEdgePath(sx, sy, tx, ty, curvature)}" class="${cls}" marker-end="${marker}"/>`;
+    })
+    .join('\n');
+
+  const nodeSvg = layout.nodes
+    .map((n) => {
+      const x = n.x + ox;
+      const y = n.y + oy;
+      const isCritical = cpm.get(n.id)?.isCritical ?? false;
+      const isMilestone = (n.data.duration ?? -1) === 0;
+      const cls = `diagram-node act-node ${isCritical ? 'critical-node' : ''} ${isMilestone ? 'milestone-node' : ''}`.trim();
+      const idLabel = escXml(n.id);
+      const nameLabel = escXml(truncate(n.data.name, 24));
+      const durLabel = n.data.duration !== undefined ? `${n.data.duration}d` : '—';
+      return [
+        `<rect class="${cls}" x="${x}" y="${y}" width="${N_NODE_W}" height="${N_NODE_H}" rx="6"/>`,
+        `<text class="text-id" x="${x + 8}" y="${y + 18}">${idLabel}</text>`,
+        `<text class="text-primary" x="${x + N_NODE_W / 2}" y="${y + N_NODE_H / 2}" text-anchor="middle" dominant-baseline="central">${nameLabel}</text>`,
+        `<text class="text-secondary" x="${x + N_NODE_W - 8}" y="${y + N_NODE_H - 10}" text-anchor="end">${escXml(durLabel)}</text>`,
+      ].join('\n');
+    })
+    .join('\n');
+
+  const titleSvg = title
+    ? `<text class="text-header" x="${N_PAD}" y="${N_PAD - 6}">${escXml(title)}</text>`
+    : '';
+
+  // Embed the shared theme CSS plus the activities-specific diagram CSS inside
+  // the SVG so the rendered output is self-contained — the JCEF host page only
+  // needs to drop the SVG into the DOM and styling resolves without any
+  // cooperation from the host stylesheet. Matches what the VS Code path
+  // produces via `prepareSvgForExport`.
+  const embedCss = generateSvgEmbedCss('transitrix') + ACTIVITIES_DIAGRAM_CSS;
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">
+<style>${embedCss}</style>
+<defs>
+  <marker id="arrow" markerWidth="8" markerHeight="8" refX="8" refY="3" orient="auto">
+    <path d="M0,0 L0,6 L8,3 z" class="arrow-fill"/>
+  </marker>
+  <marker id="arrow-crit" markerWidth="8" markerHeight="8" refX="8" refY="3" orient="auto">
+    <path d="M0,0 L0,6 L8,3 z" class="arrow-fill-critical"/>
+  </marker>
+</defs>
+${titleSvg}
+${nodeSvg}
+${edgeSvg}
+</svg>`;
+}

--- a/packages/diagrams/src/webview/render-activity-card.ts
+++ b/packages/diagrams/src/webview/render-activity-card.ts
@@ -1,0 +1,233 @@
+/**
+ * Host-neutral SVG renderer for the Activity Card notation.
+ *
+ * Step 4 of the IntelliJ epic (ADR 0001): the webview bundle must turn a
+ * validated Activity Card document into renderable SVG so JCEF can drop it into
+ * the preview panel. The VS Code path lives in
+ * `extension/src/activity-card-preview.ts` and pulls in VS Code-specific
+ * concerns (themes, title block, save dialogs, sibling-document discovery on
+ * the filesystem); this module is the host-neutral subset — pure layout → SVG
+ * with no VS Code APIs, no `node:fs`, no `node:path`.
+ *
+ * CROSS-DOCUMENT RESOLUTION CAVEAT
+ * The Activity Card is the only MULTI-DOCUMENT Studio notation: the card YAML
+ * names a project Activity, and the project's name, dates, motivation chain
+ * (Factors → Goals → Changes) and child activities are pulled BY REFERENCE from
+ * sibling `*.activities.*` / `*.fgca.*` documents in the same directory (see
+ * `../activity-card/resolver.ts`). That resolution requires reading those
+ * sibling files from disk, which is NOT available inside the JCEF host. We
+ * therefore resolve from the single in-memory card document ONLY: we synthesise
+ * a minimal `ResolvedActivityCard` whose project carries just the referenced
+ * project id (no resolved name/dates), whose milestones come straight from the
+ * card's own `milestones[]`, and whose motivation chain + child activities are
+ * empty (those cannot resolve without the siblings). The SVG layout is shared
+ * with the VS Code path via `layoutActivityCard`, so a single-document card
+ * still renders its title, dates band and milestone timeline.
+ */
+import { layoutActivityCard, ARCHIMATE_CLASS } from '../activity-card/layout.js';
+import type {
+  ActivityCardDoc,
+  ActivityCardLayout,
+  ResolvedActivityCard,
+  ResolvedMilestone,
+} from '../activity-card/types.js';
+import { generateSvgEmbedCss } from '../theme/index.js';
+import { escXml } from './render-util.js';
+
+const PAD = 24;
+
+const EMPTY_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="0" height="0" viewBox="0 0 0 0"></svg>`;
+
+export interface RenderActivityCardOptions {
+  title?: string;
+}
+
+function truncate(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  return text.slice(0, Math.max(0, maxChars - 1)) + '…';
+}
+
+/**
+ * Build a single-document resolution of the card: everything that can be read
+ * straight off the card YAML, with the cross-document fields left empty. This
+ * mirrors what `resolveActivityCard` produces, minus the parts that need the
+ * sibling `*.activities.*` / `*.fgca.*` documents (project name/dates,
+ * motivation chain, child activities).
+ */
+function resolveSingleDoc(doc: ActivityCardDoc): ResolvedActivityCard {
+  const card = doc.activity_card;
+  const rawMilestones = Array.isArray(card?.milestones) ? card.milestones : [];
+
+  const milestones: ResolvedMilestone[] = rawMilestones
+    .filter((m): m is NonNullable<typeof m> => !!m && typeof m === 'object')
+    .map((m) => ({
+      id: m.id,
+      name: m.name,
+      date: m.date,
+      description: m.description,
+      deliversChanges: Array.isArray(m.delivers_changes) ? m.delivers_changes : [],
+    }))
+    .sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
+
+  return {
+    cardId: card?.id ?? '',
+    cardDescription: card?.description,
+    // No sibling docs in the host-neutral path: the project resolves to its id
+    // only. The layout falls back to '—' for the unknown date fields.
+    project: { id: card?.project ?? '', name: card?.project ?? '' },
+    milestones,
+    motivation: { factors: [], goals: [], changes: [] },
+    childActivities: [],
+  };
+}
+
+function buildBody(layout: ActivityCardLayout, ox: number, oy: number): string {
+  const parts: string[] = [];
+
+  // Outer card.
+  parts.push(
+    `<rect class="diagram-node level-0" x="${ox}" y="${oy}" width="${layout.bounds.width}" height="${layout.bounds.height}" rx="8"/>`,
+  );
+
+  // Title (project name / id).
+  parts.push(
+    `<text class="text-header" x="${layout.title.x + ox}" y="${layout.title.y + oy}" dominant-baseline="central" font-size="18">${escXml(truncate(layout.title.name, 70))}</text>`,
+  );
+
+  // Dates band.
+  for (const d of layout.dateFields) {
+    parts.push(
+      `<rect class="diagram-node level-2" x="${d.x + ox}" y="${d.y + oy}" width="${d.width}" height="${d.height}" rx="6"/>`,
+    );
+    parts.push(
+      `<text class="text-secondary" x="${d.x + ox + 12}" y="${d.y + oy + 18}" dominant-baseline="central">${escXml(d.label)}</text>`,
+    );
+    parts.push(
+      `<text class="text-primary" x="${d.x + ox + 12}" y="${d.y + oy + 40}" dominant-baseline="central">${escXml(d.value)}</text>`,
+    );
+  }
+
+  // Section headers.
+  for (const s of layout.sectionHeaders) {
+    parts.push(
+      `<text class="text-header" x="${s.x + ox}" y="${s.y + oy + s.height / 2}" dominant-baseline="central">${escXml(s.label)}</text>`,
+    );
+  }
+
+  // Milestones.
+  for (const m of layout.milestones) {
+    parts.push(
+      `<rect class="diagram-node level-3" x="${m.x + ox}" y="${m.y + oy}" width="${m.width}" height="${m.height}" rx="6"/>`,
+    );
+    parts.push(
+      `<text class="text-secondary" x="${m.x + ox + 10}" y="${m.y + oy + 16}" dominant-baseline="central">${escXml(m.date)}</text>`,
+    );
+    parts.push(
+      `<text class="text-primary" x="${m.x + ox + 10}" y="${m.y + oy + 36}" dominant-baseline="central">${escXml(truncate(m.name, 22))}</text>`,
+    );
+    parts.push(
+      `<text class="text-secondary" x="${m.x + ox + 10}" y="${m.y + oy + 52}" dominant-baseline="central" font-style="italic">(${escXml(m.archimateClass)})</text>`,
+    );
+  }
+
+  // Motivation chain — edges first (under nodes).
+  const nodeById = new Map<string, { x: number; y: number; width: number; height: number }>();
+  for (const col of [
+    layout.chainColumns.factors,
+    layout.chainColumns.goals,
+    layout.chainColumns.changes,
+  ]) {
+    for (const n of col) nodeById.set(n.id, n);
+  }
+  for (const e of layout.chainEdges) {
+    const s = nodeById.get(e.sourceId);
+    const t = nodeById.get(e.targetId);
+    if (!s || !t) continue;
+    const x1 = s.x + s.width + ox;
+    const y1 = s.y + s.height / 2 + oy;
+    const x2 = t.x + ox;
+    const y2 = t.y + t.height / 2 + oy;
+    const mx = (x1 + x2) / 2;
+    parts.push(
+      `<path class="diagram-edge" d="M${x1},${y1} C${mx},${y1} ${mx},${y2} ${x2},${y2}" fill="none" marker-end="url(#ac-arrow)"/>`,
+    );
+  }
+  const chainLevels: Array<[typeof layout.chainColumns.factors, number]> = [
+    [layout.chainColumns.factors, 4],
+    [layout.chainColumns.goals, 5],
+    [layout.chainColumns.changes, 6],
+  ];
+  for (const [col, level] of chainLevels) {
+    for (const n of col) {
+      parts.push(
+        `<rect class="diagram-node level-${level}" x="${n.x + ox}" y="${n.y + oy}" width="${n.width}" height="${n.height}" rx="6"/>`,
+      );
+      parts.push(
+        `<text class="text-pill" x="${n.x + ox + n.width / 2}" y="${n.y + oy + n.height / 2}" text-anchor="middle" dominant-baseline="central">${escXml(truncate(n.name, Math.floor(n.width / 7)))}</text>`,
+      );
+    }
+  }
+
+  // Child activities.
+  for (const a of layout.childActivities) {
+    parts.push(
+      `<rect class="diagram-node level-1" x="${a.x + ox}" y="${a.y + oy}" width="${a.width}" height="${a.height}" rx="6"/>`,
+    );
+    parts.push(
+      `<text class="text-primary" x="${a.x + ox + 12}" y="${a.y + oy + a.height / 2}" dominant-baseline="central">${escXml(truncate(a.name, 48))} <tspan class="text-secondary" font-style="italic">(${escXml(a.archimateClass)})</tspan></text>`,
+    );
+    if (a.meta) {
+      parts.push(
+        `<text class="text-secondary" x="${a.x + a.width + ox - 12}" y="${a.y + oy + a.height / 2}" text-anchor="end" dominant-baseline="central">${escXml(truncate(a.meta, 40))}</text>`,
+      );
+    }
+  }
+
+  return parts.join('\n');
+}
+
+export function renderActivityCardSvg(
+  doc: ActivityCardDoc,
+  options: RenderActivityCardOptions = {},
+): string {
+  // `ARCHIMATE_CLASS` is referenced so the host-neutral module pins the same
+  // §5.1 class convention the layout applies; keeps the import meaningful.
+  void ARCHIMATE_CLASS;
+
+  const { title = '' } = options;
+
+  const resolved = resolveSingleDoc(doc);
+  const layout = layoutActivityCard(resolved);
+
+  if (layout.bounds.width <= 0 || layout.bounds.height <= 0) {
+    return EMPTY_SVG;
+  }
+
+  const titleH = title ? 28 : 0;
+  const w = layout.bounds.width + PAD * 2;
+  const h = layout.bounds.height + PAD * 2 + titleH;
+  const ox = PAD;
+  const oy = PAD + titleH;
+
+  const body = buildBody(layout, ox, oy);
+
+  const titleSvg = title
+    ? `<text class="text-header" x="${PAD}" y="${PAD + 14}">${escXml(`Activity Card — ${title}`)}</text>`
+    : '';
+
+  // Embed the shared theme CSS inside the SVG so the rendered output is
+  // self-contained — the JCEF host page only needs to drop the SVG into the
+  // DOM and styling resolves without any cooperation from the host stylesheet.
+  const embedCss = generateSvgEmbedCss('transitrix');
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">
+<style>${embedCss}</style>
+<defs>
+  <marker id="ac-arrow" markerWidth="8" markerHeight="8" refX="8" refY="3" orient="auto">
+    <path d="M0,0 L0,6 L8,3 z" class="arrow-fill"/>
+  </marker>
+</defs>
+${titleSvg}
+${body}
+</svg>`;
+}

--- a/packages/diagrams/src/webview/render-applications.ts
+++ b/packages/diagrams/src/webview/render-applications.ts
@@ -1,0 +1,123 @@
+/**
+ * Host-neutral renderer for the Applications catalogue notation.
+ *
+ * Mirrors the VS Code preview (`extension/src/applications-preview.ts`) but
+ * strips the VS Code-specific concerns (theme lookup, command URIs, fix-prompt
+ * scaffolding). The output is a self-contained HTML fragment — a `<section>`
+ * carrying its own `<style>` block — that the JCEF host can drop into
+ * `#transitrix-root` exactly the way it drops the goals SVG (Step 3 contract).
+ */
+import type {
+  Application,
+  ApplicationIntegration,
+  ApplicationsCatalogueHeader,
+} from '../applications/types.js';
+import { escHtml } from './render-util.js';
+
+const TYPE_LABEL: Record<string, string> = {
+  application: 'Application',
+  integration: 'Integration',
+  platform: 'Platform',
+  data_store: 'Data Store',
+};
+
+const STATUS_BADGE: Record<string, string> = {
+  Active: 'badge-active',
+  Draft: 'badge-draft',
+  Deprecated: 'badge-deprecated',
+  Decommissioning: 'badge-decommissioning',
+};
+
+function maturityDots(m: number | undefined): string {
+  if (m === undefined) return '<span class="cell-empty">—</span>';
+  const filled = '●'.repeat(Math.max(0, Math.min(5, m)));
+  const empty = '○'.repeat(5 - Math.max(0, Math.min(5, m)));
+  return `<span class="maturity-dots">${filled}${empty}</span>`;
+}
+
+function disclosureList(label: string, items: string[] | undefined): string {
+  if (!items || items.length === 0) return '';
+  const lis = items.map((i) => `<li>${escHtml(i)}</li>`).join('');
+  return `<details><summary>${escHtml(label)} (${items.length})</summary><ul>${lis}</ul></details>`;
+}
+
+function renderIntegrations(integrations: ApplicationIntegration[] | undefined): string {
+  if (!integrations || integrations.length === 0) return '';
+  const items = integrations
+    .map((intg) => {
+      const parts = [
+        intg.target ? escHtml(intg.target) : '?',
+        intg.direction ? `<span class="intg-dir">${escHtml(intg.direction)}</span>` : '',
+        intg.protocol ? `<span class="intg-proto">${escHtml(intg.protocol)}</span>` : '',
+      ]
+        .filter(Boolean)
+        .join(' ');
+      const desc = intg.description ? `<span class="intg-desc">${escHtml(intg.description)}</span>` : '';
+      return `<li>${parts}${desc ? ' — ' + desc : ''}</li>`;
+    })
+    .join('');
+  return `<details><summary>Integrations (${integrations.length})</summary><ul>${items}</ul></details>`;
+}
+
+function renderRow(a: Application): string {
+  const extras = [
+    renderIntegrations(a.integrations),
+    disclosureList('Capabilities', a.capabilities),
+    disclosureList('Products', a.products),
+  ]
+    .filter(Boolean)
+    .join('');
+  const vendorCell = a.vendor
+    ? `<span class="${a.vendor === 'Internal' ? 'vendor-internal' : 'vendor-external'}">${escHtml(a.vendor)}</span>`
+    : '<span class="cell-empty">—</span>';
+  return `<tr>
+  <td class="col-name">
+    <div class="catalogue-name">${escHtml(a.name)}</div>
+    <div class="catalogue-id">${escHtml(a.app_id)}</div>
+    ${a.description ? `<div class="catalogue-desc">${escHtml(a.description)}</div>` : ''}
+    ${extras}
+  </td>
+  <td class="col-type"><span class="type-tag">${escHtml(TYPE_LABEL[a.type] ?? a.type)}</span></td>
+  <td class="col-status"><span class="tx-badge ${escHtml(STATUS_BADGE[a.status] ?? '')}">${escHtml(a.status)}</span></td>
+  <td class="col-maturity">${maturityDots(a.maturity)}</td>
+  <td class="col-domain">${a.domain ? escHtml(a.domain) : '<span class="cell-empty">—</span>'}</td>
+  <td class="col-vendor">${vendorCell}</td>
+  <td class="col-owner">${a.owner_role ? escHtml(a.owner_role) : '<span class="cell-empty">—</span>'}</td>
+</tr>`;
+}
+
+export function renderApplicationsHtml(catalogue: ApplicationsCatalogueHeader): string {
+  const rows = catalogue.applications.map(renderRow).join('\n');
+  const emptyRow = catalogue.applications.length === 0
+    ? `<tr><td colspan="7" class="empty-catalogue">No applications defined.</td></tr>`
+    : '';
+  const header = `<header class="catalogue-header">
+    <div class="catalogue-title">${escHtml(catalogue.name)}</div>
+    <div class="catalogue-meta">
+      <span class="catalogue-id-tag">${escHtml(catalogue.id)}</span>
+      <span class="catalogue-updated">Updated ${escHtml(catalogue.updated_at)}</span>
+      ${catalogue.version ? `<span class="catalogue-version">v${escHtml(catalogue.version)}</span>` : ''}
+    </div>
+    ${catalogue.description ? `<div class="catalogue-subtitle">${escHtml(catalogue.description)}</div>` : ''}
+  </header>`;
+  return `<section class="tx-catalogue tx-applications">
+${header}
+<table class="catalogue-table">
+  <thead>
+    <tr>
+      <th>Name / ID</th>
+      <th>Type</th>
+      <th>Status</th>
+      <th>Maturity</th>
+      <th>Domain</th>
+      <th>Vendor</th>
+      <th>Owner Role</th>
+    </tr>
+  </thead>
+  <tbody>
+    ${rows}
+    ${emptyRow}
+  </tbody>
+</table>
+</section>`;
+}

--- a/packages/diagrams/src/webview/render-blocks.ts
+++ b/packages/diagrams/src/webview/render-blocks.ts
@@ -1,0 +1,91 @@
+/**
+ * Browser-safe SVG renderer for the Nested Blocks notation.
+ *
+ * Step 4 of the IntelliJ epic (ADR 0001): the webview bundle must turn a
+ * validated BlocksFile into renderable SVG so JCEF can drop it into the
+ * preview panel. The VS Code path lives in `extension/src/blocks-preview.ts`
+ * and pulls in VS Code-specific concerns (themes, title block, save dialogs);
+ * this module is the host-neutral subset — pure `layoutNestedBlocks` → SVG
+ * with no VS Code APIs, no `node:*`, and no svgbob subprocess.
+ *
+ * Follows the same shape as `render-goals.ts`: a self-contained `<svg>` with
+ * the shared theme CSS embedded in a `<style>` element and a simple optional
+ * title `<text>`.
+ */
+import { layoutNestedBlocks } from '../blocks/layout.js';
+import type { BlocksFile, BlocksLayout, LaidOutBlock } from '../blocks/types.js';
+import { generateSvgEmbedCss } from '../theme/index.js';
+import { escXml } from './render-util.js';
+
+const PAD = 24;
+
+export interface RenderBlocksOptions {
+  title?: string;
+}
+
+/**
+ * Pick the diagram-frame level class for a block at the given depth.
+ *
+ * `level-0` is the lightest fill in the brand colour ramp; deeper levels are
+ * progressively darker. The methodology spec mandates "outermost lightest"
+ * (08-blocks.md §7), so depth 1 (top-level) maps to `level-0`. The theme CSS
+ * defines `level-0` … `level-6`; deeper blocks reuse `level-6`.
+ */
+function levelClassForDepth(depth: number): string {
+  const idx = Math.min(Math.max(depth - 1, 0), 6);
+  return `level-${idx}`;
+}
+
+function truncate(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  return text.slice(0, Math.max(0, maxChars - 1)) + '…';
+}
+
+function emitBlockSvg(b: LaidOutBlock, ox: number, oy: number, parts: string[]): void {
+  const cls = levelClassForDepth(b.depth);
+  parts.push(
+    `<rect class="diagram-node ${cls}" x="${b.x + ox}" y="${b.y + oy}" width="${b.width}" height="${b.height}" rx="6"/>`,
+  );
+
+  // Header label, centred horizontally within the block's header strip.
+  const headerY = b.y + oy + b.headerHeight / 2;
+  const maxChars = Math.max(4, Math.floor(b.width / 8));
+  parts.push(
+    `<text class="text-header" x="${b.x + ox + b.width / 2}" y="${headerY}" text-anchor="middle" dominant-baseline="central">${escXml(truncate(b.name, maxChars))}</text>`,
+  );
+
+  for (const c of b.children) emitBlockSvg(c, ox, oy, parts);
+}
+
+export function renderBlocksSvg(doc: BlocksFile, options: RenderBlocksOptions = {}): string {
+  const { title = '' } = options;
+
+  const layout: BlocksLayout = layoutNestedBlocks(doc);
+
+  if (layout.blocks.length === 0) {
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="0" height="0" viewBox="0 0 0 0"></svg>`;
+  }
+
+  const w = layout.bounds.width + PAD * 2;
+  const h = layout.bounds.height + PAD * 2;
+  const ox = -layout.bounds.x + PAD;
+  const oy = -layout.bounds.y + PAD;
+
+  const parts: string[] = [];
+  for (const top of layout.blocks) emitBlockSvg(top, ox, oy, parts);
+
+  const titleSvg = title
+    ? `<text class="text-header" x="${PAD}" y="${PAD - 6}">${escXml(`Nested Blocks — ${title}`)}</text>`
+    : '';
+
+  // Embed the shared theme CSS inside the SVG so the rendered output is
+  // self-contained — the JCEF host page only needs to drop the SVG into the
+  // DOM and styling resolves without any cooperation from the host stylesheet.
+  const embedCss = generateSvgEmbedCss('transitrix');
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">
+<style>${embedCss}</style>
+${titleSvg}
+${parts.join('\n')}
+</svg>`;
+}

--- a/packages/diagrams/src/webview/render-capability-map.ts
+++ b/packages/diagrams/src/webview/render-capability-map.ts
@@ -1,0 +1,98 @@
+/**
+ * Host-neutral renderer for the Capability Map notation.
+ * Mirrors `extension/src/capability-map-preview.ts`; emits a self-contained
+ * HTML fragment for the JCEF host (Step 4 of ADR 0001).
+ */
+import type { CapabilityMapHeader, CapabilityNode } from '../capability-map/types.js';
+import { escHtml } from './render-util.js';
+
+const MATURITY_LABEL: Record<number, string> = {
+  1: 'Initial',
+  2: 'Managed',
+  3: 'Defined',
+  4: 'Quantitatively Managed',
+  5: 'Optimising',
+};
+
+function maturityBadge(level: number, kind: 'current' | 'target'): string {
+  const safe = Math.max(1, Math.min(5, level | 0));
+  const label = kind === 'current' ? 'Current' : 'Target';
+  return `<span class="maturity-pill maturity-${safe}" title="${label}: Level ${safe} — ${escHtml(MATURITY_LABEL[safe] ?? '')}">L${safe}</span>`;
+}
+
+function isHorizontal(id: string): boolean {
+  return id.startsWith('H');
+}
+
+function renderCapabilityCard(node: CapabilityNode, depth: number): string {
+  const cls = ['capability-card', `depth-${Math.min(depth, 3)}`];
+  if (node.type) cls.push(`cap-type-${node.type}`);
+  if (isHorizontal(node.id)) cls.push('cap-horizontal');
+
+  const current = maturityBadge(node.current_maturity, 'current');
+  const target = node.target_maturity !== undefined ? maturityBadge(node.target_maturity, 'target') : '';
+  const arrow = target ? '<span class="maturity-arrow">→</span>' : '';
+
+  const meta: string[] = [];
+  if (node.type) meta.push(`<span class="cap-tag cap-tag-${escHtml(node.type)}">${escHtml(node.type)}</span>`);
+  if (node.owner_role) meta.push(`<span class="cap-meta">Owner: ${escHtml(node.owner_role)}</span>`);
+  if (node.business_process) meta.push(`<span class="cap-meta">Process: ${escHtml(node.business_process)}</span>`);
+  if (node.target_date) meta.push(`<span class="cap-meta">By ${escHtml(node.target_date)}</span>`);
+
+  const apps = node.applications && node.applications.length > 0
+    ? `<div class="cap-apps"><span class="cap-apps-label">Apps:</span> ${node.applications.map((a) => `<code>${escHtml(a)}</code>`).join(' ')}</div>`
+    : '';
+
+  const childBlock = node.children && node.children.length > 0
+    ? `<div class="cap-children">${node.children.map((c) => renderCapabilityCard(c, depth + 1)).join('')}</div>`
+    : '';
+
+  return `<div class="${cls.join(' ')}">
+  <div class="capability-head">
+    <div class="capability-maturity">${current}${arrow}${target}</div>
+    <div class="capability-titles">
+      <div class="capability-name">${escHtml(node.name)}</div>
+      <div class="capability-id">${escHtml(node.id)}</div>
+    </div>
+  </div>
+  ${meta.length > 0 ? `<div class="cap-meta-row">${meta.join('')}</div>` : ''}
+  ${node.description ? `<div class="cap-desc">${escHtml(node.description)}</div>` : ''}
+  ${apps}
+  ${childBlock}
+</div>`;
+}
+
+export function renderCapabilityMapHtml(map: CapabilityMapHeader): string {
+  const header = `<header class="catalogue-header">
+    <div class="catalogue-title">${escHtml(map.name)}</div>
+    <div class="catalogue-meta">
+      <span class="catalogue-id-tag">${escHtml(map.id)}</span>
+      <span class="catalogue-updated">Assessed ${escHtml(map.assessment_date)}</span>
+    </div>
+    ${map.description ? `<div class="catalogue-subtitle">${escHtml(map.description)}</div>` : ''}
+  </header>`;
+  if (map.capabilities.length === 0) {
+    return `<section class="tx-catalogue tx-capability-map">
+${header}
+<div class="empty-map">No capabilities defined.</div>
+</section>`;
+  }
+  const verticals = map.capabilities.filter((c) => !isHorizontal(c.id));
+  const horizontals = map.capabilities.filter((c) => isHorizontal(c.id));
+  const vBlock = verticals.length > 0
+    ? `<section class="cap-axis cap-axis-v">
+  <h2 class="cap-axis-title">Vertical capabilities (domains)</h2>
+  <div class="cap-axis-list">${verticals.map((c) => renderCapabilityCard(c, 0)).join('')}</div>
+</section>`
+    : '';
+  const hBlock = horizontals.length > 0
+    ? `<section class="cap-axis cap-axis-h">
+  <h2 class="cap-axis-title">Horizontal capabilities (cross-cutting)</h2>
+  <div class="cap-axis-list">${horizontals.map((c) => renderCapabilityCard(c, 0)).join('')}</div>
+</section>`
+    : '';
+  return `<section class="tx-catalogue tx-capability-map">
+${header}
+${vBlock}${hBlock}
+</section>`;
+}

--- a/packages/diagrams/src/webview/render-fgca.ts
+++ b/packages/diagrams/src/webview/render-fgca.ts
@@ -1,0 +1,122 @@
+/**
+ * Browser-safe SVG renderer for the canonical FGCA and FGA notations.
+ *
+ * Step 4 of the IntelliJ epic (ADR 0001): the webview bundle must turn a
+ * validated FGCA/FGA document into renderable SVG so JCEF can drop it into the
+ * preview panel. The VS Code path lives in `extension/src/fgca-preview.ts` and
+ * pulls in VS Code-specific concerns (themes, title block, save dialogs,
+ * spacing/scope controls); this module is the host-neutral subset — pure
+ * column layout → SVG with no VS Code APIs, no `node:fs`, no `node:path`.
+ *
+ * FGCA and FGA share the same renderer; FGA only differs by hiding the
+ * `change` column (`hideChanges` / the layout's Goal → Activity collapse),
+ * exactly as the extension preview does.
+ */
+import {
+  layoutFGCAPreview,
+  FGCA_NODE_W as NODE_W,
+  FGCA_NODE_H as NODE_H,
+  FGCA_HEADER_H as HEADER_H,
+  FGCA_PAD as PAD,
+  type FGCAPreviewColumn,
+} from '../fgca/preview-layout.js';
+import type { FGCADoc } from '../fgca/validate.js';
+import { horizontalCubicEdgePath, DEFAULT_EDGE_CURVATURE } from '../edge-path.js';
+import { generateSvgEmbedCss } from '../theme/index.js';
+import { escXml } from './render-util.js';
+
+const COL_LABELS: Record<FGCAPreviewColumn, string> = {
+  factor: 'Factors (F)',
+  goal: 'Goals (G)',
+  change: 'Changes (C)',
+  activity: 'Activities (A)',
+};
+
+export interface RenderFgcaOptions {
+  /** `'fga'` hides the Changes column; defaults to `'fgca'`. */
+  variant?: 'fgca' | 'fga';
+  /** Optional heading rendered as a left-anchored `text-header` line. */
+  title?: string;
+}
+
+export function renderFgcaSvg(doc: FGCADoc, options: RenderFgcaOptions = {}): string {
+  const { variant = 'fgca', title = '' } = options;
+  const hideChanges = variant === 'fga';
+
+  const { nodes, edges, columns, width, height } = layoutFGCAPreview(doc, { hideChanges });
+
+  if (nodes.length === 0) {
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="0" height="0" viewBox="0 0 0 0"></svg>`;
+  }
+
+  const headerSvg = columns
+    .map(({ col, x }) =>
+      [
+        `<rect class="diagram-node layer-${col}" x="${x}" y="${PAD}" width="${NODE_W}" height="${HEADER_H}" rx="6"/>`,
+        `<text class="text-header" x="${x + NODE_W / 2}" y="${PAD + HEADER_H / 2}" text-anchor="middle" dominant-baseline="central">${escXml(COL_LABELS[col])}</text>`,
+      ].join('\n'),
+    )
+    .join('\n');
+
+  // Cubic bezier with horizontal control handles (shared geometry in
+  // @transitrix/diagrams). Uses the package default curvature — the
+  // interactive curvature control is a VS Code-only concern.
+  const edgeSvg = edges
+    .map(
+      (e) =>
+        `<path d="${horizontalCubicEdgePath(e.sx, e.sy, e.tx, e.ty, DEFAULT_EDGE_CURVATURE)}" class="diagram-edge" marker-end="url(#arrow)"/>`,
+    )
+    .join('\n');
+
+  const nodeSvg = nodes
+    .map((n) => {
+      const words = n.label.split(' ');
+      let line1 = '';
+      let line2 = '';
+      for (const w of words) {
+        if ((line1 + ' ' + w).trim().length <= 26) {
+          line1 = (line1 + ' ' + w).trim();
+        } else if ((line2 + ' ' + w).trim().length <= 26) {
+          line2 = (line2 + ' ' + w).trim();
+        } else if (!line2) {
+          line2 = w.slice(0, 24) + '…';
+          break;
+        }
+      }
+      const twoLines = line2.length > 0;
+      const y1 = twoLines ? n.y + NODE_H / 2 - 8 : n.y + NODE_H / 2 + 5;
+      const y2 = y1 + 18;
+      return [
+        `<rect class="diagram-node layer-${n.col}" x="${n.x}" y="${n.y}" width="${NODE_W}" height="${NODE_H}" rx="8"/>`,
+        `<text class="text-primary" x="${n.x + NODE_W / 2}" y="${y1}" text-anchor="middle">${escXml(line1)}</text>`,
+        twoLines
+          ? `<text class="text-secondary" x="${n.x + NODE_W / 2}" y="${y2}" text-anchor="middle">${escXml(line2)}</text>`
+          : '',
+      ]
+        .filter(Boolean)
+        .join('\n');
+    })
+    .join('\n');
+
+  const titleSvg = title
+    ? `<text class="text-header" x="${PAD}" y="${PAD - 6}">${escXml(title)}</text>`
+    : '';
+
+  // Embed the shared theme CSS inside the SVG so the rendered output is
+  // self-contained — the JCEF host page only needs to drop the SVG into the
+  // DOM and styling resolves without any cooperation from the host stylesheet.
+  const embedCss = generateSvgEmbedCss('transitrix');
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
+<style>${embedCss}</style>
+<defs>
+  <marker id="arrow" markerWidth="8" markerHeight="8" refX="8" refY="3" orient="auto">
+    <path d="M0,0 L0,6 L8,3 z" class="arrow-fill"/>
+  </marker>
+</defs>
+${titleSvg}
+${headerSvg}
+${nodeSvg}
+${edgeSvg}
+</svg>`;
+}

--- a/packages/diagrams/src/webview/render-process-blueprint.ts
+++ b/packages/diagrams/src/webview/render-process-blueprint.ts
@@ -1,0 +1,126 @@
+/**
+ * Host-neutral SVG renderer for the Process Blueprint notation.
+ *
+ * Step 4 of the IntelliJ epic (ADR 0001): ported from the pure SVG core of
+ * `extension/src/process-blueprint-preview.ts` (`layoutToSvg`). The VS Code
+ * title block (`svg-title-block.ts`) is intentionally dropped — JCEF has no
+ * VS Code APIs — and replaced with `render-goals.ts`' simple optional
+ * `<text class="text-header">` heading. No `vscode`, no `node:*`, no host APIs;
+ * the shared theme CSS is embedded inside the `<svg>` so the output is
+ * self-contained.
+ */
+import { layoutProcessBlueprint } from '../process-blueprint/layout.js';
+import type {
+  ProcessBlueprintFile,
+  ProcessBlueprintLayout,
+} from '../process-blueprint/types.js';
+import { generateSvgEmbedCss } from '../theme/index.js';
+import { escXml } from './render-util.js';
+
+const PAD = 24;
+
+function truncate(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  return text.slice(0, Math.max(0, maxChars - 1)) + '…';
+}
+
+export interface RenderProcessBlueprintOptions {
+  title?: string;
+}
+
+export function renderProcessBlueprintSvg(
+  doc: ProcessBlueprintFile,
+  options: RenderProcessBlueprintOptions = {},
+): string {
+  const { title = '' } = options;
+
+  const layout: ProcessBlueprintLayout = layoutProcessBlueprint(doc);
+
+  if (layout.bounds.width === 0 || layout.bounds.height === 0) {
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="0" height="0" viewBox="0 0 0 0"></svg>`;
+  }
+
+  const titleH = title ? PAD : 0;
+  const w = layout.bounds.width + PAD * 2;
+  const h = layout.bounds.height + PAD * 2 + titleH;
+  const ox = PAD;
+  const oy = PAD + titleH;
+
+  const parts: string[] = [];
+
+  parts.push(
+    `<rect class="diagram-node level-0" x="${ox}" y="${oy}" width="${layout.bounds.width}" height="${layout.bounds.height}" rx="6"/>`,
+  );
+
+  for (const s of layout.stageHeaders) {
+    parts.push(
+      `<rect class="diagram-node level-1" x="${s.x + ox}" y="${s.y + oy}" width="${s.width}" height="${s.height}"/>`,
+    );
+    parts.push(
+      `<text class="text-header" x="${s.x + ox + s.width / 2}" y="${s.y + oy + s.height / 2}" text-anchor="middle" dominant-baseline="central">${escXml(truncate(s.name, 28))}</text>`,
+    );
+  }
+
+  for (const l of layout.legend) {
+    parts.push(
+      `<rect class="diagram-node level-2" x="${ox}" y="${l.y + oy}" width="${layout.legendColumnWidth}" height="${l.height}"/>`,
+    );
+    parts.push(
+      `<text class="text-primary" x="${ox + 12}" y="${l.y + oy + l.height / 2}" dominant-baseline="central">${escXml(l.label)}</text>`,
+    );
+  }
+
+  for (const c of layout.goalCells) {
+    parts.push(
+      `<rect class="diagram-node level-3" x="${c.x + ox}" y="${c.y + oy}" width="${c.width}" height="${c.height}"/>`,
+    );
+    parts.push(
+      `<text class="text-secondary" x="${c.x + ox + 10}" y="${c.y + oy + c.height / 2}" dominant-baseline="central">${escXml(truncate(c.text, 32))}</text>`,
+    );
+  }
+  for (const c of layout.resultCells) {
+    parts.push(
+      `<rect class="diagram-node level-4" x="${c.x + ox}" y="${c.y + oy}" width="${c.width}" height="${c.height}"/>`,
+    );
+    parts.push(
+      `<text class="text-secondary" x="${c.x + ox + 10}" y="${c.y + oy + c.height / 2}" dominant-baseline="central">${escXml(truncate(c.text, 32))}</text>`,
+    );
+  }
+
+  for (let r = 0; r < layout.aspectRows.length; r++) {
+    const row = layout.aspectRows[r];
+    const level = 5 + (r % 3);
+    parts.push(
+      `<rect class="diagram-node level-${level}" x="${layout.legendColumnWidth + ox}" y="${row.y + oy}" width="${layout.bounds.width - layout.legendColumnWidth}" height="${row.height}" opacity="0.15"/>`,
+    );
+    for (let i = 1; i < layout.stageHeaders.length; i++) {
+      const x = layout.legendColumnWidth + i * layout.stageColumnWidth + ox;
+      parts.push(
+        `<line class="diagram-edge" x1="${x}" y1="${row.y + oy}" x2="${x}" y2="${row.y + row.height + oy}" opacity="0.3"/>`,
+      );
+    }
+    for (const p of row.pills) {
+      parts.push(
+        `<rect class="diagram-node level-${level}" x="${p.x + ox}" y="${p.y + oy}" width="${p.width}" height="${p.height}" rx="6"/>`,
+      );
+      const label = p.id ? `${p.name} · ${p.id}` : p.name;
+      parts.push(
+        `<text class="text-pill" x="${p.x + ox + p.width / 2}" y="${p.y + oy + p.height / 2}" text-anchor="middle" dominant-baseline="central">${escXml(truncate(label, Math.floor(p.width / 8)))}</text>`,
+      );
+    }
+  }
+
+  const titleSvg = title
+    ? `<text class="text-header" x="${PAD}" y="${PAD - 6}">${escXml(title)}</text>`
+    : '';
+
+  // Embed the shared theme CSS inside the SVG so the rendered output is
+  // self-contained for the JCEF host — matches render-goals.ts.
+  const embedCss = generateSvgEmbedCss('transitrix');
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">
+<style>${embedCss}</style>
+${titleSvg}
+${parts.join('\n')}
+</svg>`;
+}

--- a/packages/diagrams/src/webview/render-process-map.ts
+++ b/packages/diagrams/src/webview/render-process-map.ts
@@ -1,0 +1,93 @@
+/**
+ * Host-neutral renderer for the Process Map notation.
+ * Mirrors `extension/src/process-map-preview.ts`; emits a self-contained HTML
+ * fragment for the JCEF host (Step 4 of ADR 0001).
+ */
+import type { MapProcess, ProcessGroup, ProcessMapHeader } from '../process-map/types.js';
+import { escHtml } from './render-util.js';
+
+const STATUS_BADGE: Record<string, string> = {
+  Active: 'badge-active',
+  Draft: 'badge-draft',
+  Deprecated: 'badge-deprecated',
+};
+
+const GROUP_LABEL: Record<string, string> = {
+  operating: 'Operating',
+  supporting: 'Supporting',
+  management: 'Management',
+};
+
+function maturityDots(m: number | undefined): string {
+  if (m === undefined) return '<span class="cell-empty">—</span>';
+  const filled = '●'.repeat(Math.max(0, Math.min(5, m)));
+  const empty = '○'.repeat(5 - Math.max(0, Math.min(5, m)));
+  return `<span class="maturity-dots">${filled}${empty}</span>`;
+}
+
+function renderProcessRow(p: MapProcess): string {
+  return `<tr>
+  <td class="col-name">
+    <div class="catalogue-name">${escHtml(p.name)}</div>
+    <div class="catalogue-id">${escHtml(p.process_id)}</div>
+    ${p.description ? `<div class="catalogue-desc">${escHtml(p.description)}</div>` : ''}
+  </td>
+  <td class="col-status"><span class="tx-badge ${escHtml(STATUS_BADGE[p.status] ?? '')}">${escHtml(p.status)}</span></td>
+  <td class="col-maturity">${maturityDots(p.maturity)}</td>
+  <td class="col-owner">${p.owner_role ? escHtml(p.owner_role) : '<span class="cell-empty">—</span>'}</td>
+  <td class="col-capability">${p.capability ? `<span class="cap-tag">${escHtml(p.capability)}</span>` : '<span class="cell-empty">—</span>'}</td>
+  <td class="col-bpmn">${p.bpmn_file ? `<span class="bpmn-link" title="${escHtml(p.bpmn_file)}">📄 BPMN</span>` : '<span class="cell-empty">—</span>'}</td>
+</tr>`;
+}
+
+function renderGroup(g: ProcessGroup): string {
+  const processes = g.processes ?? [];
+  const rows = processes.length === 0
+    ? `<tr><td colspan="6" class="empty-group">No processes in this group.</td></tr>`
+    : processes.map(renderProcessRow).join('\n');
+  const typeKey = String(g.type ?? '');
+  return `<section class="group-section group-${escHtml(typeKey)}">
+  <header class="group-header">
+    <div class="group-meta">
+      <span class="group-tag group-tag-${escHtml(typeKey)}">${escHtml(GROUP_LABEL[typeKey] ?? typeKey)}</span>
+      <span class="group-id">${escHtml(g.id)}</span>
+    </div>
+    <h2 class="group-title">${escHtml(g.name)}</h2>
+    ${g.description ? `<p class="group-desc">${escHtml(g.description)}</p>` : ''}
+  </header>
+  <table class="catalogue-table">
+    <thead>
+      <tr>
+        <th>Process</th>
+        <th>Status</th>
+        <th>Maturity</th>
+        <th>Owner</th>
+        <th>Capability</th>
+        <th>BPMN</th>
+      </tr>
+    </thead>
+    <tbody>
+      ${rows}
+    </tbody>
+  </table>
+</section>`;
+}
+
+export function renderProcessMapHtml(map: ProcessMapHeader): string {
+  const header = `<header class="catalogue-header">
+    <div class="catalogue-title">${escHtml(map.name)}</div>
+    <div class="catalogue-meta">
+      <span class="catalogue-id-tag">${escHtml(map.id)}</span>
+      <span class="catalogue-updated">Updated ${escHtml(map.updated_at)}</span>
+      ${map.version ? `<span class="catalogue-version">v${escHtml(map.version)}</span>` : ''}
+    </div>
+    ${map.description ? `<div class="catalogue-subtitle">${escHtml(map.description)}</div>` : ''}
+  </header>`;
+  const body = map.groups.length === 0
+    ? '<div class="empty-map">No groups defined.</div>'
+    : map.groups.map(renderGroup).join('\n');
+  return `<section class="tx-catalogue tx-process-map">
+${header}
+${body}
+</section>`;
+}

--- a/packages/diagrams/src/webview/render-products.ts
+++ b/packages/diagrams/src/webview/render-products.ts
@@ -1,0 +1,91 @@
+/**
+ * Host-neutral renderer for the Products catalogue notation.
+ * Mirrors `extension/src/products-preview.ts`; emits a self-contained HTML
+ * fragment for the JCEF host (Step 4 of ADR 0001).
+ */
+import type { Product, ProductsCatalogueHeader } from '../products/types.js';
+import { escHtml } from './render-util.js';
+
+const TYPE_LABEL: Record<string, string> = {
+  digital_product: 'Digital Product',
+  service: 'Service',
+  platform: 'Platform',
+  bundle: 'Bundle',
+};
+
+const STATUS_BADGE: Record<string, string> = {
+  Active: 'badge-active',
+  Draft: 'badge-draft',
+  Deprecated: 'badge-deprecated',
+};
+
+function maturityDots(m: number | undefined): string {
+  if (m === undefined) return '<span class="cell-empty">—</span>';
+  const filled = '●'.repeat(Math.max(0, Math.min(5, m)));
+  const empty = '○'.repeat(5 - Math.max(0, Math.min(5, m)));
+  return `<span class="maturity-dots">${filled}${empty}</span>`;
+}
+
+function disclosureList(label: string, items: string[] | undefined): string {
+  if (!items || items.length === 0) return '';
+  const lis = items.map((i) => `<li>${escHtml(i)}</li>`).join('');
+  return `<details><summary>${escHtml(label)} (${items.length})</summary><ul>${lis}</ul></details>`;
+}
+
+function renderRow(p: Product): string {
+  const extras = [
+    disclosureList('Capabilities', p.capabilities),
+    disclosureList('Processes', p.processes),
+    disclosureList('Apps', p.supporting_apps),
+  ]
+    .filter(Boolean)
+    .join('');
+  return `<tr>
+  <td class="col-name">
+    <div class="catalogue-name">${escHtml(p.name)}</div>
+    <div class="catalogue-id">${escHtml(p.product_id)}</div>
+    ${p.description ? `<div class="catalogue-desc">${escHtml(p.description)}</div>` : ''}
+    ${extras}
+  </td>
+  <td class="col-type"><span class="type-tag">${escHtml(TYPE_LABEL[p.type] ?? p.type)}</span></td>
+  <td class="col-status"><span class="tx-badge ${escHtml(STATUS_BADGE[p.status] ?? '')}">${escHtml(p.status)}</span></td>
+  <td class="col-maturity">${maturityDots(p.maturity)}</td>
+  <td class="col-domain">${p.domain ? escHtml(p.domain) : '<span class="cell-empty">—</span>'}</td>
+  <td class="col-owner">${p.owner_role ? escHtml(p.owner_role) : '<span class="cell-empty">—</span>'}</td>
+</tr>`;
+}
+
+export function renderProductsHtml(catalogue: ProductsCatalogueHeader): string {
+  const rows = catalogue.products.map(renderRow).join('\n');
+  const emptyRow = catalogue.products.length === 0
+    ? `<tr><td colspan="6" class="empty-catalogue">No products defined.</td></tr>`
+    : '';
+  const header = `<header class="catalogue-header">
+    <div class="catalogue-title">${escHtml(catalogue.name)}</div>
+    <div class="catalogue-meta">
+      <span class="catalogue-id-tag">${escHtml(catalogue.id)}</span>
+      <span class="catalogue-updated">Updated ${escHtml(catalogue.updated_at)}</span>
+      ${catalogue.version ? `<span class="catalogue-version">v${escHtml(catalogue.version)}</span>` : ''}
+    </div>
+    ${catalogue.description ? `<div class="catalogue-subtitle">${escHtml(catalogue.description)}</div>` : ''}
+  </header>`;
+  return `<section class="tx-catalogue tx-products">
+${header}
+<table class="catalogue-table">
+  <thead>
+    <tr>
+      <th>Name / ID</th>
+      <th>Type</th>
+      <th>Status</th>
+      <th>Maturity</th>
+      <th>Domain</th>
+      <th>Owner Role</th>
+    </tr>
+  </thead>
+  <tbody>
+    ${rows}
+    ${emptyRow}
+  </tbody>
+</table>
+</section>`;
+}

--- a/packages/diagrams/src/webview/render-scenarios.ts
+++ b/packages/diagrams/src/webview/render-scenarios.ts
@@ -1,0 +1,90 @@
+/**
+ * Host-neutral renderer for the Scenarios notation.
+ * Mirrors `extension/src/scenarios-preview.ts`; emits a self-contained HTML
+ * fragment for the JCEF host (Step 4 of ADR 0001).
+ */
+import type { FactorView, ScenarioHeader } from '../scenarios/types.js';
+import { escHtml } from './render-util.js';
+
+const STATUS_BADGE: Record<string, string> = {
+  Active: 'badge-active',
+  Draft: 'badge-draft',
+  Archived: 'badge-archived',
+};
+
+const RELEVANCE_BADGE: Record<string, string> = {
+  High: 'badge-high',
+  Medium: 'badge-medium',
+  Low: 'badge-low',
+};
+
+function buildFactorsTable(factors: FactorView[] | undefined): string {
+  if (!factors || factors.length === 0) return '';
+  const rows = factors
+    .map(
+      (f) => `<tr>
+  <td class="col-factor-id">${escHtml(f.factor_id)}</td>
+  <td class="col-relevance">${
+    f.relevance
+      ? `<span class="tx-badge ${escHtml(RELEVANCE_BADGE[f.relevance] ?? '')}">${escHtml(f.relevance)}</span>`
+      : '<span class="cell-empty">—</span>'
+  }</td>
+  <td class="col-impact">${f.impact ? escHtml(f.impact) : '<span class="cell-empty">—</span>'}</td>
+</tr>`,
+    )
+    .join('\n');
+  return `<section class="scn-section">
+  <h2 class="scn-section-title">Factors view <span class="scn-count">${factors.length}</span></h2>
+  <table class="catalogue-table">
+    <thead><tr><th>Factor ID</th><th>Relevance</th><th>Impact</th></tr></thead>
+    <tbody>${rows}</tbody>
+  </table>
+</section>`;
+}
+
+function buildRefSection(label: string, items: string[]): string {
+  if (items.length === 0) return '';
+  const lis = items.map((id) => `<li><code>${escHtml(id)}</code></li>`).join('');
+  return `<section class="scn-section">
+  <h2 class="scn-section-title">${escHtml(label)} <span class="scn-count">${items.length}</span></h2>
+  <ul class="scn-ref-list">${lis}</ul>
+</section>`;
+}
+
+function extractIds(list: readonly unknown[] | undefined, key: string): string[] {
+  return (list ?? []).map((x) => String((x as Record<string, unknown>)[key] ?? ''));
+}
+
+export function renderScenarioHtml(scn: ScenarioHeader): string {
+  const blocks: string[] = [];
+  if (scn.vision) {
+    blocks.push(`<section class="scn-section scn-vision">
+  <h2 class="scn-section-title">Vision</h2>
+  <p class="scn-vision-text">${escHtml(scn.vision)}</p>
+</section>`);
+  }
+  blocks.push(buildFactorsTable(scn.factors_view));
+  blocks.push(buildRefSection('Goals', extractIds(scn.goals, 'goal_id')));
+  blocks.push(buildRefSection('Capabilities', extractIds(scn.capabilities, 'capability_id')));
+  blocks.push(buildRefSection('Activities', extractIds(scn.activities, 'activity_id')));
+  blocks.push(buildRefSection('Products', extractIds(scn.products, 'product_id')));
+  blocks.push(buildRefSection('Processes', extractIds(scn.processes, 'process_id')));
+  blocks.push(buildRefSection('Applications', extractIds(scn.applications, 'app_id')));
+  const content = blocks.filter(Boolean).join('\n');
+
+  const statusBadge = `<span class="tx-badge ${escHtml(STATUS_BADGE[scn.status] ?? '')}">${escHtml(scn.status)}</span>`;
+  const header = `<header class="catalogue-header">
+    <div class="catalogue-title">${escHtml(scn.name)}</div>
+    <div class="catalogue-meta">
+      ${statusBadge}
+      <span class="catalogue-id-tag">${escHtml(scn.id)}</span>
+      ${scn.created_at ? `<span class="catalogue-updated">Created ${escHtml(scn.created_at)}</span>` : ''}
+    </div>
+    ${scn.description ? `<div class="catalogue-subtitle">${escHtml(scn.description)}</div>` : ''}
+  </header>`;
+  const body = content || '<div class="empty-scenario">Scenario has no content yet (no vision, factors, or references).</div>';
+  return `<section class="tx-catalogue tx-scenarios">
+${header}
+${body}
+</section>`;
+}

--- a/packages/diagrams/src/webview/render-util.ts
+++ b/packages/diagrams/src/webview/render-util.ts
@@ -1,0 +1,34 @@
+/**
+ * Small set of host-neutral helpers shared by the `render-*.ts` modules.
+ *
+ * The webview bundle (ADR 0001) runs inside JCEF without access to any host
+ * APIs, so all string/markup utilities must stay framework-free here.
+ */
+
+export function escXml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/** Same encoding as `escXml`; aliased so HTML-table renderers read clearly. */
+export const escHtml = escXml;
+
+/** Pull common frontmatter for the optional preview heading. */
+export function readDocHeader(doc: unknown): {
+  title?: string;
+  subtitle?: string;
+  version?: string;
+  date?: string;
+} {
+  if (!doc || typeof doc !== 'object') return {};
+  const raw = doc as Record<string, unknown>;
+  const out: { title?: string; subtitle?: string; version?: string; date?: string } = {};
+  if (typeof raw['title'] === 'string') out.title = raw['title'];
+  if (typeof raw['description'] === 'string') out.subtitle = raw['description'];
+  if (raw['version'] !== undefined) out.version = String(raw['version']);
+  if (typeof raw['date'] === 'string') out.date = raw['date'];
+  return out;
+}

--- a/packages/diagrams/src/webview/styles.css
+++ b/packages/diagrams/src/webview/styles.css
@@ -74,3 +74,250 @@ body {
   max-width: 100%;
   height: auto;
 }
+
+/* ---------------------------------------------------------------------------
+ * Catalogue notations (Step 4)
+ *
+ * The HTML-fragment renderers (applications, products, process-map, scenarios,
+ * capability-map) emit class-tagged markup but no inline styles — the host page
+ * is the single place these classes get themed, so the JCEF preview stays
+ * consistent with the dark IntelliJ chrome above. The SVG notations embed their
+ * own theme CSS and do not depend on anything below.
+ * ------------------------------------------------------------------------- */
+
+:root {
+  --tx-panel: #2b2d30;
+  --tx-border: #393b40;
+  --tx-accent: #4aa3df;
+  --tx-tag-bg: #34373b;
+  --tx-ok-bg: #1f3a2b;
+  --tx-ok-fg: #7ee2a8;
+  --tx-info-bg: #14344a;
+  --tx-info-fg: #76c2f0;
+  --tx-warn-bg: #3d3322;
+  --tx-warn-fg: #f3d3a3;
+  --tx-danger-bg: #3d2222;
+  --tx-danger-fg: #f3a3a3;
+}
+
+.tx-catalogue {
+  max-width: 1100px;
+}
+
+.catalogue-header {
+  margin-bottom: 16px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--tx-border);
+}
+
+.catalogue-title {
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.catalogue-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  margin-top: 4px;
+  color: var(--tx-muted);
+  font-size: 12px;
+}
+
+.catalogue-id-tag,
+.group-id {
+  font-family: var(--tx-mono);
+  color: var(--tx-accent);
+}
+
+.catalogue-version {
+  font-family: var(--tx-mono);
+}
+
+.catalogue-subtitle {
+  margin-top: 6px;
+  color: var(--tx-fg);
+}
+
+.catalogue-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.catalogue-table th,
+.catalogue-table td {
+  text-align: left;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--tx-border);
+  vertical-align: top;
+}
+
+.catalogue-table th {
+  color: var(--tx-muted);
+  font-weight: 600;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.catalogue-table tbody tr:hover {
+  background: var(--tx-panel);
+}
+
+.catalogue-name {
+  font-weight: 600;
+}
+
+.catalogue-id {
+  font-family: var(--tx-mono);
+  font-size: 11px;
+  color: var(--tx-accent);
+}
+
+.catalogue-desc {
+  color: var(--tx-muted);
+  margin-top: 2px;
+}
+
+.type-tag,
+.cap-tag,
+.group-tag {
+  display: inline-block;
+  padding: 1px 7px;
+  border-radius: 10px;
+  background: var(--tx-tag-bg);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.tx-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.badge-active { background: var(--tx-ok-bg); color: var(--tx-ok-fg); }
+.badge-draft { background: var(--tx-info-bg); color: var(--tx-info-fg); }
+.badge-deprecated,
+.badge-archived { background: var(--tx-warn-bg); color: var(--tx-warn-fg); }
+.badge-decommissioning { background: var(--tx-danger-bg); color: var(--tx-danger-fg); }
+.badge-high { background: var(--tx-danger-bg); color: var(--tx-danger-fg); }
+.badge-medium { background: var(--tx-warn-bg); color: var(--tx-warn-fg); }
+.badge-low { background: var(--tx-info-bg); color: var(--tx-info-fg); }
+
+.maturity-dots {
+  letter-spacing: 1px;
+  color: var(--tx-accent);
+}
+
+.cell-empty {
+  color: var(--tx-muted);
+}
+
+.vendor-internal { color: var(--tx-ok-fg); }
+.vendor-external { color: var(--tx-info-fg); }
+
+.empty-catalogue,
+.empty-group,
+.empty-map,
+.empty-scenario {
+  text-align: center;
+  color: var(--tx-muted);
+  font-style: italic;
+  padding: 24px;
+}
+
+.intg-dir,
+.intg-proto { color: var(--tx-accent); font-family: var(--tx-mono); font-size: 11px; }
+.intg-desc { color: var(--tx-muted); }
+
+details { margin-top: 6px; font-size: 12px; }
+details summary { cursor: pointer; color: var(--tx-accent); user-select: none; }
+details ul { margin: 4px 0 0 16px; padding: 0; }
+details li { margin-bottom: 3px; }
+
+code {
+  font-family: var(--tx-mono);
+  background: var(--tx-tag-bg);
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-size: 12px;
+}
+
+/* Process map — grouped sections */
+.group-section { margin-bottom: 22px; }
+.group-header { margin-bottom: 8px; }
+.group-meta { display: flex; gap: 8px; align-items: center; }
+.group-title { font-size: 15px; margin: 4px 0 0; }
+.group-desc { color: var(--tx-muted); margin: 2px 0 0; }
+.group-tag-operating { background: var(--tx-info-bg); color: var(--tx-info-fg); }
+.group-tag-supporting { background: var(--tx-tag-bg); }
+.group-tag-management { background: var(--tx-ok-bg); color: var(--tx-ok-fg); }
+.bpmn-link { color: var(--tx-accent); white-space: nowrap; }
+
+/* Scenarios — stacked sections */
+.scn-section { margin-bottom: 18px; }
+.scn-section-title {
+  font-size: 14px;
+  margin: 0 0 8px;
+  border-bottom: 1px solid var(--tx-border);
+  padding-bottom: 4px;
+}
+.scn-count {
+  font-size: 11px;
+  color: var(--tx-muted);
+  font-weight: 400;
+}
+.scn-vision-text { margin: 0; }
+.scn-ref-list { margin: 0; padding-left: 18px; }
+.scn-ref-list li { margin-bottom: 3px; }
+
+/* Capability map — nested cards on two axes */
+.cap-axis { margin-bottom: 22px; }
+.cap-axis-title { font-size: 14px; margin: 0 0 10px; }
+.cap-axis-list { display: flex; flex-direction: column; gap: 10px; }
+.capability-card {
+  border: 1px solid var(--tx-border);
+  border-radius: 6px;
+  padding: 10px 12px;
+  background: var(--tx-panel);
+}
+.cap-children {
+  margin-top: 8px;
+  margin-left: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border-left: 2px solid var(--tx-border);
+  padding-left: 10px;
+}
+.capability-head { display: flex; gap: 10px; align-items: baseline; }
+.capability-name { font-weight: 600; }
+.capability-id { font-family: var(--tx-mono); font-size: 11px; color: var(--tx-accent); }
+.capability-maturity { display: inline-flex; gap: 4px; align-items: center; }
+.maturity-pill {
+  display: inline-block;
+  min-width: 22px;
+  text-align: center;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  background: var(--tx-tag-bg);
+}
+.maturity-1 { background: var(--tx-danger-bg); color: var(--tx-danger-fg); }
+.maturity-2 { background: var(--tx-warn-bg); color: var(--tx-warn-fg); }
+.maturity-3 { background: var(--tx-info-bg); color: var(--tx-info-fg); }
+.maturity-4,
+.maturity-5 { background: var(--tx-ok-bg); color: var(--tx-ok-fg); }
+.maturity-arrow { color: var(--tx-muted); }
+.cap-meta-row { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 6px; }
+.cap-meta { color: var(--tx-muted); font-size: 12px; }
+.cap-desc { margin-top: 6px; }
+.cap-apps { margin-top: 6px; font-size: 12px; }
+.cap-apps-label { color: var(--tx-muted); }


### PR DESCRIPTION
**Phase 4 (ADR 0001 step 4) of the IntelliJ epic** — builds on the merged Phase 3 JCEF surface (#99). Do not merge; gated.

The webview bundle now renders **every** supported notation, not just `goals`. A valid document produces markup; a malformed one surfaces the structured validation error panel (no exception reaches the JVM host). `NOTATION-NOT-WIRED` is no longer reachable for any supported kind.

### Renderers (host-neutral — no `vscode` / `node:*` / `extension/` imports)
- **SVG diagrams** — `fgca` + `fga` (one shared renderer; `fga` collapses the Change column via a layer-visibility variant), `activities` (PSND network view), `activity-card` (renders from the single in-memory doc; cross-document disk resolution is intentionally skipped — not available in JCEF), `process-blueprint`, `blocks`. Each mirrors its VS Code preview's pure SVG core and embeds the shared theme CSS via `generateSvgEmbedCss`.
- **HTML catalogues** — `applications`, `products`, `process-map`, `scenarios`, `capability-map` — emit a self-contained `<section>` styled by the host page.

### `entry.ts` dispatch
- Each kind validates the parsed YAML and renders only when valid.
- `fgca`/`fga` route through `parseCanonicalFGCA`/`parseCanonicalFGA` (carry a parsed `FGCADoc`); the validate-only notations cast the parsed doc to their typed shape inside a thunk that runs only on `valid`.
- `parseYaml` now applies `coerceDatesToIsoStrings`, matching the VS Code previews — so the canonical-minus-quotes date form validates identically.

### Styling
- `styles.css` gains a shared catalogue theme (tables, badges, maturity, process-map groups, scenario sections, nested capability cards) in the dark IntelliJ palette. The SVG notations remain fully self-contained.

### Verification
- `npm run build:webview-bundle` clean — **243.6 KB** IIFE, browser-safety guard passes (no Node-only token leaked).
- Root `tsc` + extension `tsc` clean.
- `@transitrix/diagrams` suite **620 pass** (46 files), including new `webview/__tests__/entry-notations.test.ts` — renders all 12 kinds from their example fixtures + malformed-input degradation for both a diagram and a catalogue notation.
- Core suite **235 pass**.
- The JCEF wiring (`TransitrixPreviewDialog` / `WebviewBundle`) and the Gradle build carry over unchanged from Phase 3 — only the `entry.ts` dispatch table, the renderers, and the host CSS changed, exactly as Phase 3 predicted. **The Gradle `:intellij:buildPlugin` was not run on the agent host** — still needs one manual build + install into a clean IntelliJ IDEA Community (JDK 17) to confirm each notation renders correctly.

Remaining per ADR: Step 5 (`buildPlugin` `.zip` packaging); Steps 6/7 (editor-title parity, auto-refresh, marketplace) are out of MVP scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)