### PR TITLE
chore: canonical archive root .archive/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 node_modules/
 
 # Superseded / archived trees (never delete—move content here instead of deleting)
-**/0. archive/
+.archive/
+**/0. archive/   # legacy path — still honoured until content is migrated
 
 dist/
 # Compiled output must never land beside the TypeScript sources. The diagrams

--- a/docs/repo-layout.md
+++ b/docs/repo-layout.md
@@ -51,7 +51,8 @@ This document maps **top-level folders** to **roles** so you know where to look 
 | [`scripts/`](../scripts/) | Build and dev tooling: `build-compiler-bundle.mjs`, `build-webview.mjs`, `build-extension-bundle.mjs`, `bump-extension-version.mjs`, `measure-baseline.mjs`, `ci-metrics-diff.mjs`. |
 | [`docs/`](../docs/) | **Project documentation**: this layout map, glossary, metrics baselines, validation notes. |
 | [`output/`](../output/) | **Build output** for `build-extension.bat` — packaged `.vsix` files. Gitignored. |
-| [`0. archive/`](../0.%20archive/) | **Superseded trees and accepted-task records.** Gitignored. Move content here instead of deleting. |
+| [`.archive/`](../.archive/) | **Superseded trees, agent-bus, agent-run logs, accepted-task records.** Gitignored. Canonical archive root — use this in all new prompts, scripts, and docs. |
+| `0. archive/` *(legacy)* | Former archive root (leading space in the folder name). Still gitignored and still works if content remains there; migrate to `.archive/` when convenient. |
 | [`intellij/`](../intellij/) | **IntelliJ plugin** packaging and install docs (optional IDE surface; separate from the VS Code extension). |
 
 Root config files (`package.json`, `tsconfig*.json`, `.vscode/`, `.github/workflows/`): orchestrate build, lint, test, extension packaging, CI.
@@ -93,7 +94,7 @@ Both suites are required to pass — CI (`.github/workflows/metrics-regression.y
 | Nested blocks (native YAML) | [`packages/diagrams/src/blocks/`](../packages/diagrams/src/blocks/), samples in [`examples/blocks/`](../examples/blocks/) |
 | Validation rules for a non-BPMN notation | [`packages/diagrams/src/<notation>/validate.ts`](../packages/diagrams/) |
 | Preview rendering for a non-BPMN notation | [`extension/src/<notation>-preview.ts`](../extension/src/) |
-| Adding a new notation | Pattern in [TX-020 archive](../0.%20archive/tasks/TX-020.md): library module under `packages/diagrams/src/<notation>/`, preview under `extension/src/<notation>-preview.ts`, wiring in `extension/src/extension.ts` and `extension/package.json`, example in `examples/<notation>/`. |
+| Adding a new notation | Pattern in [TX-020 archive](../.archive/tasks/TX-020.md) (legacy copy may still live under `0. archive/tasks/`): library module under `packages/diagrams/src/<notation>/`, preview under `extension/src/<notation>-preview.ts`, wiring in `extension/src/extension.ts` and `extension/package.json`, example in `examples/<notation>/`. |
 
 ---
 

--- a/run-studio-agent.ps1
+++ b/run-studio-agent.ps1
@@ -23,7 +23,7 @@ $RepoPath  = "C:\GitHub\transitrix-studio"
 $ProjLabel = "proj:transitrix-studio"
 # -----------------------------------------------------------------------------
 
-$LogDir  = Join-Path $RepoPath "0. archive\agent-runs"
+$LogDir  = Join-Path $RepoPath ".archive\agent-runs"
 New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
 $LogFile = Join-Path $LogDir ("$($AgentName.ToLower())-agent-{0:yyyy-MM-dd-HHmmss}.log" -f (Get-Date))
 
@@ -51,7 +51,7 @@ There is no human at the keyboard - never wait for interactive input.
 Working repo: $RepoPath (you are already in it).
 
 1. Orient: read ./CLAUDE.md here, and STRATEGY.md in C:\GitHub\strategy.
-   Then read your bus inbox at ./0.\ archive/agent-bus/inbox.md - act on any
+   Then read your bus inbox at ./.archive/agent-bus/inbox.md - act on any
    answer/relay entries dated after your previous run - this is how the orchestrator
    replies to your questions and relays facts from sibling agents (local-only file).
 2. Pull YOUR open tasks only:
@@ -81,7 +81,7 @@ If canon settles it, follow canon and do NOT ask.
 
 IF YOU ARE BLOCKED, UNSURE, OR A DECISION IS NEEDED (and canon does NOT settle it):
    Do not stall and do not guess. Write your question to your bus OUTBOX - append an
-   entry to ./0.\ archive/agent-bus/outbox.md (format is in that file) with
+   entry to ./.archive/agent-bus/outbox.md (format is in that file) with
    enough context to answer, referencing the hub issue. Then set the signal label:
      gh issue edit <N> -R vkgeorgia/strategy --add-label needs:answer
    The label is the SIGNAL; your outbox carries the TEXT. The orchestrator reads your


### PR DESCRIPTION
## Summary
- Add `.archive/` to `.gitignore` as the canonical gitignored archive root.
- Keep `0. archive/` gitignored as legacy until content is migrated.
- Update `docs/repo-layout.md` and `run-studio-agent.ps1` to use `.archive/` for agent-runs and agent-bus paths.
- Full agent rules live in `CLAUDE.md` (local/gitignored) — hub will mirror the same convention.

## Test plan
- [ ] N/A — docs and paths only

Made with [Cursor](https://cursor.com)