### PR TITLE
release: 1.4.0 — Process Blueprint cell wrap + compliance PDF export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,11 @@ extension/backends/
 # real surface and pollutes the VSIX. Keep `npm install` in extension/ from
 # regenerating one.
 extension/package-lock.json
-output/
+# Packaged .vsix artifacts land in output/ (see package-extension). Ignore the
+# contents but keep the directory itself so `vsce package --out ../output/`
+# works on a fresh clone.
+output/*
+!output/.gitkeep
 *.vsix
 # Python bytecode
 __pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 ## [Unreleased]
 
+## [1.4.0] — 2026-06-05
+
 ### Added
 - **`transitrix export-compliance --format pdf`** — PDF export of the compliance views (matrix / single-law / single-product / gap) via WeasyPrint. The HTML half (`renderComplianceHtml` in `@transitrix/diagrams/compliance`) builds a self-contained A4-portrait branded document; the CLI hands it to a `weasyprint` subprocess on PATH and surfaces a clear install hint when the binary is missing.
+
+### Fixed
+- **Process Blueprint goal/result cells now wrap their text** instead of truncating it to a single 32-character line. The layout word-wraps each cell to the column width and grows the goal/result rows to fit the tallest cell (capped at 6 lines with an ellipsis); both the VS Code preview and the JCEF webview renderer share the wrapped layout.
 
 ## [1.3.0] — 2026-06-02
 

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Transitrix Studio — changelog
 
+## 1.4.0 — 2026-06-05
+
+Adds PDF export for the compliance views and fixes Process Blueprint cells clipping their text.
+
+### Added
+
+- **PDF export for compliance views** — `transitrix export-compliance --format pdf` renders the matrix / single-law / single-product / gap views as a self-contained A4-portrait branded PDF via WeasyPrint (`pipx install weasyprint`); a clear install hint is shown when the binary is missing.
+
+### Fixed
+
+- **Process Blueprint goal/result cells now wrap their text** instead of cutting it off at ~32 characters with an ellipsis. Each cell word-wraps to the column width and the goal/result rows grow to fit the tallest cell (capped at 6 lines), so long stage goals and results stay readable.
+
 ## 1.2.1 — 2026-05-28
 
 Patch release. Refreshes the Marketplace description that was bundled into 1.2.0 stale (the rewrite landed after publish), and adds the N+1 hierarchy validator for Goals trees.

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -12,6 +12,27 @@ Adds PDF export for the compliance views and fixes Process Blueprint cells clipp
 
 - **Process Blueprint goal/result cells now wrap their text** instead of cutting it off at ~32 characters with an ellipsis. Each cell word-wraps to the column width and the goal/result rows grow to fit the tallest cell (capped at 6 lines), so long stage goals and results stay readable.
 
+## 1.3.0 — 2026-06-02
+
+Adds the Activity Card notation, the compliance suite (matrix / single-law / single-product / gap dashboard + Markdown export), and live in-preview controls for spacing, curvature and scope.
+
+### Added
+
+- **Activity Card notation** (`*.activity-card.transitrix.yaml`) — full preview with Save-as-SVG / PNG and Copy-as-PNG.
+- **Compliance views** — Products × Requirements **matrix** (filter by jurisdiction / severity / status), **single-law** tree (Law → Requirements → Assertions), **single-product** view (Product → bound Requirements → status), and a **gap dashboard** (requirements without assertions, assertions without evidence, stale assertions past review date; CSV export).
+- **`transitrix export-compliance` CLI** — exports the compliance matrix as Markdown (`--format md`, `--scope law:<id>|product:<id>`, `--output <path>`).
+- **Live in-preview controls** — spacing, edge curvature and scope are adjustable from a toolbar inside the Goals, FGCA, FGA and Activities previews, plus matching `transitrix.spacing.*` / `transitrix.curvature.*` / `transitrix.scope.*` settings.
+- **FGCA / FGA tree↔table toggle** — flatten the chain into a merged-cell table (`Factor | Goal | Change | Activity`; FGA: `Factor | Goal | Activity`), persisted per notation.
+
+### Changed
+
+- Every notation validator now guards each array element with an "entry must be an object" check, so malformed YAML (e.g. `goals: [null]`) degrades to a clear error panel instead of crashing the preview.
+- `activationEvents` extended to cover all eleven notation suffixes, so previews and editor-title buttons activate from a cold VS Code window.
+
+### Fixed
+
+- Goals `level` is type-checked numerically; cyclic / self-parent goal trees no longer overflow the stack; FGCA changes with no `activity_ids` render cleanly; Activity dates are format-checked before comparison.
+
 ## 1.2.1 — 2026-05-28
 
 Patch release. Refreshes the Marketplace description that was bundled into 1.2.0 stale (the rewrite landed after publish), and adds the N+1 hierarchy validator for Goals trees.

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Architecture-as-code for the modern enterprise. Author 13 notations — goals, processes, capabilities, BPMN, applications, more — as plain YAML, get live diagrams in VS Code. Diffable in git. AI-friendly. Open source. Built on ArchiMate 3.2 and BPMN 2.0.",
   "license": "MIT",
   "icon": "icon.png",

--- a/extension/src/process-blueprint-preview.ts
+++ b/extension/src/process-blueprint-preview.ts
@@ -21,6 +21,26 @@ function truncate(text: string, maxChars: number): string {
   return text.slice(0, Math.max(0, maxChars - 1)) + '…';
 }
 
+/**
+ * Render a left-anchored, vertically centred multi-line text cell. `lines` are
+ * pre-wrapped by the layout; the block is centred within the cell height.
+ */
+function textCellSvg(
+  lines: string[],
+  cls: string,
+  x: number,
+  cellTop: number,
+  cellHeight: number,
+  lineHeight: number,
+): string {
+  const ls = lines.length > 0 ? lines : [''];
+  const first = cellTop + cellHeight / 2 - ((ls.length - 1) / 2) * lineHeight;
+  const tspans = ls
+    .map((ln, i) => `<tspan x="${x}" y="${first + i * lineHeight}">${escXml(ln)}</tspan>`)
+    .join('');
+  return `<text class="${cls}" dominant-baseline="central">${tspans}</text>`;
+}
+
 function layoutToSvg(layout: ProcessBlueprintLayout, filename?: string, date?: string, version?: string): string {
   const pad = 24;
   const showTitle = filename != null && date != null;
@@ -54,12 +74,13 @@ function layoutToSvg(layout: ProcessBlueprintLayout, filename?: string, date?: s
     );
   }
 
+  const textX = layout.cellTextPadX;
   for (const c of layout.goalCells) {
     parts.push(
       `<rect class="diagram-node level-3" x="${c.x + ox}" y="${c.y + oy}" width="${c.width}" height="${c.height}"/>`,
     );
     parts.push(
-      `<text class="text-secondary" x="${c.x + ox + 10}" y="${c.y + oy + c.height / 2}" dominant-baseline="central">${escXml(truncate(c.text, 32))}</text>`,
+      textCellSvg(c.lines, 'text-secondary', c.x + ox + textX, c.y + oy, c.height, layout.textLineHeight),
     );
   }
   for (const c of layout.resultCells) {
@@ -67,7 +88,7 @@ function layoutToSvg(layout: ProcessBlueprintLayout, filename?: string, date?: s
       `<rect class="diagram-node level-4" x="${c.x + ox}" y="${c.y + oy}" width="${c.width}" height="${c.height}"/>`,
     );
     parts.push(
-      `<text class="text-secondary" x="${c.x + ox + 10}" y="${c.y + oy + c.height / 2}" dominant-baseline="central">${escXml(truncate(c.text, 32))}</text>`,
+      textCellSvg(c.lines, 'text-secondary', c.x + ox + textX, c.y + oy, c.height, layout.textLineHeight),
     );
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "ui:build": "vite build --config ui/vite.config.ts",
     "ui:preview": "npm run build && npm run ui:build && vite preview --config ui/vite.config.ts",
     "bump-extension-version": "node scripts/bump-extension-version.mjs",
-    "package-extension": "npm run extension:prep && npm run bump-extension-version && cd extension && vsce package",
+    "package-extension": "npm run extension:prep && npm run bump-extension-version && cd extension && vsce package --out ../output/",
     "sync-examples": "node scripts/sync-examples-from-methodology.mjs"
   },
   "bin": {

--- a/packages/diagrams/src/process-blueprint/layout.ts
+++ b/packages/diagrams/src/process-blueprint/layout.ts
@@ -31,6 +31,11 @@ const DEFAULTS: Required<ProcessBlueprintLayoutOptions> = {
   pillHeight: 28,
   pillGap: 4,
   cellPadding: 8,
+  textLineHeight: 15,
+  textCharWidth: 6.2,
+  cellTextPadX: 10,
+  cellTextPadY: 10,
+  maxTextLines: 6,
 };
 
 interface RawPill {
@@ -44,6 +49,59 @@ interface RawPill {
 
 function resolveOptions(options: ProcessBlueprintLayoutOptions | undefined): Required<ProcessBlueprintLayoutOptions> {
   return { ...DEFAULTS, ...(options ?? {}) };
+}
+
+/**
+ * Greedy word-wrap to a max characters-per-line budget. Words longer than the
+ * budget are hard-split; if the result exceeds `maxLines`, the last kept line
+ * is truncated with an ellipsis so a single pathological cell can't grow the
+ * whole row unbounded.
+ */
+function wrapText(text: string, maxChars: number, maxLines: number): string[] {
+  const trimmed = (text ?? '').trim();
+  if (trimmed.length === 0) return [];
+  const budget = Math.max(1, maxChars);
+
+  const words = trimmed.split(/\s+/);
+  const lines: string[] = [];
+  let cur = '';
+  const flush = (): void => {
+    if (cur.length > 0) {
+      lines.push(cur);
+      cur = '';
+    }
+  };
+
+  for (const word of words) {
+    if (word.length > budget) {
+      // Token wider than the cell: hard-break it across lines.
+      flush();
+      let rest = word;
+      while (rest.length > budget) {
+        lines.push(rest.slice(0, budget));
+        rest = rest.slice(budget);
+      }
+      cur = rest;
+      continue;
+    }
+    const candidate = cur.length > 0 ? `${cur} ${word}` : word;
+    if (candidate.length > budget) {
+      flush();
+      cur = word;
+    } else {
+      cur = candidate;
+    }
+  }
+  flush();
+
+  if (lines.length > maxLines) {
+    const capped = lines.slice(0, maxLines);
+    const last = capped[maxLines - 1];
+    const clipped = last.length > budget - 1 ? last.slice(0, budget - 1) : last;
+    capped[maxLines - 1] = `${clipped.replace(/…$/, '')}…`;
+    return capped;
+  }
+  return lines;
 }
 
 function buildStageIndex(stages: Stage[]): Map<string, number> {
@@ -170,29 +228,47 @@ export function layoutProcessBlueprint(
     height: opts.stageHeaderHeight,
   }));
 
-  // Goal + result rows
+  // Goal + result rows. Text is word-wrapped to the column width, and each row
+  // grows to fit the tallest cell so nothing is clipped.
+  const maxCharsPerLine = Math.max(
+    4,
+    Math.floor((opts.stageColumnWidth - 2 * opts.cellTextPadX) / opts.textCharWidth),
+  );
+  const wrap = (text: string): string[] => wrapText(text, maxCharsPerLine, opts.maxTextLines);
+  const rowHeightFor = (lineCounts: number[], minHeight: number): number => {
+    const maxLines = Math.max(1, ...lineCounts);
+    return Math.max(minHeight, maxLines * opts.textLineHeight + 2 * opts.cellTextPadY);
+  };
+
+  const goalLines = stages.map(s => wrap(s?.goal ?? ''));
+  const resultLines = stages.map(s => wrap(s?.result ?? ''));
+
   const goalRowY = opts.stageHeaderHeight;
-  const resultRowY = goalRowY + opts.goalRowHeight;
+  const goalRowHeight = rowHeightFor(goalLines.map(l => l.length), opts.goalRowHeight);
+  const resultRowY = goalRowY + goalRowHeight;
+  const resultRowHeight = rowHeightFor(resultLines.map(l => l.length), opts.resultRowHeight);
 
   const goalCells: StageTextCell[] = stages.map((s, i) => ({
     stageIndex: i,
     text: s?.goal ?? '',
+    lines: goalLines[i],
     x: opts.legendColumnWidth + i * opts.stageColumnWidth,
     y: goalRowY,
     width: opts.stageColumnWidth,
-    height: opts.goalRowHeight,
+    height: goalRowHeight,
   }));
 
   const resultCells: StageTextCell[] = stages.map((s, i) => ({
     stageIndex: i,
     text: s?.result ?? '',
+    lines: resultLines[i],
     x: opts.legendColumnWidth + i * opts.stageColumnWidth,
     y: resultRowY,
     width: opts.stageColumnWidth,
-    height: opts.resultRowHeight,
+    height: resultRowHeight,
   }));
 
-  const aspectsStartY = resultRowY + opts.resultRowHeight;
+  const aspectsStartY = resultRowY + resultRowHeight;
 
   // Aspect rows: only categories with at least one entry, in fixed order.
   const aspectRows: AspectRow[] = [];
@@ -250,8 +326,8 @@ export function layoutProcessBlueprint(
 
   // Legend (left column labels): one entry per row.
   const legend: LegendCell[] = [
-    { kind: 'goal', label: 'Goal', y: goalRowY, height: opts.goalRowHeight },
-    { kind: 'result', label: 'Result', y: resultRowY, height: opts.resultRowHeight },
+    { kind: 'goal', label: 'Goal', y: goalRowY, height: goalRowHeight },
+    { kind: 'result', label: 'Result', y: resultRowY, height: resultRowHeight },
     ...aspectRows.map<LegendCell>(row => ({
       kind: 'aspect',
       category: row.category,
@@ -268,6 +344,8 @@ export function layoutProcessBlueprint(
     bounds: { x: 0, y: 0, width: totalWidth, height: totalHeight },
     legendColumnWidth: opts.legendColumnWidth,
     stageColumnWidth: opts.stageColumnWidth,
+    textLineHeight: opts.textLineHeight,
+    cellTextPadX: opts.cellTextPadX,
     legend,
     stageHeaders,
     goalCells,

--- a/packages/diagrams/src/process-blueprint/types.ts
+++ b/packages/diagrams/src/process-blueprint/types.ts
@@ -48,6 +48,16 @@ export interface ProcessBlueprintLayoutOptions {
   pillHeight?: number;
   pillGap?: number;
   cellPadding?: number;
+  /** Vertical advance between wrapped text lines in goal/result cells (px). */
+  textLineHeight?: number;
+  /** Approximate glyph width used to estimate wrap width (px per char). */
+  textCharWidth?: number;
+  /** Horizontal text inset inside goal/result cells (px, both sides). */
+  cellTextPadX?: number;
+  /** Top+bottom padding added around wrapped goal/result text (px). */
+  cellTextPadY?: number;
+  /** Maximum wrapped lines per goal/result cell before truncating with an ellipsis. */
+  maxTextLines?: number;
 }
 
 export interface LayoutBounds {
@@ -78,6 +88,8 @@ export interface StageHeaderCell {
 export interface StageTextCell {
   stageIndex: number;
   text: string;
+  /** Word-wrapped lines of `text`, pre-fitted to the cell width by the layout. */
+  lines: string[];
   x: number;
   y: number;
   width: number;
@@ -108,6 +120,10 @@ export interface ProcessBlueprintLayout {
   bounds: LayoutBounds;
   legendColumnWidth: number;
   stageColumnWidth: number;
+  /** Vertical advance between wrapped text lines, so renderers stack tspans consistently. */
+  textLineHeight: number;
+  /** Horizontal text inset used for goal/result cells (px). */
+  cellTextPadX: number;
   legend: LegendCell[];
   stageHeaders: StageHeaderCell[];
   goalCells: StageTextCell[];

--- a/packages/diagrams/src/webview/render-process-blueprint.ts
+++ b/packages/diagrams/src/webview/render-process-blueprint.ts
@@ -24,6 +24,26 @@ function truncate(text: string, maxChars: number): string {
   return text.slice(0, Math.max(0, maxChars - 1)) + '…';
 }
 
+/**
+ * Render a left-anchored, vertically centred multi-line text cell. `lines` are
+ * pre-wrapped by the layout; the block is centred within the cell height.
+ */
+function textCellSvg(
+  lines: string[],
+  cls: string,
+  x: number,
+  cellTop: number,
+  cellHeight: number,
+  lineHeight: number,
+): string {
+  const ls = lines.length > 0 ? lines : [''];
+  const first = cellTop + cellHeight / 2 - ((ls.length - 1) / 2) * lineHeight;
+  const tspans = ls
+    .map((ln, i) => `<tspan x="${x}" y="${first + i * lineHeight}">${escXml(ln)}</tspan>`)
+    .join('');
+  return `<text class="${cls}" dominant-baseline="central">${tspans}</text>`;
+}
+
 export interface RenderProcessBlueprintOptions {
   title?: string;
 }
@@ -70,12 +90,13 @@ export function renderProcessBlueprintSvg(
     );
   }
 
+  const textX = layout.cellTextPadX;
   for (const c of layout.goalCells) {
     parts.push(
       `<rect class="diagram-node level-3" x="${c.x + ox}" y="${c.y + oy}" width="${c.width}" height="${c.height}"/>`,
     );
     parts.push(
-      `<text class="text-secondary" x="${c.x + ox + 10}" y="${c.y + oy + c.height / 2}" dominant-baseline="central">${escXml(truncate(c.text, 32))}</text>`,
+      textCellSvg(c.lines, 'text-secondary', c.x + ox + textX, c.y + oy, c.height, layout.textLineHeight),
     );
   }
   for (const c of layout.resultCells) {
@@ -83,7 +104,7 @@ export function renderProcessBlueprintSvg(
       `<rect class="diagram-node level-4" x="${c.x + ox}" y="${c.y + oy}" width="${c.width}" height="${c.height}"/>`,
     );
     parts.push(
-      `<text class="text-secondary" x="${c.x + ox + 10}" y="${c.y + oy + c.height / 2}" dominant-baseline="central">${escXml(truncate(c.text, 32))}</text>`,
+      textCellSvg(c.lines, 'text-secondary', c.x + ox + textX, c.y + oy, c.height, layout.textLineHeight),
     );
   }
 


### PR DESCRIPTION
## Problem

Process Blueprint goal/result cells truncated their text to 32 chars on a single line, so longer stage descriptions were cut off with an ellipsis and the diagram looked broken:

> `Capture a validated customer or…` / `Reserve stock to satisfy the or…`

## Fix

Word-wrap the text **in the layout** (single source of truth), so both the VS Code preview and the JCEF/IntelliJ webview renderer behave identically:

- `process-blueprint/layout.ts` — new `wrapText()` (greedy word-wrap; over-long tokens hard-split; `maxTextLines: 6` cap with an ellipsis so one pathological cell can't grow the whole row). Goal/Result rows now grow to `max(base, lines × lineHeight + padding)`, and the result row / aspect rows reflow below.
- `process-blueprint/types.ts` — `StageTextCell.lines: string[]`, wrap options, and `textLineHeight` / `cellTextPadX` exposed on the layout.
- `process-blueprint-preview.ts` + `webview/render-process-blueprint.ts` — emit a vertically-centred multi-line `<tspan>` block instead of one truncated `<text>`.

Stage headers and aspect pills keep their existing width-based truncation (they weren't part of the problem).

### Before → after (example `order-fulfilment`)

```
before: "Capture a validated customer or…"   (one clipped line)
after:  ["Capture a validated customer", "order."]
        ["Packed shipment scanned out of", "the warehouse and ready for", "carrier handover."]
```

## Tests

- `tsc` clean for both `packages/diagrams` and `extension` (the two pre-existing `LayoutBounds` re-export warnings are unrelated to this change).
- All 620 diagrams tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update — also cuts the 1.4.0 Marketplace release

Per Valerii's call, this branch now also bumps the version and packages the next release (minor, because it ships a user-facing feature alongside this fix):

- **Version** `1.3.0 → 1.4.0` (root + `extension/package.json`).
- **CHANGELOG** — root `CHANGELOG.md` `[Unreleased]` → `[1.4.0] — 2026-06-05` (promotes the already-merged `export-compliance --format pdf` feature + adds this fix); Marketplace `extension/CHANGELOG.md` gets a matching 1.4.0 entry.
- **Packaged**: `extension/transitrix-studio-win32-x64-1.4.0.vsix` (5.2 MB) — built locally via `vsce package --target win32-x64`, ready to upload.

### Release scope (everything on `main` since the 1.3.0 release commit)
- `export-compliance --format pdf` (#84) — user-facing.
- Process Blueprint cell text wrapping — this fix.
- IntelliJ webview-bundle work (Phase 2/4) — internal, no VS Code surface.

### Notes
- Only the **win32-x64** target was built — the native `@resvg/resvg-js` binary is installed only for this platform here. Other targets (darwin/linux) need to be packaged where their binaries are available.
- The Marketplace `extension/CHANGELOG.md` never got a **1.3.0** entry (it jumps 1.4.0 → 1.2.1); 1.3.0 was only recorded in the root changelog. Left as-is — flag if you want it backfilled.
