### PR TITLE
feat(compliance): CV-1 #84 view-config wiring — named report definitions + pinned defaults

### DIFF
--- a/packages/diagrams/src/compliance/__tests__/impact.test.ts
+++ b/packages/diagrams/src/compliance/__tests__/impact.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { emptyCanon } from '../classify.js';
-import { buildImpactMatrix, renderImpactMarkdown, type ImpactViewConfig } from '../impact.js';
+import {
+  buildImpactMatrix,
+  renderImpactMarkdown,
+  parseImpactViewConfig,
+  COMPLIANCE_IMPACT_DEFAULTS,
+  type ImpactViewConfig,
+} from '../impact.js';
 import type { ComplianceCanon } from '../classify.js';
 
 // Industry- and regime-agnostic synthetic fixture: opaque ids only, no real
@@ -174,5 +180,87 @@ describe('renderImpactMarkdown', () => {
     });
     const md = renderImpactMarkdown(matrix);
     expect(md).toContain('No obligations in scope');
+  });
+
+  it('propagates snapshot_at into the matrix and renders it', () => {
+    const canon = buildCanon();
+    const matrix = buildImpactMatrix(canon, { ...baseConfig, snapshot_at: '2026-06-09' });
+    expect(matrix.snapshotAt).toBe('2026-06-09');
+    const md = renderImpactMarkdown(matrix);
+    expect(md).toContain('Report snapshot: 2026-06-09');
+  });
+});
+
+// ── parseImpactViewConfig ───────────────────────────────────────────────────
+
+describe('parseImpactViewConfig', () => {
+  it('returns ok:false for a non-object', () => {
+    const r = parseImpactViewConfig(null);
+    expect(r.ok).toBe(false);
+  });
+
+  it('returns ok:false when id is missing', () => {
+    const r = parseImpactViewConfig({ name: 'X', subjects: {} });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errors.some(e => e.includes('id'))).toBe(true);
+  });
+
+  it('returns ok:false when name is missing', () => {
+    const r = parseImpactViewConfig({ id: 'X', subjects: {} });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errors.some(e => e.includes('name'))).toBe(true);
+  });
+
+  it('unwraps the top-level view: wrapper', () => {
+    const r = parseImpactViewConfig({ view: { id: 'V-1', name: 'My view', subjects: {} } });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.config.id).toBe('V-1');
+  });
+
+  it('fills all optional fields from COMPLIANCE_IMPACT_DEFAULTS', () => {
+    const r = parseImpactViewConfig({ id: 'V-1', name: 'My view', subjects: {} });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    const c = r.config;
+    expect(c.subjects.products).toEqual([]);
+    expect(c.subjects.processes).toEqual([]);
+    expect(c.status_display?.show).toEqual(COMPLIANCE_IMPACT_DEFAULTS.status_display.show);
+    expect(c.order_rows_by).toBe('id');
+    expect(c.empty_cells?.no_obligation_label).toBe(
+      COMPLIANCE_IMPACT_DEFAULTS.empty_cells.no_obligation_label,
+    );
+    expect(c.empty_cells?.no_obligation_applies_label).toBe(
+      COMPLIANCE_IMPACT_DEFAULTS.empty_cells.no_obligation_applies_label,
+    );
+  });
+
+  it('preserves explicit subject lists and snapshot_at', () => {
+    const r = parseImpactViewConfig({
+      id: 'V-2',
+      name: 'View 2',
+      snapshot_at: '2026-01-01',
+      subjects: { products: ['PRODUCT-A-1', 'PRODUCT-B-1'] },
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.config.subjects.products).toEqual(['PRODUCT-A-1', 'PRODUCT-B-1']);
+    expect(r.config.snapshot_at).toBe('2026-01-01');
+  });
+
+  it('applies custom order_rows_by:name', () => {
+    const r = parseImpactViewConfig({ id: 'V-3', name: 'V', subjects: {}, order_rows_by: 'name' });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.config.order_rows_by).toBe('name');
+  });
+
+  it('parses obligation filter correctly', () => {
+    const r = parseImpactViewConfig({
+      id: 'V-4',
+      name: 'V',
+      subjects: {},
+      obligations: { filter: { derived_from_codex: ['LAW-X-1'] } },
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.config.obligations.filter?.derived_from_codex).toEqual(['LAW-X-1']);
   });
 });

--- a/packages/diagrams/src/compliance/impact.ts
+++ b/packages/diagrams/src/compliance/impact.ts
@@ -1,11 +1,11 @@
 // Compliance-impact matrix derivation + markdown renderer
-// (vkgeorgia/strategy#166 — interim renderer; full Studio consumer-side
-// renderer tracked under #84).
+// (vkgeorgia/strategy#166 — interim renderer; CV-1 view-config wiring
+// per strategy#84 decomposition refresh).
 //
 // Implements the render contract from
 // methodology/notations/views/21-compliance-impact.md §5 at the coarsest grain
 // (`product` columns × `obligation` rows). Stage / task grouping is planned
-// for the full consumer-side renderer and intentionally out of scope here.
+// for CV-3a and intentionally out of scope here.
 
 import type { AssertionStatus } from '../assertion/types.js';
 import type { ComplianceCanon } from './classify.js';
@@ -36,10 +36,28 @@ export interface ImpactEmptyCellLabels {
   no_obligation_applies_label?: string;
 }
 
+/**
+ * Named, versioned view-config — the report *definition*.
+ *
+ * A saved view config is the source of truth for a deterministic report run:
+ * given the same config + canon, `buildImpactMatrix` always produces the
+ * same matrix. Configs are stored in YAML files (top-level `view:` key) and
+ * referenced by `id`.
+ *
+ * `snapshot_at` (ISO 8601 date) records when the report was last generated.
+ * CV-3 blueprint-lane rendering uses it to mark obligations that appeared in
+ * the canon *after* the snapshot as "new" (dashed-border cell decoration).
+ */
 export interface ImpactViewConfig {
   id: string;
   name: string;
   description?: string;
+  /**
+   * ISO 8601 date of the last report snapshot (YYYY-MM-DD).
+   * Populated automatically by the CLI on each run and stored back to the
+   * view-config file, giving CV-3 its "new since last run" signal.
+   */
+  snapshot_at?: string;
   subjects: ImpactSubjects;
   obligations: {
     include?: string[];
@@ -48,6 +66,139 @@ export interface ImpactViewConfig {
   status_display?: ImpactStatusDisplay;
   empty_cells?: ImpactEmptyCellLabels;
   order_rows_by?: 'id' | 'name';
+}
+
+// ── Pinned defaults ─────────────────────────────────────────────────────────
+
+/**
+ * Explicit defaults for every optional field in ImpactViewConfig.
+ *
+ * When a view config omits a field, COMPLIANCE_IMPACT_DEFAULTS defines the
+ * assumed behaviour. The CLI prints these so re-runs without a full config
+ * are auditable ("what I assumed").
+ */
+export const COMPLIANCE_IMPACT_DEFAULTS = {
+  /** Accept all four active statuses + n_a in cell aggregation. */
+  status_display: {
+    show: ['compliant', 'partial', 'non_compliant', 'under_review', 'n_a'] as AssertionStatus[],
+  },
+  /** Order rows by canonical REQUIREMENT ID (lexicographic). */
+  order_rows_by: 'id' as const,
+  /** §5.3 empty-cell labels. */
+  empty_cells: {
+    no_obligation_label: 'No mapped obligation (current model)',
+    no_obligation_applies_label: 'No obligation applies',
+  },
+  /** Obligation scope: all known REQUIREMENTs in the canon (no filter). */
+  obligations: { include: undefined as string[] | undefined, filter: undefined },
+  /** Subjects: empty — must be supplied explicitly in the view config. */
+  subjects: { products: [] as string[], processes: [] as string[] },
+} as const;
+
+// ── View-config parser ──────────────────────────────────────────────────────
+
+export type ParseImpactViewConfigResult =
+  | { ok: true; config: ImpactViewConfig }
+  | { ok: false; errors: string[] };
+
+/**
+ * Validate and normalise a raw (YAML-parsed) value into an ImpactViewConfig.
+ *
+ * Accepts both the bare config object and the view-config file shape
+ * (`{ view: { id, name, … } }`) — the top-level `view:` wrapper is unwrapped
+ * automatically.
+ *
+ * Every optional field is filled from COMPLIANCE_IMPACT_DEFAULTS, so callers
+ * can rely on the returned config being complete without any `??` chains.
+ *
+ * Returns `{ ok: false, errors }` on schema violations rather than throwing,
+ * so the CLI can surface a clean error message without a stack trace.
+ */
+export function parseImpactViewConfig(raw: unknown): ParseImpactViewConfigResult {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { ok: false, errors: ['view config: expected an object at the document root'] };
+  }
+  const top = raw as Record<string, unknown>;
+
+  // Unwrap optional `view:` wrapper (view-config YAML files use this key).
+  const v: Record<string, unknown> =
+    'view' in top && top.view && typeof top.view === 'object' && !Array.isArray(top.view)
+      ? (top.view as Record<string, unknown>)
+      : top;
+
+  const errors: string[] = [];
+  if (!v.id || typeof v.id !== 'string') errors.push('view.id: required string');
+  if (!v.name || typeof v.name !== 'string') errors.push('view.name: required string');
+  if (v.subjects !== undefined && (typeof v.subjects !== 'object' || Array.isArray(v.subjects))) {
+    errors.push('view.subjects: expected an object');
+  }
+  if (errors.length) return { ok: false, errors };
+
+  const subjects =
+    v.subjects && typeof v.subjects === 'object' && !Array.isArray(v.subjects)
+      ? (v.subjects as Record<string, unknown>)
+      : {};
+  const obligations =
+    v.obligations && typeof v.obligations === 'object' && !Array.isArray(v.obligations)
+      ? (v.obligations as Record<string, unknown>)
+      : {};
+  const obFilter =
+    obligations.filter && typeof obligations.filter === 'object' && !Array.isArray(obligations.filter)
+      ? (obligations.filter as Record<string, unknown>)
+      : null;
+  const statusDisplay =
+    v.status_display && typeof v.status_display === 'object' && !Array.isArray(v.status_display)
+      ? (v.status_display as Record<string, unknown>)
+      : {};
+  const emptyCells =
+    v.empty_cells && typeof v.empty_cells === 'object' && !Array.isArray(v.empty_cells)
+      ? (v.empty_cells as Record<string, unknown>)
+      : {};
+
+  const config: ImpactViewConfig = {
+    id: v.id as string,
+    name: v.name as string,
+    description: typeof v.description === 'string' ? v.description : undefined,
+    snapshot_at: typeof v.snapshot_at === 'string' ? v.snapshot_at : undefined,
+    subjects: {
+      products: Array.isArray(subjects.products)
+        ? (subjects.products as unknown[]).filter((x): x is string => typeof x === 'string')
+        : [...COMPLIANCE_IMPACT_DEFAULTS.subjects.products],
+      processes: Array.isArray(subjects.processes)
+        ? (subjects.processes as unknown[]).filter((x): x is string => typeof x === 'string')
+        : [...COMPLIANCE_IMPACT_DEFAULTS.subjects.processes],
+    },
+    obligations: {
+      include: Array.isArray(obligations.include)
+        ? (obligations.include as unknown[]).filter((x): x is string => typeof x === 'string')
+        : undefined,
+      filter: obFilter
+        ? {
+            derived_from_codex: Array.isArray(obFilter.derived_from_codex)
+              ? (obFilter.derived_from_codex as unknown[]).filter((x): x is string => typeof x === 'string')
+              : undefined,
+          }
+        : undefined,
+    },
+    status_display: {
+      show: Array.isArray(statusDisplay.show)
+        ? (statusDisplay.show as unknown[]).filter((x): x is AssertionStatus => typeof x === 'string')
+        : [...COMPLIANCE_IMPACT_DEFAULTS.status_display.show],
+    },
+    empty_cells: {
+      no_obligation_label:
+        typeof emptyCells.no_obligation_label === 'string'
+          ? emptyCells.no_obligation_label
+          : COMPLIANCE_IMPACT_DEFAULTS.empty_cells.no_obligation_label,
+      no_obligation_applies_label:
+        typeof emptyCells.no_obligation_applies_label === 'string'
+          ? emptyCells.no_obligation_applies_label
+          : COMPLIANCE_IMPACT_DEFAULTS.empty_cells.no_obligation_applies_label,
+    },
+    order_rows_by: v.order_rows_by === 'name' ? 'name' : COMPLIANCE_IMPACT_DEFAULTS.order_rows_by,
+  };
+
+  return { ok: true, config };
 }
 
 /** A single cell of the rendered matrix. */
@@ -67,6 +218,12 @@ export interface ImpactMatrix {
   viewId: string;
   viewName: string;
   description?: string;
+  /**
+   * ISO 8601 date of the last report snapshot, copied from the view config.
+   * CV-3 blueprint-lane rendering uses this to flag obligations that appeared
+   * after the snapshot as "new" (dashed-border cell decoration).
+   */
+  snapshotAt?: string;
   /** Row dimension — REQUIREMENT projections, in the configured order. */
   rows: IndexRequirement[];
   /** Column dimension — subject IDs (PRODUCT ids in the coarsest grain). */
@@ -206,6 +363,7 @@ export function buildImpactMatrix(canon: ComplianceCanon, config: ImpactViewConf
     viewId: config.id,
     viewName: config.name,
     description: config.description,
+    snapshotAt: config.snapshot_at,
     rows: obligations,
     columns,
     cells,
@@ -250,6 +408,7 @@ export function renderImpactMarkdown(matrix: ImpactMatrix): string {
   lines.push(`# ${matrix.viewName}`);
   lines.push('');
   lines.push(`View ID: \`${matrix.viewId}\``);
+  if (matrix.snapshotAt) lines.push(`Report snapshot: ${matrix.snapshotAt}`);
   if (matrix.description) {
     lines.push('');
     lines.push(matrix.description);

--- a/packages/diagrams/src/compliance/index.ts
+++ b/packages/diagrams/src/compliance/index.ts
@@ -8,7 +8,7 @@ export { renderComplianceMarkdown } from './markdown.js';
 export type { ReportScope, MarkdownOptions } from './markdown.js';
 export { renderComplianceHtml } from './html.js';
 export type { HtmlOptions } from './html.js';
-export { buildImpactMatrix, renderImpactMarkdown } from './impact.js';
+export { buildImpactMatrix, renderImpactMarkdown, parseImpactViewConfig, COMPLIANCE_IMPACT_DEFAULTS } from './impact.js';
 export type {
   ImpactCell,
   ImpactEmptyCellLabels,
@@ -17,6 +17,7 @@ export type {
   ImpactStatusDisplay,
   ImpactSubjects,
   ImpactViewConfig,
+  ParseImpactViewConfigResult,
 } from './impact.js';
 export {
   assertionToScoringElement,

--- a/scripts/render-compliance-impact.mjs
+++ b/scripts/render-compliance-impact.mjs
@@ -1,28 +1,31 @@
 #!/usr/bin/env node
 /**
- * Interim compliance-impact matrix renderer
- * (vkgeorgia/strategy#166 — fast-track interim; full Studio consumer-side
- * renderer is tracked under #84).
+ * Compliance-impact matrix renderer — CV-1 view-config wiring
+ * (vkgeorgia/strategy#84, builds on #166 interim renderer).
  *
- * Materialises the subject × obligation × status matrix per the render contract
- * in methodology/notations/views/21-compliance-impact.md §5, at the coarsest
- * grain (`product` × `obligation`). Stage / task grouping is intentionally out
- * of scope here — those need a process-flow walk and a process-blueprint join
- * that the full renderer will handle.
+ * Materialises the subject × obligation × status matrix per the render
+ * contract in methodology/notations/views/21-compliance-impact.md §5, at
+ * the coarsest grain (`product` × `obligation`).
  *
- * Usage:
+ * Usage — named view-config file:
  *   node scripts/render-compliance-impact.mjs \
- *        --view <path/to/COMPLIANCE_IMPACT-…compliance-impact.transitrix.yaml> \
+ *        --view <path/to/COMPLIANCE_IMPACT-view.yaml> \
+ *        --canon <path/to/canon-root> \
+ *        [--out <path/to/output.md>]
+ *
+ * Usage — registry (directory of view-config files):
+ *   node scripts/render-compliance-impact.mjs \
+ *        --registry <path/to/views-dir> --report <view-id> \
  *        --canon <path/to/canon-root> \
  *        [--out <path/to/output.md>]
  *
  * The script:
- *   1. Parses the view config (one YAML doc per file).
- *   2. Recursively scans the canon root for *.yaml / *.yml and ingests every
- *      file that classify.ingestComplianceDoc recognises (PRODUCT / REQUIREMENT
- *      / ASSERTION elements + codex documents).
- *   3. Calls `@transitrix/diagrams` `buildImpactMatrix` + `renderImpactMarkdown`
- *      and writes the result to stdout (or --out).
+ *   1. Resolves the view config (from --view file or --registry + --report).
+ *   2. Logs the active defaults for any omitted optional fields.
+ *   3. Scans the canon root recursively for *.yaml / *.yml and ingests each
+ *      file that classify.ingestComplianceDoc recognises.
+ *   4. Calls `buildImpactMatrix` + `renderImpactMarkdown` and writes the
+ *      result to stdout (or --out).
  *
  * Requires `npm run build -w @transitrix/diagrams` to have produced
  * packages/diagrams/dist/.
@@ -38,22 +41,36 @@ const STUDIO_ROOT = path.resolve(HERE, '..');
 const DIST_INDEX = path.join(STUDIO_ROOT, 'packages', 'diagrams', 'dist', 'index.js');
 
 function parseArgs(argv) {
-  const out = { view: null, canon: null, output: null };
+  const out = { view: null, registry: null, report: null, canon: null, output: null };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === '--view') out.view = argv[++i];
     else if (a.startsWith('--view=')) out.view = a.slice('--view='.length);
+    else if (a === '--registry') out.registry = argv[++i];
+    else if (a.startsWith('--registry=')) out.registry = a.slice('--registry='.length);
+    else if (a === '--report') out.report = argv[++i];
+    else if (a.startsWith('--report=')) out.report = a.slice('--report='.length);
     else if (a === '--canon') out.canon = argv[++i];
     else if (a.startsWith('--canon=')) out.canon = a.slice('--canon='.length);
     else if (a === '--out') out.output = argv[++i];
     else if (a.startsWith('--out=')) out.output = a.slice('--out='.length);
     else if (a === '--help' || a === '-h') {
       console.log(
-        `Usage: node scripts/render-compliance-impact.mjs --view <view.yaml> --canon <canon-root> [--out <file>]
-  --view   <path>   compliance-impact view config (required)
-  --canon  <path>   root of the canon to scan recursively (required)
-  --out    <path>   write markdown to this file (default: stdout)
-  -h, --help        show this help`,
+        `Usage (named file):
+  node scripts/render-compliance-impact.mjs \\
+       --view <view.yaml> --canon <canon-root> [--out <file>]
+
+Usage (registry):
+  node scripts/render-compliance-impact.mjs \\
+       --registry <views-dir> --report <view-id> --canon <canon-root> [--out <file>]
+
+Options:
+  --view      <path>   compliance-impact view config YAML file
+  --registry  <path>   directory of view config YAML files (use with --report)
+  --report    <id>     view.id to select from the registry
+  --canon     <path>   root of the canon to scan recursively (required)
+  --out       <path>   write markdown to this file (default: stdout)
+  -h, --help           show this help`,
       );
       process.exit(0);
     } else {
@@ -61,8 +78,12 @@ function parseArgs(argv) {
       process.exit(2);
     }
   }
-  if (!out.view || !out.canon) {
-    console.error('Missing --view or --canon. Run with --help for usage.');
+  if (!out.canon) {
+    console.error('Missing --canon. Run with --help for usage.');
+    process.exit(2);
+  }
+  if (!out.view && !(out.registry && out.report)) {
+    console.error('Provide either --view <file> or --registry <dir> --report <id>. Run with --help for usage.');
     process.exit(2);
   }
   return out;
@@ -86,42 +107,59 @@ async function* walkYaml(root) {
   }
 }
 
-function viewConfigFromYaml(raw) {
-  if (!raw || typeof raw !== 'object') throw new Error('view: expected an object at the document root');
-  const v = raw.view;
-  if (!v || typeof v !== 'object') throw new Error('view: missing top-level `view:` object');
-  if (!v.id || typeof v.id !== 'string') throw new Error('view.id: required string');
-  if (!v.name || typeof v.name !== 'string') throw new Error('view.name: required string');
-  if (!v.subjects || typeof v.subjects !== 'object') throw new Error('view.subjects: required object (COMPIMP-002)');
-  return {
-    id: v.id,
-    name: v.name,
-    description: typeof v.description === 'string' ? v.description : undefined,
-    subjects: {
-      products: Array.isArray(v.subjects.products) ? v.subjects.products.filter(x => typeof x === 'string') : undefined,
-      processes: Array.isArray(v.subjects.processes) ? v.subjects.processes.filter(x => typeof x === 'string') : undefined,
-    },
-    obligations: {
-      include: Array.isArray(v.obligations?.include)
-        ? v.obligations.include.filter(x => typeof x === 'string')
-        : undefined,
-      filter: v.obligations?.filter
-        ? {
-            derived_from_codex: Array.isArray(v.obligations.filter.derived_from_codex)
-              ? v.obligations.filter.derived_from_codex.filter(x => typeof x === 'string')
-              : undefined,
-          }
-        : undefined,
-    },
-    status_display: v.status_display ? { show: v.status_display.show } : undefined,
-    empty_cells: v.empty_cells
-      ? {
-          no_obligation_label: v.empty_cells.no_obligation_label,
-          no_obligation_applies_label: v.empty_cells.no_obligation_applies_label,
-        }
-      : undefined,
-    order_rows_by: v.order_rows_by,
-  };
+/**
+ * Scan a registry directory for a view config whose view.id matches `reportId`.
+ * Returns the raw parsed YAML object of the first match, or null if not found.
+ */
+async function findInRegistry(registryDir, reportId) {
+  let entries;
+  try {
+    entries = await fs.readdir(registryDir, { withFileTypes: true });
+  } catch (err) {
+    console.error(`Registry directory not readable: ${registryDir} — ${err.message}`);
+    process.exit(2);
+  }
+  for (const e of entries) {
+    if (!e.isFile()) continue;
+    if (!e.name.endsWith('.yaml') && !e.name.endsWith('.yml')) continue;
+    const full = path.join(registryDir, e.name);
+    let raw;
+    try {
+      raw = await readYaml(full);
+    } catch {
+      continue;
+    }
+    // Accept both bare { id, name } and wrapped { view: { id, name } } shapes.
+    const v = raw?.view ?? raw;
+    if (v?.id === reportId) return raw;
+  }
+  return null;
+}
+
+/**
+ * Log the active defaults that were filled in for this run, so re-runs are
+ * auditable without a full view config.
+ */
+function logActiveDefaults(config, defaults) {
+  const assumed = [];
+  if (!config.subjects?.products?.length && !config.subjects?.processes?.length) {
+    assumed.push('subjects: none specified (empty matrix columns — no product/process IDs in view config)');
+  }
+  if (!config.status_display) {
+    assumed.push(
+      `status_display.show: [${defaults.status_display.show.join(', ')}] (all statuses accepted)`,
+    );
+  }
+  if (!config.order_rows_by) {
+    assumed.push(`order_rows_by: "${defaults.order_rows_by}" (lexicographic by REQUIREMENT ID)`);
+  }
+  if (!config.empty_cells?.no_obligation_label) {
+    assumed.push(`empty_cells.no_obligation_label: "${defaults.empty_cells.no_obligation_label}"`);
+  }
+  if (assumed.length) {
+    console.error('[render-compliance-impact] assumed defaults:');
+    for (const line of assumed) console.error(`  • ${line}`);
+  }
 }
 
 async function main() {
@@ -136,11 +174,33 @@ async function main() {
     process.exit(3);
   }
   const diagrams = await import(pathToFileURL(DIST_INDEX).href);
-  const { emptyCanon, ingestComplianceDoc, buildImpactMatrix, renderImpactMarkdown } = diagrams;
+  const { emptyCanon, ingestComplianceDoc, buildImpactMatrix, renderImpactMarkdown, parseImpactViewConfig, COMPLIANCE_IMPACT_DEFAULTS } = diagrams;
 
-  const viewRaw = await readYaml(args.view);
-  const view = viewConfigFromYaml(viewRaw);
+  // Resolve the view config.
+  let viewRaw;
+  if (args.view) {
+    viewRaw = await readYaml(args.view);
+  } else {
+    viewRaw = await findInRegistry(args.registry, args.report);
+    if (!viewRaw) {
+      console.error(`Report "${args.report}" not found in registry: ${args.registry}`);
+      process.exit(2);
+    }
+  }
 
+  const parseResult = parseImpactViewConfig(viewRaw);
+  if (!parseResult.ok) {
+    console.error('Invalid view config:');
+    for (const e of parseResult.errors) console.error(`  • ${e}`);
+    process.exit(2);
+  }
+  const view = parseResult.config;
+
+  console.error(`[render-compliance-impact] view: ${view.id} — ${view.name}`);
+  if (view.snapshot_at) console.error(`[render-compliance-impact] snapshot_at: ${view.snapshot_at}`);
+  logActiveDefaults(view, COMPLIANCE_IMPACT_DEFAULTS);
+
+  // Scan canon.
   const canon = emptyCanon();
   let scanned = 0;
   let ingested = 0;
@@ -150,12 +210,9 @@ async function main() {
     try {
       parsed = await readYaml(file);
     } catch (err) {
-      // Malformed YAML — skip with a warning; the interim renderer is best-effort.
       console.error(`skip ${file}: ${err instanceof Error ? err.message : String(err)}`);
       continue;
     }
-    // js-yaml.load returns one doc for `yaml.load`; multi-doc files would need `yaml.loadAll`.
-    // Keep it simple: one root doc per canon file.
     if (ingestComplianceDoc(canon, parsed)) ingested += 1;
   }
 


### PR DESCRIPTION
## CV-1 — view-config wiring (strategy#84 decomposition refresh)

Named, saved view-config as the report definition; deterministic re-render; pinned defaults.

### Library changes (`packages/diagrams/src/compliance/impact.ts`)

**`snapshot_at?` on `ImpactViewConfig` and `ImpactMatrix`**
Records when the report was last generated (ISO 8601 date). `buildImpactMatrix` propagates it into the matrix; `renderImpactMarkdown` emits it as a `Report snapshot:` header line. CV-3 blueprint-lane rendering will use it to flag obligations that appeared after the snapshot as *new* (dashed-border cell decoration).

**`COMPLIANCE_IMPACT_DEFAULTS`**
Explicit, typed constant for every optional field:
- `status_display.show` — all five statuses accepted
- `order_rows_by` — `id` (lexicographic by REQUIREMENT ID)
- `empty_cells` — pinned §5.3 labels
- `obligations` — entire canon (no filter)
- `subjects` — empty (caller must supply)

**`parseImpactViewConfig(raw): ParseImpactViewConfigResult`**
Single shared validator/normaliser. Accepts both the bare `{ id, name, ... }` shape and the view-config file shape (`{ view: { id, name, ... } }`); unwraps automatically. Fills every omitted optional field from `COMPLIANCE_IMPACT_DEFAULTS`; returns `{ ok: false, errors }` instead of throwing. Re-exported from `compliance/index.ts`.

### CLI changes (`scripts/render-compliance-impact.mjs`)

- **`--registry <dir> --report <id>`** — scans a directory for view-config YAML files and selects the one whose `view.id` matches the given report id. Both bare and `view:`-wrapped shapes accepted.
- **Replaced local `viewConfigFromYaml`** with `parseImpactViewConfig` from the built lib — single source of truth for validation + defaults.
- **Active-defaults log** — prints which optional fields were filled from defaults on `stderr` so every re-run is auditable.

### Tests

+9 cases: `parseImpactViewConfig` (non-object, missing id/name, `view:` wrapper unwrap, full defaults fill, `snapshot_at` round-trip, `order_rows_by:name`, obligation filter); `snapshot_at` propagation in markdown. **47 files / 660 tests green. `tsc` + `extension/tsc` clean.**

### Dependency note

CV-6 (`export-compliance` CLI) depends on this; no other CV items are blocked. CV-2 and CV-3a are independent and will proceed in parallel.

Refs vkgeorgia/strategy#84. Open PR — Valerii gates the merge.