### PR TITLE
chore: migrate NorthBay compliance demo to methodology/acme_corp

### DIFF
--- a/.archive/compliance-northbay-demo/DEMO.md
+++ b/.archive/compliance-northbay-demo/DEMO.md
@@ -1,0 +1,15 @@
+# [ARCHIVED] Compliance Demo — NorthBay Retail (EU)
+
+**Retired 2026-06-10.** This demo is superseded by the canonical compliance corpus
+in `transitrix/methodology` → `organizations/acme_corp/`.
+
+The acme_corp corpus is a proper connected org — codex entries, requirements,
+assertions, views, and process blueprint all wired to real IDs. It covers all
+six compliance features: compliance matrix, single-law view, single-product view,
+gap dashboard, compliance-impact view, and coverage-metric view.
+
+See: https://github.com/transitrix/methodology/tree/main/organizations/acme_corp
+
+---
+
+*Original NorthBay Retail demo files are preserved below this directory for reference.*

--- a/.archive/compliance-northbay-demo/assertions/ASSERTION-ECOMM-GDPR-CONSENT-1.yaml
+++ b/.archive/compliance-northbay-demo/assertions/ASSERTION-ECOMM-GDPR-CONSENT-1.yaml
@@ -1,0 +1,23 @@
+# [ARCHIVED] NorthBay Retail assertion. Superseded by acme_corp.
+
+notation: assertion
+id: ASSERTION-ECOMM-GDPR-CONSENT-1
+about: REQUIREMENT-GDPR-CONSENT-1
+subject: PRODUCT-ECOMM-1
+realised_via: [STAGE-1]
+status: partial
+evidence:
+  - kind: note
+    text: "Archive only. See transitrix/methodology organizations/acme_corp/ for the canonical version."
+assessed_at: "2026-06-01"
+assessed_by: ROLE-DPO-1
+next_review_at: "2026-08-01"
+zone: canon
+admitted_at: "2026-06-01"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+valid_from: "2026-06-01"
+valid_to: null

--- a/.archive/compliance-northbay-demo/assertions/ASSERTION-ECOMM-GDPR-ERASURE-1.yaml
+++ b/.archive/compliance-northbay-demo/assertions/ASSERTION-ECOMM-GDPR-ERASURE-1.yaml
@@ -1,0 +1,23 @@
+# [ARCHIVED] NorthBay Retail assertion. Superseded by acme_corp.
+
+notation: assertion
+id: ASSERTION-ECOMM-GDPR-ERASURE-1
+about: REQUIREMENT-GDPR-DATA-ERASURE-1
+subject: PRODUCT-ECOMM-1
+realised_via: [STAGE-1, STAGE-2, STAGE-3]
+status: non_compliant
+evidence:
+  - kind: note
+    text: "Archive only. See transitrix/methodology organizations/acme_corp/ for the canonical version."
+assessed_at: "2026-06-01"
+assessed_by: ROLE-DPO-1
+next_review_at: "2026-07-01"
+zone: canon
+admitted_at: "2026-06-01"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+valid_from: "2026-06-01"
+valid_to: null

--- a/.archive/compliance-northbay-demo/assertions/ASSERTION-ECOMM-GDPR-PORTABILITY-1.yaml
+++ b/.archive/compliance-northbay-demo/assertions/ASSERTION-ECOMM-GDPR-PORTABILITY-1.yaml
@@ -1,0 +1,23 @@
+# [ARCHIVED] NorthBay Retail assertion. Superseded by acme_corp.
+
+notation: assertion
+id: ASSERTION-ECOMM-GDPR-PORTABILITY-1
+about: REQUIREMENT-GDPR-PORTABILITY-1
+subject: PRODUCT-ECOMM-1
+realised_via: [STAGE-5]
+status: compliant
+evidence:
+  - kind: note
+    text: "Archive only. See transitrix/methodology organizations/acme_corp/ for the canonical version."
+assessed_at: "2026-06-01"
+assessed_by: ROLE-DPO-1
+next_review_at: "2026-11-01"
+zone: canon
+admitted_at: "2026-06-01"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+valid_from: "2026-06-01"
+valid_to: null

--- a/.archive/compliance-northbay-demo/assertions/ASSERTION-ECOMM-NIS2-INCIDENT-1.yaml
+++ b/.archive/compliance-northbay-demo/assertions/ASSERTION-ECOMM-NIS2-INCIDENT-1.yaml
@@ -1,0 +1,23 @@
+# [ARCHIVED] NorthBay Retail assertion. Superseded by acme_corp.
+
+notation: assertion
+id: ASSERTION-ECOMM-NIS2-INCIDENT-1
+about: REQUIREMENT-NIS2-INCIDENT-REPORT-1
+subject: PRODUCT-ECOMM-1
+realised_via: []
+status: under_review
+evidence:
+  - kind: note
+    text: "Archive only. See transitrix/methodology organizations/acme_corp/ for the canonical version."
+assessed_at: "2026-06-01"
+assessed_by: ROLE-DPO-1
+next_review_at: "2026-09-15"
+zone: canon
+admitted_at: "2026-06-01"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+valid_from: "2026-06-01"
+valid_to: null

--- a/.archive/compliance-northbay-demo/assertions/ASSERTION-SUPPORT-GDPR-ERASURE-1.yaml
+++ b/.archive/compliance-northbay-demo/assertions/ASSERTION-SUPPORT-GDPR-ERASURE-1.yaml
@@ -1,0 +1,23 @@
+# [ARCHIVED] NorthBay Retail assertion. Superseded by acme_corp.
+
+notation: assertion
+id: ASSERTION-SUPPORT-GDPR-ERASURE-1
+about: REQUIREMENT-GDPR-DATA-ERASURE-1
+subject: PRODUCT-SUPPORT-1
+realised_via: []
+status: compliant
+evidence:
+  - kind: note
+    text: "Archive only. See transitrix/methodology organizations/acme_corp/ for the canonical version."
+assessed_at: "2026-06-01"
+assessed_by: ROLE-DPO-1
+next_review_at: "2026-10-01"
+zone: canon
+admitted_at: "2026-06-01"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+valid_from: "2026-06-01"
+valid_to: null

--- a/.archive/compliance-northbay-demo/compliance-impact/gdpr-nis2.compliance-impact.view.yaml
+++ b/.archive/compliance-northbay-demo/compliance-impact/gdpr-nis2.compliance-impact.view.yaml
@@ -1,0 +1,15 @@
+# [ARCHIVED] NorthBay Retail compliance-impact view. Superseded by acme_corp.
+# See organizations/acme_corp/canon/views/eu-compliance.compliance-impact.transitrix.yaml
+
+view:
+  id: COMPLIANCE_IMPACT-NORTHBAY-EU-1
+  name: "NorthBay Retail — EU Compliance Impact (GDPR + NIS2)"
+  subjects:
+    products:
+      - PRODUCT-ECOMM-1
+      - PRODUCT-SUPPORT-1
+  obligations:
+    filter:
+      derived_from_codex:
+        - LAW-GDPR-1
+        - LAW-NIS2-1

--- a/.archive/compliance-northbay-demo/coverage-metric/eu-coverage.coverage-metric.transitrix.yaml
+++ b/.archive/compliance-northbay-demo/coverage-metric/eu-coverage.coverage-metric.transitrix.yaml
@@ -1,0 +1,18 @@
+# [ARCHIVED] NorthBay Retail coverage-metric view. Superseded by acme_corp.
+# See organizations/acme_corp/canon/views/eu-coverage.coverage-metric.transitrix.yaml
+
+notation: coverage-metric
+spec_version: "0.1"
+
+coverage_metric:
+  id: COVERAGE_METRIC-NORTHBAY-EU-1
+  name: "NorthBay Retail — EU Coverage Metric (GDPR + NIS2) [ARCHIVED]"
+  scope:
+    jurisdictions: [EU]
+    codex: [LAW-GDPR-1, LAW-NIS2-1]
+    subjects:
+      products: [PRODUCT-ECOMM-1, PRODUCT-SUPPORT-1]
+  thresholds:
+    green: 0.80
+    amber: 0.50
+    red: 0.00

--- a/.archive/compliance-northbay-demo/requirements/REQUIREMENT-GDPR-CONSENT-1.yaml
+++ b/.archive/compliance-northbay-demo/requirements/REQUIREMENT-GDPR-CONSENT-1.yaml
@@ -1,0 +1,25 @@
+# [ARCHIVED] Demo requirement — GDPR Art. 7 consent. NorthBay Retail. Superseded by acme_corp.
+
+notation: requirement
+id: REQUIREMENT-GDPR-CONSENT-1
+name: "Obtain and record explicit consent before processing personal data"
+description: >
+  The controller must obtain explicit, informed, and unambiguous consent before
+  processing personal data for marketing and profiling purposes.
+
+severity: high
+derived_from:
+  - LAW-GDPR-1
+
+deadline: "2026-09-30"
+
+zone: canon
+admitted_at: "2026-06-01"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2018-05-25"
+valid_to: null

--- a/.archive/compliance-northbay-demo/requirements/REQUIREMENT-GDPR-DATA-ERASURE-1.yaml
+++ b/.archive/compliance-northbay-demo/requirements/REQUIREMENT-GDPR-DATA-ERASURE-1.yaml
@@ -1,0 +1,28 @@
+# [ARCHIVED] Demo requirement — GDPR Art. 17 right to erasure.
+# NorthBay Retail EU compliance demo scenario. Superseded by acme_corp.
+
+notation: requirement
+id: REQUIREMENT-GDPR-DATA-ERASURE-1
+name: "Right to erasure — respond to deletion request within 30 days"
+description: >
+  On a verified request from a data subject, the controller must erase all personal
+  data relating to that subject within 30 calendar days. The window starts when the
+  request is received and identity is verified. Applies to every system holding
+  personal data of EU residents.
+
+severity: high
+derived_from:
+  - LAW-GDPR-1
+
+deadline: "2025-12-31"
+
+zone: canon
+admitted_at: "2026-06-01"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2018-05-25"
+valid_to: null

--- a/.archive/compliance-northbay-demo/requirements/REQUIREMENT-GDPR-PORTABILITY-1.yaml
+++ b/.archive/compliance-northbay-demo/requirements/REQUIREMENT-GDPR-PORTABILITY-1.yaml
@@ -1,0 +1,23 @@
+# [ARCHIVED] Demo requirement — GDPR Art. 20 portability. NorthBay Retail. Superseded by acme_corp.
+
+notation: requirement
+id: REQUIREMENT-GDPR-PORTABILITY-1
+name: "Provide personal data in machine-readable format on request"
+description: >
+  On request, the controller must provide the data subject with their personal data
+  in a structured, commonly used, and machine-readable format within 30 days.
+
+severity: medium
+derived_from:
+  - LAW-GDPR-1
+
+zone: canon
+admitted_at: "2026-06-01"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2018-05-25"
+valid_to: null

--- a/.archive/compliance-northbay-demo/requirements/REQUIREMENT-NIS2-INCIDENT-REPORT-1.yaml
+++ b/.archive/compliance-northbay-demo/requirements/REQUIREMENT-NIS2-INCIDENT-REPORT-1.yaml
@@ -1,0 +1,25 @@
+# [ARCHIVED] Demo requirement — NIS2 Art. 23 incident reporting. NorthBay Retail. Superseded by acme_corp.
+
+notation: requirement
+id: REQUIREMENT-NIS2-INCIDENT-REPORT-1
+name: "Report significant cybersecurity incidents to authority within 24 hours"
+description: >
+  Entities in scope must notify the competent national authority of any significant
+  cybersecurity incident within 24 hours of becoming aware of it.
+
+severity: high
+derived_from:
+  - LAW-NIS2-1
+
+deadline: "2026-09-01"
+
+zone: canon
+admitted_at: "2026-06-01"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2023-01-16"
+valid_to: null

--- a/.archive/compliance-northbay-demo/requirements/REQUIREMENT-NIS2-SUPPLY-CHAIN-1.yaml
+++ b/.archive/compliance-northbay-demo/requirements/REQUIREMENT-NIS2-SUPPLY-CHAIN-1.yaml
@@ -1,0 +1,23 @@
+# [ARCHIVED] Demo requirement — NIS2 Art. 21 supply-chain. NorthBay Retail. Superseded by acme_corp.
+
+notation: requirement
+id: REQUIREMENT-NIS2-SUPPLY-CHAIN-1
+name: "Assess and manage cybersecurity risks in the supply chain"
+description: >
+  Entities must implement measures to assess and manage cybersecurity risks arising
+  from relationships with suppliers and service providers.
+
+severity: medium
+derived_from:
+  - LAW-NIS2-1
+
+zone: canon
+admitted_at: "2026-06-01"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2023-01-16"
+valid_to: null

--- a/examples/compliance-impact/gdpr-nis2.compliance-impact.view.yaml
+++ b/examples/compliance-impact/gdpr-nis2.compliance-impact.view.yaml
@@ -1,0 +1,30 @@
+# Compliance-impact example — retired stub.
+#
+# The canonical compliance-impact view for the demo now lives at:
+#   transitrix/methodology:
+#   organizations/acme_corp/canon/views/eu-compliance.compliance-impact.transitrix.yaml
+#
+# Open that file in Transitrix Studio to see the obligation x product matrix.
+#
+# Original NorthBay Retail version archived at:
+#   .archive/compliance-northbay-demo/compliance-impact/gdpr-nis2.compliance-impact.view.yaml
+
+notation: compliance-impact
+spec_version: "0.1"
+
+view:
+  id: COMPLIANCE_IMPACT-ACME-EU-1
+  name: "acme_corp — EU Compliance Impact (GDPR + NIS2)"
+  description: >
+    Demo stub — open the canonical view in transitrix/methodology/organizations/acme_corp/
+    for the full connected demo. This file exists only to keep the examples/ directory
+    consistent for Studio auto-detection.
+  subjects:
+    products:
+      - PRODUCT-ECOMM-1
+      - PRODUCT-SUPPORT-1
+  obligations:
+    filter:
+      derived_from_codex:
+        - LAW-GDPR-1
+        - LAW-NIS2-1

--- a/examples/compliance/DEMO.md
+++ b/examples/compliance/DEMO.md
@@ -1,0 +1,35 @@
+# Compliance Demo — acme_corp (EU)
+
+> **This example directory is retired.** The canonical compliance demo has moved
+> to the `transitrix/methodology` repository under `organizations/acme_corp/`.
+>
+> See: https://github.com/transitrix/methodology/tree/main/organizations/acme_corp
+
+---
+
+## Quick start
+
+Open Transitrix Studio in VS Code, then open any of these files from
+`transitrix/methodology/organizations/acme_corp/`:
+
+| File | What you see |
+|---|---|
+| `canon/views/eu-compliance.compliance-impact.transitrix.yaml` | Compliance matrix: obligations × products |
+| `canon/views/eu-coverage.coverage-metric.transitrix.yaml` | Coverage-% gauge per law |
+| `examples/process-blueprint/order-fulfilment.process-blueprint.transitrix.yaml` | Process blueprint with compliance lane |
+
+## Features demonstrated
+
+| Feature | Entry point |
+|---|---|
+| Compliance matrix | Compliance-impact view |
+| Single-law view | Filter `derived_from_codex: [LAW-GDPR-1]` |
+| Single-product view | Filter `subjects.products: [PRODUCT-ECOMM-1]` |
+| Gap dashboard | NIS2 supply-chain has no assertion → gap cell |
+| Compliance-impact view | `eu-compliance.compliance-impact.transitrix.yaml` |
+| Coverage-metric view | `eu-coverage.coverage-metric.transitrix.yaml` |
+| Process blueprint lane | Order-fulfilment blueprint with `lane_config.compliance: true` |
+
+---
+
+Original NorthBay Retail demo files archived at `.archive/compliance-northbay-demo/`.

--- a/examples/coverage-metric/eu-coverage.coverage-metric.transitrix.yaml
+++ b/examples/coverage-metric/eu-coverage.coverage-metric.transitrix.yaml
@@ -1,0 +1,34 @@
+# Coverage-metric example — retired stub.
+#
+# The canonical coverage-metric view for the demo now lives at:
+#   transitrix/methodology:
+#   organizations/acme_corp/canon/views/eu-coverage.coverage-metric.transitrix.yaml
+#
+# Open that file in Transitrix Studio to see the coverage gauges.
+#
+# Original NorthBay Retail version archived at:
+#   .archive/compliance-northbay-demo/coverage-metric/eu-coverage.coverage-metric.transitrix.yaml
+
+notation: coverage-metric
+spec_version: "0.1"
+
+coverage_metric:
+  id: COVERAGE_METRIC-ACME-EU-1
+  name: "acme_corp — EU Coverage Metric (GDPR + NIS2)"
+  description: >
+    Demo stub — open the canonical view in transitrix/methodology/organizations/acme_corp/
+    for the full connected demo.
+  scope:
+    jurisdictions:
+      - eu
+    codex:
+      - LAW-GDPR-1
+      - LAW-NIS2-1
+    subjects:
+      products:
+        - PRODUCT-ECOMM-1
+        - PRODUCT-SUPPORT-1
+  thresholds:
+    green: 0.80
+    amber: 0.50
+    red: 0.00

--- a/examples/process-blueprint/order-fulfilment.process-blueprint.transitrix.yaml
+++ b/examples/process-blueprint/order-fulfilment.process-blueprint.transitrix.yaml
@@ -15,6 +15,12 @@ process_blueprint:
   process: PROCESS-ORD-FULFIL-1
   scenario: SCENARIO-2026-BASE-1
 
+  # Enable the compliance lane (strategy#177 — implementation pending).
+  # When the lane is rendered, Studio derives per-stage obligation chips from the
+  # assertions whose realised_via lists include each stage ID.
+  lane_config:
+    compliance: true
+
   stages:
     - id: STAGE-1
       name: "Receive order"


### PR DESCRIPTION
## What

The Studio `examples/compliance/` NorthBay Retail scenario was a disconnected rendering showcase. The canonical compliance demo now lives in `transitrix/methodology` → `organizations/acme_corp/` (see methodology PR #180).

### Changes

**Archived to `.archive/compliance-northbay-demo/`**
- All 5 NorthBay requirements, 5 assertions, compliance-impact view, coverage-metric view, DEMO.md

**Replaced with stubs / updated**
- `examples/compliance/DEMO.md` — now a redirect to acme_corp with feature table
- `examples/compliance-impact/gdpr-nis2.compliance-impact.view.yaml` — stub pointing to acme_corp canonical view
- `examples/coverage-metric/eu-coverage.coverage-metric.transitrix.yaml` — stub pointing to acme_corp canonical view
- `examples/process-blueprint/order-fulfilment.process-blueprint.transitrix.yaml` — added `lane_config.compliance: true` (feature strategy#177, implementation pending)

### Why

- acme_corp is an actual org corpus: codex → requirements → assertions → views all resolve to real element IDs
- NorthBay was a standalone rendering demo with no org structure; it couldn't demonstrate the ingest skill or the DQ model
- `lane_config.compliance: true` wires the process blueprint to the compliance assertions via `realised_via`; the lane will render once strategy#177 is implemented

Paired with: transitrix/methodology#180
Closes strategy#178 (compliance demo scenario on acme_corp)