### PR TITLE
feat(compliance): DQ-2 — render view composite confidence in compliance previews (#162)

### DIFF
--- a/extension/src/compliance-render.ts
+++ b/extension/src/compliance-render.ts
@@ -1,5 +1,6 @@
 import { generateWebviewCss, type ThemeId } from '../../packages/diagrams/src/theme/index.js';
 import type { AssertionStatus } from '../../packages/diagrams/src/assertion/types.js';
+import type { ViewScore } from '../../packages/diagrams/src/confidence/index.js';
 
 // Shared HTML rendering for the script-less compliance views — the single-law
 // tree and single-product view (vkgeorgia/strategy#84 Phase 3). These previews
@@ -40,6 +41,12 @@ body { padding: 0; }
 #cmp-toolbar { display: flex; align-items: baseline; gap: 12px; padding: 12px 16px; border-bottom: 1px solid var(--ts-border, #cbd5e1); flex-wrap: wrap; }
 .cmp-title { font-size: 15px; font-weight: 700; color: var(--ts-text, #0f172a); }
 .cmp-subtitle { font-size: 12px; color: var(--ts-text-muted, #64748b); }
+.cmp-confidence { width: 100%; font-size: 11px; color: var(--ts-text-muted, #64748b); }
+.cmp-confidence-band { display: inline-block; padding: 0 6px; margin-right: 4px; border-radius: 3px; font-weight: 700; background: var(--ts-bg-subtle, #f1f5f9); color: var(--ts-text, #0f172a); }
+.cmp-confidence-band[data-band="A"] { background: var(--ts-status-success-bg, #d1fae5); color: var(--ts-status-success-fg, #065f46); }
+.cmp-confidence-band[data-band="B"] { background: var(--ts-status-info-bg, #e0f2fe); color: var(--ts-status-info-fg, #0c4a6e); }
+.cmp-confidence-band[data-band="C"] { background: var(--ts-status-warning-bg, #fef9c3); color: var(--ts-status-warning-fg, #854d0e); }
+.cmp-confidence-band[data-band="D"] { background: var(--ts-status-error-bg, #fee2e2); color: var(--ts-status-error-fg, #991b1b); }
 .cmp-toolbar-actions { margin-left: auto; display: inline-flex; gap: 6px; }
 .cmp-btn { font-size: 11px; padding: 2px 10px; border-radius: 4px; color: var(--ts-text-muted, #64748b); text-decoration: none; border: 1px solid var(--ts-border, #cbd5e1); }
 .cmp-btn:hover { color: var(--ts-text, #0f172a); background: var(--ts-bg-elevated, #f1f5f9); }
@@ -91,6 +98,29 @@ export interface ComplianceShellOptions {
   extraButtons?: Array<{ command: string; label: string; title: string }>;
   /** Already-built body HTML (caller is responsible for escaping). */
   bodyHtml: string;
+  /**
+   * View-level composite confidence for the rendered element set
+   * (CONTRACT §11.6). Rendered next to the formation date as a small subline
+   * under the title (DQ-2, vkgeorgia/strategy#162). Omit or pass an empty
+   * composite to suppress the line entirely.
+   */
+  confidence?: ViewScore;
+}
+
+/**
+ * Renders the §11.6 confidence header as a coloured-band pill plus the
+ * formation date + mean + sourced %. Suppresses itself for an empty
+ * element set (no view to score). Static / script-less — pure HTML.
+ */
+export function confidenceLineHtml(view: ViewScore): string {
+  const c = view.composite;
+  if (c.element_count === 0) return '';
+  const mean = c.mean.toFixed(2);
+  const coverage = Math.round(c.coverage * 100);
+  return `<span class="cmp-confidence" title="Data confidence per CONTRACT §11.6 — weakest-link headline.">`
+    + `<span class="cmp-confidence-band" data-band="${escXml(c.band)}">${escXml(c.band)}</span>`
+    + `Data confidence (as of ${escXml(view.today)}) · ${escXml(mean)} mean · ${coverage}% sourced`
+    + `</span>`;
 }
 
 /** Full webview document for a script-less compliance view (static CSP). */
@@ -110,6 +140,7 @@ ${COMPLIANCE_CSS}
     <span class="cmp-title">${escXml(opts.title)}</span>
     ${opts.subtitle ? `<span class="cmp-subtitle">${escXml(opts.subtitle)}</span>` : ''}
     <span class="cmp-toolbar-actions">${(opts.extraButtons ?? []).map(b => `<a href="command:${b.command}" class="cmp-btn" title="${escXml(b.title)}">${escXml(b.label)}</a>`).join('')}<a href="command:${opts.refreshCommand}" class="cmp-btn" title="Re-scan the workspace">Refresh</a></span>
+    ${opts.confidence ? confidenceLineHtml(opts.confidence) : ''}
   </div>
   <div id="cmp-body">
     ${opts.bodyHtml}

--- a/extension/src/gap-dashboard-preview.ts
+++ b/extension/src/gap-dashboard-preview.ts
@@ -1,9 +1,10 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import { type ThemeId } from '../../packages/diagrams/src/theme/index.js';
-import { buildComplianceIndex, buildGapReport, type GapReport } from '../../packages/diagrams/src/compliance/index.js';
+import { buildComplianceIndex, buildGapReport, scoreComplianceView, type GapReport } from '../../packages/diagrams/src/compliance/index.js';
 import { scanComplianceCanon } from './compliance-scan.js';
 import { complianceShell, escXml, openLink, statusBadge } from './compliance-render.js';
+import type { ViewScore } from '../../packages/diagrams/src/confidence/index.js';
 
 // Gap dashboard (vkgeorgia/strategy#84 Phase 4). A repo-wide operational view
 // for compliance owners: requirements with no assertion, assertions with a
@@ -24,6 +25,7 @@ export class GapDashboardPreview {
   readonly panelTitle = 'Compliance Gap Dashboard';
   private panel: vscode.WebviewPanel | undefined;
   private lastReport: GapReport | undefined;
+  private lastConfidence: ViewScore | undefined;
   private pathById = new Map<string, string>();
 
   constructor(private readonly extensionUri: vscode.Uri) {}
@@ -48,7 +50,11 @@ export class GapDashboardPreview {
     const scan = await scanComplianceCanon();
     this.pathById = scan.pathById;
     const index = buildComplianceIndex({ requirements: scan.requirements, assertions: scan.assertions });
-    this.lastReport = buildGapReport(index, { today: todayIso() });
+    const today = todayIso();
+    this.lastReport = buildGapReport(index, { today });
+    // Confidence across the full scanned canon — the dashboard's "view" is
+    // every requirement + assertion in the repo (CONTRACT §11.6).
+    this.lastConfidence = scoreComplianceView(scan.requirements, scan.assertions, today);
     const themeId = vscode.workspace.getConfiguration('transitrix').get<ThemeId>('theme', 'transitrix');
     this.panel.webview.html = this.buildHtml(this.lastReport, themeId);
   }
@@ -117,6 +123,7 @@ export class GapDashboardPreview {
       refreshCommand: REFRESH_COMMAND,
       extraButtons: [{ command: EXPORT_CSV_COMMAND, label: 'Export CSV', title: 'Save the gap report as a CSV file' }],
       bodyHtml: body,
+      confidence: this.lastConfidence,
     });
   }
 }

--- a/extension/src/single-law-preview.ts
+++ b/extension/src/single-law-preview.ts
@@ -2,9 +2,14 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { type ThemeId } from '../../packages/diagrams/src/theme/index.js';
-import { buildComplianceIndex, buildLawTree, type LawTree } from '../../packages/diagrams/src/compliance/index.js';
+import { buildComplianceIndex, buildLawTree, scoreComplianceView, type LawTree } from '../../packages/diagrams/src/compliance/index.js';
 import { scanComplianceCanon } from './compliance-scan.js';
 import { complianceShell, escXml, openLink, statusBadge } from './compliance-render.js';
+
+/** Today as ISO YYYY-MM-DD (extension host clock; the library stays clock-free). */
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
 
 // Single-law tree (vkgeorgia/strategy#84 Phase 3). Triggered from a codex file
 // (LAW / REGULATION / POLICY / INTERNAL_STANDARD) in the editor-title bar.
@@ -86,12 +91,19 @@ export class SingleLawPreview {
     const index = buildComplianceIndex({ requirements: scan.requirements, assertions: scan.assertions });
     const tree = buildLawTree(lawId, index);
 
+    // Confidence over every element rendered in the tree — requirements
+    // derived from this law + every assertion targeting them (CONTRACT §11.6).
+    const treeRequirements = tree.requirements.map(n => n.requirement);
+    const treeAssertions = tree.requirements.flatMap(n => n.assertions);
+    const confidence = scoreComplianceView(treeRequirements, treeAssertions, todayIso());
+
     this.panel.webview.html = complianceShell({
       title: lawName,
       subtitle: `${lawId} · ${tree.requirements.length} requirement(s)`,
       themeId,
       refreshCommand: REFRESH_COMMAND,
       bodyHtml: this.treeHtml(tree, scan.pathById),
+      confidence,
     });
   }
 

--- a/extension/src/single-product-preview.ts
+++ b/extension/src/single-product-preview.ts
@@ -2,9 +2,14 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { type ThemeId } from '../../packages/diagrams/src/theme/index.js';
-import { buildComplianceIndex, buildProductView, type ProductView } from '../../packages/diagrams/src/compliance/index.js';
+import { buildComplianceIndex, buildProductView, scoreComplianceView, type ProductView } from '../../packages/diagrams/src/compliance/index.js';
 import { scanComplianceCanon } from './compliance-scan.js';
 import { complianceShell, escXml, openLink, statusBadge } from './compliance-render.js';
+
+/** Today as ISO YYYY-MM-DD (extension host clock; the library stays clock-free). */
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
 
 // Single-product view (vkgeorgia/strategy#84 Phase 3). Triggered from a PRODUCT
 // file in the editor-title bar. Shows the product → every requirement an
@@ -84,12 +89,18 @@ export class SingleProductPreview {
     const index = buildComplianceIndex({ requirements: scan.requirements, assertions: scan.assertions });
     const view = buildProductView(productId, index);
 
+    // Confidence over the rendered requirement/assertion pairs (CONTRACT §11.6).
+    const viewRequirements = view.requirements.map(r => r.requirement);
+    const viewAssertions = view.requirements.map(r => r.assertion);
+    const confidence = scoreComplianceView(viewRequirements, viewAssertions, todayIso());
+
     this.panel.webview.html = complianceShell({
       title: productName,
       subtitle: `${productId} · ${view.requirements.length} requirement(s) asserted`,
       themeId,
       refreshCommand: REFRESH_COMMAND,
       bodyHtml: this.viewHtml(view, scan.pathById),
+      confidence,
     });
   }
 

--- a/packages/diagrams/src/compliance/__tests__/classify.test.ts
+++ b/packages/diagrams/src/compliance/__tests__/classify.test.ts
@@ -5,8 +5,8 @@ describe('ingestComplianceDoc', () => {
   it('buckets each artefact kind by notation / zone', () => {
     const canon = emptyCanon();
     expect(ingestComplianceDoc(canon, { notation: 'product', id: 'PRODUCT-1', name: 'P' })).toBe('PRODUCT-1');
-    expect(ingestComplianceDoc(canon, { notation: 'requirement', id: 'REQUIREMENT-1', name: 'R', severity: 'high', derived_from: ['LAW-1'] })).toBe('REQUIREMENT-1');
-    expect(ingestComplianceDoc(canon, { notation: 'assertion', id: 'ASSERTION-1', about: 'REQUIREMENT-1', subject: 'PRODUCT-1', status: 'compliant', evidence: [{ kind: 'note', text: 'x' }] })).toBe('ASSERTION-1');
+    expect(ingestComplianceDoc(canon, { notation: 'requirement', id: 'REQUIREMENT-1', name: 'R', severity: 'high', derived_from: ['LAW-1'], admitted_at: '2026-05-28' })).toBe('REQUIREMENT-1');
+    expect(ingestComplianceDoc(canon, { notation: 'assertion', id: 'ASSERTION-1', about: 'REQUIREMENT-1', subject: 'PRODUCT-1', status: 'compliant', evidence: [{ kind: 'note', text: 'x' }], admitted_at: '2026-05-28' })).toBe('ASSERTION-1');
     expect(ingestComplianceDoc(canon, { id: 'LAW-1', name: 'Law', type: 'LAW', zone: 'codex', jurisdiction: 'ge' })).toBe('LAW-1');
 
     expect(canon.products).toEqual([{ id: 'PRODUCT-1', name: 'P' }]);

--- a/packages/diagrams/src/compliance/__tests__/confidence.test.ts
+++ b/packages/diagrams/src/compliance/__tests__/confidence.test.ts
@@ -1,0 +1,98 @@
+// Bridge from the compliance index projections to the DQ-1 confidence module
+// (vkgeorgia/strategy#162 — DQ-2). Pins that:
+//   • element TYPEs lift to REQUIREMENT / ASSERTION (decay lookup keys),
+//   • admitted_at flows through to the freshness curve,
+//   • the §11.6 header line matches the spec example shape,
+//   • an empty view suppresses the header (caller-controlled).
+
+import { describe, it, expect } from 'vitest';
+import {
+  assertionToScoringElement,
+  complianceConfidenceHeader,
+  requirementToScoringElement,
+  scoreComplianceView,
+} from '../confidence.js';
+import type { IndexAssertion, IndexRequirement } from '../types.js';
+
+const req = (over: Partial<IndexRequirement> = {}): IndexRequirement => ({
+  id: 'REQUIREMENT-1', name: 'R', admitted_at: '2026-05-01', ...over,
+});
+const ass = (over: Partial<IndexAssertion> = {}): IndexAssertion => ({
+  id: 'ASSERTION-1', about: 'REQUIREMENT-1', subject: 'PRODUCT-1',
+  status: 'compliant', admitted_at: '2026-05-01', ...over,
+});
+
+describe('requirementToScoringElement / assertionToScoringElement', () => {
+  it('lifts the index projection to a ScoringElement', () => {
+    expect(requirementToScoringElement(req())).toEqual({
+      type: 'REQUIREMENT', admitted_at: '2026-05-01',
+    });
+    expect(assertionToScoringElement(ass())).toEqual({
+      type: 'ASSERTION', admitted_at: '2026-05-01',
+    });
+  });
+
+  it('leaves sources undefined — v1 has no field-zone provenance to resolve', () => {
+    // Documents the §11.5 behaviour: until DSM/Studio ingest field-zone
+    // source_quality, every element scores unsourced and is counted separately.
+    expect(requirementToScoringElement(req()).sources).toBeUndefined();
+    expect(assertionToScoringElement(ass()).sources).toBeUndefined();
+  });
+
+  it('preserves an absent admitted_at as undefined', () => {
+    expect(requirementToScoringElement(req({ admitted_at: undefined })).admitted_at).toBeUndefined();
+  });
+});
+
+describe('scoreComplianceView', () => {
+  it('scores the union of requirements + assertions and reports today', () => {
+    const v = scoreComplianceView([req()], [ass()], '2026-06-07');
+    expect(v.today).toBe('2026-06-07');
+    expect(v.elements).toHaveLength(2);
+    expect(v.composite.element_count).toBe(2);
+    // Two fresh elements (37 days old, ≤ implicit fresh_days=180) → freshness=1.0,
+    // but no sources → source_trust=0.25 floor → confidence=0.25, band D.
+    for (const e of v.elements) {
+      expect(e.freshness).toBe(1.0);
+      expect(e.source_trust).toBe(0.25);
+      expect(e.confidence).toBe(0.25);
+      expect(e.sourced).toBe(false);
+    }
+    expect(v.composite.band).toBe('D');
+    expect(v.composite.coverage).toBe(0);
+    expect(v.composite.unsourced_count).toBe(2);
+  });
+
+  it('returns the degenerate composite for an empty view', () => {
+    const v = scoreComplianceView([], [], '2026-06-07');
+    expect(v.composite.element_count).toBe(0);
+    expect(v.elements).toHaveLength(0);
+  });
+
+  it('honours per-TYPE decay overrides from the manifest config', () => {
+    // ASSERTION decays faster than REQUIREMENT — exercise the by_type lookup.
+    const v = scoreComplianceView(
+      [req({ admitted_at: '2025-01-01' })],
+      [ass({ admitted_at: '2025-01-01' })],
+      '2026-06-07',
+      {
+        by_type: {
+          REQUIREMENT: { fresh_days: 1000, stale_days: 2000, floor: 0.5 },
+          ASSERTION:   { fresh_days: 30,   stale_days: 60,   floor: 0.1 },
+        },
+      },
+    );
+    // Requirement is still well within fresh_days=1000 → freshness 1.0.
+    expect(v.elements[0].freshness).toBe(1.0);
+    // Assertion is well past stale_days=60 → freshness floors at 0.1.
+    expect(v.elements[1].freshness).toBeCloseTo(0.1, 10);
+  });
+});
+
+describe('complianceConfidenceHeader', () => {
+  it('formats the §11.6 example shape and returns empty for an empty view', () => {
+    expect(complianceConfidenceHeader([], [], '2026-06-07')).toBe('');
+    const line = complianceConfidenceHeader([req()], [ass()], '2026-06-07');
+    expect(line).toMatch(/^Data confidence \(as of 2026-06-07\): D \(weakest link\) · 0\.25 mean · 0% sourced$/);
+  });
+});

--- a/packages/diagrams/src/compliance/classify.ts
+++ b/packages/diagrams/src/compliance/classify.ts
@@ -51,7 +51,13 @@ export function ingestComplianceDoc(canon: ComplianceCanon, doc: unknown): strin
     return id;
   }
   if (d.notation === 'requirement') {
-    canon.requirements.push({ id, name: str(d.name) ?? id, severity: str(d.severity), derived_from: strArray(d.derived_from) });
+    canon.requirements.push({
+      id,
+      name: str(d.name) ?? id,
+      severity: str(d.severity),
+      derived_from: strArray(d.derived_from),
+      admitted_at: str(d.admitted_at),
+    });
     return id;
   }
   if (d.notation === 'assertion') {
@@ -64,6 +70,7 @@ export function ingestComplianceDoc(canon: ComplianceCanon, doc: unknown): strin
       assessed_at: str(d.assessed_at),
       next_review_at: str(d.next_review_at),
       evidenceCount: Array.isArray(d.evidence) ? d.evidence.length : 0,
+      admitted_at: str(d.admitted_at),
     });
     return id;
   }

--- a/packages/diagrams/src/compliance/confidence.ts
+++ b/packages/diagrams/src/compliance/confidence.ts
@@ -1,0 +1,69 @@
+// Confidence bridge for the compliance views (vkgeorgia/strategy#162 — DQ-2).
+// Maps the compliance index projections (IndexRequirement / IndexAssertion) onto
+// the DQ-1 ScoringElement shape, scores the view, and renders the §11.6 header
+// line. Lives in @transitrix/diagrams so Studio and DSM share one bridge and
+// the headline reads the same on both surfaces.
+
+import {
+  formatConfidenceHeader,
+  scoreView,
+} from '../confidence/index.js';
+import type {
+  ConfidenceDecayConfig,
+  ScoringElement,
+  ViewScore,
+} from '../confidence/index.js';
+import type { IndexAssertion, IndexRequirement } from './types.js';
+
+/**
+ * Lifts a compliance projection (requirement / assertion) to the DQ-1
+ * ScoringElement shape. `sources` is intentionally left undefined here:
+ * resolving a canon element's `derived_from` to the source_quality of the
+ * cited field artefacts (§11.4) needs the field-zone provenance model
+ * that Studio's compliance scan does not yet ingest (the DSM equivalent
+ * is escalated as DQ-3/DQ-4/DQ-5 on the strategy hub). Until then the
+ * scorer treats every element as unsourced — counted separately per §11.5
+ * — so the headline honestly reports `0% sourced` rather than guessing a
+ * trust label. The freshness signal is fully wired and remains useful.
+ */
+export function requirementToScoringElement(r: IndexRequirement): ScoringElement {
+  return { type: 'REQUIREMENT', admitted_at: r.admitted_at };
+}
+
+export function assertionToScoringElement(a: IndexAssertion): ScoringElement {
+  return { type: 'ASSERTION', admitted_at: a.admitted_at };
+}
+
+/**
+ * Scores a compliance view composed of the given requirements + assertions.
+ * Pure / derived per §11.6 — recomputed on read, never stored.
+ */
+export function scoreComplianceView(
+  requirements: IndexRequirement[],
+  assertions: IndexAssertion[],
+  today: string | Date,
+  config?: ConfidenceDecayConfig,
+): ViewScore {
+  const elements: ScoringElement[] = [
+    ...requirements.map(requirementToScoringElement),
+    ...assertions.map(assertionToScoringElement),
+  ];
+  return scoreView(elements, today, config);
+}
+
+/**
+ * Convenience wrapper — scores the view and formats the §11.6 header line.
+ * Returns an empty string for an empty element set so the caller can suppress
+ * the header (e.g. a single-law tree with no requirements). Re-exports
+ * {@link formatConfidenceHeader} for callers that already hold a `ViewScore`.
+ */
+export function complianceConfidenceHeader(
+  requirements: IndexRequirement[],
+  assertions: IndexAssertion[],
+  today: string | Date,
+  config?: ConfidenceDecayConfig,
+): string {
+  return formatConfidenceHeader(
+    scoreComplianceView(requirements, assertions, today, config),
+  );
+}

--- a/packages/diagrams/src/compliance/index.ts
+++ b/packages/diagrams/src/compliance/index.ts
@@ -8,6 +8,12 @@ export { renderComplianceMarkdown } from './markdown.js';
 export type { ReportScope, MarkdownOptions } from './markdown.js';
 export { renderComplianceHtml } from './html.js';
 export type { HtmlOptions } from './html.js';
+export {
+  assertionToScoringElement,
+  complianceConfidenceHeader,
+  requirementToScoringElement,
+  scoreComplianceView,
+} from './confidence.js';
 export type {
   ComplianceIndex,
   ComplianceIndexInput,

--- a/packages/diagrams/src/compliance/types.ts
+++ b/packages/diagrams/src/compliance/types.ts
@@ -12,6 +12,8 @@ export interface IndexRequirement {
   severity?: string;
   /** Typed IDs of the codex sources this requirement derives from. */
   derived_from?: string[];
+  /** Admission date (CONTRACT §6) — feeds DQ-1 freshness decay. */
+  admitted_at?: string;
 }
 
 /** Projection of an ASSERTION the compliance views need. */
@@ -24,6 +26,8 @@ export interface IndexAssertion {
   next_review_at?: string;
   /** Number of evidence entries — feeds the Phase 4 "no evidence" gap. */
   evidenceCount?: number;
+  /** Admission date (CONTRACT §6) — feeds DQ-1 freshness decay. */
+  admitted_at?: string;
 }
 
 export interface ComplianceIndexInput {


### PR DESCRIPTION
## Summary

- Adds a `compliance/confidence.ts` bridge in `@transitrix/diagrams` that lifts the compliance index projections (`IndexRequirement` / `IndexAssertion`) onto the DQ-1 `ScoringElement` shape, scores a view, and formats the §11.6 header line. Shared between Studio and DSM so the headline reads the same on both surfaces.
- Threads `admitted_at` through `classify` → index → scorer; absent dates keep the implicit-decay default per CONTRACT §11.
- `complianceShell` (script-less compliance webview) gains an optional `confidence: ViewScore` opt-in. When present it renders an A–D coloured-band pill plus `Data confidence (as of YYYY-MM-DD) · X.XX mean · NN% sourced` next to the formation date. Empty views suppress the line.
- Wires the three Phase 3/4 owners — `single-law-preview`, `single-product-preview`, `gap-dashboard-preview` — to compute their per-view composite and pass it through. The gap dashboard scores the full scanned canon; the single-* views score only the elements they render.
- Sources stay undefined for v1 (no field-zone provenance to resolve — DQ-3/4/5 are escalated to Valerii). The headline honestly reports `0% sourced` rather than guessing a trust label; freshness signal is fully wired.

## Acceptance (vkgeorgia/strategy#162)

- ✅ Consumes the DQ-1 view composite (weakest-link `min` + A–D band) from `@transitrix/diagrams`.
- ✅ Rendered next to the view formation date; non-intrusive; safe for the static (script-less) previews (no script tags, no CSP change).
- ✅ Consistent banding / labels with DSM surfacing (DQ-5) — DSM imports the same bridge.

## Test plan

- [x] `npm test --workspace=@transitrix/diagrams` — 48 files / 651 tests pass (includes 7 new `compliance/confidence.test.ts` cases).
- [x] `extension/` `tsc --noEmit` clean.
- [ ] Build the extension, open a single-law / single-product / gap-dashboard preview, confirm the confidence pill renders with the formation date and that an empty-canon dashboard suppresses the line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)