### PR TITLE
feat(config): add .transitrixrc, read .cervinrc as fallback (P4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- **`.transitrixrc` project config** — canonical replacement for `.cervinrc`. `loadTransitrixrc()` reads `.transitrixrc` first and falls back to `.cervinrc` (one-time deprecation notice) when absent; ships `transitrixrc.schema.json` (root + extension `schemas/`). `.cervinrc` keeps working through 1.x (removed in 2.0.0). Fourth phase of the Cervin → Transitrix rename (CLAUDE.md §Cervin naming, P4).
 - **`transitrix` CLI binary** — the primary command is now `transitrix`; it is added as a `bin` entry (and an `npm run transitrix` script) pointing at the same `dist/cli.js`. `--help` and usage text recommend `transitrix`.
 - **VS Code settings `transitrix.fileExtensions` / `transitrix.exportEnabled`** — canonical replacements for the legacy `cervin.*` keys, registered in the extension's `contributes.configuration`.
 - **VS Code commands `transitrix.openPreview` / `transitrix.exportSvg` / `transitrix.exportPng` / `transitrix.exportBpmn`** — canonical replacements for the `cervin.*` commands. The editor-title preview button now invokes `transitrix.openPreview`.

--- a/docs/notation.md
+++ b/docs/notation.md
@@ -276,7 +276,7 @@ The compiler runs four layers of validation on each input. Each layer can block 
 | 3. Semantic | `src/validator.ts` | BPMN 2.0 rules: SE/EE/ACT/SF/GW/CONN — errors block emit |
 | 4. XML conformance | `src/compiler.ts` (BpmnModdle round-trip) | Output XML must round-trip through `bpmn-moddle` without warnings |
 
-In addition, anti-pattern checks (warnings, not errors) flag suspicious-but-valid structures: floating elements, missing default flow, implicit join, gateway used as task. Warnings are configurable via the optional `.cervinrc` file at the repository root; errors are not configurable — they enforce BPMN-conformance and cannot be downgraded.
+In addition, anti-pattern checks (warnings, not errors) flag suspicious-but-valid structures: floating elements, missing default flow, implicit join, gateway used as task. Warnings are configurable via the optional `.transitrixrc` file at the repository root (legacy `.cervinrc` is still read as a fallback); errors are not configurable — they enforce BPMN-conformance and cannot be downgraded.
 
 ---
 

--- a/docs/repo-layout.md
+++ b/docs/repo-layout.md
@@ -46,7 +46,7 @@ This document maps **top-level folders** to **roles** so you know where to look 
 | [`extension/webview/`](../extension/webview/) | Browser-side entry point for the BPMN viewer webview (`viewer.ts`). Bundled into `extension/media/viewer.js` by `scripts/build-webview.mjs`. |
 | [`ui/`](../ui/) | **Local browser UI** for `cervin serve`. Vite app: BPMN editor + viewer + nested-blocks tab. Proxies `/api/*` to the local Node server in dev (`vite.config.ts`). |
 | [`examples/`](../examples/) | **Sample YAML by notation**: `bpmn/`, `activities/`, `applications/`, `products/`, `scenarios/`, `process-map/`, `capability-map/`, `goals/`, `fgca/`, `fga/`, `blocks/`, `nested-blocks/` (legacy ASCII/Markdown samples for the browser UI tab), `compliance/`, … Each subfolder has a README where applicable. |
-| [`schemas/`](../schemas/) | **JSON Schemas for AJV**: `bpmn-dsl.schema.json` (DSL grammar), `cervinrc.schema.json` (config file). Copied into `extension/schemas/` by `extension:prep`. |
+| [`schemas/`](../schemas/) | **JSON Schemas for AJV**: `bpmn-dsl.schema.json` (DSL grammar), `transitrixrc.schema.json` (config file; legacy `cervinrc.schema.json` kept). Copied into `extension/schemas/` by `extension:prep`. |
 | [`tests/`](../tests/) | **Vitest root suite.** BPMN compiler tests, layout/routing, integration, metrics regression. See *Two-suite test strategy* below. |
 | [`scripts/`](../scripts/) | Build and dev tooling: `build-compiler-bundle.mjs`, `build-webview.mjs`, `build-extension-bundle.mjs`, `bump-extension-version.mjs`, `measure-baseline.mjs`, `ci-metrics-diff.mjs`. |
 | [`docs/`](../docs/) | **Project documentation**: this layout map, glossary, metrics baselines, validation notes. |

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -621,9 +621,12 @@ Anti-pattern rules detect suspicious modeling practices that may indicate errors
   }
   ```
 
-### Configuring Anti-Pattern Rules via `.cervinrc`
+### Configuring Anti-Pattern Rules via `.transitrixrc`
 
-Anti-pattern severity and enabled state can be overridden in `.cervinrc`:
+> The canonical config file is **`.transitrixrc`**. The legacy **`.cervinrc`** is still
+> read as a fallback when `.transitrixrc` is absent (deprecated; removed in 2.0.0).
+
+Anti-pattern severity and enabled state can be overridden in `.transitrixrc`:
 
 ```yaml
 rules:

--- a/schemas/transitrixrc.schema.json
+++ b/schemas/transitrixrc.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Transitrix Studio Config Schema",
+  "description": "Schema for .transitrixrc configuration file (legacy .cervinrc is read as a fallback through 1.x).",
+  "type": "object",
+  "properties": {
+    "rules": {
+      "type": "object",
+      "title": "Rule overrides",
+      "description": "Override validation rule severity levels. Errors cannot be downgraded.",
+      "patternProperties": {
+        "^[A-Z]+-[0-9-]+$": {
+          "type": "string",
+          "enum": ["off", "warn"],
+          "description": "Rule override value: 'off' to disable, 'warn' to report as warning"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false,
+  "required": []
+}

--- a/src/cervinrc.ts
+++ b/src/cervinrc.ts
@@ -57,21 +57,28 @@ function validateCervinrcDocument(data: unknown): asserts data is CervinrcConfig
   }
 }
 
+// Cervin → Transitrix config migration (CLAUDE.md §Cervin naming, P4). The
+// canonical project config is `.transitrixrc`; `.cervinrc` is read as a
+// fallback through the 1.x line and removed in 2.0.0.
+const TRANSITRIXRC_FILE = '.transitrixrc'
+const CERVINRC_FILE = '.cervinrc'
+
+export const CERVINRC_DEPRECATION_NOTICE =
+  '.cervinrc is deprecated and will be removed in 2.0.0 — rename it to .transitrixrc.'
+
+let cervinrcNoticeShown = false
+
+function noteCervinrcDeprecation(): void {
+  if (cervinrcNoticeShown) return
+  cervinrcNoticeShown = true
+  console.warn(CERVINRC_DEPRECATION_NOTICE)
+}
+
 /**
- * Load and parse .cervinrc config file from the given directory.
- * Returns empty config if file doesn't exist.
- *
- * @param startPath Directory to search for .cervinrc (default: current working directory)
- * @returns Validated CervinrcConfig, or empty config if file not found
- * @throws ConfigError if file exists but is invalid JSON or fails schema validation
+ * Read, JSON-parse and schema-validate a single rc file. `fileLabel` is the
+ * bare filename used in error messages so they name the file actually read.
  */
-export function loadCervinrc(startPath: string = process.cwd()): CervinrcConfig {
-  const rcPath = join(startPath, '.cervinrc')
-
-  if (!existsSync(rcPath)) {
-    return {} // Optional config file
-  }
-
+function loadRcFile(rcPath: string, fileLabel: string): CervinrcConfig {
   try {
     const content = readFileSync(rcPath, 'utf8')
     const parsed = JSON.parse(content) as unknown
@@ -79,15 +86,48 @@ export function loadCervinrc(startPath: string = process.cwd()): CervinrcConfig 
     return parsed
   } catch (e) {
     if (e instanceof SyntaxError) {
-      const err = new Error(`Invalid JSON in .cervinrc: ${e.message}`) as ConfigError
+      const err = new Error(`Invalid JSON in ${fileLabel}: ${e.message}`) as ConfigError
       throw err
     }
     if ((e as ConfigError).errors) {
       throw e // Re-throw validation errors
     }
     const err = e as Error
-    throw new Error(`Failed to load .cervinrc: ${err.message}`)
+    throw new Error(`Failed to load ${fileLabel}: ${err.message}`)
   }
+}
+
+/**
+ * Load and parse the project config from the given directory. Prefers
+ * `.transitrixrc`; falls back to the legacy `.cervinrc` (with a one-time
+ * deprecation notice) when `.transitrixrc` is absent. Returns an empty config
+ * when neither exists.
+ *
+ * @param startPath Directory to search (default: current working directory)
+ * @returns Validated config, or empty config if no file is found
+ * @throws ConfigError if a file exists but is invalid JSON or fails schema validation
+ */
+export function loadTransitrixrc(startPath: string = process.cwd()): CervinrcConfig {
+  const transitrixPath = join(startPath, TRANSITRIXRC_FILE)
+  if (existsSync(transitrixPath)) {
+    return loadRcFile(transitrixPath, TRANSITRIXRC_FILE)
+  }
+
+  const cervinPath = join(startPath, CERVINRC_FILE)
+  if (existsSync(cervinPath)) {
+    noteCervinrcDeprecation()
+    return loadRcFile(cervinPath, CERVINRC_FILE)
+  }
+
+  return {} // Optional config file
+}
+
+/**
+ * @deprecated Use {@link loadTransitrixrc}. Retained as a compatibility alias
+ * through the 1.x line; reads `.transitrixrc` then falls back to `.cervinrc`.
+ */
+export function loadCervinrc(startPath: string = process.cwd()): CervinrcConfig {
+  return loadTransitrixrc(startPath)
 }
 
 /**

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -5,7 +5,7 @@ import { parseYamlToIr } from './parser.js'
 import type { ProcessIr, LayoutIr } from './ir.js'
 import { validateProcess, validator } from './validator.js'
 import type { ValidationReport, ValidationFinding, ValidatorConfig } from './validator-types.js'
-import { loadCervinrc, assertNoCriticalRuleDowngrade, mergeConfigWithDefaults } from './cervinrc.js'
+import { loadTransitrixrc, assertNoCriticalRuleDowngrade, mergeConfigWithDefaults } from './cervinrc.js'
 import { BpmnModdle } from 'bpmn-moddle'
 
 export type { LayoutDiagramOptions } from './layout-options.js'
@@ -40,9 +40,9 @@ export async function compileCervinYamlWithLayout(
   const ir = parseYamlToIr(yamlText)
 
   // RD-097: Load and apply config overrides
-  const cervinrcConfig = loadCervinrc()
-  assertNoCriticalRuleDowngrade(validator.getRules(), cervinrcConfig)
-  const enabledRules = mergeConfigWithDefaults(validator.getRules(), cervinrcConfig)
+  const rcConfig = loadTransitrixrc()
+  assertNoCriticalRuleDowngrade(validator.getRules(), rcConfig)
+  const enabledRules = mergeConfigWithDefaults(validator.getRules(), rcConfig)
 
   // Validate with config applied
   const validatorConfig: ValidatorConfig = { enabledRules }

--- a/tests/cervinrc.test.ts
+++ b/tests/cervinrc.test.ts
@@ -3,8 +3,10 @@ import { writeFileSync, unlinkSync, mkdirSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import {
   loadCervinrc,
+  loadTransitrixrc,
   assertNoCriticalRuleDowngrade,
   mergeConfigWithDefaults,
+  CERVINRC_DEPRECATION_NOTICE,
 } from '../src/cervinrc.js'
 import type { ValidationRule, CervinrcConfig, ConfigError } from '../src/validator-types.js'
 
@@ -210,5 +212,62 @@ describe('cervinrc config loader', () => {
 
     const enabled = mergeConfigWithDefaults(rules, config)
     expect(enabled.has('AP-GW-AS-TASK')).toBe(true)
+  })
+})
+
+describe('loadTransitrixrc (Cervin deprecation P4)', () => {
+  const testDir = '/tmp/transitrixrc-test'
+
+  beforeEach(() => {
+    mkdirSync(testDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true })
+  })
+
+  it('loads .transitrixrc when present', () => {
+    const config: CervinrcConfig = { rules: { 'AP-001': 'off' } }
+    writeFileSync(join(testDir, '.transitrixrc'), JSON.stringify(config))
+
+    const loaded = loadTransitrixrc(testDir)
+    expect(loaded.rules).toEqual(config.rules)
+  })
+
+  it('falls back to .cervinrc when .transitrixrc is absent', () => {
+    const config: CervinrcConfig = { rules: { 'AP-002': 'warn' } }
+    writeFileSync(join(testDir, '.cervinrc'), JSON.stringify(config))
+
+    const loaded = loadTransitrixrc(testDir)
+    expect(loaded.rules).toEqual(config.rules)
+  })
+
+  it('prefers .transitrixrc over a present .cervinrc', () => {
+    writeFileSync(join(testDir, '.transitrixrc'), JSON.stringify({ rules: { 'AP-001': 'off' } }))
+    writeFileSync(join(testDir, '.cervinrc'), JSON.stringify({ rules: { 'AP-002': 'warn' } }))
+
+    const loaded = loadTransitrixrc(testDir)
+    expect(loaded.rules).toEqual({ 'AP-001': 'off' })
+  })
+
+  it('returns empty config when neither file exists', () => {
+    expect(loadTransitrixrc(testDir)).toEqual({})
+  })
+
+  it('surfaces invalid JSON against the file actually read (.transitrixrc)', () => {
+    writeFileSync(join(testDir, '.transitrixrc'), '{ invalid json }')
+    expect(() => loadTransitrixrc(testDir)).toThrow(
+      expect.objectContaining({ message: expect.stringContaining('Invalid JSON in .transitrixrc') }),
+    )
+  })
+
+  it('loadCervinrc is an alias that still resolves .transitrixrc', () => {
+    writeFileSync(join(testDir, '.transitrixrc'), JSON.stringify({ rules: { 'AP-001': 'off' } }))
+    expect(loadCervinrc(testDir).rules).toEqual({ 'AP-001': 'off' })
+  })
+
+  it('exposes a deprecation notice naming .transitrixrc', () => {
+    expect(CERVINRC_DEPRECATION_NOTICE).toMatch(/\.transitrixrc/)
+    expect(CERVINRC_DEPRECATION_NOTICE).toMatch(/deprecated/i)
   })
 })


### PR DESCRIPTION
## Summary

Fourth phase of the **Cervin → Transitrix** rename (CLAUDE.md §Cervin naming, **P4**). Makes `.transitrixrc` the canonical project config while keeping `.cervinrc` readable. No breaking change. Closes strategy hub issue **#193**.

## Changes

- **`src/cervinrc.ts`** — new `loadTransitrixrc()` reads `.transitrixrc` first, falls back to the legacy `.cervinrc` with a **one-time** deprecation notice; a shared `loadRcFile()` makes error messages name the file actually read. `loadCervinrc()` is retained as a `@deprecated` alias delegating to `loadTransitrixrc()`. Exports `CERVINRC_DEPRECATION_NOTICE`.
- **`src/compiler.ts`** — loads config via `loadTransitrixrc()`.
- **`schemas/transitrixrc.schema.json`** (new) — synced into `extension/schemas/` by `build-compiler-bundle.mjs` (that dir is gitignored/generated); `cervinrc.schema.json` kept.
- **docs** — `notation.md` / `validation.md` / `repo-layout.md` now reference `.transitrixrc` as canonical, `.cervinrc` noted as legacy fallback.
- **tests** — `loadTransitrixrc` coverage: transitrix-first, cervin-fallback, precedence, alias, invalid-JSON file labelling, notice text. Existing `.cervinrc` tests unchanged.
- **CHANGELOG**.

## Verification

- `npm run compile` + `npm run compile:extension` — clean.
- `npx vitest run` — **256 tests green** (cervinrc suite 13 → 20).

Next: **P5** (internal compiler/config API rename, #194).

🤖 Generated with [Claude Code](https://claude.com/claude-code)