### PR TITLE
feat(compliance): CV-4 deadline badge in single-law + single-product views

### DIFF
--- a/extension/src/compliance-render.ts
+++ b/extension/src/compliance-render.ts
@@ -1,6 +1,7 @@
 import { generateWebviewCss, type ThemeId } from '../../packages/diagrams/src/theme/index.js';
 import type { AssertionStatus } from '../../packages/diagrams/src/assertion/types.js';
 import type { ViewScore } from '../../packages/diagrams/src/confidence/index.js';
+import { computeDeadlineStatus } from '../../packages/diagrams/src/compliance/impact.js';
 
 // Shared HTML rendering for the script-less compliance views — the single-law
 // tree and single-product view (vkgeorgia/strategy#84 Phase 3). These previews
@@ -23,6 +24,16 @@ export function escXml(s: string): string {
 /** A coloured status pill. */
 export function statusBadge(status: AssertionStatus): string {
   return `<span class="cmp-badge cmp-${status}">${escXml(STATUS_LABELS[status])}</span>`;
+}
+
+/**
+ * A coloured deadline pill. Returns an empty string when `deadline` is absent.
+ * Uses today (ISO YYYY-MM-DD) from the caller to stay clock-free in the library.
+ */
+export function deadlineBadge(deadline: string | undefined, today: string): string {
+  if (!deadline) return '';
+  const ds = computeDeadlineStatus(deadline, today);
+  return `<span class="cmp-deadline cmp-dl-${ds}" title="Deadline: ${escXml(deadline)}">${escXml(deadline)}</span>`;
 }
 
 /**
@@ -77,6 +88,13 @@ body { padding: 0; }
 .cmp-list th, .cmp-list td { border: 1px solid var(--ts-border, #cbd5e1); padding: 6px 12px; text-align: left; }
 .cmp-list th { background: var(--ts-bg-subtle, #f1f5f9); color: var(--ts-text, #0f172a); }
 .cmp-empty { color: var(--ts-text-muted, #64748b); padding: 24px 0; max-width: 640px; }
+
+/* Deadline pill (CV-4) */
+.cmp-deadline { display: inline-block; padding: 1px 6px; border-radius: 3px; font-size: 10px; font-family: var(--vscode-editor-font-family, monospace); margin-left: 4px; }
+.cmp-dl-past_due { background: var(--ts-status-error-bg, #fee2e2); color: var(--ts-status-error-fg, #991b1b); font-weight: 700; }
+.cmp-dl-in_force { background: var(--ts-status-warning-bg, #fef9c3); color: var(--ts-status-warning-fg, #854d0e); font-weight: 600; }
+.cmp-dl-upcoming { background: var(--ts-bg-subtle, #f1f5f9); color: var(--ts-text-muted, #64748b); }
+.cmp-dl-none { display: none; }
 
 /* Gap dashboard sections */
 .cmp-section { margin: 0 0 22px; max-width: 860px; }

--- a/extension/src/single-law-preview.ts
+++ b/extension/src/single-law-preview.ts
@@ -4,7 +4,7 @@ import yaml from 'js-yaml';
 import { type ThemeId } from '../../packages/diagrams/src/theme/index.js';
 import { buildComplianceIndex, buildLawTree, scoreComplianceView, type LawTree } from '../../packages/diagrams/src/compliance/index.js';
 import { scanComplianceCanon } from './compliance-scan.js';
-import { complianceShell, escXml, openLink, statusBadge } from './compliance-render.js';
+import { complianceShell, deadlineBadge, escXml, openLink, statusBadge } from './compliance-render.js';
 
 /** Today as ISO YYYY-MM-DD (extension host clock; the library stays clock-free). */
 function todayIso(): string {
@@ -111,9 +111,11 @@ export class SingleLawPreview {
     if (tree.requirements.length === 0) {
       return `<div class="cmp-empty">No requirements derive from <strong>${escXml(tree.lawId)}</strong>. Add <code>derived_from: [${escXml(tree.lawId)}]</code> to a requirement to bind it.</div>`;
     }
+    const today = new Date().toISOString().slice(0, 10);
     return tree.requirements.map(node => {
       const r = node.requirement;
       const sev = r.severity ? `<span class="cmp-sev cmp-sev-${escXml(r.severity)}">${escXml(r.severity)}</span>` : '';
+      const dl = deadlineBadge(r.deadline, today);
       const reqLink = openLink(OPEN_FILE_COMMAND, pathById.get(r.id), escXml(r.name), `Open ${r.id}`);
       const assertions = node.assertions.length === 0
         ? `<div class="cmp-none">No assertion targets this requirement — compliance gap.</div>`
@@ -123,7 +125,7 @@ export class SingleLawPreview {
             return `<li>${statusBadge(a.status)} ${link}${meta ? ` <span class="cmp-meta">${escXml(meta)}</span>` : ''}</li>`;
           }).join('')}</ul>`;
       return `<div class="cmp-req">
-        <div class="cmp-req-head">${sev}<span class="cmp-req-name">${reqLink}</span><span class="cmp-req-id">${escXml(r.id)}</span></div>
+        <div class="cmp-req-head">${sev}<span class="cmp-req-name">${reqLink}</span><span class="cmp-req-id">${escXml(r.id)}</span>${dl}</div>
         ${assertions}
       </div>`;
     }).join('');

--- a/extension/src/single-product-preview.ts
+++ b/extension/src/single-product-preview.ts
@@ -4,7 +4,7 @@ import yaml from 'js-yaml';
 import { type ThemeId } from '../../packages/diagrams/src/theme/index.js';
 import { buildComplianceIndex, buildProductView, scoreComplianceView, type ProductView } from '../../packages/diagrams/src/compliance/index.js';
 import { scanComplianceCanon } from './compliance-scan.js';
-import { complianceShell, escXml, openLink, statusBadge } from './compliance-render.js';
+import { complianceShell, deadlineBadge, escXml, openLink, statusBadge } from './compliance-render.js';
 
 /** Today as ISO YYYY-MM-DD (extension host clock; the library stays clock-free). */
 function todayIso(): string {
@@ -108,19 +108,22 @@ export class SingleProductPreview {
     if (view.requirements.length === 0) {
       return `<div class="cmp-empty">No assertion names <strong>${escXml(view.productId)}</strong> as its subject yet — this product has no recorded compliance claims.</div>`;
     }
+    const today = todayIso();
     const rows = view.requirements.map(({ requirement, assertion }) => {
       const reqLink = openLink(OPEN_FILE_COMMAND, pathById.get(requirement.id), escXml(requirement.name), `Open ${requirement.id}`);
       const aLink = openLink(OPEN_FILE_COMMAND, pathById.get(assertion.id), escXml(assertion.id), `Open ${assertion.id}`);
       const review = assertion.next_review_at ? escXml(assertion.next_review_at) : '—';
+      const dl = deadlineBadge(requirement.deadline, today);
       return `<tr>
         <td>${reqLink}<div class="cmp-req-id">${escXml(requirement.id)}</div></td>
         <td>${statusBadge(assertion.status)}</td>
         <td>${aLink}</td>
         <td>${review}</td>
+        <td>${dl || '—'}</td>
       </tr>`;
     }).join('');
     return `<table class="cmp-list">
-      <thead><tr><th>Requirement</th><th>Status</th><th>Assertion</th><th>Next review</th></tr></thead>
+      <thead><tr><th>Requirement</th><th>Status</th><th>Assertion</th><th>Next review</th><th>Deadline</th></tr></thead>
       <tbody>${rows}</tbody>
     </table>`;
   }


### PR DESCRIPTION
## Summary

CV-4 single-law tree + single-product views (strategy#84). Phase 3 (PR #90, merged 2026-06-02) implemented the core views; this PR aligns them with CV-3's deadline concept.

### Changes

- **compliance-render.ts**: new deadlineBadge(deadline, today) helper that calls computeDeadlineStatus from the library and renders a coloured pill. CSS for three deadline states:
  - .cmp-dl-past_due -- red, bold (deadline has passed)
  - .cmp-dl-in_force -- amber (within 30 days)
  - .cmp-dl-upcoming -- muted grey
- **single-law-preview.ts**: deadline pill rendered next to each requirement ID in the law tree.
- **single-product-preview.ts**: Deadline column added to the requirements table.

### Notes

No library changes; no new tests needed (computeDeadlineStatus is tested in CV-3). 679 tests green; tsc + extension/tsc clean.

## Test plan

- [ ] Open a codex file (LAW/REGULATION) -- single-law tree shows deadline pill on requirements that have a deadline
- [ ] Requirement with past deadline shows red pill
- [ ] Requirement with deadline within 30 days shows amber pill
- [ ] Open a product file -- single-product table has Deadline column
- [ ] Requirement without deadline shows dash