### PR TITLE
fix(cli): weasyprint subprocess timeout (TX-205)

### DIFF
--- a/src/export-compliance.ts
+++ b/src/export-compliance.ts
@@ -107,23 +107,40 @@ function parseScope(scopeArg: string | undefined): ReportScope | null {
   return null;
 }
 
+/** Bounded wait for WeasyPrint — pathological HTML/CSS must not hang the CLI. */
+export const WEASYPRINT_TIMEOUT_MS = 120_000;
+
 /** Invoke `weasyprint <html> <pdf>`. WeasyPrint is a Python tool; we shell out
  *  rather than re-implement PDF generation in JS, matching the engine the
  *  Transitrix site uses for one-pager renders so the styling stays consistent.
  *  Surfaces ENOENT as an installable-prereq message rather than a stack trace. */
-function runWeasyPrint(htmlPath: string, pdfPath: string): { ok: true } | { ok: false; message: string } {
+export function runWeasyPrint(
+  htmlPath: string,
+  pdfPath: string,
+  opts?: { timeoutMs?: number },
+): { ok: true } | { ok: false; message: string } {
+  const timeoutMs = opts?.timeoutMs ?? WEASYPRINT_TIMEOUT_MS;
   const candidates = process.platform === 'win32'
     ? ['weasyprint.exe', 'weasyprint']
     : ['weasyprint'];
   let lastErr: NodeJS.ErrnoException | null = null;
   for (const cmd of candidates) {
-    const res = spawnSync(cmd, [htmlPath, pdfPath], { encoding: 'utf-8' });
-    if (res.error && (res.error as NodeJS.ErrnoException).code === 'ENOENT') {
-      lastErr = res.error as NodeJS.ErrnoException;
-      continue;
-    }
+    const res = spawnSync(cmd, [htmlPath, pdfPath], { encoding: 'utf-8', timeout: timeoutMs });
     if (res.error) {
-      return { ok: false, message: `weasyprint failed to launch: ${res.error.message}` };
+      const err = res.error as NodeJS.ErrnoException;
+      if (err.code === 'ENOENT') {
+        lastErr = err;
+        continue;
+      }
+      if (err.code === 'ETIMEDOUT') {
+        return {
+          ok: false,
+          message:
+            `weasyprint timed out after ${Math.round(timeoutMs / 1000)}s — ` +
+            'the report may be too large or WeasyPrint may be hung.',
+        };
+      }
+      return { ok: false, message: `weasyprint failed to launch: ${err.message}` };
     }
     if (res.status !== 0) {
       const stderr = (res.stderr || '').trim();

--- a/tests/export-compliance.test.ts
+++ b/tests/export-compliance.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SpawnSyncReturns } from 'node:child_process';
+
+vi.mock('node:child_process', () => ({
+  spawnSync: vi.fn(),
+}));
+
+import { spawnSync } from 'node:child_process';
+import { runWeasyPrint, WEASYPRINT_TIMEOUT_MS } from '../src/export-compliance.js';
+
+function mockSpawnResult(
+  partial: Partial<SpawnSyncReturns<string>>,
+): SpawnSyncReturns<string> {
+  return {
+    pid: 1,
+    output: [null, '', ''],
+    stdout: '',
+    stderr: '',
+    status: 0,
+    signal: null,
+    ...partial,
+  } as SpawnSyncReturns<string>;
+}
+
+describe('runWeasyPrint', () => {
+  beforeEach(() => {
+    vi.mocked(spawnSync).mockReset();
+  });
+
+  it('passes the bounded timeout to spawnSync', () => {
+    vi.mocked(spawnSync).mockReturnValue(mockSpawnResult({ status: 0 }));
+    const result = runWeasyPrint('/tmp/report.html', '/tmp/report.pdf');
+    expect(result).toEqual({ ok: true });
+    expect(spawnSync).toHaveBeenCalledWith(
+      expect.stringMatching(/^weasyprint/),
+      ['/tmp/report.html', '/tmp/report.pdf'],
+      expect.objectContaining({ encoding: 'utf-8', timeout: WEASYPRINT_TIMEOUT_MS }),
+    );
+  });
+
+  it('surfaces ETIMEDOUT as a clean CLI error', () => {
+    const timedOut = Object.assign(new Error('spawnSync ETIMEDOUT'), { code: 'ETIMEDOUT' });
+    vi.mocked(spawnSync).mockReturnValue(mockSpawnResult({ error: timedOut, status: null }));
+    const result = runWeasyPrint('/tmp/report.html', '/tmp/report.pdf', { timeoutMs: 5_000 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain('timed out after 5s');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add `WEASYPRINT_TIMEOUT_MS` (120s) to `runWeasyPrint` `spawnSync` call.
- Surface `ETIMEDOUT` as a clean `export-compliance` error message.
- Export `runWeasyPrint` + constant for unit tests.

## Test plan
- [x] `npm run test:core -- tests/export-compliance.test.ts`
- [ ] Valerii: PDF export still works when WeasyPrint is installed

Made with [Cursor](https://cursor.com)