### PR TITLE
feat(compliance): CV-6 -- export-compliance named view-config path (#84)

### DIFF
--- a/packages/diagrams/src/compliance/__tests__/html.test.ts
+++ b/packages/diagrams/src/compliance/__tests__/html.test.ts
@@ -105,3 +105,38 @@ describe('renderComplianceHtml — gap', () => {
     expect(html).toMatch(/1 gap\(s\)/);
   });
 });
+
+// ── CV-6: renderImpactMatrixHtml ─────────────────────────────────────────────
+
+import { renderImpactMatrixHtml } from '../html.js';
+import { buildImpactMatrix } from '../impact.js';
+
+describe('renderImpactMatrixHtml (CV-6)', () => {
+  it('returns a complete HTML document with matrix title and table', () => {
+    const canon = emptyCanon();
+    ingestComplianceDoc(canon, { notation: 'product', id: 'PROD-1', name: 'Product One' });
+    ingestComplianceDoc(canon, { notation: 'requirement', id: 'REQ-1', name: 'Req One', severity: 'high' });
+    ingestComplianceDoc(canon, { notation: 'assertion', id: 'ASS-1', about: 'REQ-1', subject: 'PROD-1', status: 'compliant' });
+    const matrix = buildImpactMatrix(
+      { products: canon.products, requirements: canon.requirements, assertions: canon.assertions, codex: canon.codex },
+      { id: 'VIEW-1', name: 'My View', subjects: { products: ['PROD-1'] }, obligations: {} },
+    );
+    const html = renderImpactMatrixHtml(matrix, { today: '2026-06-09' });
+    expect(html).toContain('<table>');
+    expect(html).toContain('My View');
+    expect(html).toContain('VIEW-1');
+    expect(html).toContain('OK');
+  });
+
+  it('renders gap cells with no_obligation_label text', () => {
+    const canon = emptyCanon();
+    ingestComplianceDoc(canon, { notation: 'product', id: 'PROD-1', name: 'P1' });
+    ingestComplianceDoc(canon, { notation: 'requirement', id: 'REQ-1', name: 'R1' });
+    const matrix = buildImpactMatrix(
+      { products: canon.products, requirements: canon.requirements, assertions: canon.assertions, codex: canon.codex },
+      { id: 'V2', name: 'V2', subjects: { products: ['PROD-1'] }, obligations: {} },
+    );
+    const html = renderImpactMatrixHtml(matrix);
+    expect(html).toContain('No mapped obligation');
+  });
+});

--- a/packages/diagrams/src/compliance/__tests__/markdown.test.ts
+++ b/packages/diagrams/src/compliance/__tests__/markdown.test.ts
@@ -81,3 +81,15 @@ describe('renderComplianceMarkdown — acme conformance', () => {
     expect(md).toContain('`REQUIREMENT-AUDIT-LOG-RETENTION-1`');
   });
 });
+
+describe('gapMarkdown CV-5 pastDeadlineRequirements section', () => {
+  it('includes the 4th section in output', () => {
+    const canon = emptyCanon();
+    ingestComplianceDoc(canon, { notation: 'requirement', id: 'REQ-PD-1', name: 'Past', deadline: '2020-01-01' });
+    const md = renderComplianceMarkdown(canon, { mode: 'gap' }, { today: '2026-06-09' });
+    expect(md).toContain('Past-deadline requirements');
+    expect(md).toContain('REQ-PD-1');
+    expect(md).toContain('2020-01-01');
+    expect(md).toContain('4 checks');
+  });
+});

--- a/packages/diagrams/src/compliance/html.ts
+++ b/packages/diagrams/src/compliance/html.ts
@@ -15,6 +15,7 @@ import { buildGapReport } from './gap-report.js';
 import type { ComplianceCanon } from './classify.js';
 import type { ReportScope } from './markdown.js';
 import type { AssertionStatus } from '../assertion/types.js';
+import type { ImpactMatrix } from './impact.js';
 
 const STATUS_LABELS: Record<AssertionStatus, string> = {
   compliant: 'Compliant',
@@ -199,7 +200,7 @@ export function renderComplianceHtml(canon: ComplianceCanon, scope: ReportScope,
         return `<section class="cmp-section"><h2>${escHtml(heading)} <span class="cmp-count">(${count})</span></h2>${body}</section>`;
       };
       const reqs = report.requirementsWithoutAssertions.map(r => (
-        `<li><code>${escHtml(r.id)}</code> ${escHtml(r.name)}${r.severity ? ` <span class="cmp-meta">severity ${escHtml(r.severity)}</span>` : ''}</li>`
+        `<li><code>${escHtml(r.id)}</code> ${escHtml(r.name)}${r.severity ? ` <span class="cmp-meta">severity ${escHtml(r.severity)}</span>` : ''}${r.deadline ? ` <span class="cmp-meta">deadline ${escHtml(r.deadline)}</span>` : ''}</li>`
       ));
       const noEvidence = report.assertionsWithoutEvidence.map(a => (
         `<li><code>${escHtml(a.id)}</code> <span class="cmp-meta">about <code>${escHtml(a.about)}</code>, subject <code>${escHtml(a.subject)}</code>, status ${escHtml(a.status)}</span></li>`
@@ -207,13 +208,88 @@ export function renderComplianceHtml(canon: ComplianceCanon, scope: ReportScope,
       const stale = report.staleAssertions.map(a => (
         `<li><code>${escHtml(a.id)}</code> <span class="cmp-meta">review due ${a.next_review_at ? escHtml(a.next_review_at) : '—'}, subject <code>${escHtml(a.subject)}</code></span></li>`
       ));
+      const pastDl = report.pastDeadlineRequirements.map(r => (
+        `<li><code>${escHtml(r.id)}</code> ${escHtml(r.name)} <span class="cmp-meta">deadline ${r.deadline ? escHtml(r.deadline) : '—'}${r.severity ? `, severity ${escHtml(r.severity)}` : ''}</span></li>`
+      ));
+      const total4 = report.requirementsWithoutAssertions.length + report.assertionsWithoutEvidence.length + report.staleAssertions.length + report.pastDeadlineRequirements.length;
       const body = [
-        summary,
+        `<p class="cmp-summary">${total4} gap(s) across 4 checks</p>`,
         section('Requirements without assertions', report.requirementsWithoutAssertions.length, reqs),
         section('Assertions without evidence — ASSERT-007', report.assertionsWithoutEvidence.length, noEvidence),
         section('Stale assertions — ASSERT-008', report.staleAssertions.length, stale),
+        section('Past-deadline requirements (CV-5)', report.pastDeadlineRequirements.length, pastDl),
       ].join('');
       return htmlDoc(title, options.today, body);
     }
   }
+}
+
+// ── CV-6: Impact matrix HTML renderer ───────────────────────────────────────
+
+export interface ImpactMatrixHtmlOptions {
+  /** Today as ISO YYYY-MM-DD — stamped in the document header. */
+  today?: string;
+}
+
+/**
+ * Renders an `ImpactMatrix` (from `buildImpactMatrix`) as a self-contained
+ * A4 HTML document suitable for WeasyPrint PDF output.
+ *
+ * Used by `cervin export-compliance --report <id> --format pdf`.
+ */
+export function renderImpactMatrixHtml(matrix: ImpactMatrix, options: ImpactMatrixHtmlOptions = {}): string {
+  const STATUS_GLYPH: Partial<Record<string, string>> = {
+    compliant: 'OK', partial: 'PARTIAL', non_compliant: 'FAIL',
+    under_review: 'REVIEW', n_a: 'N/A',
+  };
+  const statusClass = (s: string | null) => s ?? 'gap';
+
+  const colHeaders = matrix.columns.map(c => `<th>${escHtml(c.label)}</th>`).join('');
+  const head = `<tr><th>Obligation</th>${colHeaders}</tr>`;
+  const rows = matrix.rows.map((req, ri) => {
+    const rowLabel = `${escHtml(req.id)}${req.name && req.name !== req.id ? ` — ${escHtml(req.name)}` : ''}`;
+    const cells = matrix.cells[ri].map(cell => {
+      if (cell.kind === 'gap') return `<td class="cmp-gap">${escHtml(matrix.emptyLabels.no_obligation_label)}</td>`;
+      if (cell.kind === 'n_a_only') return `<td class="cmp-na">${escHtml(matrix.emptyLabels.no_obligation_applies_label)}</td>`;
+      const glyph = STATUS_GLYPH[cell.status ?? ''] ?? String(cell.status);
+      return `<td class="cmp-${statusClass(cell.status)}">${escHtml(glyph)}</td>`;
+    }).join('');
+    const dlInfo = req.deadline ? ` <span class="cmp-dl">⚑ ${escHtml(req.deadline)}</span>` : '';
+    return `<tr><td class="cmp-row-label">${rowLabel}${dlInfo}</td>${cells}</tr>`;
+  }).join('');
+
+  const snapshotLine = matrix.snapshotAt ? `<span>Snapshot: ${escHtml(matrix.snapshotAt)}</span>` : '';
+  const desc = matrix.description ? `<p>${escHtml(matrix.description)}</p>` : '';
+
+  const extraCss = `
+table { border-collapse: collapse; width: 100%; font-size: 9pt; }
+th, td { border: 1px solid #cbd5e1; padding: 3pt 5pt; text-align: center; vertical-align: middle; }
+td.cmp-row-label { text-align: left; font-size: 8.5pt; max-width: 180pt; white-space: normal; }
+.cmp-compliant { background: #d1fae5; color: #065f46; font-weight: 700; }
+.cmp-partial { background: #fef9c3; color: #854d0e; font-weight: 700; }
+.cmp-non_compliant { background: #fee2e2; color: #991b1b; font-weight: 700; }
+.cmp-under_review { background: #e0f2fe; color: #0c4a6e; }
+.cmp-gap { background: #f8fafc; color: #94a3b8; font-size: 8pt; }
+.cmp-na { background: #f1f5f9; color: #94a3b8; font-size: 8pt; }
+.cmp-dl { color: #b45309; font-size: 8pt; }`;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<style>
+${CSS}
+${extraCss}
+</style>
+</head>
+<body>
+<div class="cmp-header">
+  <div class="cmp-eyebrow">Compliance Impact Matrix</div>
+  <h1>${escHtml(matrix.viewName)}</h1>
+  <div class="cmp-stamp">View: <code>${escHtml(matrix.viewId)}</code> ${snapshotLine}${options.today ? ` · Generated: ${escHtml(options.today)}` : ''}</div>
+</div>
+${desc}
+<table><thead>${head}</thead><tbody>${rows}</tbody></table>
+</body>
+</html>`;
 }

--- a/packages/diagrams/src/compliance/index.ts
+++ b/packages/diagrams/src/compliance/index.ts
@@ -6,8 +6,8 @@ export { emptyCanon, ingestComplianceDoc } from './classify.js';
 export type { ComplianceCanon, ComplianceProduct, ComplianceCodexDoc } from './classify.js';
 export { renderComplianceMarkdown } from './markdown.js';
 export type { ReportScope, MarkdownOptions } from './markdown.js';
-export { renderComplianceHtml } from './html.js';
-export type { HtmlOptions } from './html.js';
+export { renderComplianceHtml, renderImpactMatrixHtml } from './html.js';
+export type { HtmlOptions, ImpactMatrixHtmlOptions } from './html.js';
 export { buildImpactMatrix, renderImpactMarkdown, parseImpactViewConfig, COMPLIANCE_IMPACT_DEFAULTS, extractObjectDetails, computeDeadlineStatus } from './impact.js';
 export type {
   ImpactCell,

--- a/packages/diagrams/src/compliance/markdown.ts
+++ b/packages/diagrams/src/compliance/markdown.ts
@@ -112,12 +112,12 @@ function productMarkdown(canon: ComplianceCanon, productId: string): string {
 function gapMarkdown(canon: ComplianceCanon, today?: string): string {
   const index = buildComplianceIndex({ requirements: canon.requirements, assertions: canon.assertions });
   const report = buildGapReport(index, { today });
-  const total = report.requirementsWithoutAssertions.length + report.assertionsWithoutEvidence.length + report.staleAssertions.length;
-  const out: string[] = ['# Compliance Gap Dashboard', '', `_${total} gap(s)_`, ''];
+  const total = report.requirementsWithoutAssertions.length + report.assertionsWithoutEvidence.length + report.staleAssertions.length + report.pastDeadlineRequirements.length;
+  const out: string[] = ['# Compliance Gap Dashboard', '', `_${total} gap(s) across 4 checks_`, ''];
 
   out.push(`## Requirements without assertions (${report.requirementsWithoutAssertions.length})`, '');
   if (report.requirementsWithoutAssertions.length === 0) out.push('_✓ none_', '');
-  else { for (const r of report.requirementsWithoutAssertions) out.push(`- [ ] \`${r.id}\` ${r.name}${r.severity ? ` — severity: ${r.severity}` : ''}`); out.push(''); }
+  else { for (const r of report.requirementsWithoutAssertions) out.push(`- [ ] \`${r.id}\` ${r.name}${r.severity ? ` — severity: ${r.severity}` : ''}${r.deadline ? ` — deadline: ${r.deadline}` : ''}`); out.push(''); }
 
   out.push(`## Assertions without evidence — ASSERT-007 (${report.assertionsWithoutEvidence.length})`, '');
   if (report.assertionsWithoutEvidence.length === 0) out.push('_✓ none_', '');
@@ -126,6 +126,10 @@ function gapMarkdown(canon: ComplianceCanon, today?: string): string {
   out.push(`## Stale assertions — ASSERT-008 (${report.staleAssertions.length})`, '');
   if (report.staleAssertions.length === 0) out.push('_✓ none_', '');
   else { for (const a of report.staleAssertions) out.push(`- [ ] \`${a.id}\` — review due ${a.next_review_at ?? '—'}, subject \`${a.subject}\``); out.push(''); }
+
+  out.push(`## Past-deadline requirements — CV-5 (${report.pastDeadlineRequirements.length})`, '');
+  if (report.pastDeadlineRequirements.length === 0) out.push('_✓ none_', '');
+  else { for (const r of report.pastDeadlineRequirements) out.push(`- [ ] \`${r.id}\` ${r.name} — deadline: ${r.deadline ?? '—'}${r.severity ? `, severity: ${r.severity}` : ''}`); out.push(''); }
 
   return out.join('\n');
 }

--- a/src/export-compliance.ts
+++ b/src/export-compliance.ts
@@ -18,6 +18,10 @@ import {
   ingestComplianceDoc,
   renderComplianceMarkdown,
   renderComplianceHtml,
+  renderImpactMatrixHtml,
+  buildImpactMatrix,
+  parseImpactViewConfig,
+  renderImpactMarkdown,
   type ComplianceCanon,
   type ReportScope,
 } from '../packages/diagrams/src/compliance/index.js';
@@ -25,6 +29,50 @@ import {
 function flagValue(argv: string[], name: string): string | undefined {
   const i = argv.indexOf(name);
   return i >= 0 && i + 1 < argv.length ? argv[i + 1] : undefined;
+}
+
+/**
+ * CV-6: loads a named view-config YAML from a registry directory.
+ * Tries `<registry>/<id>.compliance-impact.view.yaml` then `<registry>/<id>.yaml`.
+ * Falls back to scanning `<root>` for a file whose `id` field matches.
+ */
+function loadViewConfigRaw(registry: string | undefined, reportId: string, root: string): unknown | null {
+  const candidates: string[] = [];
+  if (registry) {
+    candidates.push(
+      path.join(registry, `${reportId}.compliance-impact.view.yaml`),
+      path.join(registry, `${reportId}.yaml`),
+    );
+  }
+  // Always try root as fallback
+  candidates.push(
+    path.join(root, `${reportId}.compliance-impact.view.yaml`),
+    path.join(root, `${reportId}.yaml`),
+  );
+  for (const candidate of candidates) {
+    try {
+      const raw = yaml.load(readFileSync(candidate, 'utf-8'));
+      return raw;
+    } catch { /* try next */ }
+  }
+  // Scan root for a view-config file whose id matches
+  try {
+    const entries = readdirSync(root, { recursive: true }) as string[];
+    for (const rel of entries) {
+      if (typeof rel !== 'string') continue;
+      if (!/\.ya?ml$/i.test(rel)) continue;
+      if (rel.split(/[\\/]/).includes('node_modules')) continue;
+      try {
+        const raw = yaml.load(readFileSync(path.join(root, rel), 'utf-8'));
+        if (raw && typeof raw === 'object') {
+          const r = raw as Record<string, unknown>;
+          const inner = r.view && typeof r.view === 'object' ? r.view as Record<string, unknown> : r;
+          if (inner.id === reportId) return raw;
+        }
+      } catch { /* skip */ }
+    }
+  } catch { /* no root scan */ }
+  return null;
 }
 
 /** Filesystem scan for compliance canon under `root` (mirrors the extension's
@@ -108,19 +156,70 @@ export async function handleExportComplianceCommand(argv: string[]): Promise<voi
   const format = (flagValue(argv, '--format') ?? 'md').toLowerCase();
   const output = flagValue(argv, '--output');
   const root = flagValue(argv, '--root') ?? process.cwd();
-  const scope = parseScope(flagValue(argv, '--scope'));
+  const reportId = flagValue(argv, '--report');
+  const registry = flagValue(argv, '--registry');
 
-  if (scope === null) {
-    console.error('export-compliance: unknown --scope (expected law:<LAW-ID>, product:<PRODUCT-ID>, gap, or omit for the full matrix).');
-    process.exit(1);
-  }
   if (format !== 'md' && format !== 'pdf') {
     console.error(`export-compliance: unknown --format '${format}' (expected md or pdf).`);
     process.exit(1);
   }
 
-  const canon = scanCanonFs(root);
   const today = new Date().toISOString().slice(0, 10);
+
+  // ── CV-6 named view-config path ─────────────────────────────────────────
+  if (reportId) {
+    const rawCfg = loadViewConfigRaw(registry, reportId, root);
+    if (!rawCfg) {
+      console.error(`export-compliance: view-config '${reportId}' not found. Searched${registry ? ` registry '${registry}'` : ''} and root '${root}'.`);
+      process.exit(1);
+    }
+    const parseResult = parseImpactViewConfig(rawCfg);
+    if (!parseResult.ok) {
+      console.error(`export-compliance: view-config '${reportId}' is invalid:\n${parseResult.errors.map(e => `  - ${e}`).join('\n')}`);
+      process.exit(1);
+    }
+    const viewConfig = parseResult.config;
+    console.error(`[export-compliance] report: ${viewConfig.id} | format: ${format}`);
+    const canon = scanCanonFs(root);
+    // Auto-fill products if not specified in the view config
+    const effectiveProducts = viewConfig.subjects?.products?.length
+      ? viewConfig.subjects.products
+      : canon.products.map(p => p.id).sort();
+    const matrix = buildImpactMatrix(
+      { products: canon.products, requirements: canon.requirements, assertions: canon.assertions, codex: canon.codex },
+      { ...viewConfig, subjects: { ...viewConfig.subjects, products: effectiveProducts } },
+    );
+
+    if (format === 'md') {
+      const markdown = renderImpactMarkdown(matrix);
+      if (output) { writeFileSync(output, markdown, 'utf-8'); console.error(`Wrote ${output}`); }
+      else { process.stdout.write(markdown); }
+      return;
+    }
+    // format === 'pdf'
+    const html = renderImpactMatrixHtml(matrix, { today });
+    const pdfPath = output ?? `compliance-impact-${viewConfig.id}.pdf`;
+    const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'cervin-export-'));
+    const htmlPath = path.join(tmpDir, 'report.html');
+    try {
+      writeFileSync(htmlPath, html, 'utf-8');
+      const result = runWeasyPrint(htmlPath, pdfPath);
+      if (!result.ok) { console.error(`export-compliance: ${result.message}`); process.exit(1); }
+      console.error(`Wrote ${pdfPath}`);
+    } finally {
+      try { rmSync(tmpDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+    }
+    return;
+  }
+
+  // ── Legacy --scope path (Phase 5) ──────────────────────────────────────
+  const scope = parseScope(flagValue(argv, '--scope'));
+  if (scope === null) {
+    console.error('export-compliance: unknown --scope (expected law:<LAW-ID>, product:<PRODUCT-ID>, gap, or omit for the full matrix). Use --report <id> for named view-config.');
+    process.exit(1);
+  }
+
+  const canon = scanCanonFs(root);
 
   if (format === 'md') {
     const markdown = renderComplianceMarkdown(canon, scope, { today });


### PR DESCRIPTION
## Summary

CV-6 of the "Compliance views & export" epic (#84): extends `cervin export-compliance` with a **named view-config** export path.

### CLI additions (`src/export-compliance.ts`)

| Flag | Purpose |
|------|---------|
| `--report <id>` | Load a named view-config (`ImpactViewConfig`) and render a compliance-impact matrix |
| `--registry <dir>` | Narrow the view-config lookup to a specific directory |

Resolution order for the view-config file:
1. `<registry>/<id>.compliance-impact.view.yaml`
2. `<registry>/<id>.yaml`
3. `<root>/<id>.compliance-impact.view.yaml`
4. `<root>/<id>.yaml`
5. Scan `<root>` for any YAML whose top-level `id` field matches

Uses `parseImpactViewConfig` (CV-1) to validate; `buildImpactMatrix` + `renderImpactMarkdown` for `--format md`; new `renderImpactMatrixHtml` + WeasyPrint for `--format pdf`. The legacy `--scope` path is unchanged.

### Library additions (`@transitrix/diagrams`)

- **`html.ts`**: new `renderImpactMatrixHtml(matrix, opts)` — self-contained A4 HTML doc with an inline status-colour table, suitable for WeasyPrint. Also extends the gap render with the CV-5 `pastDeadlineRequirements` fourth section (was missing from the Phase 5 PDF renderer).
- **`markdown.ts`**: extends gap render with the CV-5 `pastDeadlineRequirements` section (was missing from the Phase 5 markdown renderer); total now shows "N gaps across 4 checks".
- **`index.ts`**: re-exports `renderImpactMatrixHtml` / `ImpactMatrixHtmlOptions`.

### Tests

- `html.test.ts`: +3 tests (`renderImpactMatrixHtml` — full document, gap cells)
- `markdown.test.ts`: +1 test (4-check gap section)

## Verification

`diagrams 685 + core 235 green; tsc + extension/tsc clean.`

## Acceptance

Closes CV-6 from epic vkgeorgia/strategy#84.