### PR TITLE
feat(compliance): CV-5 past-deadline requirements in gap dashboard

### DIFF
--- a/extension/src/gap-dashboard-preview.ts
+++ b/extension/src/gap-dashboard-preview.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 import { type ThemeId } from '../../packages/diagrams/src/theme/index.js';
 import { buildComplianceIndex, buildGapReport, scoreComplianceView, type GapReport } from '../../packages/diagrams/src/compliance/index.js';
 import { scanComplianceCanon } from './compliance-scan.js';
-import { complianceShell, escXml, openLink, statusBadge } from './compliance-render.js';
+import { complianceShell, deadlineBadge, escXml, openLink, statusBadge } from './compliance-render.js';
 import type { ViewScore } from '../../packages/diagrams/src/confidence/index.js';
 
 // Gap dashboard (vkgeorgia/strategy#84 Phase 4). A repo-wide operational view
@@ -86,15 +86,20 @@ export class GapDashboardPreview {
     for (const a of report.staleAssertions) {
       rows.push(['stale_assertion', a.id, `about=${a.about}|subject=${a.subject}`, a.status, a.next_review_at ?? '']);
     }
+    for (const r of report.pastDeadlineRequirements) {
+      rows.push(['past_deadline_requirement', r.id, r.name, r.severity ?? '', r.deadline ?? '']);
+    }
     return rows.map(cols => cols.map(esc).join(',')).join('\r\n') + '\r\n';
   }
 
   private buildHtml(report: GapReport, themeId: ThemeId): string {
-    const total = report.requirementsWithoutAssertions.length + report.assertionsWithoutEvidence.length + report.staleAssertions.length;
+    const total = report.requirementsWithoutAssertions.length + report.assertionsWithoutEvidence.length + report.staleAssertions.length + report.pastDeadlineRequirements.length;
 
+    const today = todayIso();
     const reqRows = report.requirementsWithoutAssertions.map(r => {
       const sev = r.severity ? `<span class="cmp-sev cmp-sev-${escXml(r.severity)}">${escXml(r.severity)}</span>` : '';
-      return `<li>${sev}${openLink(OPEN_FILE_COMMAND, this.pathById.get(r.id), escXml(r.name), `Open ${r.id}`)}<span class="cmp-meta">${escXml(r.id)}</span></li>`;
+      const dl = deadlineBadge(r.deadline, today);
+      return `<li>${sev}${openLink(OPEN_FILE_COMMAND, this.pathById.get(r.id), escXml(r.name), `Open ${r.id}`)}<span class="cmp-meta">${escXml(r.id)}</span>${dl}</li>`;
     }).join('');
 
     const noEvRows = report.assertionsWithoutEvidence.map(a =>
@@ -105,6 +110,12 @@ export class GapDashboardPreview {
       `<li>${statusBadge(a.status)}${openLink(OPEN_FILE_COMMAND, this.pathById.get(a.id), escXml(a.id), `Open ${a.id}`)}<span class="cmp-meta">${escXml(`review due ${a.next_review_at ?? '—'} · subject ${a.subject}`)}</span></li>`,
     ).join('');
 
+    const pastDlRows = report.pastDeadlineRequirements.map(r => {
+      const sev = r.severity ? `<span class="cmp-sev cmp-sev-${escXml(r.severity)}">${escXml(r.severity)}</span>` : '';
+      const dl = deadlineBadge(r.deadline, today);
+      return `<li>${sev}${openLink(OPEN_FILE_COMMAND, this.pathById.get(r.id), escXml(r.name), `Open ${r.id}`)}<span class="cmp-meta">${escXml(r.id)}</span> ${dl}</li>`;
+    }).join('');
+
     const section = (title: string, count: number, rowsHtml: string, okMessage: string): string =>
       `<div class="cmp-section">
         <h2>${escXml(title)} <span class="cmp-count">(${count})</span></h2>
@@ -114,11 +125,12 @@ export class GapDashboardPreview {
     const body = `
       ${section('Requirements without assertions', report.requirementsWithoutAssertions.length, reqRows, 'Every requirement has at least one assertion.')}
       ${section('Assertions without evidence (ASSERT-007)', report.assertionsWithoutEvidence.length, noEvRows, 'No compliant/partial assertion is missing evidence.')}
-      ${section('Stale assertions — review overdue (ASSERT-008)', report.staleAssertions.length, staleRows, 'No assertion is past its review date.')}`;
+      ${section('Stale assertions — review overdue (ASSERT-008)', report.staleAssertions.length, staleRows, 'No assertion is past its review date.')}
+      ${section('Past-deadline requirements (CV-5)', report.pastDeadlineRequirements.length, pastDlRows, 'No requirement has a past deadline without full compliance.')}`;
 
     return complianceShell({
       title: 'Compliance Gap Dashboard',
-      subtitle: total === 0 ? 'No gaps found' : `${total} gap(s) across 3 checks`,
+      subtitle: total === 0 ? 'No gaps found' : `${total} gap(s) across 4 checks`,
       themeId,
       refreshCommand: REFRESH_COMMAND,
       extraButtons: [{ command: EXPORT_CSV_COMMAND, label: 'Export CSV', title: 'Save the gap report as a CSV file' }],

--- a/packages/diagrams/src/compliance/__tests__/gap-report.test.ts
+++ b/packages/diagrams/src/compliance/__tests__/gap-report.test.ts
@@ -81,3 +81,49 @@ describe('gap report — acme_corp worked examples', () => {
     expect(report.staleAssertions).toEqual([]);
   });
 });
+
+describe('CV-5 -- pastDeadlineRequirements', () => {
+  it('lists requirements with past deadline and no compliant assertion', () => {
+    const indexLocal = buildComplianceIndex({
+      requirements: [
+        { id: 'REQ-PD-1', name: 'Past deadline, no assertion', deadline: '2020-01-01' },
+        { id: 'REQ-PD-2', name: 'Past deadline, non-compliant assertion', deadline: '2020-01-01' },
+        { id: 'REQ-PD-3', name: 'Past deadline, compliant assertion', deadline: '2020-01-01' },
+        { id: 'REQ-FU-1', name: 'Future deadline', deadline: '2099-01-01' },
+        { id: 'REQ-ND-1', name: 'No deadline' },
+      ],
+      assertions: [
+        { id: 'ASS-2', about: 'REQ-PD-2', subject: 'S', status: 'non_compliant' },
+        { id: 'ASS-3', about: 'REQ-PD-3', subject: 'S', status: 'compliant' },
+      ],
+    });
+    const r = buildGapReport(indexLocal, { today: '2026-06-09' });
+    // REQ-PD-1 and REQ-PD-2 are past-deadline without full compliance
+    expect(r.pastDeadlineRequirements.map(x => x.id)).toEqual(['REQ-PD-1', 'REQ-PD-2']);
+    // REQ-PD-3 has a compliant assertion -> excluded
+    expect(r.pastDeadlineRequirements.map(x => x.id)).not.toContain('REQ-PD-3');
+    // Future or no deadline -> excluded
+    expect(r.pastDeadlineRequirements.map(x => x.id)).not.toContain('REQ-FU-1');
+    expect(r.pastDeadlineRequirements.map(x => x.id)).not.toContain('REQ-ND-1');
+  });
+
+  it('is empty when no today is supplied (clock-free)', () => {
+    const idx2 = buildComplianceIndex({
+      requirements: [{ id: 'REQ-PD-1', name: 'Past', deadline: '2020-01-01' }],
+      assertions: [],
+    });
+    expect(buildGapReport(idx2, {}).pastDeadlineRequirements).toEqual([]);
+  });
+
+  it('sorts oldest deadline first', () => {
+    const idx3 = buildComplianceIndex({
+      requirements: [
+        { id: 'REQ-A', name: 'A', deadline: '2022-06-01' },
+        { id: 'REQ-B', name: 'B', deadline: '2019-01-01' },
+      ],
+      assertions: [],
+    });
+    const r3 = buildGapReport(idx3, { today: '2026-06-09' });
+    expect(r3.pastDeadlineRequirements.map(x => x.id)).toEqual(['REQ-B', 'REQ-A']);
+  });
+});

--- a/packages/diagrams/src/compliance/gap-report.ts
+++ b/packages/diagrams/src/compliance/gap-report.ts
@@ -1,14 +1,17 @@
-// Gap dashboard report (vkgeorgia/strategy#84 Phase 4).
+// Gap dashboard report (vkgeorgia/strategy#84 Phase 4 / CV-5).
 //
-// Three operational gap lists computed from the shared reverse-index (Phase 3):
+// Four operational gap lists computed from the shared reverse-index (Phase 3):
 //   1. Requirements with no Assertion targeting them (severity-sorted).
 //   2. Assertions without evidence — the ASSERT-007 case: status ∈
 //      {compliant, partial} AND no evidence. `under_review` / `non_compliant` /
 //      `n_a` are NOT positive statuses, so an empty-evidence assertion in those
 //      states is legitimate and is not flagged (matches 16-assertion.md §5).
 //   3. Stale Assertions — the ASSERT-008 case: `next_review_at` is in the past.
+//   4. Past-deadline requirements (CV-5) — REQUIREMENT.deadline < today AND
+//      the requirement has no fully-compliant assertion. Deadline-missed gaps.
 
 import type { ComplianceIndex, IndexAssertion, IndexRequirement } from './types.js';
+import { computeDeadlineStatus } from './impact.js';
 
 export interface GapReport {
   /** Requirements with no assertion about them, severity-sorted then id. */
@@ -17,6 +20,12 @@ export interface GapReport {
   assertionsWithoutEvidence: IndexAssertion[];
   /** ASSERT-008: next_review_at in the past (only when `today` is supplied). */
   staleAssertions: IndexAssertion[];
+  /**
+   * CV-5: requirements whose `deadline` is `past_due` (deadline < today) AND
+   * that lack a fully-compliant assertion. Deadline-missed gaps, deadline-sorted
+   * (oldest first). Empty when `today` is not supplied.
+   */
+  pastDeadlineRequirements: IndexRequirement[];
 }
 
 export interface GapReportOptions {
@@ -63,5 +72,23 @@ export function buildGapReport(index: ComplianceIndex, options: GapReportOptions
     return ra < rb ? -1 : ra > rb ? 1 : a.id < b.id ? -1 : 1;
   });
 
-  return { requirementsWithoutAssertions, assertionsWithoutEvidence, staleAssertions };
+  // CV-5: past-deadline requirements — deadline < today, not fully compliant.
+  const pastDeadlineRequirements = today
+    ? [...index.requirementById.values()]
+        .filter(r => {
+          if (computeDeadlineStatus(r.deadline, today) !== 'past_due') return false;
+          // Check if any assertion claims compliant status for this requirement.
+          const assertions = index.assertionsByRequirement.get(r.id) ?? [];
+          const hasCompliant = assertions.some(a => a.status === 'compliant');
+          return !hasCompliant;
+        })
+        .sort((a, b) => {
+          // Oldest deadline first — most overdue at the top.
+          const da = a.deadline ?? '';
+          const db = b.deadline ?? '';
+          return da < db ? -1 : da > db ? 1 : a.id < b.id ? -1 : 1;
+        })
+    : [];
+
+  return { requirementsWithoutAssertions, assertionsWithoutEvidence, staleAssertions, pastDeadlineRequirements };
 }


### PR DESCRIPTION
## Summary

CV-5 gap dashboard extension (strategy#84). Phase 4 (PR #91, merged 2026-06-02) implemented 3 gap checks; this PR adds the 4th: past-deadline requirements.

### Library changes (@transitrix/diagrams)

**gap-report.ts** — new GapReport.pastDeadlineRequirements field:
- Requirements whose REQUIREMENT.deadline is past_due (deadline < today) AND that lack any compliant assertion.
- Sorted oldest-deadline-first (most overdue at top).
- Uses computeDeadlineStatus from impact.ts (CV-3).
- Empty when 	oday is not supplied — library stays clock-free.

### Extension changes

**gap-dashboard-preview.ts**:
- New 4th section: 'Past-deadline requirements (CV-5)' with green all-clear when empty.
- Deadline badge added to requirements in the first section (Requirements without assertions).
- Subtitle updated to 'N gap(s) across 4 checks'.
- CSV export includes past_deadline_requirement rows.

### Tests

3 new tests for pastDeadlineRequirements: basic filtering, clock-free empty, oldest-first sort. 47 files / 682 tests green; tsc + extension/tsc clean.

## Test plan

- [ ] Open gap dashboard -- 4th section 'Past-deadline requirements' appears
- [ ] Add a requirement with deadline: 2020-01-01, no assertion -> appears in section 4
- [ ] Add a compliant assertion -> disappears from section 4
- [ ] Requirement with future deadline is NOT listed
- [ ] Export CSV includes past_deadline_requirement rows
- [ ] All-clear state shows green tick when no past-deadline gaps