### PR TITLE
fix(process-blueprint): type option defaults so compile:extension passes

### DIFF
--- a/.github/workflows/metrics-regression.yml
+++ b/.github/workflows/metrics-regression.yml
@@ -33,8 +33,14 @@ jobs:
         run: npm run build
 
       - name: Type-check (core + extension)
+        # The extension is not a root workspace and ships no lockfile (TX-204),
+        # so its deps (e.g. @resvg/resvg-js used by raster.ts) aren't installed
+        # by the root `npm ci` — install them here so `compile:extension` can
+        # resolve them. This step guards against type-check regressions in the
+        # bundled @transitrix/diagrams sources (TX-192).
         run: |
           npm run compile
+          npm install --prefix extension --no-save --no-audit --no-fund
           npm run compile:extension
 
       - name: Prepare extension assets

--- a/.github/workflows/metrics-regression.yml
+++ b/.github/workflows/metrics-regression.yml
@@ -32,6 +32,11 @@ jobs:
       - name: Build project
         run: npm run build
 
+      - name: Type-check (core + extension)
+        run: |
+          npm run compile
+          npm run compile:extension
+
       - name: Prepare extension assets
         run: npm run extension:prep
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 - **`cervin.*` extension settings are deprecated, use `transitrix.*`.** The legacy `cervin.fileExtensions` / `cervin.exportEnabled` keys are read as a fallback when their `transitrix.*` counterpart is unset (existing configs keep working) and are marked deprecated in the settings UI; removal is slated for 2.0.0. A one-time migration notice is shown on activation when a legacy key is in effect. Second phase of the Cervin → Transitrix rename (CLAUDE.md §Cervin naming, P2).
 - **`cervin.*` extension commands are deprecated, use `transitrix.*`.** The four `cervin.*` commands are kept as aliases for one release so existing keybindings and macros survive; they are hidden from the Command Palette and labelled "(deprecated)", and invoking one logs a one-time deprecation notice before delegating to the canonical handler. Removal is slated for 2.0.0. Third phase of the Cervin → Transitrix rename (CLAUDE.md §Cervin naming, P3).
 
+### Fixed
+- **`npm run compile:extension` is green again** — `process-blueprint/layout.ts` no longer types its option defaults as `Required<ProcessBlueprintLayoutOptions>` (which forced the opt-in `complianceLane` / `complianceInput` fields to be non-`undefined`). A `ResolvedLayoutOptions` type keeps the sizing fields required while leaving the compliance pair optional. Type-only change — no layout behaviour change. CI now runs `compile` + `compile:extension` so the type-check regression (introduced with the compliance lane, #129) can't reappear silently.
+
 ## [1.4.1] — 2026-06-09
 
 ### Fixed

--- a/packages/diagrams/src/process-blueprint/layout.ts
+++ b/packages/diagrams/src/process-blueprint/layout.ts
@@ -27,6 +27,22 @@ const ASPECT_LABEL: Record<AspectCategory, string> = {
   information_entities: 'Information',
 };
 
+// The compliance lane is opt-in, so its two options have no meaningful default
+// (absent = lane disabled). Every other option is a sizing value that always
+// resolves to a number — keep those `Required`, but exclude the compliance pair
+// rather than forcing them to a non-optional type they can't satisfy.
+type SizingOptionKeys = Exclude<
+  keyof ProcessBlueprintLayoutOptions,
+  'complianceLane' | 'complianceInput'
+>;
+
+/**
+ * Options after defaults are applied: every sizing field is guaranteed present;
+ * the compliance lane fields stay optional (undefined = lane disabled).
+ */
+type ResolvedLayoutOptions = Required<Pick<ProcessBlueprintLayoutOptions, SizingOptionKeys>> &
+  Pick<ProcessBlueprintLayoutOptions, 'complianceLane' | 'complianceInput'>;
+
 const DEFAULTS = {
   legendColumnWidth: 140,
   stageColumnWidth: 220,
@@ -42,9 +58,7 @@ const DEFAULTS = {
   cellTextPadX: 10,
   cellTextPadY: 10,
   maxTextLines: 6,
-  complianceLane: undefined,
-  complianceInput: undefined,
-} satisfies Required<ProcessBlueprintLayoutOptions>;
+} satisfies Required<Pick<ProcessBlueprintLayoutOptions, SizingOptionKeys>>;
 
 interface RawPill {
   category: AspectCategory;
@@ -55,7 +69,7 @@ interface RawPill {
   endStageIndex: number;
 }
 
-function resolveOptions(options: ProcessBlueprintLayoutOptions | undefined): Required<ProcessBlueprintLayoutOptions> {
+function resolveOptions(options: ProcessBlueprintLayoutOptions | undefined): ResolvedLayoutOptions {
   return { ...DEFAULTS, ...(options ?? {}) };
 }
 
@@ -241,7 +255,7 @@ function deriveComplianceRow(
   stages: Stage[],
   stageIndexById: Map<string, number>,
   input: ComplianceLaneInput,
-  opts: Required<ProcessBlueprintLayoutOptions>,
+  opts: ResolvedLayoutOptions,
   yStart: number,
 ): ComplianceRow | undefined {
   const {


### PR DESCRIPTION
## Summary

Fixes the pre-existing `npm run compile:extension` type errors in `packages/diagrams/src/process-blueprint/layout.ts`. Closes strategy hub issue **#192**.

## Root cause

`DEFAULTS` was declared `satisfies Required<ProcessBlueprintLayoutOptions>`, but `Required<…>` strips the `?` from the opt-in `complianceLane` / `complianceInput` fields, so the `: undefined` defaults were no longer assignable (`ComplianceLaneConfig` / `ComplianceLaneInput`). Three `TS2322` errors resulted (layout.ts:45/46/59). Regression from the compliance-lane work (#129); CI never caught it because `compile:extension` (a separate type-check script) wasn't part of the gate.

## Fix

- New `ResolvedLayoutOptions` type: sizing fields stay `Required`, the compliance pair stays **optional** (`undefined` = lane disabled). Removed the two `undefined` entries from `DEFAULTS`; retyped `resolveOptions()` and `deriveComplianceRow()`'s `opts` parameter.
- **Type-only change — no layout behaviour change.** The `deriveComplianceRow` guard `if (!laneConfig?.enabled) return undefined;` already narrows `complianceLane` to defined past that point, so making it optional is safe.
- **CI**: added a `Type-check (core + extension)` step running `npm run compile` and `npm run compile:extension`, so a future type-check regression can't merge silently.

## Verification

- `npm run compile` — clean. `npm run compile:extension` — **clean (exit 0)**, was 3 errors.
- `npx vitest run` — **249 core tests green**.
- `npm --workspace packages/diagrams test` — **749 diagrams tests green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)