### PR TITLE
docs(adr): IntelliJ rendering-approach — build sequencing on #28 M2 + index

### DIFF
--- a/docs/adr/0001-intellij-mvp-tech-choice.md
+++ b/docs/adr/0001-intellij-mvp-tech-choice.md
@@ -118,6 +118,34 @@ The IntelliJ MVP plugin is built as follows.
   is worse: JCEF is shipped by the IDE, so the plugin only contributes the JS,
   not the browser.
 
+## Build sequencing — depends on epic #28 M2
+
+The **decision** above is unblocked and recorded now. The **build** is not: the
+JCEF bundle consumes `@transitrix/diagrams`, so the plugin build is sequenced
+**after epic [vkgeorgia/strategy#28](https://github.com/vkgeorgia/strategy/issues/28)
+M2** — the milestone that makes `@transitrix/diagrams` a consumable, published
+package. Until M2 lands:
+
+- No build/consume work starts (only this ADR and, when ratified, the scaffold
+  spike below).
+- For an early spike, an **interim path / git dependency** on the in-repo
+  `packages/diagrams/` is acceptable to prove the JCEF wire end-to-end; it is
+  replaced by the published dependency once M2 ships. The interim path is a
+  spike convenience, not the shipped MVP dependency.
+
+## MVP scope — read-only previews, content-parity with the VS Code static previews
+
+The IntelliJ MVP renders **read-only previews only** (no editing, no mutation).
+Its content-parity target is the VS Code extension's **static previews** — the
+ones hosted with `enableScripts: false` that render a diagram (and inline
+validation badges / error panel) without interactive scripting. "Parity of
+content" means the IDEA preview shows the *same rendered diagram and the same
+validation outcome* for the same source file as the corresponding VS Code static
+preview; it does **not** imply parity with the interactive (scripted) previews,
+which are out of scope for the MVP. Because the renderer is the shared
+`@transitrix/diagrams` bundle, this content parity is structural, not a
+re-implementation to keep in sync.
+
 ## Implementation plan (out of scope for this ADR PR)
 
 This ADR PR records the decision only. Subsequent PRs, each in its own
@@ -142,6 +170,8 @@ gates every merge.
 ## References
 
 - Epic [vkgeorgia/strategy#135](https://github.com/vkgeorgia/strategy/issues/135).
+- Rendering-approach ADR task [vkgeorgia/strategy#204](https://github.com/vkgeorgia/strategy/issues/204).
+- `@transitrix/diagrams` publish milestone: epic [vkgeorgia/strategy#28](https://github.com/vkgeorgia/strategy/issues/28) M2.
 - Shared rendering library: `packages/diagrams/`.
 - VS Code preview infrastructure for cross-reference: `extension/src/` and `extension/package.json` `activationEvents`.
 - Packaging trade-off precedent (native binaries vs. universal artifact): `docs/packaging.md`.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -1,0 +1,15 @@
+# Transitrix Studio ADRs (numbered) — index
+
+Earlier numbered Architecture Decision Records (`NNNN-<slug>.md`). These remain
+valid and are referenced from elsewhere. New ADRs are recorded in the dated
+family form under [`../decisions/`](../decisions/) — see
+[`../decisions/INDEX.md`](../decisions/INDEX.md). Some numbered ADRs reference an
+authoritative methodology ADR via a `methodology_adr` field.
+
+`Status` values: **Proposed** (direction not yet gated) · **Accepted** (decided)
+· **Superseded** (replaced by a later ADR).
+
+| ADR | Decision | Status | Scope |
+|---|---|---|---|
+| [0001](0001-intellij-mvp-tech-choice.md) | IntelliJ IDEA extension MVP — rendering & validation technology (JCEF + reuse `@transitrix/diagrams`) | Proposed | epic #135 |
+| [0002](0002-process-blueprint-compliance-lane.md) | Process Blueprint compliance lane (Studio implementation) | Accepted | transitrix-studio |


### PR DESCRIPTION
## What

Closes the gaps in the IntelliJ rendering-approach ADR called for by strategy **#204** (epic #135), **without duplicating** the decision.

ADR `0001-intellij-mvp-tech-choice.md` (status: Proposed) **already records** the rendering approach #204 asks for: JCEF tool window hosting the shared `@transitrix/diagrams` JS bundle, with re-implementing renderers on the JVM explicitly weighed and rejected, and a read-only MVP. Rather than file a parallel ADR on the same topic (which the family ADR convention warns against), this PR sharpens the existing Proposed ADR to cover #204's specific acceptance points:

- **Build sequencing** — the design is unblocked and recorded now, but the build is sequenced **after epic #28 M2** (published `@transitrix/diagrams`). An interim path/git dependency on `packages/diagrams/` is acceptable for an early spike, not for the shipped MVP.
- **MVP scope** — content-parity with the VS Code **static** previews (`enableScripts: false`), explicitly *not* the interactive (scripted) previews.
- **Indexing** — adds `docs/adr/INDEX.md` (the numbered ADRs were previously unindexed), cross-linked to the dated `docs/decisions/INDEX.md`.

## Acceptance (strategy #204)

- [x] ADR present + indexed, `status: proposed`.
- [x] Mechanism chosen with justification; reuse vs re-implementation explicitly weighed (existing §"Why this, not the alternatives").
- [x] MVP scope (read-only, content-parity with VS Code static previews) and the #28 M2 dependency recorded.

## Notes

Docs-only; design only (no build work, per #204 and the #28 M2 gate). Valerii ratifies / gates the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)