### PR TITLE
feat(process-blueprint): compliance lane -- derived obligation projection per stage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,11 @@ test-parse.mjs
 quick-build-extension.sh
 quick-start-util.sh
 
+# Per-user display preferences (lane toggles, decoration preferences).
+# The folder is tracked via .gitkeep; its contents stay local only.
+.transitrix/display-preferences/*
+!.transitrix/display-preferences/.gitkeep
+
 # Local environment / secrets
 .env
 .env.*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,21 @@ node scripts/debug/debug-ports.mjs examples/bpmn/feature-release.cervin.yaml
 
 These are intended for development only. Not for end-user consumption.
 
+## Per-user display preferences
+
+The `.transitrix/display-preferences/` folder is the designated home for **per-user,
+local** display preferences (lane toggles, decoration preferences for diagram previews
+such as the Process Blueprint compliance lane).
+
+The folder is tracked by `.transitrix/display-preferences/.gitkeep` so its location
+is defined in the repo and every contributor has it; its *contents* are `.gitignore`d
+and **never committed**. Each contributor keeps their own preference files locally
+without affecting others.
+
+Naming convention for preference files (all `.json`): one file per notation, e.g.
+`process-blueprint.json`. The exact schema is determined by the tooling layer; there
+is no enforced schema in v0.1. See ADR 0002 for the compliance-lane toggle.
+
 ## Licensing
 
 By submitting a pull request, you agree that your contribution is licensed under the project's MIT License (see [LICENSE](LICENSE)) on the same terms as the project itself (inbound = outbound), and that you have the right to submit it (no employer or third-party rights conflict).

--- a/docs/adr/0002-process-blueprint-compliance-lane.md
+++ b/docs/adr/0002-process-blueprint-compliance-lane.md
@@ -1,0 +1,89 @@
+---
+adr: "0002"
+status: Accepted
+date: 2026-06-10
+scope: transitrix-studio
+methodology_adr: docs/decisions/2026-06-09-compliance-impact-as-blueprint-lane.md
+tags: [process-blueprint, compliance-lane, layout, renderer, extension, per-user-settings]
+---
+
+# ADR 0002 — Process Blueprint compliance lane (Studio implementation)
+
+## Context
+
+The methodology ADR `docs/decisions/2026-06-09-compliance-impact-as-blueprint-lane.md`
+(accepted 2026-06-09) specifies a **derived, opt-in compliance lane** for the Process
+Blueprint notation. This ADR records the implementation decisions made in Transitrix
+Studio for strategy hub task #177.
+
+The methodology ADR settles _what_ the lane is and _what_ its decorations mean.
+This document records _how_ it is implemented in the `@transitrix/diagrams` library and
+the VS Code extension.
+
+## Decisions
+
+### 1. Compliance lane is a layout-level feature, not a schema change
+
+The lane is computed inside `layoutProcessBlueprint` via a new `deriveComplianceRow()`
+helper that accepts `ComplianceLaneInput` (assertions + requirements projection) as an
+extra `options` parameter. No new field is written to the blueprint document canon —
+consistent with the methodology ADR's "derived, not stored" principle.
+
+### 2. Three new option fields on `ProcessBlueprintLayoutOptions`
+
+- `complianceLane?: ComplianceLaneConfig` — toggles the lane, carries the jurisdiction
+  filter, the previous-snapshot map (for "new" decoration), and the reference date.
+- `complianceInput?: ComplianceLaneInput` — the minimal projection of assertions,
+  requirements, and codex jurisdiction map needed by the derivation function.
+
+### 3. Decoration signals map 1-to-1 to the methodology ADR §3
+
+| Signal    | Source                                                  | Visual in SVG          |
+|-----------|--------------------------------------------------------|------------------------|
+| `new`     | Law ID absent from `previousSnapshot[stageId]`         | `stroke-dasharray="4 2"` on chip rect |
+| `gap`     | Any bound assertion has status `non_compliant`/`partial`| Warning fill (`--ts-status-warning-bg/fg`) |
+| `deadline`| Gap present **and** `REQUIREMENT.deadline` → `past_due`/`in_force`/`upcoming` | Error fill + `!` badge circle |
+
+Decorations are orthogonal and stack; a chip may carry all three simultaneously.
+
+### 4. Jurisdiction filter is applied at derivation time
+
+When `ComplianceLaneConfig.jurisdictions` is non-empty, the derivation function
+discards any law chip whose codex jurisdiction (from `ComplianceLaneInput.codexJurisdictions`)
+is not in the filter list. If jurisdiction data is absent, no filtering is applied.
+
+### 5. `lane_config.compliance: true` in the YAML document activates the lane
+
+The spec field `lane_config:` is parsed by the extension's `resolveLaneConfig()` helper.
+The lane defaults to **disabled** per the methodology ADR; authors must opt in per document.
+
+### 6. Per-user display preferences folder
+
+A `.transitrix/display-preferences/` folder is tracked via `.gitkeep` but its contents
+are `.gitignore`d. This implements the methodology ADR §6 contract: per-user lane
+toggles and decoration preferences stay local, are never committed, and the folder
+appears empty to every other user. The folder path is documented in `CONTRIBUTING.md`.
+
+### 7. Compliance data is scanned at preview time, not embedded in the blueprint
+
+The VS Code preview calls the existing `scanComplianceCanon()` workspace scanner when
+`lane_config.compliance: true`. Scan failures are non-fatal — the blueprint renders
+without the compliance lane rather than surfacing an error.
+
+## Consequences
+
+- `ProcessBlueprintLayout` gains an optional `complianceRow?: ComplianceRow` field;
+  renderers that don't need the compliance lane can safely ignore it.
+- The `LegendCell.kind` union is extended with `'compliance'`.
+- CSS theme gains `.compliance-gap`, `.compliance-deadline`, `.compliance-badge`,
+  `.compliance-badge-text` classes for both light and dark themes.
+- The extension `process-blueprint-preview.ts` `buildHtml` method is now `async`
+  (async scan behind an opt-in guard; no performance impact when lane is disabled).
+- 26 new unit tests in `packages/diagrams/src/process-blueprint/__tests__/compliance-lane.test.ts`
+  cover decoration logic, jurisdiction filtering, null-guards, legend, and geometry.
+
+## Out of scope (backlog)
+
+- Drill-down to verbatim source segments (noted in methodology ADR).
+- DSM viewer compliance lane (separate task when DSM viewer migrates to `@transitrix/diagrams`).
+- Named report lane pinning in the versioned view-config (requires report-skill integration).

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -1,0 +1,199 @@
+---
+title: "Transitrix Feature List"
+doc_type: living-design-doc
+established_by: "Win-Claude"
+last_updated: "2026-06-10"
+scope: "transitrix-methodology, transitrix-studio"
+---
+
+# Transitrix Feature List
+
+Covers **Transitrix Methodology** (notation specs + CLI skills) and **Transitrix Studio** (VS Code extension + CLI + shared library). Current as of Studio v1.4.1 / Methodology HEAD.
+
+---
+
+## Transitrix Methodology
+
+### Notation library — 15 view notations
+
+| Notation | Purpose | Status |
+|---|---|---|
+| **BPMN** | BPMN 2.0 process flow — lanes, gateways, sequence flows | documented |
+| **FGCA** | Full strategy-to-execution chain: Factor → Goal → Change → Activity | documented |
+| **FGA** | Simplified chain: Factor → Goal → Activity (no Changes layer) | draft |
+| **Goals** | Strategic goal hierarchy as a tree | documented |
+| **Capability Map** | Capability hierarchy with CMMI V2.0 maturity and addressing | documented |
+| **Process Map** | Top-level catalogue of processes (Operating / Supporting / Management) | draft |
+| **Activities** | Project Schedule Network Diagram in Activity-on-Node (AoN) form | documented |
+| **Blocks** | Multi-level container layout — recursive nested-boxes architecture overview | documented |
+| **Products** | Inventory of products and services (catalogue view) | draft |
+| **Applications** | Inventory of applications and integrations (catalogue view) | draft |
+| **Scenarios** | Report-config view over `SCENARIO` elements | draft |
+| **Process Blueprint** | Wide value-chain blueprint — stages, goals, results, systems, actors, equipment; **opt-in compliance lane** (derived obligation projection per stage with new/gap/deadline decorations; `lane_config.compliance: true`) | draft |
+| **Activity Card** | Single-project narrative view — FGCA chain, dates, milestones, gate decisions | documented |
+| **Compliance Impact** | Report-config view deriving the obligation × subject matrix from Assertions + process flow | draft |
+| **Coverage Metric** | Report-config view measuring coverage of canon per jurisdiction | draft |
+
+### Element notations — 8 standalone primitives
+
+| Notation | Purpose | Status |
+|---|---|---|
+| **Codex** | External laws / regulations and internal policies / standards | documented |
+| **Requirement** | Positive obligation derived from a codex source | documented |
+| **Assertion** | Links a Requirement to a subject (Product / Process / Capability) | documented |
+| **Relation** | First-class, time-aware relation between two canonical primitives | documented |
+| **Actor** | Active-structure identity: person / business\_unit / system | draft |
+| **Stakeholder** | Motivation-layer interest primitive with stake profile | draft |
+| **Amendment** | Field-zone detection record that a watched codex source has been amended | draft |
+| **Segment** | Field-zone extracted chunk of a codex source (article / clause / paragraph) | draft |
+
+### Schema foundations
+
+- **Flat top-level arrays with reference-based hierarchy** — universal form rule across all four strategy-chain notations (FGCA, FGA, Goals, Activities). Hierarchy expressed via `parent` / cross-layer ID references inside flat arrays; no nested wrapper keys.
+- **Element aliases** — `aliases:` field on every element primitive (Option A, ADR 2026-06-06). Enables name-variant matching without duplicating elements.
+- **Coverage Profiles** — adopter-level vocabulary scoping in `transitrix.yaml`. Three shipped presets: `minimal`, `core`, `full`. Custom profiles extend a preset by adding or removing TYPEs.
+- **Data Quality model** — `confidence:` and `freshness:` fields on canon primitives per CONTRACT §11. Scored DQ-1..DQ-5 in Studio previews.
+- **Deterministic TYPE → placement resolver** — automatic `canon/elements/<layer>/` placement from TYPE alone (ELEMENT_PRIMITIVES §4).
+- **ID grammar enforcement** — ID-grammar violations surfaced at emit time (IDS §1).
+- **ISSUE type retired** — architectural problems modelled as ASSESSMENT (ArchiMate-aligned); team tracking uses Work Items.
+- **BUSINESS\_OBJECT replaces INFORMATION\_ENTITY** — ArchiMate-aligned rename.
+- **EQUIPMENT** — first-class catalogued element in layer 04\_technology.
+
+### Ingest CLI (`transitrix ingest`)
+
+| Feature | Description |
+|---|---|
+| **Two-route ingestion** | Field route (raw docs → SEGMENT/AMENDMENT) and codex route (structured codex sources) |
+| **Duplicate-source detection** | Detects re-admitted sources by `source_hash` (F1) |
+| **Repo-check doctor** | Data-free health check before ingestion; `transitrix:repo-check` skill (F2) |
+| **Suggest-profile discovery** | Auto-suggests a coverage profile from the repo's existing content (F3) |
+| **Markitdown fallback** | Tries `python -m markitdown` when the primary binary is absent (F6) |
+| **Cross-source entity resolution** | Name / alias matching across sources (F8) |
+| **Codex source artefact resolution** | Review-queue resolves codex source artefacts (F13) |
+| **ID-grammar enforcement at emit** | Violations surfaced before writing any files (F14) |
+| **Idempotent review-queue** | Running review-queue twice does not re-admit already-admitted candidates |
+| **Coverage profile resolution** | Resolves custom / short-form profiles without silent full-fallback |
+
+### Regulatory Intelligence CLI (`transitrix reg-intel`)
+
+| Feature | Description |
+|---|---|
+| **Scheduler core** | `list-due` + `update-scan` — lists sources due for re-check and updates last-scanned timestamps |
+| **Change-signal gate** | `check-signal` — lightweight pre-flight before a full snapshot fetch |
+| **Snapshot fetch** | `fetch-snapshot` — downloads and stores a versioned snapshot with content-aware cosmetic-diff |
+| **Review digest** | Structured digest output + JSON schema |
+| **SEGMENT shaper** | `segment` command — splits a document into clause-level SEGMENT primitives |
+| **CLASSIFY shaper** | `classify` command — classifies segments by relevance and obligation type |
+| **Contract validator** | `validate` command — checks an amendment record against the contract schema |
+| **AMENDMENT emitter** | `amendment` command — emits a structured AMENDMENT primitive from a validated record |
+| **Operational templates** | Daily scheduler, fetch recipes, snapshots README |
+
+---
+
+## Transitrix Studio
+
+### VS Code extension
+
+#### Preview engine
+
+| Feature | Description |
+|---|---|
+| **Goals tree preview** | `*.goals.transitrix.yaml` — tree layout with zoom, save-as-SVG/PNG, copy-as-PNG |
+| **FGCA preview** | Full four-layer strategy chain with tree↔table view toggle |
+| **FGA preview** | Three-layer strategy chain with tree↔table view toggle |
+| **Activities preview** | AoN network diagram with dates, durations |
+| **Blocks preview** | Recursive nested-box layout |
+| **Capability Map preview** | CMMI maturity colouring, addressing, vertical/horizontal orientation |
+| **Process Map preview** | Three-group catalogue |
+| **Scenarios preview** | Report-config view |
+| **Process Blueprint preview** | Wide stage layout with text-wrapping goal/result cells; opt-in compliance lane with new/gap/deadline chip decorations (ADR 0002) |
+| **Activity Card preview** | Single-project narrative: FGCA chain, dates, milestones, gate decisions |
+| **Products / Applications previews** | Catalogue views |
+| **Compliance matrix preview** | Products × Requirements grid with jurisdiction / severity / status toolbar filters |
+| **Single-law compliance preview** | Law → Requirements → Assertions tree (from any Codex file) |
+| **Single-product compliance preview** | Product → bound Requirements → status |
+| **Compliance gap dashboard** | Requirements without Assertions, stale Assertions; CSV export |
+
+#### Live preview controls (interactive webviews)
+
+| Feature | Description |
+|---|---|
+| **Spacing controls** | `transitrix.spacing.<notation>.{horizontalGap,verticalGap}` — adjustable in-preview |
+| **Edge curvature controls** | `transitrix.curvature.<notation>` — adjustable in-preview (0 = straight) |
+| **Scope filters** | `transitrix.scope.<notation>.{rootId,maxLevel}` — scope to a subtree or level cap |
+| **Tree ↔ table toggle** | FGCA and FGA flatten into a merged-cell table; persisted per notation |
+| **Nonce-CSP webviews** | All interactive previews run under strict nonce-based Content Security Policy |
+
+#### Export
+
+| Feature | Description |
+|---|---|
+| **Save as SVG** | Goals, FGCA, FGA, Activities, Blocks, Process Blueprint, Activity Card |
+| **Save as PNG / Copy as PNG** | All notation previews |
+| **`transitrix export-compliance --format md`** | Compliance matrix as Markdown (`--scope law:<id>|product:<id>`) |
+| **`transitrix export-compliance --format pdf`** | A4-portrait branded PDF via WeasyPrint; clean `ETIMEDOUT` error if binary absent |
+
+#### Editor integration
+
+| Feature | Description |
+|---|---|
+| **Cold-start activation** | All 11 notation file suffixes in `activationEvents`; previews open from a cold VS Code |
+| **Editor-title commands** | Quick-access preview buttons in editor title bar |
+| **Language support** | Syntax highlighting and schema validation for all notation files |
+
+### IntelliJ IDEA extension (MVP, v1.3.0+)
+
+| Feature | Description |
+|---|---|
+| **Phase 1 — Gradle scaffold** | Build wiring, plugin descriptor, packaging script |
+| **Phase 2 — browser-safe webview bundle** | JCEF-compatible bundle from `@transitrix/diagrams` |
+| **Phase 3 — JCEF preview, Goals end-to-end** | Goals notation rendered in JCEF webview panel |
+| **Phase 4 — remaining 11 notations** | All notation renderers wired into the JCEF bundle |
+| **Phase 5 — packaging + install docs** | Packaging script and installation documentation |
+
+### `@transitrix/diagrams` shared library
+
+| Module | Description |
+|---|---|
+| **Goals** | Types, validator, layout, renderer |
+| **FGCA / FGA** | Types, flat-canon parser, validator, layout, renderer |
+| **Activities** | Types, cross-doc resolver, validator, layout, renderer (AoN) |
+| **Capability Map** | Types, validator, layout, renderer |
+| **Blocks** | Types, validator, layout, renderer |
+| **Process Blueprint** | Types, validator, layout, renderer (text-wrapping cells); compliance lane derivation + chip renderer with three stacking decorations |
+| **Activity Card** | Types, cross-doc resolver, validator, layout, renderer |
+| **Compliance** | Requirement + Assertion schemas/validators (REQ-001..003, ASSERT-001..008); compliance HTML renderer (`renderComplianceHtml`); matrix, single-law, single-product, gap-dashboard views |
+| **Data Quality (DQ-1)** | Confidence-scoring module per CONTRACT §11; DQ-2 composite confidence in compliance previews |
+| **Geometry module** | Shared `LayoutBounds` export; deduplicated across diagram modules |
+| **Null-guard validators** | All array-based validators guard against `null` / non-object entries before field access |
+
+### CLI (`transitrix`)
+
+| Command | Description |
+|---|---|
+| **`transitrix compile`** | Compiles notation YAML to SVG / layout JSON |
+| **`transitrix serve`** | Serves the web UI for browser-based preview |
+| **`transitrix export-compliance`** | Exports compliance views as Markdown or PDF |
+| **`transitrix ingest`** | Ingests field documents into the methodology zone |
+| **`transitrix reg-intel`** | Regulatory intelligence commands (scheduler, fetch, classify, emit) |
+
+### Security posture
+
+- `serve-ui.ts` path containment — drive-aware prefix check rejects paths on different Windows drives
+- `serve-ui.ts` stream error handling — `createReadStream` error handler destroys the socket cleanly
+- Interactive previews — nonce-CSP; static previews `enableScripts: false`; user content escaped
+- `export-compliance` — argv-list `spawnSync`, no shell; bounded timeout with `ETIMEDOUT` surface
+- Blocks backend — `svgbobCommand` allowlist rejects shell metacharacters (TX-R001)
+
+---
+
+## Planned / In Progress
+
+| Item | Scope | Status |
+|---|---|---|
+| **Cervin → Transitrix deprecation** (P1–P7) | Studio CLI, extension settings/commands, project config, API aliases | Planned across 1.x minor releases; breaking removal in 2.0.0 |
+| **TX-021 — Activity multi-value fields** | DSM backend trilogy complete (predecessors, goals, tags); frontend multi-value UIs pending | PRs #14 (goals modal), #15 (tags modal), #16 (swagger regen) open |
+| **Ingest skill (strategy#145)** | Methodology | Skill design complete; real-data ingestion scheduled |
+| **Report skill** | Methodology | ADR accepted: CLI-first thin skill; rides IG-7 |
+| **Coverage Profiles enforcement** | Studio + Methodology | Spec v0.1 done; tool enforcement pending |
+| **Actor / Stakeholder notations** | Methodology | Draft specs; implementation deferred |

--- a/extension/src/process-blueprint-preview.ts
+++ b/extension/src/process-blueprint-preview.ts
@@ -6,11 +6,15 @@ import { TITLE_BLOCK_H, titleBlockSvg, todayIso } from './svg-title-block.js';
 import {
   validateProcessBlueprint,
   layoutProcessBlueprint,
+  type ComplianceLaneConfig,
+  type ComplianceLaneInput,
+  type LaneConfig,
   type ProcessBlueprintFile,
   type ProcessBlueprintLayout,
 } from '../../packages/diagrams/src/process-blueprint/index.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
+import { scanComplianceCanon, type ScannedCanon } from './compliance-scan.js';
 
 function escXml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
@@ -39,6 +43,40 @@ function textCellSvg(
     .map((ln, i) => `<tspan x="${x}" y="${first + i * lineHeight}">${escXml(ln)}</tspan>`)
     .join('');
   return `<text class="${cls}" dominant-baseline="central">${tspans}</text>`;
+}
+
+function complianceChipSvg(
+  chip: import('../../packages/diagrams/src/process-blueprint/types.js').ComplianceChip,
+  ox: number,
+  oy: number,
+): string {
+  const { x, y, width, height, lawId, decorations } = chip;
+  const ax = x + ox;
+  const ay = y + oy;
+  const hasNew = decorations.includes('new');
+  const hasGap = decorations.includes('gap');
+  const hasDeadline = decorations.includes('deadline');
+  let rectClass = 'diagram-node level-5 compliance-chip';
+  if (hasDeadline) rectClass += ' compliance-deadline';
+  else if (hasGap) rectClass += ' compliance-gap';
+  const strokeDash = hasNew ? ' stroke-dasharray="4 2"' : '';
+  const parts: string[] = [];
+  parts.push(
+    `<rect class="${rectClass}" x="${ax}" y="${ay}" width="${width}" height="${height}" rx="6"${strokeDash}/>`,
+  );
+  parts.push(
+    `<text class="text-pill" x="${ax + width / 2}" y="${ay + height / 2}" text-anchor="middle" dominant-baseline="central">${escXml(truncate(lawId, Math.floor(width / 8)))}</text>`,
+  );
+  if (hasDeadline) {
+    const br = 5;
+    const bx = ax + width - br - 3;
+    const by = ay + br + 3;
+    parts.push(`<circle class="compliance-badge" cx="${bx}" cy="${by}" r="${br}"/>`);
+    parts.push(
+      `<text class="compliance-badge-text" x="${bx}" y="${by}" text-anchor="middle" dominant-baseline="central">!</text>`,
+    );
+  }
+  return parts.join('\n');
 }
 
 function layoutToSvg(layout: ProcessBlueprintLayout, filename?: string, date?: string, version?: string): string {
@@ -115,11 +153,59 @@ function layoutToSvg(layout: ProcessBlueprintLayout, filename?: string, date?: s
     }
   }
 
+  // Compliance row (optional).
+  if (layout.complianceRow) {
+    const row = layout.complianceRow;
+    parts.push(
+      `<rect class="diagram-node level-5" x="${layout.legendColumnWidth + ox}" y="${row.y + oy}" width="${layout.bounds.width - layout.legendColumnWidth}" height="${row.height}" opacity="0.10"/>`,
+    );
+    for (let i = 1; i < layout.stageHeaders.length; i++) {
+      const x = layout.legendColumnWidth + i * layout.stageColumnWidth + ox;
+      parts.push(
+        `<line class="diagram-edge" x1="${x}" y1="${row.y + oy}" x2="${x}" y2="${row.y + row.height + oy}" opacity="0.3"/>`,
+      );
+    }
+    for (const chip of row.chips) {
+      parts.push(complianceChipSvg(chip, ox, oy));
+    }
+  }
+
   const titleSvg = showTitle ? titleBlockSvg('Process Blueprint', filename!, date!, pad, pad, version) : '';
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">
 ${titleSvg}
 ${parts.join('\n')}
 </svg>`;
+}
+
+/** Extract compliance lane config from the blueprint's `lane_config:` block. */
+function resolveLaneConfig(lc: LaneConfig | undefined): ComplianceLaneConfig {
+  return {
+    enabled: lc?.compliance === true,
+    jurisdictions: Array.isArray(lc?.compliance_filter?.jurisdictions)
+      ? (lc!.compliance_filter!.jurisdictions as string[]).filter((x): x is string => typeof x === 'string')
+      : [],
+  };
+}
+
+/** Project scanned compliance canon into the minimal shape the layout needs. */
+function buildComplianceLaneInput(canon: ScannedCanon): ComplianceLaneInput {
+  const codexJurisdictions: Record<string, string> = {};
+  for (const c of canon.codex) {
+    if (c.jurisdiction) codexJurisdictions[c.id] = c.jurisdiction;
+  }
+  return {
+    assertions: canon.assertions.map(a => ({
+      about: a.about,
+      status: a.status,
+      realised_via: a.realised_via,
+    })),
+    requirements: canon.requirements.map(r => ({
+      id: r.id,
+      derived_from: r.derived_from,
+      deadline: r.deadline,
+    })),
+    codexJurisdictions,
+  };
 }
 
 export class ProcessBlueprintPreview {
@@ -156,10 +242,10 @@ export class ProcessBlueprintPreview {
 
   private async pushDocument(doc: vscode.TextDocument): Promise<void> {
     if (!this.panel) return;
-    this.panel.webview.html = this.buildHtml(doc.getText(), path.basename(doc.fileName));
+    this.panel.webview.html = await this.buildHtml(doc.getText(), path.basename(doc.fileName));
   }
 
-  private buildHtml(yamlText: string, filename: string): string {
+  private async buildHtml(yamlText: string, filename: string): Promise<string> {
     let svgContent = '';
     let errorMsg = '';
     let warnings: string[] = [];
@@ -177,7 +263,23 @@ export class ProcessBlueprintPreview {
         const pb = (file as unknown as { process_blueprint?: { version?: unknown; date?: unknown } }).process_blueprint ?? {};
         const docVersion = typeof pb.version === 'string' ? pb.version : undefined;
         const docDate = typeof pb.date === 'string' ? pb.date : todayIso();
-        const layout = layoutProcessBlueprint(file);
+
+        // Compliance lane — scan workspace when opt-in via lane_config.compliance: true.
+        const laneCfg = resolveLaneConfig(file.process_blueprint?.lane_config);
+        let complianceInput: ComplianceLaneInput | undefined;
+        if (laneCfg.enabled) {
+          try {
+            const canon = await scanComplianceCanon();
+            complianceInput = buildComplianceLaneInput(canon);
+          } catch {
+            // Non-fatal: render blueprint without compliance lane if scan fails.
+          }
+        }
+
+        const layout = layoutProcessBlueprint(file, {
+          complianceLane: laneCfg,
+          complianceInput,
+        });
         svgContent = layoutToSvg(layout, filename, docDate, docVersion);
       }
     } catch (e) {

--- a/packages/diagrams/src/process-blueprint/__tests__/compliance-lane.test.ts
+++ b/packages/diagrams/src/process-blueprint/__tests__/compliance-lane.test.ts
@@ -1,0 +1,320 @@
+import { describe, it, expect } from 'vitest';
+import { layoutProcessBlueprint } from '../layout.js';
+import type {
+  ComplianceLaneAssertion,
+  ComplianceLaneInput,
+  ComplianceLaneRequirement,
+  ProcessBlueprintFile,
+} from '../types.js';
+
+// ── fixtures ────────────────────────────────────────────────────────────────
+
+const STAGES: ProcessBlueprintFile['process_blueprint']['stages'] = [
+  { id: 'STAGE-1', name: 'Receive', goal: 'g1', result: 'r1' },
+  { id: 'STAGE-2', name: 'Process', goal: 'g2', result: 'r2' },
+  { id: 'STAGE-3', name: 'Ship', goal: 'g3', result: 'r3' },
+];
+
+function buildFile(overrides: Partial<ProcessBlueprintFile['process_blueprint']> = {}): ProcessBlueprintFile {
+  return {
+    notation: 'process-blueprint',
+    process_blueprint: { id: 'PROCESS_BLUEPRINT-T-1', name: 'Test', stages: STAGES, ...overrides },
+  };
+}
+
+const REQ_A: ComplianceLaneRequirement = { id: 'REQ-1', derived_from: ['LAW-GDPR-1'] };
+const REQ_B: ComplianceLaneRequirement = { id: 'REQ-2', derived_from: ['LAW-GDPR-1', 'LAW-SOX-2'] };
+const REQ_DEADLINE: ComplianceLaneRequirement = {
+  id: 'REQ-3',
+  derived_from: ['LAW-PCI-3'],
+  deadline: '2020-01-01', // past_due
+};
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+function makeAssertion(
+  about: string,
+  status: ComplianceLaneAssertion['status'],
+  realisedVia: string[],
+): ComplianceLaneAssertion {
+  return { about, status, realised_via: realisedVia };
+}
+
+function layout(
+  file: ProcessBlueprintFile,
+  input: ComplianceLaneInput,
+  overrides: { jurisdictions?: string[]; previousSnapshot?: Record<string, string[]> } = {},
+) {
+  return layoutProcessBlueprint(file, {
+    complianceLane: { enabled: true, ...overrides },
+    complianceInput: input,
+  });
+}
+
+// ── tests ───────────────────────────────────────────────────────────────────
+
+describe('compliance lane derivation', () => {
+  it('returns no complianceRow when lane is disabled (default)', () => {
+    const l = layoutProcessBlueprint(buildFile(), {});
+    expect(l.complianceRow).toBeUndefined();
+  });
+
+  it('returns no complianceRow when enabled but no input provided', () => {
+    const l = layoutProcessBlueprint(buildFile(), { complianceLane: { enabled: true } });
+    expect(l.complianceRow).toBeUndefined();
+  });
+
+  it('returns no complianceRow when assertions have no realised_via matching stage IDs', () => {
+    const input: ComplianceLaneInput = {
+      assertions: [makeAssertion('REQ-1', 'compliant', ['STEP-99'])],
+      requirements: [REQ_A],
+    };
+    const l = layout(buildFile(), input);
+    expect(l.complianceRow).toBeUndefined();
+  });
+
+  it('derives a chip for each law-stage pair', () => {
+    const input: ComplianceLaneInput = {
+      assertions: [makeAssertion('REQ-1', 'compliant', ['STAGE-1'])],
+      requirements: [REQ_A],
+    };
+    const l = layout(buildFile(), input);
+    expect(l.complianceRow).toBeDefined();
+    const chips = l.complianceRow!.chips;
+    expect(chips).toHaveLength(1);
+    expect(chips[0].lawId).toBe('LAW-GDPR-1');
+    expect(chips[0].stageIndex).toBe(0);
+  });
+
+  it('produces one chip per law per stage (same law, two stages → two chips)', () => {
+    const input: ComplianceLaneInput = {
+      assertions: [makeAssertion('REQ-1', 'compliant', ['STAGE-1', 'STAGE-2'])],
+      requirements: [REQ_A],
+    };
+    const l = layout(buildFile(), input);
+    const chips = l.complianceRow!.chips;
+    expect(chips).toHaveLength(2);
+    expect(chips.map(c => c.stageIndex).sort()).toEqual([0, 1]);
+    expect(chips.every(c => c.lawId === 'LAW-GDPR-1')).toBe(true);
+  });
+
+  it('merges multiple assertions for the same law-stage into one chip', () => {
+    const input: ComplianceLaneInput = {
+      assertions: [
+        makeAssertion('REQ-1', 'compliant', ['STAGE-1']),
+        makeAssertion('REQ-1', 'partial', ['STAGE-1']),
+      ],
+      requirements: [REQ_A],
+    };
+    const l = layout(buildFile(), input);
+    expect(l.complianceRow!.chips).toHaveLength(1);
+  });
+
+  describe('decoration: new', () => {
+    it('marks chip as new when law is not in previous snapshot', () => {
+      const input: ComplianceLaneInput = {
+        assertions: [makeAssertion('REQ-1', 'compliant', ['STAGE-1'])],
+        requirements: [REQ_A],
+      };
+      const l = layout(buildFile(), input, { previousSnapshot: { 'STAGE-1': [] } });
+      expect(l.complianceRow!.chips[0].decorations).toContain('new');
+    });
+
+    it('does not mark chip as new when law is in previous snapshot', () => {
+      const input: ComplianceLaneInput = {
+        assertions: [makeAssertion('REQ-1', 'compliant', ['STAGE-1'])],
+        requirements: [REQ_A],
+      };
+      const l = layout(buildFile(), input, { previousSnapshot: { 'STAGE-1': ['LAW-GDPR-1'] } });
+      expect(l.complianceRow!.chips[0].decorations).not.toContain('new');
+    });
+  });
+
+  describe('decoration: gap', () => {
+    it('marks chip as gap when assertion status is non_compliant', () => {
+      const input: ComplianceLaneInput = {
+        assertions: [makeAssertion('REQ-1', 'non_compliant', ['STAGE-1'])],
+        requirements: [REQ_A],
+      };
+      const l = layout(buildFile(), input);
+      expect(l.complianceRow!.chips[0].decorations).toContain('gap');
+    });
+
+    it('marks chip as gap when assertion status is partial', () => {
+      const input: ComplianceLaneInput = {
+        assertions: [makeAssertion('REQ-1', 'partial', ['STAGE-2'])],
+        requirements: [REQ_A],
+      };
+      const l = layout(buildFile(), input);
+      expect(l.complianceRow!.chips[0].decorations).toContain('gap');
+    });
+
+    it('does not mark chip as gap for compliant assertion', () => {
+      const input: ComplianceLaneInput = {
+        assertions: [makeAssertion('REQ-1', 'compliant', ['STAGE-1'])],
+        requirements: [REQ_A],
+      };
+      const l = layout(buildFile(), input);
+      expect(l.complianceRow!.chips[0].decorations).not.toContain('gap');
+    });
+
+    it('propagates gap if any assertion for the same law-stage is non-compliant', () => {
+      const input: ComplianceLaneInput = {
+        assertions: [
+          makeAssertion('REQ-1', 'compliant', ['STAGE-1']),
+          makeAssertion('REQ-1', 'non_compliant', ['STAGE-1']),
+        ],
+        requirements: [REQ_A],
+      };
+      const l = layout(buildFile(), input);
+      expect(l.complianceRow!.chips[0].decorations).toContain('gap');
+    });
+  });
+
+  describe('decoration: deadline', () => {
+    it('marks chip as deadline when gap exists and requirement deadline is past_due', () => {
+      const input: ComplianceLaneInput = {
+        assertions: [makeAssertion('REQ-3', 'non_compliant', ['STAGE-1'])],
+        requirements: [REQ_DEADLINE],
+      };
+      const l = layout(buildFile(), input);
+      const d = l.complianceRow!.chips[0].decorations;
+      expect(d).toContain('gap');
+      expect(d).toContain('deadline');
+    });
+
+    it('does not mark deadline when gap is absent even if deadline is past_due', () => {
+      const input: ComplianceLaneInput = {
+        assertions: [makeAssertion('REQ-3', 'compliant', ['STAGE-1'])],
+        requirements: [REQ_DEADLINE],
+      };
+      const l = layout(buildFile(), input);
+      expect(l.complianceRow!.chips[0].decorations).not.toContain('deadline');
+    });
+
+    it('does not mark deadline when no deadline on requirement', () => {
+      const input: ComplianceLaneInput = {
+        assertions: [makeAssertion('REQ-1', 'non_compliant', ['STAGE-1'])],
+        requirements: [REQ_A],
+      };
+      const l = layout(buildFile(), input);
+      expect(l.complianceRow!.chips[0].decorations).not.toContain('deadline');
+    });
+
+    it('all three decorations can stack on the same chip', () => {
+      const input: ComplianceLaneInput = {
+        assertions: [makeAssertion('REQ-3', 'non_compliant', ['STAGE-1'])],
+        requirements: [REQ_DEADLINE],
+      };
+      const l = layout(buildFile(), input, { previousSnapshot: { 'STAGE-1': [] } });
+      const d = l.complianceRow!.chips[0].decorations;
+      expect(d).toContain('new');
+      expect(d).toContain('gap');
+      expect(d).toContain('deadline');
+    });
+  });
+
+  describe('jurisdiction filter', () => {
+    it('passes through all laws when no jurisdictions filter', () => {
+      const input: ComplianceLaneInput = {
+        assertions: [makeAssertion('REQ-2', 'compliant', ['STAGE-1'])],
+        requirements: [REQ_B], // derived_from: [LAW-GDPR-1, LAW-SOX-2]
+        codexJurisdictions: { 'LAW-GDPR-1': 'EU', 'LAW-SOX-2': 'US' },
+      };
+      const l = layout(buildFile(), input, { jurisdictions: [] });
+      expect(l.complianceRow!.chips).toHaveLength(2);
+    });
+
+    it('filters to only the selected jurisdictions', () => {
+      const input: ComplianceLaneInput = {
+        assertions: [makeAssertion('REQ-2', 'compliant', ['STAGE-1'])],
+        requirements: [REQ_B],
+        codexJurisdictions: { 'LAW-GDPR-1': 'EU', 'LAW-SOX-2': 'US' },
+      };
+      const l = layout(buildFile(), input, { jurisdictions: ['EU'] });
+      expect(l.complianceRow!.chips).toHaveLength(1);
+      expect(l.complianceRow!.chips[0].lawId).toBe('LAW-GDPR-1');
+    });
+
+    it('returns no row when jurisdiction filter excludes all laws', () => {
+      const input: ComplianceLaneInput = {
+        assertions: [makeAssertion('REQ-2', 'compliant', ['STAGE-1'])],
+        requirements: [REQ_B],
+        codexJurisdictions: { 'LAW-GDPR-1': 'EU', 'LAW-SOX-2': 'US' },
+      };
+      const l = layout(buildFile(), input, { jurisdictions: ['AU'] });
+      expect(l.complianceRow).toBeUndefined();
+    });
+  });
+
+  describe('null-guards', () => {
+    it('tolerates null assertion entries without throwing', () => {
+      const input: ComplianceLaneInput = {
+        assertions: [null as unknown as ComplianceLaneAssertion, makeAssertion('REQ-1', 'compliant', ['STAGE-1'])],
+        requirements: [REQ_A],
+      };
+      expect(() => layout(buildFile(), input)).not.toThrow();
+    });
+
+    it('skips assertions with no realised_via', () => {
+      const input: ComplianceLaneInput = {
+        assertions: [{ about: 'REQ-1', status: 'compliant' }],
+        requirements: [REQ_A],
+      };
+      const l = layout(buildFile(), input);
+      expect(l.complianceRow).toBeUndefined();
+    });
+
+    it('skips assertions whose requirement is not in the input', () => {
+      const input: ComplianceLaneInput = {
+        assertions: [makeAssertion('REQ-MISSING', 'non_compliant', ['STAGE-1'])],
+        requirements: [REQ_A],
+      };
+      const l = layout(buildFile(), input);
+      expect(l.complianceRow).toBeUndefined();
+    });
+  });
+
+  describe('legend', () => {
+    it('adds a compliance legend entry when the row is present', () => {
+      const input: ComplianceLaneInput = {
+        assertions: [makeAssertion('REQ-1', 'compliant', ['STAGE-1'])],
+        requirements: [REQ_A],
+      };
+      const l = layout(buildFile(), input);
+      const complianceLegend = l.legend.find(entry => entry.kind === 'compliance');
+      expect(complianceLegend).toBeDefined();
+      expect(complianceLegend!.label).toBe('Compliance');
+    });
+
+    it('does not add compliance legend when row is absent', () => {
+      const l = layoutProcessBlueprint(buildFile(), {});
+      expect(l.legend.some(e => e.kind === 'compliance')).toBe(false);
+    });
+  });
+
+  describe('layout geometry', () => {
+    it('total height grows by the compliance row height', () => {
+      const withoutLane = layoutProcessBlueprint(buildFile(), {});
+      const input: ComplianceLaneInput = {
+        assertions: [makeAssertion('REQ-1', 'compliant', ['STAGE-1'])],
+        requirements: [REQ_A],
+      };
+      const withLane = layout(buildFile(), input);
+      expect(withLane.bounds.height).toBeGreaterThan(withoutLane.bounds.height);
+      expect(withLane.bounds.height).toBe(withoutLane.bounds.height + withLane.complianceRow!.height);
+    });
+
+    it('chip x aligns to the stage column', () => {
+      const input: ComplianceLaneInput = {
+        assertions: [makeAssertion('REQ-1', 'compliant', ['STAGE-2'])],
+        requirements: [REQ_A],
+      };
+      const l = layout(buildFile(), input);
+      const chip = l.complianceRow!.chips[0];
+      // Chip x must be at the start of stage-2's column (index 1) + cellPadding.
+      const expectedX = l.legendColumnWidth + 1 * l.stageColumnWidth + 8; // default cellPadding = 8
+      expect(chip.x).toBe(expectedX);
+    });
+  });
+});

--- a/packages/diagrams/src/process-blueprint/index.ts
+++ b/packages/diagrams/src/process-blueprint/index.ts
@@ -2,6 +2,7 @@ export type {
   AspectCategory,
   Stage,
   AspectEntry,
+  LaneConfig,
   ProcessBlueprintHeader,
   ProcessBlueprintFile,
   ProcessBlueprintLayoutOptions,
@@ -11,6 +12,13 @@ export type {
   AspectPill,
   AspectRow,
   ProcessBlueprintLayout,
+  ComplianceDecoration,
+  ComplianceChip,
+  ComplianceRow,
+  ComplianceLaneConfig,
+  ComplianceLaneAssertion,
+  ComplianceLaneRequirement,
+  ComplianceLaneInput,
 } from './types.js';
 
 export { validateProcessBlueprint } from './validate.js';

--- a/packages/diagrams/src/process-blueprint/layout.ts
+++ b/packages/diagrams/src/process-blueprint/layout.ts
@@ -3,6 +3,12 @@ import type {
   AspectEntry,
   AspectPill,
   AspectRow,
+  ComplianceChip,
+  ComplianceDecoration,
+  ComplianceLaneAssertion,
+  ComplianceLaneInput,
+  ComplianceLaneRequirement,
+  ComplianceRow,
   ProcessBlueprintLayoutOptions,
   LegendCell,
   ProcessBlueprintFile,
@@ -21,7 +27,7 @@ const ASPECT_LABEL: Record<AspectCategory, string> = {
   information_entities: 'Information',
 };
 
-const DEFAULTS: Required<ProcessBlueprintLayoutOptions> = {
+const DEFAULTS = {
   legendColumnWidth: 140,
   stageColumnWidth: 220,
   stageHeaderHeight: 40,
@@ -36,7 +42,9 @@ const DEFAULTS: Required<ProcessBlueprintLayoutOptions> = {
   cellTextPadX: 10,
   cellTextPadY: 10,
   maxTextLines: 6,
-};
+  complianceLane: undefined,
+  complianceInput: undefined,
+} satisfies Required<ProcessBlueprintLayoutOptions>;
 
 interface RawPill {
   category: AspectCategory;
@@ -207,6 +215,141 @@ function packPillsIntoSlots(pills: RawPill[]): { slot: number[]; maxSlot: number
   return { slot, maxSlot };
 }
 
+// ── Compliance lane derivation ────────────────────────────────────────────────
+
+/** ISO 8601 date comparison helper — no Date parsing, string comparison is valid for YYYY-MM-DD. */
+function deadlineStatus(
+  deadline: string | undefined,
+  today: string,
+): 'past_due' | 'in_force' | 'upcoming' | 'none' {
+  if (!deadline) return 'none';
+  if (deadline < today) return 'past_due';
+  const daysAway = Math.round(
+    (new Date(deadline).getTime() - new Date(today).getTime()) / (1000 * 60 * 60 * 24),
+  );
+  return daysAway <= 30 ? 'in_force' : 'upcoming';
+}
+
+/**
+ * Derive the laid-out compliance row for a process blueprint.
+ *
+ * For each stage, gathers the laws that bind that stage (via the
+ * assertion → requirement → derived_from chain), applies the jurisdiction
+ * filter, and computes the three orthogonal decorations per law chip.
+ */
+function deriveComplianceRow(
+  stages: Stage[],
+  stageIndexById: Map<string, number>,
+  input: ComplianceLaneInput,
+  opts: Required<ProcessBlueprintLayoutOptions>,
+  yStart: number,
+): ComplianceRow | undefined {
+  const {
+    complianceLane: laneConfig,
+    legendColumnWidth,
+    stageColumnWidth,
+    cellPadding,
+    pillHeight,
+    pillGap,
+    aspectRowMinHeight,
+  } = opts;
+
+  if (!laneConfig?.enabled) return undefined;
+
+  const today = laneConfig.referenceDate ?? new Date().toISOString().slice(0, 10);
+  const filterJurisdictions = laneConfig.jurisdictions?.length ? new Set(laneConfig.jurisdictions) : null;
+
+  // Build requirement index: id → requirement.
+  const reqById = new Map<string, ComplianceLaneRequirement>();
+  for (const r of input.requirements) {
+    if (r?.id) reqById.set(r.id, r);
+  }
+
+  // Per-stage accumulation: stageIdx → lawId → { worstStatus, deadline }
+  type LawAccumulator = { gap: boolean; deadline: string | undefined };
+  const stageAccum = new Map<number, Map<string, LawAccumulator>>();
+
+  for (const a of input.assertions) {
+    if (!a || typeof a !== 'object') continue;
+    const realisedVia: string[] = Array.isArray(a.realised_via) ? a.realised_via : [];
+    if (realisedVia.length === 0) continue;
+
+    const req = reqById.get(a.about);
+    if (!req) continue;
+
+    const lawIds: string[] = Array.isArray(req.derived_from)
+      ? (req.derived_from as string[]).filter((x): x is string => typeof x === 'string')
+      : [];
+    if (lawIds.length === 0) continue;
+
+    for (const stageRef of realisedVia) {
+      if (typeof stageRef !== 'string') continue;
+      const idx = stageIndexById.get(stageRef.trim());
+      if (idx === undefined) continue;
+
+      for (const lawId of lawIds) {
+        // Apply jurisdiction filter.
+        if (filterJurisdictions) {
+          const jur = input.codexJurisdictions?.[lawId];
+          if (!jur || !filterJurisdictions.has(jur)) continue;
+        }
+
+        if (!stageAccum.has(idx)) stageAccum.set(idx, new Map());
+        const lawMap = stageAccum.get(idx)!;
+        const existing = lawMap.get(lawId);
+        const isGap = a.status === 'non_compliant' || a.status === 'partial';
+        if (!existing) {
+          lawMap.set(lawId, { gap: isGap, deadline: req.deadline });
+        } else {
+          existing.gap = existing.gap || isGap;
+          // Keep the earlier deadline (more urgent).
+          if (req.deadline && (!existing.deadline || req.deadline < existing.deadline)) {
+            existing.deadline = req.deadline;
+          }
+        }
+      }
+    }
+  }
+
+  if (stageAccum.size === 0) return undefined;
+
+  // Determine how many slots (rows) per stage.
+  const slotsPerStage = new Map<number, number>();
+  for (const [idx, lawMap] of stageAccum) {
+    slotsPerStage.set(idx, lawMap.size);
+  }
+  const maxSlots = Math.max(0, ...slotsPerStage.values());
+  if (maxSlots === 0) return undefined;
+
+  const contentHeight = maxSlots * (pillHeight + pillGap) - pillGap;
+  const rowHeight = Math.max(aspectRowMinHeight, contentHeight + 2 * cellPadding);
+
+  const chips: ComplianceChip[] = [];
+
+  for (const [stageIdx, lawMap] of stageAccum) {
+    const prevLawIds = new Set<string>(laneConfig.previousSnapshot?.[stages[stageIdx]?.id ?? ''] ?? []);
+    let slot = 0;
+
+    for (const [lawId, accum] of lawMap) {
+      const decorations: ComplianceDecoration[] = [];
+      if (!prevLawIds.has(lawId)) decorations.push('new');
+      if (accum.gap) {
+        decorations.push('gap');
+        const ds = deadlineStatus(accum.deadline, today);
+        if (ds !== 'none') decorations.push('deadline');
+      }
+
+      const x = legendColumnWidth + stageIdx * stageColumnWidth + cellPadding;
+      const width = stageColumnWidth - 2 * cellPadding;
+      const y = yStart + cellPadding + slot * (pillHeight + pillGap);
+      chips.push({ stageIndex: stageIdx, lawId, decorations, x, y, width, height: pillHeight });
+      slot++;
+    }
+  }
+
+  return { y: yStart, height: rowHeight, chips };
+}
+
 export function layoutProcessBlueprint(
   file: ProcessBlueprintFile,
   options?: ProcessBlueprintLayoutOptions,
@@ -324,6 +467,21 @@ export function layoutProcessBlueprint(
     aspectCursorY += rowHeight;
   }
 
+  // Compliance lane — derived from assertions/requirements, rendered after aspect rows.
+  let complianceRow: import('./types.js').ComplianceRow | undefined;
+  if (opts.complianceLane?.enabled && opts.complianceInput) {
+    complianceRow = deriveComplianceRow(
+      stages,
+      stageIndexById,
+      opts.complianceInput,
+      opts,
+      aspectCursorY,
+    );
+    if (complianceRow) {
+      aspectCursorY += complianceRow.height;
+    }
+  }
+
   // Legend (left column labels): one entry per row.
   const legend: LegendCell[] = [
     { kind: 'goal', label: 'Goal', y: goalRowY, height: goalRowHeight },
@@ -335,6 +493,9 @@ export function layoutProcessBlueprint(
       y: row.y,
       height: row.height,
     })),
+    ...(complianceRow
+      ? [{ kind: 'compliance' as const, label: 'Compliance', y: complianceRow.y, height: complianceRow.height }]
+      : []),
   ];
 
   const totalWidth = opts.legendColumnWidth + stages.length * opts.stageColumnWidth;
@@ -351,5 +512,6 @@ export function layoutProcessBlueprint(
     goalCells,
     resultCells,
     aspectRows,
+    complianceRow,
   };
 }

--- a/packages/diagrams/src/process-blueprint/types.ts
+++ b/packages/diagrams/src/process-blueprint/types.ts
@@ -1,5 +1,101 @@
 export type AspectCategory = 'systems' | 'actors' | 'equipment' | 'information_entities';
 
+// ── Compliance lane types ────────────────────────────────────────────────────
+
+/**
+ * One of the three orthogonal decoration signals that can appear on a compliance
+ * law chip (ADR 2026-06-09-compliance-impact-as-blueprint-lane §3):
+ * - `new`      — law's impact on this stage appeared since the previous snapshot
+ * - `gap`      — a bound assertion has status `non_compliant` or `partial`
+ * - `deadline` — gap is present AND the requirement carries a deadline that is
+ *                past, imminent, or in-force
+ */
+export type ComplianceDecoration = 'new' | 'gap' | 'deadline';
+
+/** Input shape for a requirement — minimal projection the compliance lane needs. */
+export interface ComplianceLaneRequirement {
+  id: string;
+  /** Typed IDs of codex sources (law IDs displayed as chips). */
+  derived_from?: string[];
+  /**
+   * ISO 8601 compliance deadline on the external regulatory source.
+   * Used to compute the `deadline` decoration.
+   */
+  deadline?: string;
+}
+
+/** Input shape for an assertion — minimal projection the compliance lane needs. */
+export interface ComplianceLaneAssertion {
+  /** Requirement ID this assertion is about. */
+  about: string;
+  /** Compliance realisation status. */
+  status: 'compliant' | 'partial' | 'non_compliant' | 'under_review' | 'n_a';
+  /**
+   * Typed IDs of stages / process steps where the requirement is realised.
+   * When empty/absent, the assertion covers the entire subject, not a specific stage.
+   */
+  realised_via?: string[];
+}
+
+/**
+ * Input data for the compliance lane derivation.
+ * Passed via `ProcessBlueprintLayoutOptions.complianceInput`.
+ */
+export interface ComplianceLaneInput {
+  assertions: ComplianceLaneAssertion[];
+  requirements: ComplianceLaneRequirement[];
+  /**
+   * Codex jurisdiction map: codexId → jurisdiction code.
+   * Required only when `ComplianceLaneConfig.jurisdictions` is non-empty.
+   */
+  codexJurisdictions?: Record<string, string>;
+}
+
+/**
+ * Runtime configuration for the compliance lane.
+ * Passed via `ProcessBlueprintLayoutOptions.complianceLane`.
+ */
+export interface ComplianceLaneConfig {
+  /** When false (default), the compliance lane is not rendered. */
+  enabled: boolean;
+  /**
+   * Jurisdiction filter: if non-empty, only show laws whose codex jurisdiction
+   * is in this list. Requires `ComplianceLaneInput.codexJurisdictions`.
+   */
+  jurisdictions?: string[];
+  /**
+   * Per-stage map of law IDs known from the previous generated snapshot.
+   * Key: stage ID; Value: array of law IDs.
+   * A law not present in the previous snapshot is decorated as `new`.
+   */
+  previousSnapshot?: Record<string, string[]>;
+  /**
+   * Reference date for deadline-status computation (YYYY-MM-DD).
+   * Defaults to today when not supplied.
+   */
+  referenceDate?: string;
+}
+
+/** One law chip rendered inside a compliance cell. */
+export interface ComplianceChip {
+  stageIndex: number;
+  /** Codex / law ID shown as the chip label. */
+  lawId: string;
+  /** Active decorations — a subset of the three orthogonal signals. */
+  decorations: ComplianceDecoration[];
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** Laid-out compliance row (one per blueprint when the lane is enabled). */
+export interface ComplianceRow {
+  y: number;
+  height: number;
+  chips: ComplianceChip[];
+}
+
 export interface Stage {
   id: string;
   name: string;
@@ -13,6 +109,16 @@ export interface AspectEntry {
   name: string;
   stages: string[];
   description?: string;
+}
+
+/** Rendering-config block that selects which lanes are visible (spec §5 `lane_config:`). */
+export interface LaneConfig {
+  /** Enable the derived compliance lane. Default: false. */
+  compliance?: boolean;
+  compliance_filter?: {
+    /** ISO jurisdiction codes; empty array means all jurisdictions. */
+    jurisdictions?: string[];
+  };
 }
 
 export interface ProcessBlueprintHeader {
@@ -30,6 +136,8 @@ export interface ProcessBlueprintHeader {
   actors?: AspectEntry[];
   equipment?: AspectEntry[];
   information_entities?: AspectEntry[];
+  /** Optional rendering config selecting which lanes to show. */
+  lane_config?: LaneConfig;
 }
 
 export interface ProcessBlueprintFile {
@@ -58,13 +166,17 @@ export interface ProcessBlueprintLayoutOptions {
   cellTextPadY?: number;
   /** Maximum wrapped lines per goal/result cell before truncating with an ellipsis. */
   maxTextLines?: number;
+  /** Enable and configure the derived compliance lane. Default: disabled. */
+  complianceLane?: ComplianceLaneConfig;
+  /** Assertion + requirement data for the compliance lane derivation. */
+  complianceInput?: ComplianceLaneInput;
 }
 
 import type { LayoutBounds } from '../geometry.js';
 export type { LayoutBounds };
 
 export interface LegendCell {
-  kind: 'goal' | 'result' | 'aspect';
+  kind: 'goal' | 'result' | 'aspect' | 'compliance';
   category?: AspectCategory;
   label: string;
   y: number;
@@ -125,4 +237,6 @@ export interface ProcessBlueprintLayout {
   goalCells: StageTextCell[];
   resultCells: StageTextCell[];
   aspectRows: AspectRow[];
+  /** Compliance lane row — present only when the lane is enabled and has data. */
+  complianceRow?: ComplianceRow;
 }

--- a/packages/diagrams/src/theme/themes.ts
+++ b/packages/diagrams/src/theme/themes.ts
@@ -147,7 +147,13 @@ ${levelRules}
 .maturity-2{fill:var(${cv.maturity2});}
 .maturity-3{fill:var(${cv.maturity3});}
 .maturity-4{fill:var(${cv.maturity4});}
-.maturity-5{fill:var(${cv.maturity5});}`;
+.maturity-5{fill:var(${cv.maturity5});}
+.compliance-gap{fill:var(${cv.statusWarningBg});stroke:var(${cv.statusWarningFg});}
+.compliance-gap text{fill:var(${cv.statusWarningFg});}
+.compliance-deadline{fill:var(${cv.statusErrorBg});stroke:var(${cv.statusErrorFg});}
+.compliance-deadline text{fill:var(${cv.statusErrorFg});}
+.compliance-badge{fill:var(${cv.statusErrorFg});}
+.compliance-badge-text{fill:var(${cv.textInverse});font-family:${t.fontFamily};font-size:8px;font-weight:700;}`;
 }
 
 /**

--- a/packages/diagrams/src/webview/render-process-blueprint.ts
+++ b/packages/diagrams/src/webview/render-process-blueprint.ts
@@ -11,6 +11,7 @@
  */
 import { layoutProcessBlueprint } from '../process-blueprint/layout.js';
 import type {
+  ComplianceChip,
   ProcessBlueprintFile,
   ProcessBlueprintLayout,
 } from '../process-blueprint/types.js';
@@ -42,6 +43,48 @@ function textCellSvg(
     .map((ln, i) => `<tspan x="${x}" y="${first + i * lineHeight}">${escXml(ln)}</tspan>`)
     .join('');
   return `<text class="${cls}" dominant-baseline="central">${tspans}</text>`;
+}
+
+/**
+ * Render a single compliance law chip.
+ *
+ * Three orthogonal decorations are expressed as SVG overrides:
+ * - `new`      — dashed stroke border  (`stroke-dasharray="4 2"`)
+ * - `gap`      — warning-level fill    (`class="…compliance-gap"`)
+ * - `deadline` — urgent fill override  (`class="…compliance-deadline"`) + a small
+ *                badge circle in the top-right corner
+ */
+function complianceChipSvg(chip: ComplianceChip, ox: number, oy: number): string {
+  const { x, y, width, height, lawId, decorations } = chip;
+  const ax = x + ox;
+  const ay = y + oy;
+  const rx = 6;
+  const hasNew = decorations.includes('new');
+  const hasGap = decorations.includes('gap');
+  const hasDeadline = decorations.includes('deadline');
+
+  let rectClass = 'diagram-node level-5 compliance-chip';
+  if (hasDeadline) rectClass += ' compliance-deadline';
+  else if (hasGap) rectClass += ' compliance-gap';
+
+  const strokeDash = hasNew ? ' stroke-dasharray="4 2"' : '';
+  const parts: string[] = [];
+  parts.push(
+    `<rect class="${rectClass}" x="${ax}" y="${ay}" width="${width}" height="${height}" rx="${rx}"${strokeDash}/>`,
+  );
+  parts.push(
+    `<text class="text-pill" x="${ax + width / 2}" y="${ay + height / 2}" text-anchor="middle" dominant-baseline="central">${escXml(truncate(lawId, Math.floor(width / 8)))}</text>`,
+  );
+  if (hasDeadline) {
+    const br = 5;
+    const bx = ax + width - br - 3;
+    const by = ay + br + 3;
+    parts.push(`<circle class="compliance-badge" cx="${bx}" cy="${by}" r="${br}"/>`);
+    parts.push(
+      `<text class="compliance-badge-text" x="${bx}" y="${by}" text-anchor="middle" dominant-baseline="central">!</text>`,
+    );
+  }
+  return parts.join('\n');
 }
 
 export interface RenderProcessBlueprintOptions {
@@ -128,6 +171,23 @@ export function renderProcessBlueprintSvg(
       parts.push(
         `<text class="text-pill" x="${p.x + ox + p.width / 2}" y="${p.y + oy + p.height / 2}" text-anchor="middle" dominant-baseline="central">${escXml(truncate(label, Math.floor(p.width / 8)))}</text>`,
       );
+    }
+  }
+
+  // Compliance row (optional).
+  if (layout.complianceRow) {
+    const row = layout.complianceRow;
+    parts.push(
+      `<rect class="diagram-node level-5" x="${layout.legendColumnWidth + ox}" y="${row.y + oy}" width="${layout.bounds.width - layout.legendColumnWidth}" height="${row.height}" opacity="0.10"/>`,
+    );
+    for (let i = 1; i < layout.stageHeaders.length; i++) {
+      const x = layout.legendColumnWidth + i * layout.stageColumnWidth + ox;
+      parts.push(
+        `<line class="diagram-edge" x1="${x}" y1="${row.y + oy}" x2="${x}" y2="${row.y + row.height + oy}" opacity="0.3"/>`,
+      );
+    }
+    for (const chip of row.chips) {
+      parts.push(complianceChipSvg(chip, ox, oy));
     }
   }
 


### PR DESCRIPTION
## Summary

Implements strategy hub #177 — compliance lane for the Process Blueprint renderer.

Per accepted methodology ADR `docs/decisions/2026-06-09-compliance-impact-as-blueprint-lane.md` (unblocked by #176).

- `@transitrix/diagrams` — compliance lane derivation + chip renderer with three stacking decorations
- VS Code extension — workspace scan wired behind `lane_config.compliance: true`
- 26 new tests, 712 total passing
- Local ADR `docs/adr/0002` cross-referencing the methodology ADR
- Per-user display preferences folder tracked via `.gitkeep`, contents gitignored

### What the compliance lane does

When `lane_config.compliance: true` is set in a blueprint document, the renderer derives — for each stage — which regulatory obligations bind that stage by walking the `ASSERTION.realised_via -> REQUIREMENT.derived_from -> codex ID` chain. Each law appears as a chip with up to three stacking decorations:

| Decoration | Signal | Visual |
|---|---|---|
| `new` | Law appeared since the previous snapshot | Dashed border |
| `gap` | Bound assertion is `non_compliant` or `partial` | Warning fill |
| `deadline` | Gap + `REQUIREMENT.deadline` is past/imminent | Error fill + badge |

### Out of scope

- Drill-down to verbatim source segments (backlog per ADR)
- Named report lane pinning in versioned view-config
- DSM viewer compliance lane (separate task)

## Test plan

- [ ] `npx vitest run` in `packages/diagrams/` — 712 tests pass including 26 new compliance-lane tests
- [ ] Blueprint with `lane_config.compliance: true` and matching assertions in workspace — compliance lane row renders
- [ ] Blueprint without `lane_config.compliance` — no compliance row (disabled by default)
