### PR TITLE
feat(intellij): Phase 5 — packaging script + install docs (#135)

### DIFF
--- a/intellij/README.md
+++ b/intellij/README.md
@@ -6,19 +6,15 @@ the existing VS Code extension under [`../extension/`](../extension/).
 The rendering and validation technology choice is recorded in
 [`../docs/adr/0001-intellij-mvp-tech-choice.md`](../docs/adr/0001-intellij-mvp-tech-choice.md).
 
-This subdirectory is the **first PR of the implementation plan from the ADR
-(step 1)**: it scaffolds an empty Gradle plugin project with a placeholder
-preview action that proves the plugin manifest loads in a running IDE.
+All five implementation steps from that ADR have landed:
 
-The next PRs land the actual previews:
-
-- Step 2 — make `@transitrix/diagrams` browser-safe and produce the
-  esbuild-bundled webview JS.
-- Step 3 — wire the JCEF preview (`JBCefBrowser`) and ship the first notation
-  (goals) end-to-end.
-- Step 4 — extend to the remaining ten notation suffixes and the validation
-  error panel.
-- Step 5 — Gradle `buildPlugin` packaging into a distributable `.zip`.
+1. Gradle plugin scaffold (this directory).
+2. Browser-safe `@transitrix/diagrams` webview bundle
+   (`scripts/build-webview-bundle.mjs`).
+3. JCEF preview surface (`JBCefBrowser`) with the **goals** notation wired
+   end-to-end.
+4. Remaining ten notation suffixes + the validation error panel.
+5. Distributable `.zip` packaging via Gradle `buildPlugin` (this README).
 
 ## Build path isolation
 
@@ -26,6 +22,12 @@ The Gradle build under `intellij/` is **fully isolated** from the repo's Node
 toolchain. The root `package.json` does not reference Gradle and this build
 does not invoke `npm` / `tsc` / the extension prep pipeline. Each ships its
 own versioned artifact (`.vsix` from `extension/`, `.zip` from here).
+
+The one seam between them is the bundled webview: `:syncWebviewBundle`
+copies `packages/diagrams/dist/webview/transitrix-render.{js,css}` into the
+plugin jar. Those files are produced by `node scripts/build-webview-bundle.mjs`
+on the Node side. The packaging script below runs both steps in order so a
+fresh checkout reaches a `.zip` with a single command.
 
 ## Bootstrapping the Gradle wrapper
 
@@ -38,15 +40,82 @@ gradle wrapper
 
 After that, `./gradlew runIde` opens a sandbox IDE with the plugin loaded.
 
+## Packaging the distributable `.zip`
+
+From the repo root:
+
+```sh
+node scripts/package-intellij-plugin.mjs
+```
+
+This:
+
+1. Rebuilds the browser-safe `@transitrix/diagrams` bundle.
+2. Invokes `:buildPlugin` (using `intellij/gradlew[.bat]` if present, else a
+   system-installed `gradle`).
+3. Prints the produced artifact path and install instructions.
+
+The artifact lands at:
+
+```
+intellij/build/distributions/transitrix-intellij-<pluginVersion>.zip
+```
+
+Useful flags:
+
+- `--skip-bundle` — reuse the existing `packages/diagrams/dist/webview/`
+  outputs (faster iteration when only the Kotlin side changed).
+- `--help` — full usage.
+
+If you'd rather drive Gradle directly:
+
+```sh
+node scripts/build-webview-bundle.mjs
+cd intellij
+./gradlew buildPlugin --console=plain   # or `gradlew.bat` on Windows
+```
+
+## Installing in IntelliJ IDEA
+
+Tested baseline: **IntelliJ IDEA Community 2024.2+** (JCEF-bearing IDE, per
+`gradle.properties` `pluginSinceBuild = 242`). The `.zip` also installs into
+Ultimate and the other JetBrains IDEs that satisfy the platform `sinceBuild`.
+
+1. **Settings → Plugins**.
+2. The ⚙ (gear) icon → **Install Plugin from Disk…**.
+3. Pick the `transitrix-intellij-<version>.zip` produced above.
+4. Restart the IDE when prompted.
+
+Smoke-test:
+
+1. Open any `*.goals.transitrix.yaml`, `*.fgca.transitrix.yaml`, etc.
+   (the `examples/` directory at the repo root has one of every supported
+   suffix).
+2. Right-click in the editor → **Transitrix: Preview Notation**.
+3. The JCEF preview should render the same SVG / catalogue the VS Code
+   extension produces. Malformed input shows the validation error panel
+   instead of crashing.
+
+If the IDE lacks JCEF (rare on official 2024.2+ builds), the plugin surfaces
+a clear error dialog rather than failing silently — see
+`TransitrixPreviewDialog.kt`.
+
 ## Versioning
 
 The plugin version lives in `gradle.properties` (`pluginVersion`) and is
 **independent** of the VS Code extension's `package.json` version, per the
-ADR — the two artifacts ship on their own cadences.
+ADR — the two artifacts ship on their own cadences. Bump it by editing the
+property; there's no shared bump script (the root `bump-extension-version.mjs`
+deliberately touches only the VS Code side).
 
 ## Status
 
-Scaffolding only. The placeholder action shows an info dialog on right-click
-of a Transitrix notation file; no JCEF, no rendering, no validation surface
-yet. Follow the epic [`vkgeorgia/strategy#135`](https://github.com/vkgeorgia/strategy/issues/135)
-for the next PRs.
+MVP packaging is complete. Out of scope for this MVP (deferred per the epic):
+
+- Editor-title parity with the VS Code extension.
+- Auto-refresh on save outside the active preview.
+- JetBrains Marketplace publication, signing, multi-IDE `verifyPlugin`.
+- PNG export (resvg-js native binary path).
+
+Follow epic [`vkgeorgia/strategy#135`](https://github.com/vkgeorgia/strategy/issues/135)
+for any post-MVP work.

--- a/scripts/package-intellij-plugin.mjs
+++ b/scripts/package-intellij-plugin.mjs
@@ -1,0 +1,131 @@
+/**
+ * Phase 5 of the IntelliJ MVP epic — package the plugin as a distributable
+ * `.zip` (ADR 0001 step 5).
+ *
+ * Two steps, in order:
+ *   1. Refresh the browser-safe `@transitrix/diagrams` bundle on disk
+ *      (`packages/diagrams/dist/webview/transitrix-render.{js,css}`).
+ *      `intellij/build.gradle.kts :syncWebviewBundle` reads these files and
+ *      would fail loudly otherwise — running it here keeps a single command
+ *      between a fresh checkout and a ready-to-install `.zip`.
+ *   2. Invoke Gradle's `:buildPlugin` task under `intellij/`. The IntelliJ
+ *      Platform Gradle Plugin v2 produces
+ *      `intellij/build/distributions/<rootProject>-<version>.zip`, which is the
+ *      artifact Valerii loads via Settings → Plugins → ⚙ → Install Plugin from
+ *      Disk… for the hand-test.
+ *
+ * Picking the Gradle invocation:
+ *   - If `intellij/gradlew[.bat]` exists, use it — that's the pinned wrapper.
+ *   - Otherwise fall back to a system-installed `gradle` so a host with the
+ *     wrapper not yet bootstrapped (the wrapper jar is `.gitignore`d per the
+ *     intellij README) can still package without an extra `gradle wrapper` run.
+ *   - Print a clean install hint if neither is available, instead of throwing
+ *     a raw ENOENT.
+ *
+ * Out of scope (deferred): publishing to the JetBrains Marketplace, signing,
+ * `verifyPlugin` against multiple IDE builds. Same posture as the VS Code
+ * extension — produce the artifact, hand it to Valerii.
+ */
+import { spawn } from 'node:child_process';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const intellijDir = path.join(root, 'intellij');
+const bundleScript = path.join(root, 'scripts', 'build-webview-bundle.mjs');
+const distDir = path.join(intellijDir, 'build', 'distributions');
+
+const USAGE = `package-intellij-plugin: build the IntelliJ plugin .zip.
+
+Usage:
+  node scripts/package-intellij-plugin.mjs            Build the .zip
+  node scripts/package-intellij-plugin.mjs --skip-bundle
+                                                       Skip the webview bundle
+                                                       step (use the existing
+                                                       packages/diagrams/dist/
+                                                       webview/ outputs as-is).
+
+Output:
+  intellij/build/distributions/transitrix-intellij-<version>.zip`;
+
+const argv = process.argv.slice(2);
+if (argv.includes('-h') || argv.includes('--help')) {
+  console.log(USAGE);
+  process.exit(0);
+}
+const skipBundle = argv.includes('--skip-bundle');
+
+function run(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: 'inherit',
+      shell: false,
+      ...options,
+    });
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`${command} ${args.join(' ')} exited with code ${code}`));
+    });
+  });
+}
+
+async function pickGradle() {
+  const wrapperName = process.platform === 'win32' ? 'gradlew.bat' : 'gradlew';
+  const wrapperPath = path.join(intellijDir, wrapperName);
+  try {
+    await fs.access(wrapperPath);
+    return { command: wrapperPath, label: `intellij/${wrapperName}` };
+  } catch {
+    // Fall through to system gradle.
+  }
+  const systemName = process.platform === 'win32' ? 'gradle.bat' : 'gradle';
+  return { command: systemName, label: `${systemName} (system)` };
+}
+
+if (!skipBundle) {
+  console.log('• Refreshing webview bundle…');
+  await run(process.execPath, [bundleScript]);
+} else {
+  console.log('• Skipping webview bundle refresh (--skip-bundle).');
+}
+
+const { command, label } = await pickGradle();
+console.log(`• Building IntelliJ plugin via ${label}…`);
+try {
+  await run(command, ['buildPlugin', '--console=plain'], { cwd: intellijDir });
+} catch (err) {
+  if (err && err.code === 'ENOENT') {
+    console.error(
+      '\nGradle was not found. Either bootstrap the wrapper once with ' +
+        '`gradle wrapper` inside intellij/, or install Gradle 8.10+ ' +
+        '(https://gradle.org/install/) and rerun.',
+    );
+    process.exit(1);
+  }
+  throw err;
+}
+
+try {
+  const entries = await fs.readdir(distDir);
+  const zips = entries.filter((name) => name.endsWith('.zip'));
+  if (zips.length === 0) {
+    console.error(`\nNo .zip artifact found under ${path.relative(root, distDir)}.`);
+    process.exit(1);
+  }
+  console.log('\nPlugin artifact(s):');
+  for (const name of zips) {
+    const full = path.join(distDir, name);
+    const stat = await fs.stat(full);
+    const sizeKb = (stat.size / 1024).toFixed(1);
+    console.log(`  ${path.relative(root, full)} (${sizeKb} KB)`);
+  }
+  console.log(
+    '\nInstall in IntelliJ IDEA: Settings → Plugins → ⚙ → ' +
+      'Install Plugin from Disk… → select the .zip above.',
+  );
+} catch (err) {
+  console.error(`\nFailed to inspect ${path.relative(root, distDir)}: ${err.message}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

ADR 0001 step 5 — the last MVP step of epic [vkgeorgia/strategy#135](https://github.com/vkgeorgia/strategy/issues/135). Builds the IntelliJ plugin as a distributable `.zip` Valerii can install via **Settings → Plugins → ⚙ → Install Plugin from Disk…**.

- `scripts/package-intellij-plugin.mjs` — one-command path from a fresh checkout to the `.zip`: refreshes the webview bundle, invokes Gradle `:buildPlugin` under `intellij/` (wrapper if present, else system `gradle`), prints the artifact path + install hint. `--skip-bundle` for iteration when only Kotlin changed.
- `intellij/README.md` — replaces the "scaffolding only" status with packaging instructions, IDE install steps, the JCEF-bearing baseline (IDEA 2024.2+, per `gradle.properties` `pluginSinceBuild = 242`), and a smoke-test checklist.

No `build.gradle.kts` change needed — the IntelliJ Platform Gradle Plugin v2 already provides `:buildPlugin` and the artifact name is deterministic (`intellij/build/distributions/transitrix-intellij-<pluginVersion>.zip`); the existing `processResources → syncWebviewBundle` wire from Phase 1 keeps the bundle in the jar.

## Test plan

- [x] `npm run compile` (root tsc) — clean.
- [x] `npm run compile:extension` — clean.
- [x] `npm run build` — clean.
- [x] `npm test` — **620 pass**, same coverage as Phase 4.
- [x] `node scripts/build-webview-bundle.mjs` — clean (244.7 KB IIFE, browser-safety guard passes).
- [x] `node scripts/package-intellij-plugin.mjs --help` — usage renders.
- [ ] **Open verification gap (carried from Phases 3/4)**: Gradle is not installed on the agent host, so `:buildPlugin` itself was not exercised end-to-end here. The standard JetBrains scaffold from Phase 1 is unchanged; one manual `node scripts/package-intellij-plugin.mjs` on a JDK 17 + Gradle 8.10+ host is needed to produce the final `.zip` and confirm install + each notation in a clean IntelliJ IDEA Community 2024.2.

## Scope discipline

One concern (packaging). No changes to the JCEF wiring, the entry dispatch, or any notation renderer. Marketplace publication, signing, and `verifyPlugin` against multiple IDE builds remain explicitly out of MVP scope per the ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)