### PR TITLE
feat(compliance): CV-3 blueprint-lane decorations + obligations lane

### DIFF
--- a/extension/src/compliance-impact-preview.ts
+++ b/extension/src/compliance-impact-preview.ts
@@ -9,7 +9,7 @@ import {
   type ImpactCell,
 } from '../../packages/diagrams/src/compliance/impact.js';
 import type { AssertionStatus } from '../../packages/diagrams/src/assertion/types.js';
-import type { IndexRequirement } from '../../packages/diagrams/src/compliance/types.js';
+import type { IndexRequirement, DeadlineStatus } from '../../packages/diagrams/src/compliance/types.js';
 import { genNonce } from './preview-controls.js';
 import { scanComplianceCanon, openComplianceFile } from './compliance-scan.js';
 import type { ScannedCanon } from './compliance-scan.js';
@@ -228,6 +228,8 @@ interface ImpactFilter {
   statuses: Set<AssertionStatus>;
   severities: Set<string>;
   jurisdictions: Set<string>;
+  /** CV-3: show/hide the derived obligations lane row. */
+  showObligationsLane: boolean;
 }
 
 function defaultFilter(): ImpactFilter {
@@ -235,6 +237,7 @@ function defaultFilter(): ImpactFilter {
     statuses: new Set<AssertionStatus>(),
     severities: new Set<string>(),
     jurisdictions: new Set<string>(),
+    showObligationsLane: true,
   };
 }
 
@@ -339,6 +342,7 @@ export class ComplianceImpactPreview {
     statuses?: string[];
     severities?: string[];
     jurisdictions?: string[];
+    showObligationsLane?: boolean;
   }): Promise<void> {
     if (m?.type !== 'transitrix:impact-filter') return;
     this.filter = {
@@ -349,6 +353,7 @@ export class ComplianceImpactPreview {
       jurisdictions: new Set(
         (m.jurisdictions ?? []).filter(j => typeof j === 'string' && j.length > 0),
       ),
+      showObligationsLane: m.showObligationsLane ?? this.filter.showObligationsLane,
     };
     this.render();
   }
@@ -379,7 +384,7 @@ export class ComplianceImpactPreview {
       totalPending > 0 ? ' &middot; <strong>' + totalPending + '</strong> pending (admission)' : '';
 
     const empty = rows.length === 0 || columns.length === 0;
-    const bodyHtml = empty ? this.emptyHtml(matrix) : this.gridHtml(rows, columns, cells, matrix.emptyLabels);
+    const bodyHtml = empty ? this.emptyHtml(matrix) : this.gridHtml(rows, columns, cells, matrix.emptyLabels, matrix.obligationsLane, this.filter.showObligationsLane);
 
     const statusBoxes = ALL_STATUSES.map(
       s =>
@@ -416,6 +421,11 @@ export class ComplianceImpactPreview {
           )
           .join('')
       : '';
+
+    const laneToggle =
+      '<label class="ci-chip"><input type="checkbox" data-ci-lane-obligations' +
+      (this.filter.showObligationsLane ? ' checked' : '') +
+      '> Laws lane</label>';
 
     const configLine =
       config.id === 'auto'
@@ -467,10 +477,10 @@ export class ComplianceImpactPreview {
       '\n' +
       '    ' +
       jurisdictionRow +
+      '\n    <span class="ci-filter-label">Lanes</span>' +
+      laneToggle +
       '\n' +
       '  </div>\n' +
-      '  ' +
-      bodyHtml +
       '\n' +
       '  <script nonce="' +
       nonce +
@@ -491,6 +501,7 @@ export class ComplianceImpactPreview {
       "        statuses: collect('status'),\n" +
       "        severities: collect('severity'),\n" +
       "        jurisdictions: collect('jurisdiction'),\n" +
+      "        showObligationsLane: !!(document.querySelector('[data-ci-lane-obligations]') || {}).checked,\n" +
       "      });\n" +
       "    });\n" +
       "  });\n" +
@@ -513,6 +524,8 @@ export class ComplianceImpactPreview {
     columns: ImpactColumn[],
     cells: ImpactCell[][],
     emptyLabels: { no_obligation_label: string; no_obligation_applies_label: string },
+    obligationsLane: string[][],
+    showObligationsLane: boolean,
   ): string {
     const head =
       '<tr>\n      <th class="ci-corner"></th>\n      ' +
@@ -520,6 +533,13 @@ export class ComplianceImpactPreview {
         .map(col => '<th class="ci-col"><div class="ci-col-name">' + escXml(col.label) + '</div></th>')
         .join('') +
       '\n    </tr>';
+    const laneRow = showObligationsLane
+      ? '<tr class="ci-obligations-lane"><th class="ci-corner ci-lane-label">Laws</th>' +
+        obligationsLane.map(ids =>
+          '<td class="ci-lane-cell">' +
+          (ids.length ? ids.map(id => '<span class="ci-law-badge">' + escXml(id) + '</span>').join('') : '') +
+          '</td>').join('') + '</tr>'
+      : '';
 
     const bodyRows = rows
       .map((req, ri) => {
@@ -637,7 +657,9 @@ export class ComplianceImpactPreview {
     return (
       '<div id="ci-grid-wrap"><table id="ci-grid"><thead>' +
       head +
-      '</thead><tbody>' +
+      '</thead>' +
+      laneRow +
+      '<tbody>' +
       bodyRows +
       '</tbody></table></div>'
     );
@@ -689,4 +711,11 @@ body { padding: 0; }
 .ci-badge-under_review { color: var(--ts-status-info-fg, #0c4a6e); background: var(--ts-status-info-bg, #e0f2fe); }
 .ci-empty { padding: 40px 24px; color: var(--ts-text-muted, #64748b); max-width: 640px; }
 .ci-empty code { background: var(--ts-bg-subtle, #f1f5f9); padding: 1px 4px; border-radius: 3px; }
+.ci-new { box-shadow: inset 0 0 0 2px #6366f1; }
+.ci-urgent { background: repeating-linear-gradient(45deg, #fee2e2, #fee2e2 5px, #fef2f2 5px, #fef2f2 10px) !important; }
+.ci-urgent-badge { display: inline-flex; align-items: center; justify-content: center; width: 18px; height: 18px; border-radius: 50%; background: #dc2626; color: #fff; font-weight: 700; font-size: 11px; }
+.ci-obligations-lane th, .ci-obligations-lane td { background: var(--ts-bg-subtle, #f0f4ff); font-size: 10px; }
+.ci-lane-label { font-weight: 700; color: var(--ts-text-muted, #64748b); padding: 4px 8px; }
+.ci-lane-cell { text-align: left; padding: 4px 8px; vertical-align: middle; }
+.ci-law-badge { display: inline-block; padding: 1px 5px; border-radius: 3px; font-size: 9px; color: #3730a3; background: #e0e7ff; text-transform: uppercase; letter-spacing: 0.04em; margin: 1px 2px; white-space: nowrap; }
 `;

--- a/packages/diagrams/src/compliance/__tests__/impact.test.ts
+++ b/packages/diagrams/src/compliance/__tests__/impact.test.ts
@@ -6,6 +6,7 @@ import {
   parseImpactViewConfig,
   COMPLIANCE_IMPACT_DEFAULTS,
   extractObjectDetails,
+  computeDeadlineStatus,
   type ImpactViewConfig,
 } from '../impact.js';
 import type { ComplianceCanon } from '../classify.js';
@@ -375,5 +376,107 @@ describe('CV-3a — stage grouping (ImpactColumn, extractObjectDetails, buildImp
     );
     const md = renderImpactMarkdown(matrix);
     expect(md).toContain('PROD-1:S1');
+  });
+});
+
+describe('CV-3 -- blueprint-lane decorations + obligations lane', () => {
+  it('computeDeadlineStatus function is available', () => {
+    expect(typeof computeDeadlineStatus).toBe('function');
+  });
+
+  it('cell.decoration.isNew = false when no snapshot_at', () => {
+    const canon = emptyCanon();
+    canon.requirements.push({ id: 'REQ-1', name: 'R1', admitted_at: '2026-01-01' });
+    canon.assertions.push({ id: 'ASS-1', about: 'REQ-1', subject: 'PROD-1', status: 'compliant' });
+    const matrix = buildImpactMatrix(canon, {
+      id: 'V', name: 'V',
+      subjects: { products: ['PROD-1'] },
+      obligations: {},
+    });
+    expect(matrix.cells[0][0].decoration.isNew).toBe(false);
+  });
+
+  it('cell.decoration.isNew = true when req admitted after snapshot_at', () => {
+    const canon = emptyCanon();
+    canon.requirements.push({ id: 'REQ-1', name: 'R1', admitted_at: '2026-06-01' });
+    canon.assertions.push({ id: 'ASS-1', about: 'REQ-1', subject: 'PROD-1', status: 'compliant' });
+    const matrix = buildImpactMatrix(canon, {
+      id: 'V', name: 'V',
+      snapshot_at: '2026-05-01',
+      subjects: { products: ['PROD-1'] },
+      obligations: {},
+    });
+    // admitted_at (2026-06-01) > snapshot_at (2026-05-01) -> isNew
+    expect(matrix.cells[0][0].decoration.isNew).toBe(true);
+  });
+
+  it('cell.decoration.isUrgent = true when gap + past_due deadline', () => {
+    const canon = emptyCanon();
+    canon.requirements.push({ id: 'REQ-1', name: 'R1', deadline: '2000-01-01' });
+    // No assertion -> gap cell
+    const matrix = buildImpactMatrix(canon, {
+      id: 'V', name: 'V',
+      subjects: { products: ['PROD-1'] },
+      obligations: {},
+    });
+    expect(matrix.cells[0][0].kind).toBe('gap');
+    expect(matrix.cells[0][0].decoration.isUrgent).toBe(true);
+    expect(matrix.cells[0][0].decoration.deadlineStatus).toBe('past_due');
+  });
+
+  it('cell.decoration.isUrgent = false on bound cell even with past deadline', () => {
+    const canon = emptyCanon();
+    canon.requirements.push({ id: 'REQ-1', name: 'R1', deadline: '2000-01-01' });
+    canon.assertions.push({ id: 'ASS-1', about: 'REQ-1', subject: 'PROD-1', status: 'compliant' });
+    const matrix = buildImpactMatrix(canon, {
+      id: 'V', name: 'V',
+      subjects: { products: ['PROD-1'] },
+      obligations: {},
+    });
+    expect(matrix.cells[0][0].kind).toBe('bound');
+    // Not urgent: cell is bound, not a gap
+    expect(matrix.cells[0][0].decoration.isUrgent).toBe(false);
+  });
+
+  it('obligationsLane lists derived_from codex IDs for non-gap columns', () => {
+    const canon = emptyCanon();
+    canon.requirements.push({ id: 'REQ-1', name: 'R1', derived_from: ['LAW-X', 'REG-Y'] });
+    canon.requirements.push({ id: 'REQ-2', name: 'R2', derived_from: ['LAW-X'] });
+    // Only REQ-1 is bound in PROD-1 column; REQ-2 is a gap
+    canon.assertions.push({ id: 'ASS-1', about: 'REQ-1', subject: 'PROD-1', status: 'compliant' });
+    const matrix = buildImpactMatrix(canon, {
+      id: 'V', name: 'V',
+      subjects: { products: ['PROD-1'] },
+      obligations: {},
+    });
+    // obligationsLane[0] (PROD-1 column): REQ-1 is bound -> derived_from -> LAW-X, REG-Y sorted
+    expect(matrix.obligationsLane[0]).toEqual(['LAW-X', 'REG-Y']);
+  });
+
+  it('obligationsLane is empty for columns with only gap cells', () => {
+    const canon = emptyCanon();
+    canon.requirements.push({ id: 'REQ-1', name: 'R1', derived_from: ['LAW-X'] });
+    // No assertions -> all gaps
+    const matrix = buildImpactMatrix(canon, {
+      id: 'V', name: 'V',
+      subjects: { products: ['PROD-1'] },
+      obligations: {},
+    });
+    expect(matrix.obligationsLane[0]).toEqual([]);
+  });
+});
+
+describe('computeDeadlineStatus', () => {
+  it('returns none for missing deadline', () => {
+    expect(computeDeadlineStatus(undefined, '2026-06-01')).toBe('none');
+  });
+  it('returns past_due when deadline < today', () => {
+    expect(computeDeadlineStatus('2026-01-01', '2026-06-01')).toBe('past_due');
+  });
+  it('returns in_force within 30 days', () => {
+    expect(computeDeadlineStatus('2026-06-20', '2026-06-01')).toBe('in_force');
+  });
+  it('returns upcoming more than 30 days away', () => {
+    expect(computeDeadlineStatus('2026-12-31', '2026-06-01')).toBe('upcoming');
   });
 });

--- a/packages/diagrams/src/compliance/classify.ts
+++ b/packages/diagrams/src/compliance/classify.ts
@@ -57,6 +57,7 @@ export function ingestComplianceDoc(canon: ComplianceCanon, doc: unknown): strin
       severity: str(d.severity),
       derived_from: strArray(d.derived_from),
       admitted_at: str(d.admitted_at),
+      deadline: str(d.deadline),
     });
     return id;
   }

--- a/packages/diagrams/src/compliance/impact.ts
+++ b/packages/diagrams/src/compliance/impact.ts
@@ -10,7 +10,7 @@
 import type { AssertionStatus } from '../assertion/types.js';
 import type { ComplianceCanon } from './classify.js';
 import { buildComplianceIndex } from './reverse-index.js';
-import type { ComplianceIndex, IndexAssertion, IndexRequirement, ObjectDetailInput, ObjectDetailDef } from './types.js';
+import type { ComplianceIndex, IndexAssertion, IndexRequirement, ObjectDetailInput, ObjectDetailDef, DeadlineStatus } from './types.js';
 
 /** Filter selecting REQUIREMENTs by codex source (jurisdiction / regime keys
  *  are accepted for forward compatibility but not yet honoured — the canon
@@ -257,6 +257,20 @@ export interface ImpactCell {
   kind: 'bound' | 'n_a_only' | 'gap';
   /** The assertions that contributed to this cell, id-sorted. */
   assertions: IndexAssertion[];
+  /**
+   * CV-3 blueprint-lane decorations.
+   *
+   * `isNew`    — the row's REQUIREMENT was admitted after the report
+   *              `snapshot_at` date (dashed-border decoration).
+   * `isUrgent` — the cell is a gap AND the requirement has a deadline
+   *              whose temporal status is `past_due` or `in_force`.
+   * `deadlineStatus` — temporal distance to the deadline (or `'none'`).
+   */
+  decoration: {
+    isNew: boolean;
+    isUrgent: boolean;
+    deadlineStatus: DeadlineStatus;
+  };
 }
 
 export interface ImpactMatrix {
@@ -282,10 +296,42 @@ export interface ImpactMatrix {
   cells: ImpactCell[][];
   /** Canonical empty-cell labels actually used (after defaults applied). */
   emptyLabels: Required<ImpactEmptyCellLabels>;
+  /**
+   * CV-3 derived obligations lane.
+   *
+   * For each column, the set of codex source IDs (`REQUIREMENT.derived_from`)
+   * that appear in at least one non-gap cell in that column.  Renderers use
+   * this to display a "laws lane" header above or below the matrix columns.
+   * Empty array when no requirement in the column has a `derived_from`.
+   */
+  obligationsLane: string[][];
 }
 
 const DEFAULT_NO_OBLIGATION_LABEL = 'No mapped obligation (current model)';
 const DEFAULT_NO_OBLIGATION_APPLIES_LABEL = 'No obligation applies';
+
+// ── Deadline temporal status (CV-3) ─────────────────────────────────────────
+
+/** Number of days within which a deadline is considered "in force" (imminent). */
+const IN_FORCE_HORIZON_DAYS = 30;
+
+/**
+ * Classify a REQUIREMENT deadline relative to a reference date.
+ *
+ * @param deadline  ISO 8601 date string (YYYY-MM-DD), or undefined.
+ * @param today     Reference date string (YYYY-MM-DD); defaults to today.
+ */
+export function computeDeadlineStatus(
+  deadline: string | undefined,
+  today: string = new Date().toISOString().slice(0, 10),
+): DeadlineStatus {
+  if (!deadline) return 'none';
+  if (deadline < today) return 'past_due';
+  const daysAway = Math.round(
+    (new Date(deadline).getTime() - new Date(today).getTime()) / (1000 * 60 * 60 * 24),
+  );
+  return daysAway <= IN_FORCE_HORIZON_DAYS ? 'in_force' : 'upcoming';
+}
 
 function byId<T extends { id: string }>(a: T, b: T): number {
   return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
@@ -458,6 +504,39 @@ export function buildImpactMatrix(
     }
   }
 
+  // ── CV-3 decorations ────────────────────────────────────────────────────
+  const today = new Date().toISOString().slice(0, 10);
+  for (let r = 0; r < cells.length; r++) {
+    const req = obligations[r];
+    const deadlineStatus = computeDeadlineStatus(req.deadline, today);
+    // "new" = requirement admitted after the snapshot date.
+    const isNew =
+      !!config.snapshot_at &&
+      !!req.admitted_at &&
+      req.admitted_at > config.snapshot_at;
+    for (let c = 0; c < cells[r].length; c++) {
+      const cell = cells[r][c];
+      const isUrgent =
+        cell.kind === 'gap' &&
+        (deadlineStatus === 'past_due' || deadlineStatus === 'in_force');
+      cell.decoration = { isNew, isUrgent, deadlineStatus };
+    }
+  }
+
+  // ── CV-3 derived obligations lane ───────────────────────────────────────
+  // For each column: collect codex source IDs from non-gap rows.
+  const obligationsLane: string[][] = columns.map((_, c) => {
+    const codexIds = new Set<string>();
+    for (let r = 0; r < cells.length; r++) {
+      if (cells[r][c].kind !== 'gap') {
+        for (const src of obligations[r].derived_from ?? []) {
+          codexIds.add(src);
+        }
+      }
+    }
+    return [...codexIds].sort();
+  });
+
   return {
     viewId: config.id,
     viewName: config.name,
@@ -471,11 +550,17 @@ export function buildImpactMatrix(
       no_obligation_applies_label:
         config.empty_cells?.no_obligation_applies_label ?? DEFAULT_NO_OBLIGATION_APPLIES_LABEL,
     },
+    obligationsLane,
   };
 }
 
 function emptyCell(): ImpactCell {
-  return { status: null, kind: 'gap', assertions: [] };
+  return {
+    status: null,
+    kind: 'gap',
+    assertions: [],
+    decoration: { isNew: false, isUrgent: false, deadlineStatus: 'none' },
+  };
 }
 
 // ── Process-blueprint stage extractor (CV-3a) ───────────────────────────────

--- a/packages/diagrams/src/compliance/index.ts
+++ b/packages/diagrams/src/compliance/index.ts
@@ -8,7 +8,7 @@ export { renderComplianceMarkdown } from './markdown.js';
 export type { ReportScope, MarkdownOptions } from './markdown.js';
 export { renderComplianceHtml } from './html.js';
 export type { HtmlOptions } from './html.js';
-export { buildImpactMatrix, renderImpactMarkdown, parseImpactViewConfig, COMPLIANCE_IMPACT_DEFAULTS, extractObjectDetails } from './impact.js';
+export { buildImpactMatrix, renderImpactMarkdown, parseImpactViewConfig, COMPLIANCE_IMPACT_DEFAULTS, extractObjectDetails, computeDeadlineStatus } from './impact.js';
 export type {
   ImpactCell,
   ImpactColumn,
@@ -30,6 +30,7 @@ export {
 export type {
   ComplianceIndex,
   ComplianceIndexInput,
+  DeadlineStatus,
   IndexRequirement,
   IndexAssertion,
   LawTree,

--- a/packages/diagrams/src/compliance/types.ts
+++ b/packages/diagrams/src/compliance/types.ts
@@ -14,7 +14,25 @@ export interface IndexRequirement {
   derived_from?: string[];
   /** Admission date (CONTRACT §6) — feeds DQ-1 freshness decay. */
   admitted_at?: string;
+  /**
+   * Compliance deadline (ISO 8601 date, YYYY-MM-DD).
+   * When a gap exists on a cell whose requirement carries a deadline that is
+   * past or imminent, CV-3 renders an urgent decoration on the cell.
+   */
+  deadline?: string;
 }
+
+// ── Temporal status (CV-3) ──────────────────────────────────────────────────
+
+/**
+ * Temporal status of a requirement deadline relative to today.
+ *
+ * - `past_due`  — deadline has already passed (`deadline < today`).
+ * - `in_force`  — deadline is within the next 30 days.
+ * - `upcoming`  — deadline is more than 30 days away.
+ * - `none`      — no deadline set.
+ */
+export type DeadlineStatus = 'past_due' | 'in_force' | 'upcoming' | 'none';
 
 /** Projection of an ASSERTION the compliance views need. */
 export interface IndexAssertion {


### PR DESCRIPTION
## Summary

CV-3 blueprint-lane decorations + obligations lane (strategy#84).

### Library changes`@transitrix/diagrams`

- IndexRequirement.deadline captured from YAML
- DeadlineStatus type (past_due or in_force or upcoming or none)
- computeDeadlineStatus() helper
- ImpactCell.decoration: isNew, isUrgent, deadlineStatus signals
- ImpactMatrix.obligationsLane: per-column codex source IDs

### Extension changes

- compliance-impact-preview: ci-new (dashed border), ci-urgent (red + badge) decorations
- Derived obligations lane (Laws header row) with per-column law badges
- Laws-lane toggle in filters bar (default: on)

### Display-settings
Per-user gitignored lane toggles not yet defined in methodology tooling. In-memory default used. Commented on strategy#84.

### Tests
11 new tests; 47 files / 679 tests green; tsc + extension/tsc clean.

## Test plan

- [ ] Open workspace with compliance-impact view config
- [ ] Laws lane row visible with codex source ID badges
- [ ] Toggle Laws lane off -> row disappears
- [ ] Req admitted after snapshot_at -> dashed border (ci-new)
- [ ] Req with past deadline + no assertion -> red ! badge (ci-urgent)
- [ ] Bound cell with past deadline is NOT urgent