### PR TITLE
feat(extension): migrate cervin.* settings to transitrix.* (P2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Added
+- **VS Code settings `transitrix.fileExtensions` / `transitrix.exportEnabled`** — canonical replacements for the legacy `cervin.*` keys, registered in the extension's `contributes.configuration`.
+
+### Deprecated
+- **`cervin.*` extension settings are deprecated, use `transitrix.*`.** The legacy `cervin.fileExtensions` / `cervin.exportEnabled` keys are read as a fallback when their `transitrix.*` counterpart is unset (existing configs keep working) and are marked deprecated in the settings UI; removal is slated for 2.0.0. A one-time migration notice is shown on activation when a legacy key is in effect. Second phase of the Cervin → Transitrix rename (CLAUDE.md §Cervin naming, P2).
+
 ## [1.4.1] — 2026-06-09
 
 ### Fixed

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Transitrix Studio — changelog
 
+## Unreleased
+
+### Changed
+
+- **Settings renamed `cervin.*` → `transitrix.*`.** `transitrix.fileExtensions` and `transitrix.exportEnabled` are now the canonical keys. The legacy `cervin.fileExtensions` / `cervin.exportEnabled` keys are still read as a fallback when the new key is unset (so existing configs keep working), but are deprecated and will be removed in 2.0.0. A one-time migration notice is shown on activation when a legacy key is in effect.
+
 ## 1.4.0 — 2026-06-05
 
 Adds PDF export for the compliance views and fixes Process Blueprint cells clipping their text.

--- a/extension/README.md
+++ b/extension/README.md
@@ -52,6 +52,20 @@ Transitrix and Mermaid are **complementary, not competing**. Use **Mermaid** for
 
 Recognised BPMN file suffixes are configurable in **Settings → Transitrix Studio**.
 
+## Settings
+
+Configure under **Settings → Transitrix Studio**. The canonical keys are `transitrix.*`.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `transitrix.fileExtensions` | `[".cervin.yaml", ".bpmn.transitrix.yaml"]` | File suffixes recognised as Transitrix BPMN source files (leading dot required). |
+| `transitrix.exportEnabled` | `false` | Show the experimental BPMN/SVG/PNG export commands. |
+
+> **Deprecated:** the legacy `cervin.fileExtensions` and `cervin.exportEnabled` keys
+> are still read as a fallback when their `transitrix.*` counterpart is unset, but are
+> deprecated and will be removed in **2.0.0**. Rename them to `transitrix.*`. If a
+> legacy key is in effect you'll see a one-time migration notice on activation.
+
 ## Learn more
 
 - 🌐 **Site** — [transitrix.com](https://transitrix.com)

--- a/extension/package.json
+++ b/extension/package.json
@@ -73,7 +73,7 @@
     "configuration": {
       "title": "Transitrix Studio",
       "properties": {
-        "cervin.fileExtensions": {
+        "transitrix.fileExtensions": {
           "type": "array",
           "items": {
             "type": "string"
@@ -84,10 +84,28 @@
           ],
           "description": "File suffixes recognized as Transitrix BPMN source files (must include the leading dot)."
         },
-        "cervin.exportEnabled": {
+        "transitrix.exportEnabled": {
           "type": "boolean",
           "default": false,
           "description": "Show experimental BPMN/SVG/PNG export commands (not finished yet)."
+        },
+        "cervin.fileExtensions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            ".cervin.yaml",
+            ".bpmn.transitrix.yaml"
+          ],
+          "description": "Deprecated — use transitrix.fileExtensions. Read as a fallback through 1.x; removed in 2.0.0.",
+          "deprecationMessage": "Deprecated: use transitrix.fileExtensions instead. This key is read as a fallback through the 1.x line and removed in 2.0.0."
+        },
+        "cervin.exportEnabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Deprecated — use transitrix.exportEnabled. Read as a fallback through 1.x; removed in 2.0.0.",
+          "deprecationMessage": "Deprecated: use transitrix.exportEnabled instead. This key is read as a fallback through the 1.x line and removed in 2.0.0."
         },
         "transitrix.theme": {
           "type": "string",
@@ -387,19 +405,19 @@
         "command": "cervin.exportSvg",
         "title": "Transitrix: Export as SVG",
         "category": "Transitrix",
-        "enablement": "config.cervin.exportEnabled"
+        "enablement": "config.transitrix.exportEnabled || config.cervin.exportEnabled"
       },
       {
         "command": "cervin.exportPng",
         "title": "Transitrix: Export as PNG",
         "category": "Transitrix",
-        "enablement": "config.cervin.exportEnabled"
+        "enablement": "config.transitrix.exportEnabled || config.cervin.exportEnabled"
       },
       {
         "command": "cervin.exportBpmn",
         "title": "Transitrix: Export as .bpmn",
         "category": "Transitrix",
-        "enablement": "config.cervin.exportEnabled"
+        "enablement": "config.transitrix.exportEnabled || config.cervin.exportEnabled"
       },
       {
         "command": "transitrixStudio.previewGoals",

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -24,6 +24,7 @@ import { CoverageMetricPreview } from './coverage-metric-preview.js';
 import { openComplianceFile } from './compliance-scan.js';
 import type { LayoutMetrics, ValidationReport } from './types.js';
 import {
+  checkCervinSettingsMigration,
   documentMatchesCervinSource,
   formatExtensionHint,
   getConfiguredExtensions,
@@ -117,6 +118,11 @@ function notYet(label: string): void {
 }
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
+  // Cervin → Transitrix settings migration (P2): warn once if a user config
+  // still relies on a legacy `cervin.*` key while its `transitrix.*` counterpart
+  // is unset.
+  checkCervinSettingsMigration();
+
   // TX-R003: cache the in-flight Promise, not the resolved result. Two
   // concurrent calls during the brief window before `loadCompiler` resolves
   // would otherwise both pass the `if (!compileFn)` guard and run the loader
@@ -170,7 +176,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       const exts = getConfiguredExtensions();
       if (!doc || !documentMatchesCervinSource(doc)) {
         vscode.window.showWarningMessage(
-          `Open a file with one of these suffixes: ${formatExtensionHint(exts)} (configure with cervin.fileExtensions).`,
+          `Open a file with one of these suffixes: ${formatExtensionHint(exts)} (configure with transitrix.fileExtensions).`,
         );
         return;
       }

--- a/extension/src/settings-migration.ts
+++ b/extension/src/settings-migration.ts
@@ -1,0 +1,37 @@
+// Cervin → Transitrix settings migration (CLAUDE.md §Cervin naming, P2).
+//
+// The canonical configuration keys are `transitrix.*`; the legacy `cervin.*`
+// keys are kept as read-only fallbacks through the 1.x line (removed in 2.0.0).
+// The pure resolver below has no `vscode` dependency so it can be unit-tested
+// from the root vitest suite; the vscode-aware wiring lives in
+// `source-files.ts` / `extension.ts`.
+
+export interface ResolvedSetting<T> {
+  value: T | undefined;
+  /** true when the effective value came from the legacy `cervin.*` key. */
+  usedCervinFallback: boolean;
+}
+
+/**
+ * Prefer the canonical `transitrix.*` value; fall back to the legacy `cervin.*`
+ * value only when the new key is unset or empty. `isEmpty` decides what "unset"
+ * means for the setting's type (e.g. an empty array). `undefined` always counts
+ * as unset.
+ */
+export function resolveCervinFallback<T>(
+  transitrixValue: T | undefined,
+  cervinValue: T | undefined,
+  isEmpty: (v: T) => boolean = () => false,
+): ResolvedSetting<T> {
+  if (transitrixValue !== undefined && !isEmpty(transitrixValue)) {
+    return { value: transitrixValue, usedCervinFallback: false };
+  }
+  if (cervinValue !== undefined && !isEmpty(cervinValue)) {
+    return { value: cervinValue, usedCervinFallback: true };
+  }
+  return { value: transitrixValue ?? cervinValue, usedCervinFallback: false };
+}
+
+export const CERVIN_SETTINGS_DEPRECATION_NOTICE =
+  'Transitrix Studio: `cervin.*` settings are deprecated and will be removed in 2.0.0 — ' +
+  'rename them to `transitrix.*` (e.g. `transitrix.fileExtensions`, `transitrix.exportEnabled`).';

--- a/extension/src/source-files.ts
+++ b/extension/src/source-files.ts
@@ -1,10 +1,56 @@
 import * as vscode from 'vscode';
 
+import {
+  CERVIN_SETTINGS_DEPRECATION_NOTICE,
+  resolveCervinFallback,
+} from './settings-migration.js';
+
 // NOTE (RD-071): DEFAULT_CERVIN_EXTENSIONS and normalizeExtension are intentionally
 // duplicated in src/cli-parse.ts (as DEFAULT_CERVIN_FILE_EXTENSIONS / normalizeExt).
 // The extension bundles its own compiler copy and cannot share imports with the CLI
 // package. Keep both lists in sync when adding/removing extensions.
 export const DEFAULT_CERVIN_EXTENSIONS = ['.cervin.yaml', '.bpmn.transitrix.yaml'];
+
+// Settings keys subject to the cervin.* → transitrix.* migration (P2).
+const MIGRATED_SETTING_KEYS = ['fileExtensions', 'exportEnabled'];
+
+let cervinSettingsNoticeShown = false;
+
+/**
+ * Surface the cervin.* → transitrix.* settings deprecation exactly once per
+ * session — both to the extension console and as a single warning toast.
+ */
+export function noteCervinSettingsDeprecation(): void {
+  if (cervinSettingsNoticeShown) return;
+  cervinSettingsNoticeShown = true;
+  console.warn(CERVIN_SETTINGS_DEPRECATION_NOTICE);
+  void vscode.window.showWarningMessage(CERVIN_SETTINGS_DEPRECATION_NOTICE);
+}
+
+function userHasSet(cfg: vscode.WorkspaceConfiguration, key: string): boolean {
+  const inspected = cfg.inspect(key);
+  return (
+    inspected?.globalValue !== undefined ||
+    inspected?.workspaceValue !== undefined ||
+    inspected?.workspaceFolderValue !== undefined
+  );
+}
+
+/**
+ * On activate (P2): if any migrated setting is configured only under the legacy
+ * `cervin.*` key while its `transitrix.*` counterpart is unset, the legacy value
+ * is the one taking effect — warn once so users migrate before 2.0.0.
+ */
+export function checkCervinSettingsMigration(): void {
+  const transitrixCfg = vscode.workspace.getConfiguration('transitrix');
+  const cervinCfg = vscode.workspace.getConfiguration('cervin');
+  const usingLegacy = MIGRATED_SETTING_KEYS.some(
+    (key) => userHasSet(cervinCfg, key) && !userHasSet(transitrixCfg, key),
+  );
+  if (usingLegacy) {
+    noteCervinSettingsDeprecation();
+  }
+}
 
 export function normalizeExtension(s: string): string {
   const t = s.trim();
@@ -13,7 +59,22 @@ export function normalizeExtension(s: string): string {
 }
 
 export function getConfiguredExtensions(): string[] {
-  const raw = vscode.workspace.getConfiguration('cervin').get<unknown>('fileExtensions');
+  const transitrixRaw = vscode.workspace
+    .getConfiguration('transitrix')
+    .get<unknown>('fileExtensions');
+  const cervinRaw = vscode.workspace.getConfiguration('cervin').get<unknown>('fileExtensions');
+
+  // Prefer transitrix.fileExtensions; fall back to the legacy cervin.* value.
+  const resolved = resolveCervinFallback<unknown>(
+    transitrixRaw,
+    cervinRaw,
+    (v) => !Array.isArray(v) || v.length === 0,
+  );
+  if (resolved.usedCervinFallback) {
+    noteCervinSettingsDeprecation();
+  }
+
+  const raw = resolved.value;
   if (!Array.isArray(raw) || raw.length === 0) {
     return [...DEFAULT_CERVIN_EXTENSIONS];
   }

--- a/tests/settings-migration.test.ts
+++ b/tests/settings-migration.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CERVIN_SETTINGS_DEPRECATION_NOTICE,
+  resolveCervinFallback,
+} from '../extension/src/settings-migration.js';
+
+const isEmptyArray = (v: unknown): boolean => !Array.isArray(v) || v.length === 0;
+
+describe('resolveCervinFallback (Cervin deprecation P2)', () => {
+  it('prefers the transitrix value when set', () => {
+    expect(resolveCervinFallback('new', 'old')).toEqual({
+      value: 'new',
+      usedCervinFallback: false,
+    });
+  });
+
+  it('falls back to the cervin value when transitrix is undefined', () => {
+    expect(resolveCervinFallback(undefined, 'old')).toEqual({
+      value: 'old',
+      usedCervinFallback: true,
+    });
+  });
+
+  it('treats an empty array as unset and falls back', () => {
+    const r = resolveCervinFallback<unknown>([], ['.cervin.yaml'], isEmptyArray);
+    expect(r).toEqual({ value: ['.cervin.yaml'], usedCervinFallback: true });
+  });
+
+  it('keeps a non-empty transitrix array over the legacy one', () => {
+    const r = resolveCervinFallback<unknown>(['.a'], ['.b'], isEmptyArray);
+    expect(r).toEqual({ value: ['.a'], usedCervinFallback: false });
+  });
+
+  it('reports no fallback when both are unset', () => {
+    expect(resolveCervinFallback(undefined, undefined)).toEqual({
+      value: undefined,
+      usedCervinFallback: false,
+    });
+    const r = resolveCervinFallback<unknown>([], [], isEmptyArray);
+    expect(r).toEqual({ value: [], usedCervinFallback: false });
+  });
+
+  it('does not flag fallback for a falsy-but-set transitrix boolean', () => {
+    expect(resolveCervinFallback(false, true)).toEqual({
+      value: false,
+      usedCervinFallback: false,
+    });
+  });
+
+  it('exposes a deprecation notice naming the transitrix keys', () => {
+    expect(CERVIN_SETTINGS_DEPRECATION_NOTICE).toMatch(/transitrix\./);
+    expect(CERVIN_SETTINGS_DEPRECATION_NOTICE).toMatch(/deprecated/i);
+  });
+});


### PR DESCRIPTION
## Summary

Second phase of the **Cervin → Transitrix** gradual rename (CLAUDE.md §Cervin naming, **P2**). No breaking change — existing `cervin.*` user configs keep working via read-fallback.

Closes the acceptance criteria of strategy hub issue **#189**.

## Changes

- **`extension/package.json`** — register `transitrix.fileExtensions` and `transitrix.exportEnabled` as the canonical settings. The legacy `cervin.*` keys are kept with a `deprecationMessage` (struck through in the Settings UI). Export-command `enablement` now reads `config.transitrix.exportEnabled || config.cervin.exportEnabled`.
- **`extension/src/settings-migration.ts`** (new) — pure `resolveCervinFallback()` resolver + `CERVIN_SETTINGS_DEPRECATION_NOTICE`. No `vscode` import, so it's unit-testable from the root vitest suite.
- **`extension/src/source-files.ts`** — `getConfiguredExtensions()` reads `transitrix.fileExtensions` first and falls back to `cervin.fileExtensions`; `checkCervinSettingsMigration()` warns **once** on activate (console + single toast) when a legacy key is in effect while its `transitrix.*` counterpart is unset (detected via `config.inspect()`). The `openPreview` hint now points at `transitrix.fileExtensions`.
- **`extension/src/extension.ts`** — runs the migration check on activate.
- **README + CHANGELOGs** — settings table lists `transitrix.*` as canonical; `cervin.*` noted as deprecated (removal in 2.0.0).

## Verification

- `npx vitest run` — **244 tests green** (7 new in `tests/settings-migration.test.ts`).
- `extension/package.json` validated as JSON.

## Notes

- `npm run compile:extension` reports **pre-existing** type errors in `packages/diagrams/src/process-blueprint/layout.ts` (from #129, `complianceLane` optionality) — confirmed present on a clean `main` checkout via `git stash`, unrelated to this PR and out of scope. My changed files add no new type errors.
- The when-clause `||` fallback handles command visibility for `exportEnabled`; the activate-time `inspect()` check covers the one-time deprecation notice for both keys.

Next phase: **P3** (extension commands, #190).

🤖 Generated with [Claude Code](https://claude.com/claude-code)