### PR TITLE
feat(compliance): #166 interim compliance-impact matrix renderer

### DIFF
--- a/packages/diagrams/src/compliance/__tests__/impact.test.ts
+++ b/packages/diagrams/src/compliance/__tests__/impact.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from 'vitest';
+import { emptyCanon } from '../classify.js';
+import { buildImpactMatrix, renderImpactMarkdown, type ImpactViewConfig } from '../impact.js';
+import type { ComplianceCanon } from '../classify.js';
+
+// Industry- and regime-agnostic synthetic fixture: opaque ids only, no real
+// regulator / product names, per #166 acceptance ("Output is aggregates only —
+// no subject/obligation names tied to any real corpus").
+function buildCanon(): ComplianceCanon {
+  const canon = emptyCanon();
+  canon.products.push({ id: 'PRODUCT-A-1', name: 'Product A' });
+  canon.products.push({ id: 'PRODUCT-B-1', name: 'Product B' });
+  canon.requirements.push(
+    { id: 'REQUIREMENT-FOO-1', name: 'Foo', derived_from: ['LAW-X-1'] },
+    { id: 'REQUIREMENT-BAR-1', name: 'Bar', derived_from: ['LAW-X-1', 'REGULATION-Y-1'] },
+    { id: 'REQUIREMENT-BAZ-1', name: 'Baz', derived_from: ['REGULATION-Y-1'] },
+    // Internal-only requirement, no codex derivation:
+    { id: 'REQUIREMENT-INT-1', name: 'Internal-only' },
+  );
+  canon.assertions.push(
+    // (PRODUCT-A-1, FOO) — two assertions; partial wins over compliant per §5.2 step 4.
+    { id: 'ASSERTION-1', about: 'REQUIREMENT-FOO-1', subject: 'PRODUCT-A-1', status: 'compliant' },
+    { id: 'ASSERTION-2', about: 'REQUIREMENT-FOO-1', subject: 'PRODUCT-A-1', status: 'partial' },
+    // (PRODUCT-A-1, BAR) — single n_a → modelled fact ("No obligation applies").
+    { id: 'ASSERTION-3', about: 'REQUIREMENT-BAR-1', subject: 'PRODUCT-A-1', status: 'n_a' },
+    // (PRODUCT-B-1, BAR) — non_compliant.
+    { id: 'ASSERTION-4', about: 'REQUIREMENT-BAR-1', subject: 'PRODUCT-B-1', status: 'non_compliant' },
+    // (PRODUCT-B-1, BAZ) — under_review beats compliant.
+    { id: 'ASSERTION-5', about: 'REQUIREMENT-BAZ-1', subject: 'PRODUCT-B-1', status: 'under_review' },
+    { id: 'ASSERTION-6', about: 'REQUIREMENT-BAZ-1', subject: 'PRODUCT-B-1', status: 'compliant' },
+  );
+  return canon;
+}
+
+const baseConfig: ImpactViewConfig = {
+  id: 'COMPLIANCE_IMPACT-FIXTURE-1',
+  name: 'Fixture matrix',
+  subjects: { products: ['PRODUCT-A-1', 'PRODUCT-B-1'] },
+  obligations: {},
+};
+
+describe('buildImpactMatrix', () => {
+  it('aggregates statuses per §5.2 step 4 — non_compliant > partial > under_review > compliant', () => {
+    const canon = buildCanon();
+    const matrix = buildImpactMatrix(canon, {
+      ...baseConfig,
+      obligations: { include: ['REQUIREMENT-FOO-1', 'REQUIREMENT-BAR-1', 'REQUIREMENT-BAZ-1'] },
+    });
+    expect(matrix.columns).toEqual(['PRODUCT-A-1', 'PRODUCT-B-1']);
+    expect(matrix.rows.map(r => r.id)).toEqual(['REQUIREMENT-BAR-1', 'REQUIREMENT-BAZ-1', 'REQUIREMENT-FOO-1']);
+
+    const cellFor = (req: string, subject: string) => {
+      const r = matrix.rows.findIndex(x => x.id === req);
+      const c = matrix.columns.indexOf(subject);
+      return matrix.cells[r][c];
+    };
+
+    expect(cellFor('REQUIREMENT-FOO-1', 'PRODUCT-A-1').status).toBe('partial');
+    expect(cellFor('REQUIREMENT-FOO-1', 'PRODUCT-A-1').kind).toBe('bound');
+    expect(cellFor('REQUIREMENT-BAR-1', 'PRODUCT-A-1').kind).toBe('n_a_only');
+    expect(cellFor('REQUIREMENT-BAR-1', 'PRODUCT-B-1').status).toBe('non_compliant');
+    expect(cellFor('REQUIREMENT-BAZ-1', 'PRODUCT-B-1').status).toBe('under_review');
+    expect(cellFor('REQUIREMENT-FOO-1', 'PRODUCT-B-1').kind).toBe('gap');
+    expect(cellFor('REQUIREMENT-BAZ-1', 'PRODUCT-A-1').kind).toBe('gap');
+  });
+
+  it('selects obligations by `filter.derived_from_codex`', () => {
+    const canon = buildCanon();
+    const matrix = buildImpactMatrix(canon, {
+      ...baseConfig,
+      obligations: { filter: { derived_from_codex: ['REGULATION-Y-1'] } },
+    });
+    expect(matrix.rows.map(r => r.id)).toEqual(['REQUIREMENT-BAR-1', 'REQUIREMENT-BAZ-1']);
+  });
+
+  it('`include` wins when both `include` and `filter` are present (COMPIMP-007)', () => {
+    const canon = buildCanon();
+    const matrix = buildImpactMatrix(canon, {
+      ...baseConfig,
+      obligations: {
+        include: ['REQUIREMENT-INT-1'],
+        filter: { derived_from_codex: ['LAW-X-1'] },
+      },
+    });
+    expect(matrix.rows.map(r => r.id)).toEqual(['REQUIREMENT-INT-1']);
+  });
+
+  it('distinguishes modelling gap from n_a-only per §5.3', () => {
+    const canon = buildCanon();
+    const matrix = buildImpactMatrix(canon, {
+      ...baseConfig,
+      obligations: { include: ['REQUIREMENT-BAR-1'] },
+    });
+    const aCell = matrix.cells[0][matrix.columns.indexOf('PRODUCT-A-1')];
+    const bCell = matrix.cells[0][matrix.columns.indexOf('PRODUCT-B-1')];
+    expect(aCell.kind).toBe('n_a_only');
+    expect(bCell.kind).toBe('bound');
+    expect(bCell.status).toBe('non_compliant');
+  });
+
+  it('respects `status_display.show` — filtered-out statuses leave the cell as a gap', () => {
+    const canon = buildCanon();
+    const matrix = buildImpactMatrix(canon, {
+      ...baseConfig,
+      obligations: { include: ['REQUIREMENT-BAZ-1'] },
+      status_display: { show: ['non_compliant'] }, // under_review + compliant filtered out
+    });
+    const cell = matrix.cells[0][matrix.columns.indexOf('PRODUCT-B-1')];
+    expect(cell.kind).toBe('gap');
+  });
+
+  it('keeps subjects with no binding obligation as columns so the gap is visible', () => {
+    const canon = buildCanon();
+    const matrix = buildImpactMatrix(canon, {
+      ...baseConfig,
+      subjects: { products: ['PRODUCT-A-1', 'PRODUCT-B-1', 'PRODUCT-NONE-1'] },
+      obligations: { include: ['REQUIREMENT-FOO-1'] },
+    });
+    expect(matrix.columns).toContain('PRODUCT-NONE-1');
+    const cell = matrix.cells[0][matrix.columns.indexOf('PRODUCT-NONE-1')];
+    expect(cell.kind).toBe('gap');
+  });
+
+  it('orders rows alphabetically by name when `order_rows_by: name`', () => {
+    const canon = buildCanon();
+    const matrix = buildImpactMatrix(canon, {
+      ...baseConfig,
+      obligations: { include: ['REQUIREMENT-FOO-1', 'REQUIREMENT-BAR-1', 'REQUIREMENT-BAZ-1'] },
+      order_rows_by: 'name',
+    });
+    expect(matrix.rows.map(r => r.name)).toEqual(['Bar', 'Baz', 'Foo']);
+  });
+});
+
+describe('renderImpactMarkdown', () => {
+  it('renders a header, table, and §5.3 legend', () => {
+    const canon = buildCanon();
+    const matrix = buildImpactMatrix(canon, {
+      ...baseConfig,
+      obligations: { include: ['REQUIREMENT-FOO-1', 'REQUIREMENT-BAR-1'] },
+    });
+    const md = renderImpactMarkdown(matrix);
+    expect(md).toContain('# Fixture matrix');
+    expect(md).toContain('View ID: `COMPLIANCE_IMPACT-FIXTURE-1`');
+    expect(md).toContain('| Obligation | PRODUCT-A-1 | PRODUCT-B-1 |');
+    expect(md).toContain('PARTIAL');
+    expect(md).toContain('FAIL');
+    expect(md).toContain('No mapped obligation (current model)');
+    expect(md).toContain('No obligation applies');
+    expect(md).toContain('## Legend');
+  });
+
+  it('honours custom empty-cell labels', () => {
+    const canon = buildCanon();
+    const matrix = buildImpactMatrix(canon, {
+      ...baseConfig,
+      obligations: { include: ['REQUIREMENT-FOO-1', 'REQUIREMENT-BAR-1'] },
+      empty_cells: {
+        no_obligation_label: 'GAP',
+        no_obligation_applies_label: 'EXCLUDED',
+      },
+    });
+    const md = renderImpactMarkdown(matrix);
+    expect(md).toContain('GAP');
+    expect(md).toContain('EXCLUDED');
+    expect(md).not.toContain('No mapped obligation (current model)');
+  });
+
+  it('renders a placeholder when zero obligations are selected', () => {
+    const canon = buildCanon();
+    const matrix = buildImpactMatrix(canon, {
+      ...baseConfig,
+      obligations: { include: ['REQUIREMENT-DOES-NOT-EXIST-1'] },
+    });
+    const md = renderImpactMarkdown(matrix);
+    expect(md).toContain('No obligations in scope');
+  });
+});

--- a/packages/diagrams/src/compliance/impact.ts
+++ b/packages/diagrams/src/compliance/impact.ts
@@ -1,0 +1,294 @@
+// Compliance-impact matrix derivation + markdown renderer
+// (vkgeorgia/strategy#166 — interim renderer; full Studio consumer-side
+// renderer tracked under #84).
+//
+// Implements the render contract from
+// methodology/notations/views/21-compliance-impact.md §5 at the coarsest grain
+// (`product` columns × `obligation` rows). Stage / task grouping is planned
+// for the full consumer-side renderer and intentionally out of scope here.
+
+import type { AssertionStatus } from '../assertion/types.js';
+import type { ComplianceCanon } from './classify.js';
+import { buildComplianceIndex } from './reverse-index.js';
+import type { ComplianceIndex, IndexAssertion, IndexRequirement } from './types.js';
+
+/** Filter selecting REQUIREMENTs by codex source (jurisdiction / regime keys
+ *  are accepted for forward compatibility but not yet honoured — the canon
+ *  projection does not carry those fields). */
+export interface ImpactObligationFilter {
+  derived_from_codex?: string[];
+}
+
+export interface ImpactSubjects {
+  products?: string[];
+  processes?: string[];
+}
+
+export interface ImpactStatusDisplay {
+  show?: AssertionStatus[];
+}
+
+export interface ImpactEmptyCellLabels {
+  /** Label used when no admitted ASSERTION binds the cell (modelling gap). */
+  no_obligation_label?: string;
+  /** Label used when an admitted ASSERTION exists with status `n_a`
+   *  (modelled fact: the obligation does not apply). */
+  no_obligation_applies_label?: string;
+}
+
+export interface ImpactViewConfig {
+  id: string;
+  name: string;
+  description?: string;
+  subjects: ImpactSubjects;
+  obligations: {
+    include?: string[];
+    filter?: ImpactObligationFilter;
+  };
+  status_display?: ImpactStatusDisplay;
+  empty_cells?: ImpactEmptyCellLabels;
+  order_rows_by?: 'id' | 'name';
+}
+
+/** A single cell of the rendered matrix. */
+export interface ImpactCell {
+  /** Resolved status when an ASSERTION binds the cell, else null. */
+  status: AssertionStatus | null;
+  /** Empty-cell condition per §5.3 — one of:
+   *  - `bound`   : at least one admitted ASSERTION binds the cell; `status` is set.
+   *  - `n_a_only`: every binding ASSERTION has status `n_a` (modelled fact).
+   *  - `gap`     : no admitted ASSERTION binds the cell (modelling gap). */
+  kind: 'bound' | 'n_a_only' | 'gap';
+  /** The assertions that contributed to this cell, id-sorted. */
+  assertions: IndexAssertion[];
+}
+
+export interface ImpactMatrix {
+  viewId: string;
+  viewName: string;
+  description?: string;
+  /** Row dimension — REQUIREMENT projections, in the configured order. */
+  rows: IndexRequirement[];
+  /** Column dimension — subject IDs (PRODUCT ids in the coarsest grain). */
+  columns: string[];
+  /** Cells, indexed as `cell[rowIdx][colIdx]`. */
+  cells: ImpactCell[][];
+  /** Canonical empty-cell labels actually used (after defaults applied). */
+  emptyLabels: Required<ImpactEmptyCellLabels>;
+}
+
+const DEFAULT_NO_OBLIGATION_LABEL = 'No mapped obligation (current model)';
+const DEFAULT_NO_OBLIGATION_APPLIES_LABEL = 'No obligation applies';
+
+function byId<T extends { id: string }>(a: T, b: T): number {
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+}
+
+function resolveObligations(
+  config: ImpactViewConfig,
+  index: ComplianceIndex,
+  allRequirements: IndexRequirement[],
+): IndexRequirement[] {
+  // `include` wins over `filter` per §4 (and COMPIMP-007).
+  if (config.obligations.include?.length) {
+    const out: IndexRequirement[] = [];
+    for (const id of config.obligations.include) {
+      const r = index.requirementById.get(id);
+      if (r) out.push(r);
+    }
+    return out;
+  }
+  const codices = config.obligations.filter?.derived_from_codex ?? [];
+  if (codices.length === 0) return [...allRequirements].sort(byId);
+  const seen = new Set<string>();
+  const out: IndexRequirement[] = [];
+  for (const codex of codices) {
+    for (const r of index.requirementsByLaw.get(codex) ?? []) {
+      if (!seen.has(r.id)) {
+        seen.add(r.id);
+        out.push(r);
+      }
+    }
+  }
+  return out;
+}
+
+function orderRows(rows: IndexRequirement[], key: 'id' | 'name' | undefined): IndexRequirement[] {
+  const sorted = [...rows];
+  if (key === 'name') {
+    sorted.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+  } else {
+    sorted.sort(byId);
+  }
+  return sorted;
+}
+
+/** Aggregate multiple matching assertions into one cell value, per §5.2 step 4.
+ *  Assumes at least one assertion matches an allowed status; caller filters. */
+function aggregateStatus(assertions: IndexAssertion[]): AssertionStatus {
+  let sawPartial = false;
+  let sawUnderReview = false;
+  let sawCompliant = false;
+  for (const a of assertions) {
+    if (a.status === 'non_compliant') return 'non_compliant';
+    if (a.status === 'partial') sawPartial = true;
+    else if (a.status === 'under_review') sawUnderReview = true;
+    else if (a.status === 'compliant') sawCompliant = true;
+  }
+  if (sawPartial) return 'partial';
+  if (sawUnderReview) return 'under_review';
+  if (sawCompliant) return 'compliant';
+  return 'n_a';
+}
+
+/**
+ * Build the matrix per §5.2 at the `product` × `obligation` grain.
+ *
+ * Subjects are taken from `config.subjects.products` and
+ * `config.subjects.processes` directly (in that order; no PRODUCT→PROCESS
+ * derivation walk yet — that needs a `realises` index out of scope here).
+ * Subjects with no binding obligation still appear as columns so the gap is
+ * visible. Rows are the resolved obligations, ordered per `order_rows_by`.
+ */
+export function buildImpactMatrix(canon: ComplianceCanon, config: ImpactViewConfig): ImpactMatrix {
+  const index = buildComplianceIndex({
+    requirements: canon.requirements,
+    assertions: canon.assertions,
+  });
+
+  const obligations = orderRows(resolveObligations(config, index, canon.requirements), config.order_rows_by);
+
+  const products = config.subjects.products ?? [];
+  const processes = config.subjects.processes ?? [];
+  const columns = [...products, ...processes];
+
+  const allowedStatuses = new Set<AssertionStatus>(
+    config.status_display?.show ?? ['compliant', 'partial', 'non_compliant', 'under_review', 'n_a'],
+  );
+
+  const rowIndex = new Set(obligations.map(r => r.id));
+  const cells: ImpactCell[][] = obligations.map(() => columns.map(() => emptyCell()));
+
+  // Walk the assertions index per subject and fill cells whose obligation is in scope.
+  for (let c = 0; c < columns.length; c++) {
+    const subject = columns[c];
+    const subjectAssertions = index.assertionsBySubject.get(subject) ?? [];
+    for (const a of subjectAssertions) {
+      if (!rowIndex.has(a.about)) continue;
+      if (!allowedStatuses.has(a.status)) continue;
+      const rowIdx = obligations.findIndex(r => r.id === a.about);
+      if (rowIdx < 0) continue;
+      cells[rowIdx][c].assertions.push(a);
+    }
+  }
+
+  // Resolve each cell to a status / kind.
+  for (let r = 0; r < cells.length; r++) {
+    for (let c = 0; c < cells[r].length; c++) {
+      const cell = cells[r][c];
+      cell.assertions.sort(byId);
+      if (cell.assertions.length === 0) {
+        cell.kind = 'gap';
+        cell.status = null;
+        continue;
+      }
+      if (cell.assertions.every(a => a.status === 'n_a')) {
+        cell.kind = 'n_a_only';
+        cell.status = 'n_a';
+        continue;
+      }
+      cell.kind = 'bound';
+      cell.status = aggregateStatus(cell.assertions);
+    }
+  }
+
+  return {
+    viewId: config.id,
+    viewName: config.name,
+    description: config.description,
+    rows: obligations,
+    columns,
+    cells,
+    emptyLabels: {
+      no_obligation_label: config.empty_cells?.no_obligation_label ?? DEFAULT_NO_OBLIGATION_LABEL,
+      no_obligation_applies_label:
+        config.empty_cells?.no_obligation_applies_label ?? DEFAULT_NO_OBLIGATION_APPLIES_LABEL,
+    },
+  };
+}
+
+function emptyCell(): ImpactCell {
+  return { status: null, kind: 'gap', assertions: [] };
+}
+
+// ── Markdown rendering ──────────────────────────────────────────────────────
+
+const STATUS_GLYPH: Record<AssertionStatus, string> = {
+  compliant: 'OK',
+  partial: 'PARTIAL',
+  non_compliant: 'FAIL',
+  under_review: 'REVIEW',
+  n_a: 'N/A',
+};
+
+function escMd(s: string): string {
+  return s.replace(/\|/g, '\\|');
+}
+
+/**
+ * Render the matrix as a GitHub-flavoured markdown table.
+ *
+ * Cell display:
+ *   - `bound`    → the §5.2 deterministic status label.
+ *   - `n_a_only` → the "No obligation applies" label (or `view.empty_cells`
+ *                  override).
+ *   - `gap`      → the "No mapped obligation (current model)" label (or
+ *                  override).
+ */
+export function renderImpactMarkdown(matrix: ImpactMatrix): string {
+  const lines: string[] = [];
+  lines.push(`# ${matrix.viewName}`);
+  lines.push('');
+  lines.push(`View ID: \`${matrix.viewId}\``);
+  if (matrix.description) {
+    lines.push('');
+    lines.push(matrix.description);
+  }
+  lines.push('');
+
+  if (matrix.rows.length === 0) {
+    lines.push('_No obligations in scope — the configured filter / include selected zero REQUIREMENTs._');
+    return lines.join('\n') + '\n';
+  }
+  if (matrix.columns.length === 0) {
+    lines.push('_No subjects in scope — `view.subjects` is empty._');
+    return lines.join('\n') + '\n';
+  }
+
+  const header = ['Obligation', ...matrix.columns.map(escMd)];
+  lines.push('| ' + header.join(' | ') + ' |');
+  lines.push('|' + header.map(() => '---').join('|') + '|');
+
+  for (let r = 0; r < matrix.rows.length; r++) {
+    const row = matrix.rows[r];
+    const rowLabel = `${row.id}${row.name && row.name !== row.id ? ` — ${row.name}` : ''}`;
+    const cells = matrix.cells[r].map(cell => renderCell(cell, matrix.emptyLabels));
+    lines.push('| ' + [escMd(rowLabel), ...cells].join(' | ') + ' |');
+  }
+
+  // Legend — the §5.3 distinction must be visible in the rendered output.
+  lines.push('');
+  lines.push('## Legend');
+  lines.push('');
+  lines.push('- **OK / PARTIAL / FAIL / REVIEW / N/A** — aggregated `ASSERTION.status` per §5.2.');
+  lines.push(`- **${escMd(matrix.emptyLabels.no_obligation_label)}** — modelling gap; no admitted ASSERTION binds this (obligation, subject) pair.`);
+  lines.push(`- **${escMd(matrix.emptyLabels.no_obligation_applies_label)}** — modelled fact; an admitted ASSERTION with status \`n_a\` excludes this pair.`);
+
+  return lines.join('\n') + '\n';
+}
+
+function renderCell(cell: ImpactCell, labels: Required<ImpactEmptyCellLabels>): string {
+  if (cell.kind === 'gap') return escMd(labels.no_obligation_label);
+  if (cell.kind === 'n_a_only') return escMd(labels.no_obligation_applies_label);
+  return STATUS_GLYPH[cell.status as AssertionStatus];
+}

--- a/packages/diagrams/src/compliance/index.ts
+++ b/packages/diagrams/src/compliance/index.ts
@@ -8,6 +8,16 @@ export { renderComplianceMarkdown } from './markdown.js';
 export type { ReportScope, MarkdownOptions } from './markdown.js';
 export { renderComplianceHtml } from './html.js';
 export type { HtmlOptions } from './html.js';
+export { buildImpactMatrix, renderImpactMarkdown } from './impact.js';
+export type {
+  ImpactCell,
+  ImpactEmptyCellLabels,
+  ImpactMatrix,
+  ImpactObligationFilter,
+  ImpactStatusDisplay,
+  ImpactSubjects,
+  ImpactViewConfig,
+} from './impact.js';
 export {
   assertionToScoringElement,
   complianceConfidenceHeader,

--- a/scripts/render-compliance-impact.mjs
+++ b/scripts/render-compliance-impact.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+/**
+ * Interim compliance-impact matrix renderer
+ * (vkgeorgia/strategy#166 — fast-track interim; full Studio consumer-side
+ * renderer is tracked under #84).
+ *
+ * Materialises the subject × obligation × status matrix per the render contract
+ * in methodology/notations/views/21-compliance-impact.md §5, at the coarsest
+ * grain (`product` × `obligation`). Stage / task grouping is intentionally out
+ * of scope here — those need a process-flow walk and a process-blueprint join
+ * that the full renderer will handle.
+ *
+ * Usage:
+ *   node scripts/render-compliance-impact.mjs \
+ *        --view <path/to/COMPLIANCE_IMPACT-…compliance-impact.transitrix.yaml> \
+ *        --canon <path/to/canon-root> \
+ *        [--out <path/to/output.md>]
+ *
+ * The script:
+ *   1. Parses the view config (one YAML doc per file).
+ *   2. Recursively scans the canon root for *.yaml / *.yml and ingests every
+ *      file that classify.ingestComplianceDoc recognises (PRODUCT / REQUIREMENT
+ *      / ASSERTION elements + codex documents).
+ *   3. Calls `@transitrix/diagrams` `buildImpactMatrix` + `renderImpactMarkdown`
+ *      and writes the result to stdout (or --out).
+ *
+ * Requires `npm run build -w @transitrix/diagrams` to have produced
+ * packages/diagrams/dist/.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import yaml from 'js-yaml';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const STUDIO_ROOT = path.resolve(HERE, '..');
+const DIST_INDEX = path.join(STUDIO_ROOT, 'packages', 'diagrams', 'dist', 'index.js');
+
+function parseArgs(argv) {
+  const out = { view: null, canon: null, output: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--view') out.view = argv[++i];
+    else if (a.startsWith('--view=')) out.view = a.slice('--view='.length);
+    else if (a === '--canon') out.canon = argv[++i];
+    else if (a.startsWith('--canon=')) out.canon = a.slice('--canon='.length);
+    else if (a === '--out') out.output = argv[++i];
+    else if (a.startsWith('--out=')) out.output = a.slice('--out='.length);
+    else if (a === '--help' || a === '-h') {
+      console.log(
+        `Usage: node scripts/render-compliance-impact.mjs --view <view.yaml> --canon <canon-root> [--out <file>]
+  --view   <path>   compliance-impact view config (required)
+  --canon  <path>   root of the canon to scan recursively (required)
+  --out    <path>   write markdown to this file (default: stdout)
+  -h, --help        show this help`,
+      );
+      process.exit(0);
+    } else {
+      console.error(`Unknown argument: ${a}`);
+      process.exit(2);
+    }
+  }
+  if (!out.view || !out.canon) {
+    console.error('Missing --view or --canon. Run with --help for usage.');
+    process.exit(2);
+  }
+  return out;
+}
+
+async function readYaml(file) {
+  const text = await fs.readFile(file, 'utf8');
+  return yaml.load(text);
+}
+
+async function* walkYaml(root) {
+  const entries = await fs.readdir(root, { withFileTypes: true });
+  for (const e of entries) {
+    const full = path.join(root, e.name);
+    if (e.isDirectory()) {
+      if (e.name === 'node_modules' || e.name.startsWith('.')) continue;
+      yield* walkYaml(full);
+    } else if (e.isFile() && (e.name.endsWith('.yaml') || e.name.endsWith('.yml'))) {
+      yield full;
+    }
+  }
+}
+
+function viewConfigFromYaml(raw) {
+  if (!raw || typeof raw !== 'object') throw new Error('view: expected an object at the document root');
+  const v = raw.view;
+  if (!v || typeof v !== 'object') throw new Error('view: missing top-level `view:` object');
+  if (!v.id || typeof v.id !== 'string') throw new Error('view.id: required string');
+  if (!v.name || typeof v.name !== 'string') throw new Error('view.name: required string');
+  if (!v.subjects || typeof v.subjects !== 'object') throw new Error('view.subjects: required object (COMPIMP-002)');
+  return {
+    id: v.id,
+    name: v.name,
+    description: typeof v.description === 'string' ? v.description : undefined,
+    subjects: {
+      products: Array.isArray(v.subjects.products) ? v.subjects.products.filter(x => typeof x === 'string') : undefined,
+      processes: Array.isArray(v.subjects.processes) ? v.subjects.processes.filter(x => typeof x === 'string') : undefined,
+    },
+    obligations: {
+      include: Array.isArray(v.obligations?.include)
+        ? v.obligations.include.filter(x => typeof x === 'string')
+        : undefined,
+      filter: v.obligations?.filter
+        ? {
+            derived_from_codex: Array.isArray(v.obligations.filter.derived_from_codex)
+              ? v.obligations.filter.derived_from_codex.filter(x => typeof x === 'string')
+              : undefined,
+          }
+        : undefined,
+    },
+    status_display: v.status_display ? { show: v.status_display.show } : undefined,
+    empty_cells: v.empty_cells
+      ? {
+          no_obligation_label: v.empty_cells.no_obligation_label,
+          no_obligation_applies_label: v.empty_cells.no_obligation_applies_label,
+        }
+      : undefined,
+    order_rows_by: v.order_rows_by,
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  try {
+    await fs.access(DIST_INDEX);
+  } catch {
+    console.error(
+      `Built diagrams bundle not found at ${DIST_INDEX}. Run \`npm run build -w @transitrix/diagrams\` first.`,
+    );
+    process.exit(3);
+  }
+  const diagrams = await import(pathToFileURL(DIST_INDEX).href);
+  const { emptyCanon, ingestComplianceDoc, buildImpactMatrix, renderImpactMarkdown } = diagrams;
+
+  const viewRaw = await readYaml(args.view);
+  const view = viewConfigFromYaml(viewRaw);
+
+  const canon = emptyCanon();
+  let scanned = 0;
+  let ingested = 0;
+  for await (const file of walkYaml(args.canon)) {
+    scanned += 1;
+    let parsed;
+    try {
+      parsed = await readYaml(file);
+    } catch (err) {
+      // Malformed YAML — skip with a warning; the interim renderer is best-effort.
+      console.error(`skip ${file}: ${err instanceof Error ? err.message : String(err)}`);
+      continue;
+    }
+    // js-yaml.load returns one doc for `yaml.load`; multi-doc files would need `yaml.loadAll`.
+    // Keep it simple: one root doc per canon file.
+    if (ingestComplianceDoc(canon, parsed)) ingested += 1;
+  }
+
+  console.error(
+    `[render-compliance-impact] scanned=${scanned} ingested=${ingested} ` +
+      `(products=${canon.products.length}, requirements=${canon.requirements.length}, ` +
+      `assertions=${canon.assertions.length})`,
+  );
+
+  const matrix = buildImpactMatrix(canon, view);
+  const md = renderImpactMarkdown(matrix);
+
+  if (args.output) {
+    await fs.writeFile(args.output, md, 'utf8');
+    console.error(`wrote ${args.output}`);
+  } else {
+    process.stdout.write(md);
+  }
+}
+
+main().catch(err => {
+  console.error(err instanceof Error ? err.stack ?? err.message : String(err));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Interim renderer for the **compliance-impact matrix** per `methodology/notations/views/21-compliance-impact.md` §5, at the coarsest grain (`product` × `obligation`). Closes the immediate gap from `vkgeorgia/strategy#166` ("compliance-impact view is currently non-renderable end-to-end"). The full Studio consumer-side renderer (stage / task grouping, in-IDE preview) remains tracked under `#84`.

## Changes

- `packages/diagrams/src/compliance/impact.ts`
  - `buildImpactMatrix(canon, viewConfig)` — pure derivation per §5.2.
    - Aggregates multiple matching ASSERTIONs per cell with the §5.2 step 4 deterministic precedence: `non_compliant > partial > under_review > compliant`; all-`n_a` → `n_a`.
    - Honours `obligations.include` / `obligations.filter.derived_from_codex` (include wins, COMPIMP-007) and `status_display.show`.
    - Stage / task grouping intentionally out of scope — needs a process-flow walk + process-blueprint join the full consumer-side renderer will own.
  - `renderImpactMarkdown(matrix)` — GFM table + `## Legend` that surfaces the §5.3 distinction between **modelling gap** ("No mapped obligation (current model)") and **modelled fact** ("No obligation applies"). Both labels are overridable via `view.empty_cells`.
- `packages/diagrams/src/compliance/__tests__/impact.test.ts` — 10 cases (aggregation precedence, codex filter, include-vs-filter precedence, §5.3 distinction, `status_display`, unbound subjects-as-columns, ordering, markdown rendering, custom labels).
- `packages/diagrams/src/compliance/index.ts` — exports the new module.
- `scripts/render-compliance-impact.mjs` — thin standalone CLI: loads a view config, walks a canon root for `*.yaml` / `*.yml`, ingests through the existing `ingestComplianceDoc` classifier, prints the rendered markdown matrix to stdout (or `--out`). Output is aggregates only (subject / obligation IDs, no real-corpus names) per the issue's acceptance.

## Acceptance check (against the hub issue)

| Acceptance | Outcome |
|---|---|
| Given a compliance-impact view config + canon, output a readable subject × obligation × status matrix. | `node scripts/render-compliance-impact.mjs --view <…> --canon <…>` writes a GFM table with the matrix + legend. |
| Output is aggregates only — no subject/obligation names tied to any real corpus (industry- and regime-agnostic). | The fixture uses opaque IDs (`PRODUCT-A-1`, `REQUIREMENT-FOO-1`, `LAW-X-1`). The renderer ships no built-in subject / obligation names. |
| Interim — may live methodology-side as a standalone script. | Lives Studio-side per the routing label (`proj:transitrix-studio` is the long-term home), still a small standalone script. |

## Out of scope

- Full consumer-side Studio preview (in-IDE webview + filter UI) — `#84`.
- Stage / task grouping (`grouping.columns: product-stage-task`) — needs process-flow walk + process-blueprint join; deferred to the full renderer.
- `proposed → shown-distinct` admission-state rendering — admitted-only matches the §2.2 default.

## Test plan

- [x] `npm test -w @transitrix/diagrams` — 47 files / 653 tests pass (10 new).
- [x] `cd extension && npx tsc --noEmit` — clean.
- [ ] Smoke: hand-run `node scripts/render-compliance-impact.mjs --view … --canon …` against a small canon and eyeball the rendered table (needs `npm run build -w @transitrix/diagrams` first — see note below).

> **Note.** The pre-existing `@transitrix/diagrams` build break (`Module "./activity-card/index" has already exported a member named 'LayoutBounds'` on `src/index.ts:5,12`) is unrelated to this PR — it reproduces on `main` at `033ba43`. The CLI script needs `dist/` to run end-to-end; once that pre-existing TS error is resolved (separate triage), the script is exercisable without further changes.

Refs vkgeorgia/strategy#166. Open PR — Valerii gates the merge.