### PR TITLE
feat(extension): migrate cervin.* commands to transitrix.* (P3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Added
+- **VS Code commands `transitrix.openPreview` / `transitrix.exportSvg` / `transitrix.exportPng` / `transitrix.exportBpmn`** — canonical replacements for the `cervin.*` commands. The editor-title preview button now invokes `transitrix.openPreview`.
+
+### Deprecated
+- **`cervin.*` extension commands are deprecated, use `transitrix.*`.** The four `cervin.*` commands are kept as aliases for one release so existing keybindings and macros survive; they are hidden from the Command Palette and labelled "(deprecated)", and invoking one logs a one-time deprecation notice before delegating to the canonical handler. Removal is slated for 2.0.0. Third phase of the Cervin → Transitrix rename (CLAUDE.md §Cervin naming, P3).
+
 ## [1.4.1] — 2026-06-09
 
 ### Fixed

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Transitrix Studio — changelog
 
+## Unreleased
+
+### Changed
+
+- **Commands renamed `cervin.*` → `transitrix.*`.** `transitrix.openPreview`, `transitrix.exportSvg`, `transitrix.exportPng` and `transitrix.exportBpmn` are now the canonical commands (the editor-title preview button uses `transitrix.openPreview`). The legacy `cervin.*` commands remain as deprecated aliases for one release so existing keybindings and macros keep working — they're hidden from the Command Palette and invoking one shows a one-time deprecation notice. Removal in 2.0.0.
+
 ## 1.4.0 — 2026-06-05
 
 Adds PDF export for the compliance views and fixes Process Blueprint cells clipping their text.

--- a/extension/package.json
+++ b/extension/package.json
@@ -378,26 +378,50 @@
     ],
     "commands": [
       {
-        "command": "cervin.openPreview",
+        "command": "transitrix.openPreview",
         "title": "Transitrix: Open Preview",
         "category": "Transitrix",
         "icon": "$(graph)"
       },
       {
-        "command": "cervin.exportSvg",
+        "command": "transitrix.exportSvg",
         "title": "Transitrix: Export as SVG",
         "category": "Transitrix",
         "enablement": "config.cervin.exportEnabled"
       },
       {
-        "command": "cervin.exportPng",
+        "command": "transitrix.exportPng",
         "title": "Transitrix: Export as PNG",
         "category": "Transitrix",
         "enablement": "config.cervin.exportEnabled"
       },
       {
-        "command": "cervin.exportBpmn",
+        "command": "transitrix.exportBpmn",
         "title": "Transitrix: Export as .bpmn",
+        "category": "Transitrix",
+        "enablement": "config.cervin.exportEnabled"
+      },
+      {
+        "command": "cervin.openPreview",
+        "title": "Transitrix: Open Preview (deprecated, use transitrix.openPreview)",
+        "category": "Transitrix",
+        "icon": "$(graph)"
+      },
+      {
+        "command": "cervin.exportSvg",
+        "title": "Transitrix: Export as SVG (deprecated, use transitrix.exportSvg)",
+        "category": "Transitrix",
+        "enablement": "config.cervin.exportEnabled"
+      },
+      {
+        "command": "cervin.exportPng",
+        "title": "Transitrix: Export as PNG (deprecated, use transitrix.exportPng)",
+        "category": "Transitrix",
+        "enablement": "config.cervin.exportEnabled"
+      },
+      {
+        "command": "cervin.exportBpmn",
+        "title": "Transitrix: Export as .bpmn (deprecated, use transitrix.exportBpmn)",
         "category": "Transitrix",
         "enablement": "config.cervin.exportEnabled"
       },
@@ -683,10 +707,28 @@
       }
     ],
     "menus": {
+      "commandPalette": [
+        {
+          "command": "cervin.openPreview",
+          "when": "false"
+        },
+        {
+          "command": "cervin.exportSvg",
+          "when": "false"
+        },
+        {
+          "command": "cervin.exportPng",
+          "when": "false"
+        },
+        {
+          "command": "cervin.exportBpmn",
+          "when": "false"
+        }
+      ],
       "editor/title": [
         {
           "when": "resourceFilename =~ /\\.(cervin|bpmn)\\.yaml$/",
-          "command": "cervin.openPreview",
+          "command": "transitrix.openPreview",
           "group": "navigation@-10"
         },
         {

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -116,6 +116,20 @@ function notYet(label: string): void {
   );
 }
 
+// Cervin → Transitrix command migration (CLAUDE.md §Cervin naming, P3). The
+// `cervin.*` commands are kept as deprecated aliases for one release so existing
+// keybindings and macros survive; invoking one warns once and delegates to the
+// canonical `transitrix.*` handler.
+const cervinCommandNoticeShown = new Set<string>();
+
+function noteCervinCommandDeprecation(legacyId: string, canonicalId: string): void {
+  if (cervinCommandNoticeShown.has(legacyId)) return;
+  cervinCommandNoticeShown.add(legacyId);
+  const msg = `Transitrix Studio: the '${legacyId}' command is deprecated and will be removed in 2.0.0 — use '${canonicalId}' instead.`;
+  console.warn(msg);
+  void vscode.window.showWarningMessage(msg);
+}
+
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
   // TX-R003: cache the in-flight Promise, not the resolved result. Two
   // concurrent calls during the brief window before `loadCompiler` resolves
@@ -164,21 +178,35 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   const gapDashboardPreview = new GapDashboardPreview(context.extensionUri);
   const coverageMetricPreview = new CoverageMetricPreview(context.extensionUri);
 
+  const openPreviewHandler = async (): Promise<void> => {
+    const doc = vscode.window.activeTextEditor?.document;
+    const exts = getConfiguredExtensions();
+    if (!doc || !documentMatchesCervinSource(doc)) {
+      vscode.window.showWarningMessage(
+        `Open a file with one of these suffixes: ${formatExtensionHint(exts)} (configure with cervin.fileExtensions).`,
+      );
+      return;
+    }
+    await preview.showOrReveal(doc);
+  };
+
+  // Canonical transitrix.* commands (P3) plus deprecated cervin.* aliases that
+  // delegate to the same handler after a one-time deprecation notice.
+  const aliasOf = (legacyId: string, canonicalId: string, run: () => void | Promise<void>) =>
+    vscode.commands.registerCommand(legacyId, () => {
+      noteCervinCommandDeprecation(legacyId, canonicalId);
+      return run();
+    });
+
   context.subscriptions.push(
-    vscode.commands.registerCommand('cervin.openPreview', async () => {
-      const doc = vscode.window.activeTextEditor?.document;
-      const exts = getConfiguredExtensions();
-      if (!doc || !documentMatchesCervinSource(doc)) {
-        vscode.window.showWarningMessage(
-          `Open a file with one of these suffixes: ${formatExtensionHint(exts)} (configure with cervin.fileExtensions).`,
-        );
-        return;
-      }
-      await preview.showOrReveal(doc);
-    }),
-    vscode.commands.registerCommand('cervin.exportSvg', () => notYet('SVG')),
-    vscode.commands.registerCommand('cervin.exportPng', () => notYet('PNG')),
-    vscode.commands.registerCommand('cervin.exportBpmn', () => notYet('.bpmn export')),
+    vscode.commands.registerCommand('transitrix.openPreview', openPreviewHandler),
+    vscode.commands.registerCommand('transitrix.exportSvg', () => notYet('SVG')),
+    vscode.commands.registerCommand('transitrix.exportPng', () => notYet('PNG')),
+    vscode.commands.registerCommand('transitrix.exportBpmn', () => notYet('.bpmn export')),
+    aliasOf('cervin.openPreview', 'transitrix.openPreview', openPreviewHandler),
+    aliasOf('cervin.exportSvg', 'transitrix.exportSvg', () => notYet('SVG')),
+    aliasOf('cervin.exportPng', 'transitrix.exportPng', () => notYet('PNG')),
+    aliasOf('cervin.exportBpmn', 'transitrix.exportBpmn', () => notYet('.bpmn export')),
     vscode.commands.registerCommand('transitrixStudio.previewGoals', async () => {
       const doc = vscode.window.activeTextEditor?.document;
       if (!doc || !isGoalsFile(doc)) {


### PR DESCRIPTION
## Summary

Third phase of the **Cervin → Transitrix** gradual rename (CLAUDE.md §Cervin naming, **P3**). No breaking change — `cervin.*` commands keep working as deprecated aliases for one release so existing keybindings/macros survive.

Closes the acceptance criteria of strategy hub issue **#190**.

## Changes

- **`extension/package.json`**
  - Register canonical commands `transitrix.openPreview`, `transitrix.exportSvg`, `transitrix.exportPng`, `transitrix.exportBpmn`.
  - Keep the four `cervin.*` commands, retitled `… (deprecated, use transitrix.*)`, and hide them from the Command Palette via a `menus.commandPalette` `when: false` block (they stay invokable from keybindings/macros).
  - The `editor/title` preview button now invokes `transitrix.openPreview`.
- **`extension/src/extension.ts`** — register the `transitrix.*` handlers (the `openPreview` body extracted into a shared `openPreviewHandler`). The `cervin.*` commands are thin aliases (`aliasOf`) that fire a **one-time** deprecation notice (console + toast) and delegate to the canonical handler.
- **CHANGELOGs** — note the command rename and the one-release alias window (removal in 2.0.0).

## Verification

- `npx vitest run` — **237 tests green**.
- `node scripts/verify-extension-packaging.mjs` — OK.
- `extension/package.json` validated as JSON; `compile:extension` adds no new type errors from changed files.

## Notes

- `compile:extension` still reports the **pre-existing** `packages/diagrams/process-blueprint/layout.ts` type errors (from #129) — present on clean `main`, unrelated and out of scope.
- `cervin.exportEnabled` is left in the command `enablement` clauses here; the settings-side `transitrix.exportEnabled` fallback lands in P2 (#134). These PRs are independent and both based on `main`.

Next phase: **P7** (2.0.0 alias removal, #191) — breaking, deferred to the 2.0 train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)