### PR TITLE
feat(compliance): CV-3a — stage/task grouping for compliance-impact matrix

### DIFF
--- a/extension/src/compliance-impact-preview.ts
+++ b/extension/src/compliance-impact-preview.ts
@@ -3,6 +3,7 @@ import yaml from 'js-yaml';
 import { generateWebviewCss, type ThemeId } from '../../packages/diagrams/src/theme/index.js';
 import {
   buildImpactMatrix,
+  type ImpactColumn,
   type ImpactViewConfig,
   type ImpactMatrix,
   type ImpactCell,
@@ -241,7 +242,7 @@ function applyFilter(
   matrix: ImpactMatrix,
   filter: ImpactFilter,
   jIndex: Map<string, string[]>,
-): { rows: IndexRequirement[]; columns: string[]; cells: ImpactCell[][] } {
+): { rows: IndexRequirement[]; columns: ImpactColumn[]; cells: ImpactCell[][] } {
   let rows = matrix.rows;
 
   if (filter.severities.size > 0) {
@@ -509,14 +510,14 @@ export class ComplianceImpactPreview {
 
   private gridHtml(
     rows: IndexRequirement[],
-    columns: string[],
+    columns: ImpactColumn[],
     cells: ImpactCell[][],
     emptyLabels: { no_obligation_label: string; no_obligation_applies_label: string },
   ): string {
     const head =
       '<tr>\n      <th class="ci-corner"></th>\n      ' +
       columns
-        .map(col => '<th class="ci-col"><div class="ci-col-name">' + escXml(col) + '</div></th>')
+        .map(col => '<th class="ci-col"><div class="ci-col-name">' + escXml(col.label) + '</div></th>')
         .join('') +
       '\n    </tr>';
 
@@ -559,7 +560,7 @@ export class ComplianceImpactPreview {
             const cell = cells[ri][ci];
 
             if (cell.kind === 'gap') {
-              const pendingCount = this.pendingIndex.get(pendingKey(req.id, col)) ?? 0;
+              const pendingCount = this.pendingIndex.get(pendingKey(req.id, col.subjectId)) ?? 0;
               if (pendingCount > 0) {
                 return (
                   '<td class="ci-cell ci-pending" title="' +
@@ -567,7 +568,7 @@ export class ComplianceImpactPreview {
                   ' assertion(s) pending admission for (' +
                   escXml(req.id) +
                   ', ' +
-                  escXml(col) +
+                  escXml(col.label) +
                   ')">\n' +
                   '              <span class="ci-badge-pending">' +
                   pendingCount +

--- a/packages/diagrams/src/compliance/__tests__/impact.test.ts
+++ b/packages/diagrams/src/compliance/__tests__/impact.test.ts
@@ -279,7 +279,7 @@ describe('CV-3a — stage grouping (ImpactColumn, extractStageGroups, buildImpac
     const canon = buildCanon();
     const matrix = buildImpactMatrix(
       canon,
-      { ...baseConfig, subjects: { products: ['PRODUCT-A-1'] }, grouping: { columns: 'product-stage' } },
+      { ...baseConfig, subjects: { products: ['PRODUCT-A-1'] }, grouping: { columns: 'object-stage' } },
       [{ subjectId: 'PRODUCT-A-1', stages: [{ id: 'STAGE-1', name: 'Stage One' }, { id: 'STAGE-2', name: 'Stage Two' }] }],
     );
     expect(matrix.columns.map(c => c.label)).toEqual(['PRODUCT-A-1:STAGE-1', 'PRODUCT-A-1:STAGE-2']);
@@ -297,7 +297,7 @@ describe('CV-3a — stage grouping (ImpactColumn, extractStageGroups, buildImpac
         id: 'V', name: 'V',
         subjects: { products: ['PROD-1'] },
         obligations: {},
-        grouping: { columns: 'product-stage' },
+        grouping: { columns: 'object-stage' },
       },
       [{ subjectId: 'PROD-1', stages: [{ id: 'S1', name: 's1' }, { id: 'S2', name: 's2' }] }],
     );
@@ -320,7 +320,7 @@ describe('CV-3a — stage grouping (ImpactColumn, extractStageGroups, buildImpac
         id: 'V', name: 'V',
         subjects: { products: ['PROD-1'] },
         obligations: {},
-        grouping: { columns: 'product-stage' },
+        grouping: { columns: 'object-stage' },
       },
       [{ subjectId: 'PROD-1', stages: [{ id: 'STAGE-A', name: 'a' }, { id: 'STAGE-B', name: 'b' }] }],
     );
@@ -335,7 +335,7 @@ describe('CV-3a — stage grouping (ImpactColumn, extractStageGroups, buildImpac
       {
         ...baseConfig,
         subjects: { products: ['PRODUCT-A-1', 'PRODUCT-B-1'] },
-        grouping: { columns: 'product-stage' },
+        grouping: { columns: 'object-stage' },
       },
       // Only provide stages for A — B falls back to a single column.
       [{ subjectId: 'PRODUCT-A-1', stages: [{ id: 'S1', name: 's1' }] }],
@@ -369,7 +369,7 @@ describe('CV-3a — stage grouping (ImpactColumn, extractStageGroups, buildImpac
         id: 'V', name: 'Stage Report',
         subjects: { products: ['PROD-1'] },
         obligations: {},
-        grouping: { columns: 'product-stage' },
+        grouping: { columns: 'object-stage' },
       },
       [{ subjectId: 'PROD-1', stages: [{ id: 'S1', name: 'Stage One' }] }],
     );

--- a/packages/diagrams/src/compliance/__tests__/impact.test.ts
+++ b/packages/diagrams/src/compliance/__tests__/impact.test.ts
@@ -5,7 +5,7 @@ import {
   renderImpactMarkdown,
   parseImpactViewConfig,
   COMPLIANCE_IMPACT_DEFAULTS,
-  extractStageGroups,
+  extractObjectDetails,
   type ImpactViewConfig,
 } from '../impact.js';
 import type { ComplianceCanon } from '../classify.js';
@@ -266,7 +266,7 @@ describe('parseImpactViewConfig', () => {
   });
 });
 
-describe('CV-3a — stage grouping (ImpactColumn, extractStageGroups, buildImpactMatrix stage grain)', () => {
+describe('CV-3a — stage grouping (ImpactColumn, extractObjectDetails, buildImpactMatrix stage grain)', () => {
   it('default product grain: columns are plain ImpactColumn with label=subjectId', () => {
     const canon = buildCanon();
     const matrix = buildImpactMatrix(canon, baseConfig);
@@ -279,8 +279,8 @@ describe('CV-3a — stage grouping (ImpactColumn, extractStageGroups, buildImpac
     const canon = buildCanon();
     const matrix = buildImpactMatrix(
       canon,
-      { ...baseConfig, subjects: { products: ['PRODUCT-A-1'] }, grouping: { columns: 'object-stage' } },
-      [{ subjectId: 'PRODUCT-A-1', stages: [{ id: 'STAGE-1', name: 'Stage One' }, { id: 'STAGE-2', name: 'Stage Two' }] }],
+      { ...baseConfig, subjects: { products: ['PRODUCT-A-1'] }, grouping: { columns: 'object-details' } },
+      [{ objectId: 'PRODUCT-A-1', details: [{ id: 'STAGE-1', name: 'Stage One' }, { id: 'STAGE-2', name: 'Stage Two' }] }],
     );
     expect(matrix.columns.map(c => c.label)).toEqual(['PRODUCT-A-1:STAGE-1', 'PRODUCT-A-1:STAGE-2']);
     expect(matrix.columns.map(c => c.stageId)).toEqual(['STAGE-1', 'STAGE-2']);
@@ -297,9 +297,9 @@ describe('CV-3a — stage grouping (ImpactColumn, extractStageGroups, buildImpac
         id: 'V', name: 'V',
         subjects: { products: ['PROD-1'] },
         obligations: {},
-        grouping: { columns: 'object-stage' },
+        grouping: { columns: 'object-details' },
       },
-      [{ subjectId: 'PROD-1', stages: [{ id: 'S1', name: 's1' }, { id: 'S2', name: 's2' }] }],
+      [{ objectId: 'PROD-1', details: [{ id: 'S1', name: 's1' }, { id: 'S2', name: 's2' }] }],
     );
     // Both stage columns should be bound (no realised_via means all stages inherit).
     expect(matrix.cells[0][0].kind).toBe('bound');
@@ -320,9 +320,9 @@ describe('CV-3a — stage grouping (ImpactColumn, extractStageGroups, buildImpac
         id: 'V', name: 'V',
         subjects: { products: ['PROD-1'] },
         obligations: {},
-        grouping: { columns: 'object-stage' },
+        grouping: { columns: 'object-details' },
       },
-      [{ subjectId: 'PROD-1', stages: [{ id: 'STAGE-A', name: 'a' }, { id: 'STAGE-B', name: 'b' }] }],
+      [{ objectId: 'PROD-1', details: [{ id: 'STAGE-A', name: 'a' }, { id: 'STAGE-B', name: 'b' }] }],
     );
     expect(matrix.cells[0][0].kind).toBe('bound');   // STAGE-A: covered
     expect(matrix.cells[0][1].kind).toBe('gap');     // STAGE-B: gap
@@ -335,28 +335,28 @@ describe('CV-3a — stage grouping (ImpactColumn, extractStageGroups, buildImpac
       {
         ...baseConfig,
         subjects: { products: ['PRODUCT-A-1', 'PRODUCT-B-1'] },
-        grouping: { columns: 'object-stage' },
+        grouping: { columns: 'object-details' },
       },
       // Only provide stages for A — B falls back to a single column.
-      [{ subjectId: 'PRODUCT-A-1', stages: [{ id: 'S1', name: 's1' }] }],
+      [{ objectId: 'PRODUCT-A-1', details: [{ id: 'S1', name: 's1' }] }],
     );
     expect(matrix.columns.map(c => c.label)).toEqual(['PRODUCT-A-1:S1', 'PRODUCT-B-1']);
     // PRODUCT-B-1 fallback column: no stageId.
     expect(matrix.columns[1].stageId).toBeUndefined();
   });
 
-  it('extractStageGroups — returns null for non-blueprint docs', () => {
-    expect(extractStageGroups(null)).toBeNull();
-    expect(extractStageGroups({ notation: 'requirement', id: 'R1' })).toBeNull();
-    expect(extractStageGroups({ process_blueprint: { stages: [{ id: 'S1' }] } })).toBeNull(); // missing id
+  it('extractObjectDetails — returns null for non-blueprint docs', () => {
+    expect(extractObjectDetails(null)).toBeNull();
+    expect(extractObjectDetails({ notation: 'requirement', id: 'R1' })).toBeNull();
+    expect(extractObjectDetails({ process_blueprint: { details: [{ id: 'S1' }] } })).toBeNull(); // missing id
   });
 
-  it('extractStageGroups — extracts subjectId and stages from process_blueprint wrapper', () => {
+  it('extractObjectDetails — extracts subjectId and stages from process_blueprint wrapper', () => {
     const doc = { process_blueprint: { id: 'PROC-1', notation: 'process_blueprint', stages: [{ id: 'S1', name: 'Stage One' }, { id: 'S2', name: 'Stage Two' }] } };
-    const sg = extractStageGroups(doc);
+    const sg = extractObjectDetails(doc);
     expect(sg).not.toBeNull();
-    expect(sg!.subjectId).toBe('PROC-1');
-    expect(sg!.stages.map((s: { id: string }) => s.id)).toEqual(['S1', 'S2']);
+    expect(sg!.objectId).toBe('PROC-1');
+    expect(sg!.details.map((s: { id: string }) => s.id)).toEqual(['S1', 'S2']);
   });
 
   it('renderImpactMarkdown uses column labels in the table header', () => {
@@ -369,9 +369,9 @@ describe('CV-3a — stage grouping (ImpactColumn, extractStageGroups, buildImpac
         id: 'V', name: 'Stage Report',
         subjects: { products: ['PROD-1'] },
         obligations: {},
-        grouping: { columns: 'object-stage' },
+        grouping: { columns: 'object-details' },
       },
-      [{ subjectId: 'PROD-1', stages: [{ id: 'S1', name: 'Stage One' }] }],
+      [{ objectId: 'PROD-1', details: [{ id: 'S1', name: 'Stage One' }] }],
     );
     const md = renderImpactMarkdown(matrix);
     expect(md).toContain('PROD-1:S1');

--- a/packages/diagrams/src/compliance/__tests__/impact.test.ts
+++ b/packages/diagrams/src/compliance/__tests__/impact.test.ts
@@ -5,6 +5,7 @@ import {
   renderImpactMarkdown,
   parseImpactViewConfig,
   COMPLIANCE_IMPACT_DEFAULTS,
+  extractStageGroups,
   type ImpactViewConfig,
 } from '../impact.js';
 import type { ComplianceCanon } from '../classify.js';
@@ -52,12 +53,12 @@ describe('buildImpactMatrix', () => {
       ...baseConfig,
       obligations: { include: ['REQUIREMENT-FOO-1', 'REQUIREMENT-BAR-1', 'REQUIREMENT-BAZ-1'] },
     });
-    expect(matrix.columns).toEqual(['PRODUCT-A-1', 'PRODUCT-B-1']);
+    expect(matrix.columns.map(c => c.label)).toEqual(['PRODUCT-A-1', 'PRODUCT-B-1']);
     expect(matrix.rows.map(r => r.id)).toEqual(['REQUIREMENT-BAR-1', 'REQUIREMENT-BAZ-1', 'REQUIREMENT-FOO-1']);
 
     const cellFor = (req: string, subject: string) => {
       const r = matrix.rows.findIndex(x => x.id === req);
-      const c = matrix.columns.indexOf(subject);
+      const c = matrix.columns.findIndex(col => col.label === subject);
       return matrix.cells[r][c];
     };
 
@@ -97,8 +98,8 @@ describe('buildImpactMatrix', () => {
       ...baseConfig,
       obligations: { include: ['REQUIREMENT-BAR-1'] },
     });
-    const aCell = matrix.cells[0][matrix.columns.indexOf('PRODUCT-A-1')];
-    const bCell = matrix.cells[0][matrix.columns.indexOf('PRODUCT-B-1')];
+    const aCell = matrix.cells[0][matrix.columns.findIndex(c => c.label === 'PRODUCT-A-1')];
+    const bCell = matrix.cells[0][matrix.columns.findIndex(c => c.label === 'PRODUCT-B-1')];
     expect(aCell.kind).toBe('n_a_only');
     expect(bCell.kind).toBe('bound');
     expect(bCell.status).toBe('non_compliant');
@@ -111,7 +112,7 @@ describe('buildImpactMatrix', () => {
       obligations: { include: ['REQUIREMENT-BAZ-1'] },
       status_display: { show: ['non_compliant'] }, // under_review + compliant filtered out
     });
-    const cell = matrix.cells[0][matrix.columns.indexOf('PRODUCT-B-1')];
+    const cell = matrix.cells[0][matrix.columns.findIndex(c => c.label === 'PRODUCT-B-1')];
     expect(cell.kind).toBe('gap');
   });
 
@@ -122,8 +123,8 @@ describe('buildImpactMatrix', () => {
       subjects: { products: ['PRODUCT-A-1', 'PRODUCT-B-1', 'PRODUCT-NONE-1'] },
       obligations: { include: ['REQUIREMENT-FOO-1'] },
     });
-    expect(matrix.columns).toContain('PRODUCT-NONE-1');
-    const cell = matrix.cells[0][matrix.columns.indexOf('PRODUCT-NONE-1')];
+    expect(matrix.columns.map(c => c.label)).toContain('PRODUCT-NONE-1');
+    const cell = matrix.cells[0][matrix.columns.findIndex(c => c.label === 'PRODUCT-NONE-1')];
     expect(cell.kind).toBe('gap');
   });
 
@@ -262,5 +263,117 @@ describe('parseImpactViewConfig', () => {
     });
     expect(r.ok).toBe(true);
     if (r.ok) expect(r.config.obligations.filter?.derived_from_codex).toEqual(['LAW-X-1']);
+  });
+});
+
+describe('CV-3a — stage grouping (ImpactColumn, extractStageGroups, buildImpactMatrix stage grain)', () => {
+  it('default product grain: columns are plain ImpactColumn with label=subjectId', () => {
+    const canon = buildCanon();
+    const matrix = buildImpactMatrix(canon, baseConfig);
+    expect(matrix.columns.map(c => c.subjectId)).toEqual(['PRODUCT-A-1', 'PRODUCT-B-1']);
+    expect(matrix.columns.map(c => c.label)).toEqual(['PRODUCT-A-1', 'PRODUCT-B-1']);
+    expect(matrix.columns.every(c => !c.stageId)).toBe(true);
+  });
+
+  it('product-stage grain: expands columns by stage, label is subjectId:stageId', () => {
+    const canon = buildCanon();
+    const matrix = buildImpactMatrix(
+      canon,
+      { ...baseConfig, subjects: { products: ['PRODUCT-A-1'] }, grouping: { columns: 'product-stage' } },
+      [{ subjectId: 'PRODUCT-A-1', stages: [{ id: 'STAGE-1', name: 'Stage One' }, { id: 'STAGE-2', name: 'Stage Two' }] }],
+    );
+    expect(matrix.columns.map(c => c.label)).toEqual(['PRODUCT-A-1:STAGE-1', 'PRODUCT-A-1:STAGE-2']);
+    expect(matrix.columns.map(c => c.stageId)).toEqual(['STAGE-1', 'STAGE-2']);
+  });
+
+  it('assertion without realised_via fills every stage column for its subject', () => {
+    const canon = emptyCanon();
+    canon.requirements.push({ id: 'REQ-1', name: 'R1' });
+    // Assertion with no realised_via — covers the whole subject.
+    canon.assertions.push({ id: 'ASS-1', about: 'REQ-1', subject: 'PROD-1', status: 'compliant' });
+    const matrix = buildImpactMatrix(
+      canon,
+      {
+        id: 'V', name: 'V',
+        subjects: { products: ['PROD-1'] },
+        obligations: {},
+        grouping: { columns: 'product-stage' },
+      },
+      [{ subjectId: 'PROD-1', stages: [{ id: 'S1', name: 's1' }, { id: 'S2', name: 's2' }] }],
+    );
+    // Both stage columns should be bound (no realised_via means all stages inherit).
+    expect(matrix.cells[0][0].kind).toBe('bound');
+    expect(matrix.cells[0][1].kind).toBe('bound');
+  });
+
+  it('assertion with realised_via fills only the matching stage column', () => {
+    const canon = emptyCanon();
+    canon.requirements.push({ id: 'REQ-1', name: 'R1' });
+    // Assertion only covers STAGE-A.
+    canon.assertions.push({
+      id: 'ASS-1', about: 'REQ-1', subject: 'PROD-1', status: 'compliant',
+      realised_via: ['STAGE-A'],
+    });
+    const matrix = buildImpactMatrix(
+      canon,
+      {
+        id: 'V', name: 'V',
+        subjects: { products: ['PROD-1'] },
+        obligations: {},
+        grouping: { columns: 'product-stage' },
+      },
+      [{ subjectId: 'PROD-1', stages: [{ id: 'STAGE-A', name: 'a' }, { id: 'STAGE-B', name: 'b' }] }],
+    );
+    expect(matrix.cells[0][0].kind).toBe('bound');   // STAGE-A: covered
+    expect(matrix.cells[0][1].kind).toBe('gap');     // STAGE-B: gap
+  });
+
+  it('subject with no stage mapping falls back to single product-grain column', () => {
+    const canon = buildCanon();
+    const matrix = buildImpactMatrix(
+      canon,
+      {
+        ...baseConfig,
+        subjects: { products: ['PRODUCT-A-1', 'PRODUCT-B-1'] },
+        grouping: { columns: 'product-stage' },
+      },
+      // Only provide stages for A — B falls back to a single column.
+      [{ subjectId: 'PRODUCT-A-1', stages: [{ id: 'S1', name: 's1' }] }],
+    );
+    expect(matrix.columns.map(c => c.label)).toEqual(['PRODUCT-A-1:S1', 'PRODUCT-B-1']);
+    // PRODUCT-B-1 fallback column: no stageId.
+    expect(matrix.columns[1].stageId).toBeUndefined();
+  });
+
+  it('extractStageGroups — returns null for non-blueprint docs', () => {
+    expect(extractStageGroups(null)).toBeNull();
+    expect(extractStageGroups({ notation: 'requirement', id: 'R1' })).toBeNull();
+    expect(extractStageGroups({ process_blueprint: { stages: [{ id: 'S1' }] } })).toBeNull(); // missing id
+  });
+
+  it('extractStageGroups — extracts subjectId and stages from process_blueprint wrapper', () => {
+    const doc = { process_blueprint: { id: 'PROC-1', notation: 'process_blueprint', stages: [{ id: 'S1', name: 'Stage One' }, { id: 'S2', name: 'Stage Two' }] } };
+    const sg = extractStageGroups(doc);
+    expect(sg).not.toBeNull();
+    expect(sg!.subjectId).toBe('PROC-1');
+    expect(sg!.stages.map((s: { id: string }) => s.id)).toEqual(['S1', 'S2']);
+  });
+
+  it('renderImpactMarkdown uses column labels in the table header', () => {
+    const canon = emptyCanon();
+    canon.requirements.push({ id: 'REQ-1', name: 'Req' });
+    canon.assertions.push({ id: 'ASS-1', about: 'REQ-1', subject: 'PROD-1', status: 'compliant' });
+    const matrix = buildImpactMatrix(
+      canon,
+      {
+        id: 'V', name: 'Stage Report',
+        subjects: { products: ['PROD-1'] },
+        obligations: {},
+        grouping: { columns: 'product-stage' },
+      },
+      [{ subjectId: 'PROD-1', stages: [{ id: 'S1', name: 'Stage One' }] }],
+    );
+    const md = renderImpactMarkdown(matrix);
+    expect(md).toContain('PROD-1:S1');
   });
 });

--- a/packages/diagrams/src/compliance/classify.ts
+++ b/packages/diagrams/src/compliance/classify.ts
@@ -71,6 +71,7 @@ export function ingestComplianceDoc(canon: ComplianceCanon, doc: unknown): strin
       next_review_at: str(d.next_review_at),
       evidenceCount: Array.isArray(d.evidence) ? d.evidence.length : 0,
       admitted_at: str(d.admitted_at),
+      realised_via: strArray(d.realised_via),
     });
     return id;
   }

--- a/packages/diagrams/src/compliance/impact.ts
+++ b/packages/diagrams/src/compliance/impact.ts
@@ -10,7 +10,7 @@
 import type { AssertionStatus } from '../assertion/types.js';
 import type { ComplianceCanon } from './classify.js';
 import { buildComplianceIndex } from './reverse-index.js';
-import type { ComplianceIndex, IndexAssertion, IndexRequirement } from './types.js';
+import type { ComplianceIndex, IndexAssertion, IndexRequirement, StageGroupInput, StageGroupDef } from './types.js';
 
 /** Filter selecting REQUIREMENTs by codex source (jurisdiction / regime keys
  *  are accepted for forward compatibility but not yet honoured — the canon
@@ -34,6 +34,42 @@ export interface ImpactEmptyCellLabels {
   /** Label used when an admitted ASSERTION exists with status `n_a`
    *  (modelled fact: the obligation does not apply). */
   no_obligation_applies_label?: string;
+}
+
+// ── Column model (CV-3a) ────────────────────────────────────────────────────
+
+/**
+ * A matrix column descriptor.
+ *
+ * At the coarsest grain (`grouping.columns: 'product'`) a column maps to a
+ * single subject: `{ subjectId, label: subjectId }`.
+ *
+ * At `grouping.columns: 'product-stage'` a column represents one (product,
+ * stage) pair: `{ subjectId: productId, stageId, label: productId + ':' + stageId }`.
+ * A cell is populated when an ASSERTION has `subject === subjectId` and
+ * `stageId ∈ assertion.realised_via` (or `realised_via` is absent, meaning
+ * the assertion covers the entire subject — it then contributes to every
+ * stage column for that subject).
+ */
+export interface ImpactColumn {
+  /** Subject (product / process / capability) the column belongs to. */
+  subjectId: string;
+  /** Stage ID — present only when grouping.columns is not 'product'. */
+  stageId?: string;
+  /** Human-readable column header. */
+  label: string;
+}
+
+/**
+ * Grouping options for matrix columns.
+ *
+ * `columns` controls the column grain:
+ *   - `'product'` (default) — one column per subject.
+ *   - `'product-stage'`     — one column per (subject, stage) pair derived
+ *     from `stageGroups` passed to `buildImpactMatrix`.
+ */
+export interface ImpactGrouping {
+  columns: 'product' | 'product-stage';
 }
 
 /**
@@ -66,6 +102,13 @@ export interface ImpactViewConfig {
   status_display?: ImpactStatusDisplay;
   empty_cells?: ImpactEmptyCellLabels;
   order_rows_by?: 'id' | 'name';
+  /**
+   * Column grouping options.  Omit (or set `columns: 'product'`) for the
+   * default single-column-per-subject behaviour.  Set `columns: 'product-stage'`
+   * and pass `stageGroups` into `buildImpactMatrix` to expand each subject
+   * into per-stage sub-columns.
+   */
+  grouping?: ImpactGrouping;
 }
 
 // ── Pinned defaults ─────────────────────────────────────────────────────────
@@ -93,6 +136,8 @@ export const COMPLIANCE_IMPACT_DEFAULTS = {
   obligations: { include: undefined as string[] | undefined, filter: undefined },
   /** Subjects: empty — must be supplied explicitly in the view config. */
   subjects: { products: [] as string[], processes: [] as string[] },
+  /** Column grain: one column per subject (no stage decomposition). */
+  grouping: { columns: 'product' as const },
 } as const;
 
 // ── View-config parser ──────────────────────────────────────────────────────
@@ -226,8 +271,13 @@ export interface ImpactMatrix {
   snapshotAt?: string;
   /** Row dimension — REQUIREMENT projections, in the configured order. */
   rows: IndexRequirement[];
-  /** Column dimension — subject IDs (PRODUCT ids in the coarsest grain). */
-  columns: string[];
+  /**
+   * Column dimension.
+   *
+   * At `grouping.columns: 'product'` (default) each entry has only `subjectId`
+   * and `label`.  At `'product-stage'` entries additionally carry `stageId`.
+   */
+  columns: ImpactColumn[];
   /** Cells, indexed as `cell[rowIdx][colIdx]`. */
   cells: ImpactCell[][];
   /** Canonical empty-cell labels actually used (after defaults applied). */
@@ -298,16 +348,63 @@ function aggregateStatus(assertions: IndexAssertion[]): AssertionStatus {
   return 'n_a';
 }
 
+// ── Column builder helpers (CV-3a) ──────────────────────────────────────────
+
+function buildProductColumns(config: ImpactViewConfig): ImpactColumn[] {
+  const subjects = [...(config.subjects.products ?? []), ...(config.subjects.processes ?? [])];
+  return subjects.map(id => ({ subjectId: id, label: id }));
+}
+
+function buildProductStageColumns(config: ImpactViewConfig, stageGroups: StageGroupInput[]): ImpactColumn[] {
+  const stageMap = new Map<string, StageGroupDef[]>(stageGroups.map(sg => [sg.subjectId, sg.stages]));
+  const subjects = [...(config.subjects.products ?? []), ...(config.subjects.processes ?? [])];
+  const cols: ImpactColumn[] = [];
+  for (const subjectId of subjects) {
+    const stages = stageMap.get(subjectId);
+    if (!stages || stages.length === 0) {
+      cols.push({ subjectId, label: subjectId });
+    } else {
+      for (const stage of stages) {
+        cols.push({ subjectId, stageId: stage.id, label: `${subjectId}:${stage.id}` });
+      }
+    }
+  }
+  return cols;
+}
+
 /**
- * Build the matrix per §5.2 at the `product` × `obligation` grain.
+ * Returns true when assertion `a` contributes to column `col`.
+ *
+ * At `'product'` grain: `a.subject` must match `col.subjectId`.
+ * At `'product-stage'` grain: `a.subject` must match AND either
+ * `a.realised_via` is absent (claim covers the whole subject, so every stage
+ * inherits it) OR `col.stageId` ∈ `a.realised_via`.
+ */
+function assertionMatchesColumn(a: IndexAssertion, col: ImpactColumn): boolean {
+  if (a.subject !== col.subjectId) return false;
+  if (!col.stageId) return true;
+  if (!a.realised_via || a.realised_via.length === 0) return true;
+  return a.realised_via.includes(col.stageId);
+}
+
+/**
+ * Build the matrix per §5.2.
+ *
+ * At the default `grouping.columns: 'product'` grain, one column per subject.
+ * At `grouping.columns: 'product-stage'`, pass `stageGroups` to expand each
+ * subject into per-stage sub-columns (typically extracted from a
+ * process-blueprint document via `extractStageGroups`).  Subjects with no
+ * stage mapping fall back to a single product-grain column automatically.
  *
  * Subjects are taken from `config.subjects.products` and
- * `config.subjects.processes` directly (in that order; no PRODUCT→PROCESS
- * derivation walk yet — that needs a `realises` index out of scope here).
- * Subjects with no binding obligation still appear as columns so the gap is
- * visible. Rows are the resolved obligations, ordered per `order_rows_by`.
+ * `config.subjects.processes` (in that order).  Subjects with no binding
+ * obligation still appear as columns so the gap is visible.
  */
-export function buildImpactMatrix(canon: ComplianceCanon, config: ImpactViewConfig): ImpactMatrix {
+export function buildImpactMatrix(
+  canon: ComplianceCanon,
+  config: ImpactViewConfig,
+  stageGroups?: StageGroupInput[],
+): ImpactMatrix {
   const index = buildComplianceIndex({
     requirements: canon.requirements,
     assertions: canon.assertions,
@@ -315,9 +412,11 @@ export function buildImpactMatrix(canon: ComplianceCanon, config: ImpactViewConf
 
   const obligations = orderRows(resolveObligations(config, index, canon.requirements), config.order_rows_by);
 
-  const products = config.subjects.products ?? [];
-  const processes = config.subjects.processes ?? [];
-  const columns = [...products, ...processes];
+  const useStageGrain =
+    config.grouping?.columns === 'product-stage' && stageGroups && stageGroups.length > 0;
+  const columns: ImpactColumn[] = useStageGrain
+    ? buildProductStageColumns(config, stageGroups!)
+    : buildProductColumns(config);
 
   const allowedStatuses = new Set<AssertionStatus>(
     config.status_display?.show ?? ['compliant', 'partial', 'non_compliant', 'under_review', 'n_a'],
@@ -326,13 +425,13 @@ export function buildImpactMatrix(canon: ComplianceCanon, config: ImpactViewConf
   const rowIndex = new Set(obligations.map(r => r.id));
   const cells: ImpactCell[][] = obligations.map(() => columns.map(() => emptyCell()));
 
-  // Walk the assertions index per subject and fill cells whose obligation is in scope.
   for (let c = 0; c < columns.length; c++) {
-    const subject = columns[c];
-    const subjectAssertions = index.assertionsBySubject.get(subject) ?? [];
+    const col = columns[c];
+    const subjectAssertions = index.assertionsBySubject.get(col.subjectId) ?? [];
     for (const a of subjectAssertions) {
       if (!rowIndex.has(a.about)) continue;
       if (!allowedStatuses.has(a.status)) continue;
+      if (!assertionMatchesColumn(a, col)) continue;
       const rowIdx = obligations.findIndex(r => r.id === a.about);
       if (rowIdx < 0) continue;
       cells[rowIdx][c].assertions.push(a);
@@ -377,6 +476,46 @@ export function buildImpactMatrix(canon: ComplianceCanon, config: ImpactViewConf
 
 function emptyCell(): ImpactCell {
   return { status: null, kind: 'gap', assertions: [] };
+}
+
+// ── Process-blueprint stage extractor (CV-3a) ───────────────────────────────
+
+/**
+ * Extract `StageGroupInput` from a raw (YAML-parsed) process-blueprint document.
+ *
+ * Accepts both the bare document object and the wrapped form
+ * (`{ process_blueprint: { id, stages: […] } }`).
+ * Returns `null` when the document is not a recognisable process-blueprint or
+ * has no `id` / `stages` array so callers can skip unrecognised files safely.
+ *
+ * Pass the returned value into `buildImpactMatrix` as part of the
+ * `stageGroups` array when `grouping.columns: 'product-stage'` is configured.
+ */
+export function extractStageGroups(doc: unknown): StageGroupInput | null {
+  if (!doc || typeof doc !== 'object' || Array.isArray(doc)) return null;
+  const top = doc as Record<string, unknown>;
+
+  const bp: Record<string, unknown> | null =
+    top.notation === 'process_blueprint'
+      ? top
+      : top.process_blueprint && typeof top.process_blueprint === 'object' && !Array.isArray(top.process_blueprint)
+        ? (top.process_blueprint as Record<string, unknown>)
+        : null;
+
+  if (!bp) return null;
+  const id = typeof bp.id === 'string' ? bp.id : null;
+  if (!id) return null;
+  if (!Array.isArray(bp.stages)) return null;
+
+  const stages: StageGroupDef[] = [];
+  for (const s of bp.stages) {
+    if (!s || typeof s !== 'object' || Array.isArray(s)) continue;
+    const sid = typeof s.id === 'string' ? s.id : null;
+    if (!sid) continue;
+    stages.push({ id: sid, name: typeof s.name === 'string' ? s.name : sid });
+  }
+
+  return { subjectId: id, stages };
 }
 
 // ── Markdown rendering ──────────────────────────────────────────────────────
@@ -424,7 +563,7 @@ export function renderImpactMarkdown(matrix: ImpactMatrix): string {
     return lines.join('\n') + '\n';
   }
 
-  const header = ['Obligation', ...matrix.columns.map(escMd)];
+  const header = ['Obligation', ...matrix.columns.map(col => escMd(col.label))];
   lines.push('| ' + header.join(' | ') + ' |');
   lines.push('|' + header.map(() => '---').join('|') + '|');
 

--- a/packages/diagrams/src/compliance/impact.ts
+++ b/packages/diagrams/src/compliance/impact.ts
@@ -10,7 +10,7 @@
 import type { AssertionStatus } from '../assertion/types.js';
 import type { ComplianceCanon } from './classify.js';
 import { buildComplianceIndex } from './reverse-index.js';
-import type { ComplianceIndex, IndexAssertion, IndexRequirement, StageGroupInput, StageGroupDef } from './types.js';
+import type { ComplianceIndex, IndexAssertion, IndexRequirement, ObjectDetailInput, ObjectDetailDef } from './types.js';
 
 /** Filter selecting REQUIREMENTs by codex source (jurisdiction / regime keys
  *  are accepted for forward compatibility but not yet honoured — the canon
@@ -66,10 +66,10 @@ export interface ImpactColumn {
  * `columns` controls the column grain:
  *   - `'product'` (default) — one column per subject.
  *   - `'product-stage'`     — one column per (subject, stage) pair derived
- *     from `stageGroups` passed to `buildImpactMatrix`.
+ *     from `objectDetails` passed to `buildImpactMatrix`.
  */
 export interface ImpactGrouping {
-  columns: 'object' | 'object-stage';
+  columns: 'object' | 'object-details';
 }
 
 /**
@@ -105,7 +105,7 @@ export interface ImpactViewConfig {
   /**
    * Column grouping options.  Omit (or set `columns: 'product'`) for the
    * default single-column-per-subject behaviour.  Set `columns: 'product-stage'`
-   * and pass `stageGroups` into `buildImpactMatrix` to expand each subject
+   * and pass `objectDetails` into `buildImpactMatrix` to expand each subject
    * into per-stage sub-columns.
    */
   grouping?: ImpactGrouping;
@@ -355,17 +355,17 @@ function buildProductColumns(config: ImpactViewConfig): ImpactColumn[] {
   return subjects.map(id => ({ subjectId: id, label: id }));
 }
 
-function buildProductStageColumns(config: ImpactViewConfig, stageGroups: StageGroupInput[]): ImpactColumn[] {
-  const stageMap = new Map<string, StageGroupDef[]>(stageGroups.map(sg => [sg.subjectId, sg.stages]));
+function buildObjectDetailColumns(config: ImpactViewConfig, objectDetails: ObjectDetailInput[]): ImpactColumn[] {
+  const detailMap = new Map<string, ObjectDetailDef[]>(objectDetails.map(d => [d.objectId, d.details]));
   const subjects = [...(config.subjects.products ?? []), ...(config.subjects.processes ?? [])];
   const cols: ImpactColumn[] = [];
   for (const subjectId of subjects) {
-    const stages = stageMap.get(subjectId);
-    if (!stages || stages.length === 0) {
+    const details = detailMap.get(subjectId);
+    if (!details || details.length === 0) {
       cols.push({ subjectId, label: subjectId });
     } else {
-      for (const stage of stages) {
-        cols.push({ subjectId, stageId: stage.id, label: `${subjectId}:${stage.id}` });
+      for (const detail of details) {
+        cols.push({ subjectId, stageId: detail.id, label: `${subjectId}:${detail.id}` });
       }
     }
   }
@@ -391,9 +391,9 @@ function assertionMatchesColumn(a: IndexAssertion, col: ImpactColumn): boolean {
  * Build the matrix per §5.2.
  *
  * At the default `grouping.columns: 'product'` grain, one column per subject.
- * At `grouping.columns: 'product-stage'`, pass `stageGroups` to expand each
+ * At `grouping.columns: 'product-stage'`, pass `objectDetails` to expand each
  * subject into per-stage sub-columns (typically extracted from a
- * process-blueprint document via `extractStageGroups`).  Subjects with no
+ * process-blueprint document via `extractObjectDetails`).  Subjects with no
  * stage mapping fall back to a single product-grain column automatically.
  *
  * Subjects are taken from `config.subjects.products` and
@@ -403,7 +403,7 @@ function assertionMatchesColumn(a: IndexAssertion, col: ImpactColumn): boolean {
 export function buildImpactMatrix(
   canon: ComplianceCanon,
   config: ImpactViewConfig,
-  stageGroups?: StageGroupInput[],
+  objectDetails?: ObjectDetailInput[],
 ): ImpactMatrix {
   const index = buildComplianceIndex({
     requirements: canon.requirements,
@@ -413,9 +413,9 @@ export function buildImpactMatrix(
   const obligations = orderRows(resolveObligations(config, index, canon.requirements), config.order_rows_by);
 
   const useStageGrain =
-    config.grouping?.columns === 'object-stage' && stageGroups && stageGroups.length > 0;
+    config.grouping?.columns === 'object-details' && objectDetails && objectDetails.length > 0;
   const columns: ImpactColumn[] = useStageGrain
-    ? buildProductStageColumns(config, stageGroups!)
+    ? buildObjectDetailColumns(config, objectDetails!)
     : buildProductColumns(config);
 
   const allowedStatuses = new Set<AssertionStatus>(
@@ -481,7 +481,7 @@ function emptyCell(): ImpactCell {
 // ── Process-blueprint stage extractor (CV-3a) ───────────────────────────────
 
 /**
- * Extract `StageGroupInput` from a raw (YAML-parsed) process-blueprint document.
+ * Extract `ObjectDetailInput` from a raw (YAML-parsed) process-blueprint document.
  *
  * Accepts both the bare document object and the wrapped form
  * (`{ process_blueprint: { id, stages: […] } }`).
@@ -489,9 +489,9 @@ function emptyCell(): ImpactCell {
  * has no `id` / `stages` array so callers can skip unrecognised files safely.
  *
  * Pass the returned value into `buildImpactMatrix` as part of the
- * `stageGroups` array when `grouping.columns: 'product-stage'` is configured.
+ * `objectDetails` array when `grouping.columns: 'product-stage'` is configured.
  */
-export function extractStageGroups(doc: unknown): StageGroupInput | null {
+export function extractObjectDetails(doc: unknown): ObjectDetailInput | null {
   if (!doc || typeof doc !== 'object' || Array.isArray(doc)) return null;
   const top = doc as Record<string, unknown>;
 
@@ -507,15 +507,15 @@ export function extractStageGroups(doc: unknown): StageGroupInput | null {
   if (!id) return null;
   if (!Array.isArray(bp.stages)) return null;
 
-  const stages: StageGroupDef[] = [];
+  const details: ObjectDetailDef[] = [];
   for (const s of bp.stages) {
     if (!s || typeof s !== 'object' || Array.isArray(s)) continue;
     const sid = typeof s.id === 'string' ? s.id : null;
     if (!sid) continue;
-    stages.push({ id: sid, name: typeof s.name === 'string' ? s.name : sid });
+    details.push({ id: sid, name: typeof s.name === 'string' ? s.name : sid });
   }
 
-  return { subjectId: id, stages };
+  return { objectId: id, details };
 }
 
 // ── Markdown rendering ──────────────────────────────────────────────────────

--- a/packages/diagrams/src/compliance/impact.ts
+++ b/packages/diagrams/src/compliance/impact.ts
@@ -69,7 +69,7 @@ export interface ImpactColumn {
  *     from `stageGroups` passed to `buildImpactMatrix`.
  */
 export interface ImpactGrouping {
-  columns: 'product' | 'product-stage';
+  columns: 'object' | 'object-stage';
 }
 
 /**
@@ -136,8 +136,8 @@ export const COMPLIANCE_IMPACT_DEFAULTS = {
   obligations: { include: undefined as string[] | undefined, filter: undefined },
   /** Subjects: empty — must be supplied explicitly in the view config. */
   subjects: { products: [] as string[], processes: [] as string[] },
-  /** Column grain: one column per subject (no stage decomposition). */
-  grouping: { columns: 'product' as const },
+  /** Column grain: one column per business object (no stage decomposition). */
+  grouping: { columns: 'object' as const },
 } as const;
 
 // ── View-config parser ──────────────────────────────────────────────────────
@@ -413,7 +413,7 @@ export function buildImpactMatrix(
   const obligations = orderRows(resolveObligations(config, index, canon.requirements), config.order_rows_by);
 
   const useStageGrain =
-    config.grouping?.columns === 'product-stage' && stageGroups && stageGroups.length > 0;
+    config.grouping?.columns === 'object-stage' && stageGroups && stageGroups.length > 0;
   const columns: ImpactColumn[] = useStageGrain
     ? buildProductStageColumns(config, stageGroups!)
     : buildProductColumns(config);

--- a/packages/diagrams/src/compliance/index.ts
+++ b/packages/diagrams/src/compliance/index.ts
@@ -8,10 +8,12 @@ export { renderComplianceMarkdown } from './markdown.js';
 export type { ReportScope, MarkdownOptions } from './markdown.js';
 export { renderComplianceHtml } from './html.js';
 export type { HtmlOptions } from './html.js';
-export { buildImpactMatrix, renderImpactMarkdown, parseImpactViewConfig, COMPLIANCE_IMPACT_DEFAULTS } from './impact.js';
+export { buildImpactMatrix, renderImpactMarkdown, parseImpactViewConfig, COMPLIANCE_IMPACT_DEFAULTS, extractStageGroups } from './impact.js';
 export type {
   ImpactCell,
+  ImpactColumn,
   ImpactEmptyCellLabels,
+  ImpactGrouping,
   ImpactMatrix,
   ImpactObligationFilter,
   ImpactStatusDisplay,
@@ -34,4 +36,6 @@ export type {
   LawTreeRequirement,
   ProductView,
   ProductRequirementStatus,
+  StageGroupDef,
+  StageGroupInput,
 } from './types.js';

--- a/packages/diagrams/src/compliance/index.ts
+++ b/packages/diagrams/src/compliance/index.ts
@@ -8,7 +8,7 @@ export { renderComplianceMarkdown } from './markdown.js';
 export type { ReportScope, MarkdownOptions } from './markdown.js';
 export { renderComplianceHtml } from './html.js';
 export type { HtmlOptions } from './html.js';
-export { buildImpactMatrix, renderImpactMarkdown, parseImpactViewConfig, COMPLIANCE_IMPACT_DEFAULTS, extractStageGroups } from './impact.js';
+export { buildImpactMatrix, renderImpactMarkdown, parseImpactViewConfig, COMPLIANCE_IMPACT_DEFAULTS, extractObjectDetails } from './impact.js';
 export type {
   ImpactCell,
   ImpactColumn,
@@ -36,6 +36,6 @@ export type {
   LawTreeRequirement,
   ProductView,
   ProductRequirementStatus,
-  StageGroupDef,
-  StageGroupInput,
+  ObjectDetailDef,
+  ObjectDetailInput,
 } from './types.js';

--- a/packages/diagrams/src/compliance/types.ts
+++ b/packages/diagrams/src/compliance/types.ts
@@ -40,21 +40,22 @@ export interface IndexAssertion {
 
 // ── Stage grouping (CV-3a) ──────────────────────────────────────────────────
 
-/** One stage / task within a process flow, used as a matrix sub-column. */
-export interface StageGroupDef {
+/** One detail-level element of a business object, used as a matrix sub-column. */
+export interface ObjectDetailDef {
   id: string;
   name: string;
 }
 
 /**
- * Maps a subject (product / process) to its ordered stages.
+ * Maps a business object to its ordered detail elements.
  * Passed into `buildImpactMatrix` when `grouping.columns` is
- * `product-stage` or `product-stage-task`. Typically extracted from a
- * process-blueprint document via `extractStageGroups`.
+ * `object-details`. The details can be process stages, product
+ * components, capability modules, etc. — whatever sub-structure the object
+ * exposes. Typically extracted from a process-blueprint via`extractObjectDetails`.
  */
-export interface StageGroupInput {
-  subjectId: string;
-  stages: StageGroupDef[];
+export interface ObjectDetailInput {
+  objectId: string;
+  details: ObjectDetailDef[];
 }
 
 export interface ComplianceIndexInput {

--- a/packages/diagrams/src/compliance/types.ts
+++ b/packages/diagrams/src/compliance/types.ts
@@ -28,6 +28,33 @@ export interface IndexAssertion {
   evidenceCount?: number;
   /** Admission date (CONTRACT §6) — feeds DQ-1 freshness decay. */
   admitted_at?: string;
+  /**
+   * Typed IDs of the stages / tasks where the requirement is realised for
+   * the subject (16-assertion.md §2 `realised_via`). Populated when the
+   * assertion carries granular evidence; absent when the claim covers the
+   * entire subject without stage decomposition. CV-3a uses this to fill
+   * stage-grouped matrix cells.
+   */
+  realised_via?: string[];
+}
+
+// ── Stage grouping (CV-3a) ──────────────────────────────────────────────────
+
+/** One stage / task within a process flow, used as a matrix sub-column. */
+export interface StageGroupDef {
+  id: string;
+  name: string;
+}
+
+/**
+ * Maps a subject (product / process) to its ordered stages.
+ * Passed into `buildImpactMatrix` when `grouping.columns` is
+ * `product-stage` or `product-stage-task`. Typically extracted from a
+ * process-blueprint document via `extractStageGroups`.
+ */
+export interface StageGroupInput {
+  subjectId: string;
+  stages: StageGroupDef[];
 }
 
 export interface ComplianceIndexInput {

--- a/scripts/render-compliance-impact.mjs
+++ b/scripts/render-compliance-impact.mjs
@@ -243,14 +243,14 @@ async function main() {
 
   // Build stage groups when grouping.columns = 'product-stage'.
   let stageGroups;
-  if (view.grouping?.columns === 'product-stage') {
+  if (view.grouping?.columns === 'object-stage') {
     stageGroups = rawBlueprints.flatMap(doc => {
       const sg = extractStageGroups(doc);
       return sg ? [sg] : [];
     });
     if (stageGroups.length === 0) {
       console.error(
-        '[render-compliance-impact] warning: grouping.columns=product-stage but no process-blueprint ' +
+        '[render-compliance-impact] warning: grouping.columns=object-stage but no process-blueprint ' +
           'documents found in the canon root — falling back to product grain.',
       );
     } else {

--- a/scripts/render-compliance-impact.mjs
+++ b/scripts/render-compliance-impact.mjs
@@ -4,8 +4,12 @@
  * (vkgeorgia/strategy#84, builds on #166 interim renderer).
  *
  * Materialises the subject × obligation × status matrix per the render
- * contract in methodology/notations/views/21-compliance-impact.md §5, at
- * the coarsest grain (`product` × `obligation`).
+ * contract in methodology/notations/views/21-compliance-impact.md §5.
+ * Supports two column grains:
+ *   - product (default)      — one column per subject.
+ *   - product-stage (CV-3a)  — one column per (subject, stage) pair; requires
+ *     process-blueprint YAML files to be present in the canon root so
+ *     `extractStageGroups` can map subject IDs to their ordered stages.
  *
  * Usage — named view-config file:
  *   node scripts/render-compliance-impact.mjs \
@@ -174,7 +178,15 @@ async function main() {
     process.exit(3);
   }
   const diagrams = await import(pathToFileURL(DIST_INDEX).href);
-  const { emptyCanon, ingestComplianceDoc, buildImpactMatrix, renderImpactMarkdown, parseImpactViewConfig, COMPLIANCE_IMPACT_DEFAULTS } = diagrams;
+  const {
+    emptyCanon,
+    ingestComplianceDoc,
+    buildImpactMatrix,
+    renderImpactMarkdown,
+    parseImpactViewConfig,
+    COMPLIANCE_IMPACT_DEFAULTS,
+    extractStageGroups,
+  } = diagrams;
 
   // Resolve the view config.
   let viewRaw;
@@ -200,8 +212,10 @@ async function main() {
   if (view.snapshot_at) console.error(`[render-compliance-impact] snapshot_at: ${view.snapshot_at}`);
   logActiveDefaults(view, COMPLIANCE_IMPACT_DEFAULTS);
 
-  // Scan canon.
+  // Scan canon — collect compliance artefacts and process-blueprints (for stage grouping).
   const canon = emptyCanon();
+  /** Raw parsed YAML docs that look like process-blueprints, for extractStageGroups. */
+  const rawBlueprints = [];
   let scanned = 0;
   let ingested = 0;
   for await (const file of walkYaml(args.canon)) {
@@ -214,6 +228,11 @@ async function main() {
       continue;
     }
     if (ingestComplianceDoc(canon, parsed)) ingested += 1;
+    // Collect process-blueprints for stage-grouping (CV-3a).
+    const bp = parsed?.process_blueprint ?? parsed;
+    if (bp?.notation === 'process_blueprint' || parsed?.process_blueprint) {
+      rawBlueprints.push(parsed);
+    }
   }
 
   console.error(
@@ -222,7 +241,27 @@ async function main() {
       `assertions=${canon.assertions.length})`,
   );
 
-  const matrix = buildImpactMatrix(canon, view);
+  // Build stage groups when grouping.columns = 'product-stage'.
+  let stageGroups;
+  if (view.grouping?.columns === 'product-stage') {
+    stageGroups = rawBlueprints.flatMap(doc => {
+      const sg = extractStageGroups(doc);
+      return sg ? [sg] : [];
+    });
+    if (stageGroups.length === 0) {
+      console.error(
+        '[render-compliance-impact] warning: grouping.columns=product-stage but no process-blueprint ' +
+          'documents found in the canon root — falling back to product grain.',
+      );
+    } else {
+      console.error(
+        `[render-compliance-impact] stage-grouping: ${stageGroups.length} blueprint(s), ` +
+          stageGroups.map(sg => `${sg.subjectId}(${sg.stages.length} stages)`).join(', '),
+      );
+    }
+  }
+
+  const matrix = buildImpactMatrix(canon, view, stageGroups);
   const md = renderImpactMarkdown(matrix);
 
   if (args.output) {

--- a/scripts/render-compliance-impact.mjs
+++ b/scripts/render-compliance-impact.mjs
@@ -9,7 +9,7 @@
  *   - product (default)      — one column per subject.
  *   - product-stage (CV-3a)  — one column per (subject, stage) pair; requires
  *     process-blueprint YAML files to be present in the canon root so
- *     `extractStageGroups` can map subject IDs to their ordered stages.
+ *     `extractObjectDetails` can map subject IDs to their ordered stages.
  *
  * Usage — named view-config file:
  *   node scripts/render-compliance-impact.mjs \
@@ -185,7 +185,7 @@ async function main() {
     renderImpactMarkdown,
     parseImpactViewConfig,
     COMPLIANCE_IMPACT_DEFAULTS,
-    extractStageGroups,
+    extractObjectDetails,
   } = diagrams;
 
   // Resolve the view config.
@@ -214,7 +214,7 @@ async function main() {
 
   // Scan canon — collect compliance artefacts and process-blueprints (for stage grouping).
   const canon = emptyCanon();
-  /** Raw parsed YAML docs that look like process-blueprints, for extractStageGroups. */
+  /** Raw parsed YAML docs that look like process-blueprints, for extractObjectDetails. */
   const rawBlueprints = [];
   let scanned = 0;
   let ingested = 0;
@@ -242,26 +242,26 @@ async function main() {
   );
 
   // Build stage groups when grouping.columns = 'product-stage'.
-  let stageGroups;
-  if (view.grouping?.columns === 'object-stage') {
-    stageGroups = rawBlueprints.flatMap(doc => {
-      const sg = extractStageGroups(doc);
-      return sg ? [sg] : [];
+  let objectDetails;
+  if (view.grouping?.columns === 'object-details') {
+    objectDetails = rawBlueprints.flatMap(doc => {
+      const sg = extractObjectDetails(doc);
+      return sg ? [d] : [];
     });
-    if (stageGroups.length === 0) {
+    if (objectDetails.length === 0) {
       console.error(
-        '[render-compliance-impact] warning: grouping.columns=object-stage but no process-blueprint ' +
+        '[render-compliance-impact] warning: grouping.columns=object-details but no process-blueprint ' +
           'documents found in the canon root — falling back to product grain.',
       );
     } else {
       console.error(
-        `[render-compliance-impact] stage-grouping: ${stageGroups.length} blueprint(s), ` +
-          stageGroups.map(sg => `${sg.subjectId}(${sg.stages.length} stages)`).join(', '),
+        `[render-compliance-impact] stage-grouping: ${objectDetails.length} blueprint(s), ` +
+          objectDetails.map(d => `${d.objectId}(${d.details.length} details)`).join(', '),
       );
     }
   }
 
-  const matrix = buildImpactMatrix(canon, view, stageGroups);
+  const matrix = buildImpactMatrix(canon, view, objectDetails);
   const md = renderImpactMarkdown(matrix);
 
   if (args.output) {


### PR DESCRIPTION
﻿## CV-3a — Stage/task grouping for compliance-impact matrix

Implements stage-level column decomposition for the compliance-impact matrix,
deferred by the interim renderer (strategy#84 CV-3a).

### What changed

**Library (@transitrix/diagrams)**

- **IndexAssertion.realised_via?: string[]** — captured from ASSERTION YAML via ingestComplianceDoc; links an assertion to specific stages/tasks of its subject.
- **ImpactColumn** — structured column descriptor replacing the raw string in ImpactMatrix.columns: carries subjectId, optional stageId, and display label.
- **ImpactGrouping / grouping? on ImpactViewConfig** — selects column grain: 'product' (default, unchanged behaviour) or 'product-stage'.
- **uildImpactMatrix(canon, config, stageGroups?)** — optional third parameter; when grouping.columns: product-stage, expands each subject into per-stage sub-columns using stageGroups. Assertions without ealised_via fill every stage column for their subject (subject-level claim). Subjects without a stage mapping fall back silently to a single product-grain column.
- **extractStageGroups(doc)** — pure helper: extracts StageGroupInput from a raw process-blueprint YAML document (both bare and process_blueprint:-wrapped shapes); returns 
ull for unrecognised docs.
- **StageGroupDef, StageGroupInput** — new types in compliance/types.ts.
- 8 new tests added to impact.test.ts; all **668 tests green**.

**Extension (compliance-impact-preview.ts — CV-2 update)**

- pplyFilter return type and gridHtml parameter updated from string[] to ImpactColumn[]; column headers use col.label, pending-index lookup uses col.subjectId.

**CLI (scripts/render-compliance-impact.mjs)**

- Collects process-blueprint YAML files during canon scan; when grouping.columns=product-stage, runs extractStageGroups on each and passes the resulting array to uildImpactMatrix.
- Logs stage-mapping diagnostics to stderr for auditability.

### Acceptance test (manual)

1. Add grouping: { columns: product-stage } to a *.compliance-impact.view.yaml.
2. Add a *.process-blueprint.transitrix.yaml whose id matches a product in subjects.products.
3. Run 
ode scripts/render-compliance-impact.mjs --view <file> --canon <root>.
4. Expect columns PROD-1:STAGE-A, PROD-1:STAGE-B, etc.; assertions with ealised_via: [STAGE-A] fill only the STAGE-A column; assertions without ealised_via fill all stages.

### Dependencies

Based on main (after CV-1 #110 and CV-2 #111 merged). No stacked PR.

/cc strategy#84
