### PR TITLE
feat(cli): add `validate --scope=repo` (port lint.py whole-repo checks to TS)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -64,6 +64,7 @@ transitrix <input.yaml> <output.bpmn> [--no-metrics] [--no-validate]
 transitrix serve [--port 8765] [--host 127.0.0.1]
 transitrix metrics <input.yaml> [--json]
 transitrix validate <input.yaml> [--json]
+transitrix validate --scope=repo [--root <dir>] [--json]
 transitrix export-compliance [--format md|pdf] [--scope law:<ID>|product:<ID>|gap] [--output <path>] [--root <dir>]
 ```
 
@@ -72,7 +73,7 @@ transitrix export-compliance [--format md|pdf] [--scope law:<ID>|product:<ID>|ga
 | *(default)* / `compile` | YAML → BPMN 2.0 XML with computed layout; prints layout-quality metrics and validation findings. Exit 1 on validation errors. |
 | `serve` | Local web UI (run `npm run ui:build` once beforehand). |
 | `metrics` | Layout-quality metrics only (`--json` for CI). |
-| `validate` | Validation only, no XML output (`--json` for CI). Exit 1 on errors. |
+| `validate` | Validation only, no XML output (`--json` for CI). Exit 1 on errors. Default scope is a single file; `--scope=repo` runs whole-`canon/` checks (referential integrity, atomicity, id uniqueness, policy) over `--root` (default cwd) — see [validation.md](validation.md#validation-scope-file-vs-repo). |
 | `export-compliance` | Markdown or PDF report of the compliance views (matrix by default; `law:` / `product:` / `gap` scopes). Scans `--root` (default cwd). PDF needs WeasyPrint on PATH (`pipx install weasyprint`). |
 
 Flags: `--no-metrics` suppresses the metrics report on compile; `--no-validate`
@@ -85,6 +86,7 @@ pass `--ext=.suffix1,.suffix2`.
 ```bash
 transitrix compile order.bpmn.transitrix.yaml order.bpmn
 transitrix validate order.bpmn.transitrix.yaml --json
+transitrix validate --scope=repo --root organizations/acme_corp
 transitrix metrics order.bpmn.transitrix.yaml --json
 transitrix export-compliance --format md --scope gap --output gaps.md
 transitrix serve --port 9000

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -12,6 +12,42 @@ The Transitrix Studio validator provides **3 layers of validation**:
 
 Validation is **non-blocking**: findings are surfaced in the API, CLI, and web UI, but do not prevent compilation.
 
+## Validation scope (file vs repo)
+
+Validation runs on one execution axis — **`scope`** (methodology ADR
+`2026-06-11-validation-two-axis-model.md`; Studio referencing ADR
+[`decisions/2026-06-11-validation-runtime-convergence.md`](decisions/2026-06-11-validation-runtime-convergence.md)):
+
+| Scope | Command | Coverage |
+|-------|---------|----------|
+| **file** (default) | `transitrix validate <input.yaml>` | A single notation file: the BPMN structural/semantic rules documented below. |
+| **repo** | `transitrix validate --scope=repo [--root <dir>]` | The whole loaded `canon/` model: referential integrity, atomicity, id uniqueness, policy. |
+
+`--scope=repo` ports the whole-repo checks previously owned by the methodology's
+Python `.validators/lint.py` onto the shared `@transitrix/diagrams` model
+(`packages/diagrams/src/repo-validate/`), so there is a single validation
+runtime. It scans `<root>/canon/elements/**` (elements) and
+`<root>/canon/relations/**` (relations), then reports findings shaped
+`{ scope, id, message }`. Any finding exits non-zero — the CI gate.
+
+Repo-scope checks (parity reference: the `acme_corp` worked example, which
+passes with zero findings):
+
+- **YAML syntax** — an unparseable canon file is reported and graph checks are skipped.
+- **ID uniqueness** — the same `id` defined in more than one file.
+- **Atomicity** — an element file carrying an inline `relations:` section (relations belong in `canon/relations/`).
+- **Referential integrity** — a relation endpoint (`from`/`to`, or the legacy `source`/`target`) that does not resolve to a known element.
+- **Policy** — an element marked `Active`/`Production` (`metadata.status`) with no `metadata.owner`.
+- **ArchiMate layer-semantics** — *deferred* (lint.py ships this as a no-op stub; ported faithfully as a no-op until the methodology defines the rules).
+
+```
+$ transitrix validate --scope=repo --root organizations/acme_corp
+✓ organizations/acme_corp — repo-scope validation passed
+```
+
+The richer `target`/`category` finding taxonomy is intentionally **not** adopted
+yet (deferred per the ADR until a consumer needs it).
+
 ## Rule Categories
 
 Rules are organized by element category using stable ID prefixes:

--- a/packages/diagrams/src/index.ts
+++ b/packages/diagrams/src/index.ts
@@ -13,6 +13,7 @@ export * from "./goals/index";
 export * from "./process-blueprint/index";
 export * from "./process-map/index";
 export * from "./products/index";
+export * from "./repo-validate/index";
 export * from "./requirement/index";
 export * from "./scenarios/index";
 export * from "./theme/index";

--- a/packages/diagrams/src/repo-validate/__tests__/validate-repo.test.ts
+++ b/packages/diagrams/src/repo-validate/__tests__/validate-repo.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+import { validateRepoModel } from '../validate-repo.js';
+import type { RepoDoc, RepoModelInput } from '../types.js';
+
+function el(path: string, data: Record<string, unknown> | null, parseError?: string): RepoDoc {
+  return { path, data, parseError };
+}
+
+/** A small clean model mirroring the acme_corp shape: relations use `from`/`to`
+ *  and every endpoint resolves to an element. Should produce zero findings —
+ *  the parity bar against lint.py on the worked example. */
+function cleanModel(): RepoModelInput {
+  return {
+    elements: [
+      el('canon/elements/01_motivation/goals/GOAL-OPS-1.yaml', { notation: 'goal', id: 'GOAL-OPS-1' }),
+      el('canon/elements/01_motivation/assessments/ASSESSMENT-1.yaml', { notation: 'assessment', id: 'ASSESSMENT-1' }),
+      el('canon/elements/02_business/capabilities/CAPABILITY-V1.yaml', { notation: 'capability', id: 'CAPABILITY-V1' }),
+      // sidecar with no `id` — must be ignored (no duplicate, not an element)
+      el('canon/elements/02_business/capabilities/CAPABILITY-V1.history.yaml', { target: 'CAPABILITY-V1', attribute_versions: [] }),
+    ],
+    relations: [
+      el('canon/relations/REL-1.yaml', { notation: 'relation', id: 'REL-1', from: 'ASSESSMENT-1', to: 'GOAL-OPS-1' }),
+    ],
+  };
+}
+
+describe('validateRepoModel — parity / clean tree', () => {
+  it('produces zero findings on a clean model (acme_corp parity)', () => {
+    expect(validateRepoModel(cleanModel())).toEqual([]);
+  });
+
+  it('ignores sidecar docs without an id (no false duplicate)', () => {
+    const findings = validateRepoModel(cleanModel());
+    expect(findings.filter((f) => f.message.includes('Duplicate'))).toEqual([]);
+  });
+
+  it('every finding carries the frozen { scope, id, message } shape', () => {
+    const model = cleanModel();
+    model.relations.push(el('canon/relations/REL-BAD.yaml', { notation: 'relation', id: 'REL-BAD', from: 'NOPE', to: 'GOAL-OPS-1' }));
+    const findings = validateRepoModel(model);
+    expect(findings.length).toBeGreaterThan(0);
+    for (const f of findings) {
+      expect(Object.keys(f).sort()).toEqual(['id', 'message', 'scope']);
+      expect(f.scope).toBe('repo');
+    }
+  });
+});
+
+describe('validateRepoModel — referential integrity', () => {
+  it('flags a relation whose `from` endpoint is unknown', () => {
+    const model = cleanModel();
+    model.relations = [el('canon/relations/REL-X.yaml', { notation: 'relation', id: 'REL-X', from: 'MISSING-1', to: 'GOAL-OPS-1' })];
+    const findings = validateRepoModel(model);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ scope: 'repo', id: 'REL-X' });
+    expect(findings[0].message).toContain('MISSING-1');
+    expect(findings[0].message).toContain('(from)');
+  });
+
+  it('flags a relation whose `to` endpoint is unknown', () => {
+    const model = cleanModel();
+    model.relations = [el('canon/relations/REL-Y.yaml', { notation: 'relation', id: 'REL-Y', from: 'GOAL-OPS-1', to: 'MISSING-2' })];
+    const findings = validateRepoModel(model);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].message).toContain('(to)');
+  });
+
+  it('accepts lint.py-style `source`/`target` endpoint keys', () => {
+    const model = cleanModel();
+    model.relations = [el('canon/relations/REL-ST.yaml', { id: 'REL-ST', source: 'ASSESSMENT-1', target: 'GOAL-OPS-1' })];
+    expect(validateRepoModel(model)).toEqual([]);
+  });
+
+  it('resolves `{ id }` object endpoints', () => {
+    const model = cleanModel();
+    model.relations = [el('canon/relations/REL-OBJ.yaml', { id: 'REL-OBJ', from: { id: 'ASSESSMENT-1' }, to: { id: 'GOAL-OPS-1' } })];
+    expect(validateRepoModel(model)).toEqual([]);
+  });
+});
+
+describe('validateRepoModel — atomicity', () => {
+  it('flags an element file that contains an inline `relations` section', () => {
+    const model = cleanModel();
+    model.elements.push(el('canon/elements/02_business/E.yaml', { id: 'ELEMENT-1', relations: [{ to: 'GOAL-OPS-1' }] }));
+    const findings = validateRepoModel(model);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ scope: 'repo', id: 'ELEMENT-1' });
+    expect(findings[0].message).toContain('Atomicity');
+  });
+});
+
+describe('validateRepoModel — id uniqueness', () => {
+  it('flags the same id defined in two files', () => {
+    const model = cleanModel();
+    model.elements.push(el('canon/elements/dupe-a.yaml', { id: 'DUP-1' }));
+    model.elements.push(el('canon/elements/dupe-b.yaml', { id: 'DUP-1' }));
+    const findings = validateRepoModel(model);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ scope: 'repo', id: 'DUP-1' });
+    expect(findings[0].message).toContain('dupe-a.yaml');
+    expect(findings[0].message).toContain('dupe-b.yaml');
+  });
+
+  it('flags an element/relation id collision across zones', () => {
+    const model = cleanModel();
+    model.elements.push(el('canon/elements/clash.yaml', { id: 'CLASH-1' }));
+    model.relations.push(el('canon/relations/clash.yaml', { id: 'CLASH-1', from: 'GOAL-OPS-1', to: 'ASSESSMENT-1' }));
+    const findings = validateRepoModel(model);
+    expect(findings.filter((f) => f.id === 'CLASH-1')).toHaveLength(1);
+  });
+});
+
+describe('validateRepoModel — policy', () => {
+  it('flags an Active element with no owner', () => {
+    const model = cleanModel();
+    model.elements.push(el('canon/elements/svc.yaml', { id: 'SVC-1', metadata: { status: 'Active' } }));
+    const findings = validateRepoModel(model);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ scope: 'repo', id: 'SVC-1' });
+    expect(findings[0].message).toContain('Policy');
+  });
+
+  it('does not flag an Active element that has an owner', () => {
+    const model = cleanModel();
+    model.elements.push(el('canon/elements/svc.yaml', { id: 'SVC-2', metadata: { status: 'Active', owner: 'team-a' } }));
+    expect(validateRepoModel(model)).toEqual([]);
+  });
+
+  it('does not flag elements using the canon admission record (no metadata.status)', () => {
+    // acme_corp elements use `zone`/`admitted_by`, not `metadata.status` — must not fire.
+    const model = cleanModel();
+    model.elements.push(el('canon/elements/g.yaml', { id: 'GOAL-X', zone: 'canon', admitted_by: 'v.korobeinikov' }));
+    expect(validateRepoModel(model)).toEqual([]);
+  });
+});
+
+describe('validateRepoModel — syntax', () => {
+  it('reports a parse error and skips graph checks', () => {
+    const model = cleanModel();
+    model.elements.push(el('canon/elements/broken.yaml', null, 'bad indentation'));
+    // also add a dangling relation that would otherwise fire — it must be suppressed
+    model.relations.push(el('canon/relations/REL-Z.yaml', { id: 'REL-Z', from: 'MISSING', to: 'GOAL-OPS-1' }));
+    const findings = validateRepoModel(model);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ scope: 'repo', id: '' });
+    expect(findings[0].message).toContain('YAML syntax error');
+    expect(findings[0].message).toContain('broken.yaml');
+  });
+});

--- a/packages/diagrams/src/repo-validate/index.ts
+++ b/packages/diagrams/src/repo-validate/index.ts
@@ -1,0 +1,2 @@
+export { validateRepoModel } from './validate-repo.js';
+export type { RepoDoc, RepoFinding, RepoModelInput } from './types.js';

--- a/packages/diagrams/src/repo-validate/types.ts
+++ b/packages/diagrams/src/repo-validate/types.ts
@@ -1,0 +1,50 @@
+// Repo-scope validation types (vkgeorgia/transitrix-studio#141).
+//
+// `validate --scope=repo` runs whole-model checks over a loaded `canon/` tree —
+// referential integrity, atomicity, ID uniqueness, policy — the checks that the
+// methodology's Python `.validators/lint.py` owns today. This converges those
+// checks onto the shared TypeScript model so there is a single validation
+// runtime (methodology ADR
+// `2026-06-11-validation-two-axis-model.md`; Studio referencing ADR
+// `docs/decisions/2026-06-11-validation-runtime-convergence.md`).
+//
+// The finding shape is deliberately minimal — `{ scope, id, message }`. The
+// richer `target` / `category` reporting taxonomy is explicitly DEFERRED per the
+// ADR until a real consumer needs it; do not add it here.
+
+/** A single repo-scope validation finding. Shape is frozen at `{ scope, id, message }`. */
+export interface RepoFinding {
+  /** Always `'repo'` — the execution axis this finding came from. */
+  scope: 'repo';
+  /**
+   * The offending element/relation id, or `''` when the finding is not tied to
+   * a single id (e.g. a YAML syntax error in a file with no parseable id).
+   */
+  id: string;
+  /** Human-readable description of the violation. */
+  message: string;
+}
+
+/** A parsed canon document fed to the repo validator. IO (the filesystem walk)
+ *  lives in the CLI; the validator itself stays pure and testable. */
+export interface RepoDoc {
+  /** Source file path, relative to the scanned root — used in messages. */
+  path: string;
+  /**
+   * The parsed top-level YAML mapping, or `null` when the file failed to parse.
+   * A `null` data with a non-empty `parseError` produces a syntax finding.
+   */
+  data: Record<string, unknown> | null;
+  /** Set when the YAML failed to parse; surfaced as a syntax finding. */
+  parseError?: string;
+}
+
+/** The loaded repository model: element docs and relation docs, partitioned by
+ *  canon zone exactly as `lint.py` partitions them (`canon/elements/**` vs
+ *  `canon/relations/**`). */
+export interface RepoModelInput {
+  /** Documents found under `canon/elements/**`. */
+  elements: RepoDoc[];
+  /** Documents found under `canon/relations/**`. */
+  relations: RepoDoc[];
+}

--- a/packages/diagrams/src/repo-validate/validate-repo.ts
+++ b/packages/diagrams/src/repo-validate/validate-repo.ts
@@ -1,0 +1,196 @@
+// Repo-scope validator (vkgeorgia/transitrix-studio#141).
+//
+// Pure port of the whole-repo checks owned by the methodology's
+// `.validators/lint.py`, run over the shared TypeScript model instead of Python.
+// Parity reference: the `acme_corp` worked example, which `lint.py` passes with
+// zero findings — this validator must also produce zero findings on it.
+//
+// Ported checks (mirroring lint.py's phases):
+//   1. YAML syntax        (phase 1) — unparseable canon file -> finding.
+//   2. ID uniqueness                — same `id` defined in >1 file -> finding.
+//                                     (lint.py silently last-wins; we surface it,
+//                                      but acme_corp has no duplicates, so parity
+//                                      holds on the reference fixture.)
+//   3. Atomicity          (phase 3) — element file carrying a `relations:` key.
+//   4. Referential integ. (phase 4) — relation endpoint not resolving to a known
+//                                     element id. We resolve the canonical
+//                                     `from`/`to` keys (the real relation schema)
+//                                     and also accept lint.py's `source`/`target`.
+//   5. Semantic rules     (phase 5) — ArchiMate layer-semantics. lint.py ships
+//                                     this as a no-op stub; ported faithfully as a
+//                                     no-op (see `checkLayerSemantics`). Deferred
+//                                     until the methodology defines the rules.
+//   6. Policy             (phase 6) — element marked Active/Production with no
+//                                     owner.
+//
+// Findings stay `{ scope, id, message }` — no severity, no target/category
+// taxonomy (deferred per the ADR).
+
+import type { RepoDoc, RepoFinding, RepoModelInput } from './types.js';
+
+const PScope: RepoFinding['scope'] = 'repo';
+
+/** Statuses that, per lint.py's policy check, require an owner. */
+const OWNER_REQUIRED_STATUSES = new Set(['Active', 'Production']);
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/** Read a string `id` from a parsed doc, or `null` if absent/non-string.
+ *  Mirrors lint.py, which only treats a doc as an element/relation when it has
+ *  a top-level `id` (sidecars such as versioned-attribute files have no `id`
+ *  and are ignored). */
+function docId(doc: RepoDoc): string | null {
+  if (!doc.data) return null;
+  const id = doc.data['id'];
+  return typeof id === 'string' && id.length > 0 ? id : null;
+}
+
+/** Resolve a relation endpoint, which may be a bare id string or a `{ id }`
+ *  mapping (lint.py accepts both). Returns the id string or `null`. */
+function endpointId(value: unknown): string | null {
+  if (typeof value === 'string') return value.length > 0 ? value : null;
+  if (isRecord(value)) {
+    const id = value['id'];
+    if (typeof id === 'string' && id.length > 0) return id;
+  }
+  return null;
+}
+
+/** Phase 1 — unparseable canon files surface as findings. */
+function checkSyntax(docs: RepoDoc[], findings: RepoFinding[]): void {
+  for (const doc of docs) {
+    if (doc.parseError) {
+      findings.push({
+        scope: PScope,
+        id: '',
+        message: `YAML syntax error in ${doc.path}: ${doc.parseError}`,
+      });
+    }
+  }
+}
+
+/** Phase 2 (as a check) — the same id defined in more than one file. */
+function checkIdUniqueness(input: RepoModelInput, findings: RepoFinding[]): void {
+  const filesById = new Map<string, string[]>();
+  for (const doc of [...input.elements, ...input.relations]) {
+    const id = docId(doc);
+    if (!id) continue;
+    const list = filesById.get(id);
+    if (list) list.push(doc.path);
+    else filesById.set(id, [doc.path]);
+  }
+  for (const [id, files] of filesById) {
+    if (files.length > 1) {
+      findings.push({
+        scope: PScope,
+        id,
+        message: `Duplicate id '${id}' defined in ${files.length} files: ${files.join(', ')}`,
+      });
+    }
+  }
+}
+
+/** Phase 3 — relations must live in their own files, not inline on elements. */
+function checkAtomicity(input: RepoModelInput, findings: RepoFinding[]): void {
+  for (const doc of input.elements) {
+    const id = docId(doc);
+    if (id && doc.data && 'relations' in doc.data) {
+      findings.push({
+        scope: PScope,
+        id,
+        message:
+          `Atomicity violation: element '${id}' (${doc.path}) contains a ` +
+          `'relations' section. Move relations to separate files under canon/relations/.`,
+      });
+    }
+  }
+}
+
+/** Phase 4 — every relation endpoint must resolve to a known element id. */
+function checkReferentialIntegrity(input: RepoModelInput, findings: RepoFinding[]): void {
+  const elementIds = new Set<string>();
+  for (const doc of input.elements) {
+    const id = docId(doc);
+    if (id) elementIds.add(id);
+  }
+
+  for (const doc of input.relations) {
+    if (!doc.data) continue;
+    const relId = docId(doc) ?? '';
+    // Canonical relation schema uses `from`/`to`; `source`/`target` accepted for
+    // lint.py compatibility.
+    const fromId = endpointId(doc.data['from']) ?? endpointId(doc.data['source']);
+    const toId = endpointId(doc.data['to']) ?? endpointId(doc.data['target']);
+
+    if (fromId && !elementIds.has(fromId)) {
+      findings.push({
+        scope: PScope,
+        id: relId,
+        message: `Referential integrity: relation '${relId || doc.path}' endpoint '${fromId}' (from) does not resolve to a known element.`,
+      });
+    }
+    if (toId && !elementIds.has(toId)) {
+      findings.push({
+        scope: PScope,
+        id: relId,
+        message: `Referential integrity: relation '${relId || doc.path}' endpoint '${toId}' (to) does not resolve to a known element.`,
+      });
+    }
+  }
+}
+
+/** Phase 5 — ArchiMate layer-semantics on relations.
+ *
+ * lint.py ships `_check_semantic_rules` as a no-op stub (`pass`). It is ported
+ * here faithfully as a no-op so repo-scope validation reaches parity with
+ * lint.py on the reference fixture. Real layer-semantics rules are DEFERRED
+ * until the methodology defines them; when it does, they land here (a relation
+ * whose `type` is illegal between its endpoints' ArchiMate layers). Kept as a
+ * named hook so the intent — and the gap — is explicit rather than missing. */
+function checkLayerSemantics(_input: RepoModelInput, _findings: RepoFinding[]): void {
+  // Intentionally empty — parity with lint.py's stubbed phase 5. Do not add
+  // rules here without coordinating the methodology semantics canon.
+}
+
+/** Phase 6 — an element that is Active/Production must declare an owner. */
+function checkPolicy(input: RepoModelInput, findings: RepoFinding[]): void {
+  for (const doc of input.elements) {
+    const id = docId(doc);
+    if (!id || !doc.data) continue;
+    const metadata = doc.data['metadata'];
+    if (!isRecord(metadata)) continue;
+    const status = metadata['status'];
+    const owner = metadata['owner'];
+    if (typeof status === 'string' && OWNER_REQUIRED_STATUSES.has(status) && !owner) {
+      findings.push({
+        scope: PScope,
+        id,
+        message: `Policy: element '${id}' has status '${status}' but no owner assigned.`,
+      });
+    }
+  }
+}
+
+/**
+ * Run all repo-scope checks over a loaded canon model and return the findings.
+ * Pure: no IO, deterministic order (syntax, uniqueness, atomicity, referential,
+ * semantics, policy). Reaches parity with `lint.py` on the `acme_corp` fixture
+ * (zero findings on a clean tree).
+ */
+export function validateRepoModel(input: RepoModelInput): RepoFinding[] {
+  const findings: RepoFinding[] = [];
+  checkSyntax([...input.elements, ...input.relations], findings);
+  // A syntax error means the model is not reliably loaded; skip the graph checks
+  // and report the syntax problems first (mirrors lint.py, which bails after
+  // phase 1 on syntax errors).
+  if (findings.length > 0) return findings;
+
+  checkIdUniqueness(input, findings);
+  checkAtomicity(input, findings);
+  checkReferentialIntegrity(input, findings);
+  checkLayerSemantics(input, findings);
+  checkPolicy(input, findings);
+  return findings;
+}

--- a/src/cli-parse.ts
+++ b/src/cli-parse.ts
@@ -54,6 +54,71 @@ export function parseCliFileArgv(argv: string[]): ParseCliFileArgvResult {
   return { ok: true, positional, extList, wantsHelp };
 }
 
+export type ValidateScope = 'file' | 'repo';
+
+export type ParseValidateArgvResult =
+  | {
+      ok: true;
+      scope: ValidateScope;
+      root: string | undefined;
+      positional: string[];
+      extList: string[];
+      wantsHelp: boolean;
+    }
+  | { ok: false; error: '--ext_requires_value' | '--scope_requires_value' | '--root_requires_value' | 'bad_scope'; scope?: ValidateScope };
+
+/**
+ * Parse `validate` argv (#141). Recognises `--scope=file|repo` (and the spaced
+ * `--scope repo` form) and `--root <dir>` for repo-scope; everything else is
+ * delegated to {@link parseCliFileArgv}. Default scope is `file`, preserving the
+ * existing per-file `validate <input.yaml>` behaviour.
+ */
+export function parseValidateArgv(argv: string[]): ParseValidateArgvResult {
+  let scope: ValidateScope = 'file';
+  let root: string | undefined;
+  const rest: string[] = [];
+
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--scope') {
+      const v = argv[++i];
+      if (v === undefined) return { ok: false, error: '--scope_requires_value' };
+      if (v !== 'file' && v !== 'repo') return { ok: false, error: 'bad_scope' };
+      scope = v;
+      continue;
+    }
+    if (a.startsWith('--scope=')) {
+      const v = a.slice('--scope='.length);
+      if (v !== 'file' && v !== 'repo') return { ok: false, error: 'bad_scope' };
+      scope = v;
+      continue;
+    }
+    if (a === '--root') {
+      const v = argv[++i];
+      if (v === undefined) return { ok: false, error: '--root_requires_value' };
+      root = v;
+      continue;
+    }
+    if (a.startsWith('--root=')) {
+      root = a.slice('--root='.length);
+      continue;
+    }
+    rest.push(a);
+  }
+
+  const parsed = parseCliFileArgv(rest);
+  if (!parsed.ok) return { ok: false, error: '--ext_requires_value', scope };
+
+  return {
+    ok: true,
+    scope,
+    root,
+    positional: parsed.positional,
+    extList: parsed.extList,
+    wantsHelp: parsed.wantsHelp,
+  };
+}
+
 export function inputMatchesExtension(filePath: string, exts: string[]): boolean {
   const lowered = filePath.replace(/\\/g, '/').toLowerCase();
   return exts.some((e) => lowered.endsWith(e.toLowerCase()));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@ import {
   inputMatchesExtension,
   invokedAsCervin,
   parseCliFileArgv,
+  parseValidateArgv,
 } from './cli-parse.js';
 import { compileTransitrixYamlWithLayout } from './compiler.js';
 import { computeLayoutMetrics } from './metrics.js';
@@ -25,6 +26,7 @@ function printUsage(): void {
        transitrix metrics [--ext=.cervin.yaml,.bpmn.transitrix.yaml] <input.yaml> [--json]
        transitrix validate <input.yaml> [--json]
        transitrix validate [--ext=.cervin.yaml,.bpmn.transitrix.yaml] <input.yaml> [--json]
+       transitrix validate --scope=repo [--root <dir>] [--json]
        transitrix export-compliance [--format md|pdf] [--scope law:<ID>|product:<ID>|gap] [--output <path>] [--root <dir>]
 
   ('cervin' is a deprecated alias of 'transitrix'; both run the same CLI.)
@@ -32,7 +34,9 @@ function printUsage(): void {
   serve     — local web UI (run npm run ui:build once beforehand).
   <compile> — YAML → BPMN 2.0 XML with layout metrics.
   metrics   — layout quality metrics (with --json for CI).
-  validate  — BPMN validation only (no XML output; exit 1 on errors).
+  validate  — validation only (no XML output; exit 1 on errors). Default scope
+              is a single file; --scope=repo runs whole-canon checks
+              (referential integrity, atomicity, id uniqueness, policy).
   export-compliance — Markdown or PDF report of the compliance views (matrix by
               default; law:/product:/gap scopes). Scans --root (default cwd) for
               requirement/assertion/product/codex canon. PDF rendering requires
@@ -183,25 +187,55 @@ function printValidationReport(src: string, validation: ValidationReport, suppre
 }
 
 async function handleValidateCommand(argv: string[]): Promise<void> {
-  const parsed = parseCliFileArgv(argv);
+  const parsed = parseValidateArgv(argv);
   if (!parsed.ok) {
-    console.error('cervin: --ext requires a comma-separated list of suffixes.');
+    if (parsed.error === 'bad_scope') {
+      console.error('cervin validate: --scope must be "file" or "repo".');
+    } else if (parsed.error === '--scope_requires_value') {
+      console.error('cervin validate: --scope requires a value (file|repo).');
+    } else if (parsed.error === '--root_requires_value') {
+      console.error('cervin validate: --root requires a directory path.');
+    } else {
+      console.error('cervin: --ext requires a comma-separated list of suffixes.');
+    }
     process.exit(1);
   }
 
-  const { positional, extList, wantsHelp } = parsed;
+  const { scope, root, positional, extList, wantsHelp } = parsed;
   const exts = extList.length > 0 ? extList : DEFAULT_CERVIN_FILE_EXTENSIONS;
   const useJson = argv.includes('--json');
 
   if (wantsHelp) {
-    console.error(`usage: cervin validate <input.yaml> [--json]`);
+    console.error(`usage: transitrix validate <input.yaml> [--json]                 (file scope, default)`);
+    console.error(`       transitrix validate --scope=repo [--root <dir>] [--json]`);
     console.error('');
-    console.error('Run BPMN validation without compilation.');
-    console.error('Validator checks for structural and semantic errors.');
-    console.error('Exits with code 1 if any errors found (warnings do not block).');
+    console.error('file scope — single-file structural/semantic validation (default).');
+    console.error('repo scope — whole-canon checks (referential integrity, atomicity,');
+    console.error('             id uniqueness, policy) over <root> (default: cwd).');
+    console.error('Exits with code 1 if any findings.');
     process.exit(0);
   }
 
+  // Repo scope (#141): whole-canon checks on the @transitrix/diagrams model.
+  if (scope === 'repo') {
+    const repoRoot = root ?? process.cwd();
+    // Lazy import keeps the @transitrix/diagrams source out of the
+    // rootDir-restricted emit build (see repo-validate.ts header).
+    const repoModule = './repo-validate.js';
+    type RepoFinding = { scope: 'repo'; id: string; message: string };
+    const { runRepoValidate, reportRepoFindings } = (await import(repoModule)) as {
+      runRepoValidate: (root: string) => RepoFinding[];
+      reportRepoFindings: (root: string, findings: RepoFinding[], useJson: boolean) => void;
+    };
+    const findings = runRepoValidate(repoRoot);
+    reportRepoFindings(repoRoot, findings, useJson);
+    if (findings.length > 0) {
+      process.exit(1);
+    }
+    return;
+  }
+
+  // ----- file scope (existing behaviour) -----
   const [src] = positional;
   if (!src) {
     console.error('cervin validate: missing input file');

--- a/src/repo-validate.ts
+++ b/src/repo-validate.ts
@@ -1,0 +1,121 @@
+// `transitrix validate --scope=repo` handler (vkgeorgia/transitrix-studio#141).
+//
+// Lives in its own module — separate from cli.ts — because it imports the
+// repo-scope validator from `@transitrix/diagrams` *source*. The root emit build
+// (`tsconfig.build.json`, `rootDir: src`) cannot emit files outside `src/`, so
+// this module is excluded there and loaded by cli.ts via a runtime dynamic
+// import (same pattern as export-compliance.ts). It is still type-checked by
+// `npm run compile` (the root program has no rootDir restriction).
+//
+// The filesystem walk lives here (IO); the checks live in the pure
+// `validateRepoModel` so they stay testable and shared.
+
+import { readdirSync, readFileSync } from 'node:fs';
+import * as path from 'node:path';
+import yaml from 'js-yaml';
+import {
+  validateRepoModel,
+  type RepoDoc,
+  type RepoFinding,
+  type RepoModelInput,
+} from '../packages/diagrams/src/repo-validate/index.js';
+
+/** Directory segments that are tooling/scaffolding, never canon content.
+ *  Mirrors lint.py, which skips `.templates/` and `.validators/`. */
+const SKIP_SEGMENTS = new Set(['node_modules', '.templates', '.validators']);
+
+function segments(rel: string): string[] {
+  return rel.split(/[\\/]/);
+}
+
+function isYaml(rel: string): boolean {
+  return /\.ya?ml$/i.test(rel);
+}
+
+function shouldSkip(rel: string): boolean {
+  return segments(rel).some((s) => SKIP_SEGMENTS.has(s));
+}
+
+/** Read + parse one YAML file into a RepoDoc, capturing parse errors. */
+function readDoc(root: string, rel: string): RepoDoc {
+  try {
+    const parsed = yaml.load(readFileSync(path.join(root, rel), 'utf-8'));
+    const data =
+      parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : null;
+    return { path: rel.replace(/\\/g, '/'), data };
+  } catch (e) {
+    const err = e as Error;
+    return { path: rel.replace(/\\/g, '/'), data: null, parseError: err.message };
+  }
+}
+
+/** Collect canon docs under `<root>/canon/<zone>/**` exactly as lint.py globs
+ *  them: elements from `canon/elements/**`, relations from `canon/relations/**`.
+ *  Partitioning by zone (not by `notation`) keeps parity with the reference
+ *  linter's element/relation universe. */
+export function loadRepoModel(root: string): RepoModelInput {
+  const elements: RepoDoc[] = [];
+  const relations: RepoDoc[] = [];
+
+  let entries: string[] = [];
+  try {
+    entries = readdirSync(path.join(root, 'canon'), { recursive: true }) as string[];
+  } catch {
+    return { elements, relations };
+  }
+
+  for (const rel of entries) {
+    if (typeof rel !== 'string' || !isYaml(rel) || shouldSkip(rel)) continue;
+    const segs = segments(rel);
+    const zone = segs[0]; // first segment under canon/
+    const fullRel = path.join('canon', rel);
+    if (zone === 'elements') {
+      elements.push(readDoc(root, fullRel));
+    } else if (zone === 'relations') {
+      relations.push(readDoc(root, fullRel));
+    }
+  }
+
+  return { elements, relations };
+}
+
+/** Load the canon model under `root` and run the repo-scope checks. */
+export function runRepoValidate(root: string): RepoFinding[] {
+  return validateRepoModel(loadRepoModel(root));
+}
+
+/** Print findings (human or JSON). Returns nothing; the caller sets exit code. */
+export function reportRepoFindings(root: string, findings: RepoFinding[], useJson: boolean): void {
+  if (useJson) {
+    console.log(
+      JSON.stringify(
+        { scope: 'repo', root, valid: findings.length === 0, findings },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  if (findings.length === 0) {
+    console.log(`✓ ${root} — repo-scope validation passed`);
+    console.log();
+    return;
+  }
+
+  console.log();
+  console.log(`✗ ${root}`);
+  console.log();
+  console.log('Repo-scope validation:');
+  for (const f of findings) {
+    const where = f.id ? f.id : '(file)';
+    console.log(`  \x1b[31m✗ ${where}\x1b[0m ${f.message}`);
+  }
+  console.log();
+  console.log(
+    `Repo-scope validation: \x1b[31m${findings.length} finding${findings.length === 1 ? '' : 's'}\x1b[0m`,
+  );
+  console.log();
+}

--- a/tests/cli-parse.test.ts
+++ b/tests/cli-parse.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_CERVIN_FILE_EXTENSIONS,
   invokedAsCervin,
   parseCliFileArgv,
+  parseValidateArgv,
   inputMatchesExtension,
 } from '../src/cli-parse.js';
 
@@ -49,6 +50,42 @@ describe('cli-parse', () => {
       ok: true,
       positional: ['models/x.cervin.yaml', 'out/generated.bpmn'],
     });
+  });
+});
+
+describe('parseValidateArgv (#141 — validate scope)', () => {
+  it('defaults to file scope, preserving per-file back-compat', () => {
+    const r = parseValidateArgv(['model.cervin.yaml', '--json']);
+    expect(r).toMatchObject({ ok: true, scope: 'file', root: undefined });
+    if (r.ok) expect(r.positional).toContain('model.cervin.yaml');
+  });
+
+  it('parses --scope=repo with --root (equals and spaced forms)', () => {
+    expect(parseValidateArgv(['--scope=repo', '--root=./org'])).toMatchObject({ ok: true, scope: 'repo', root: './org' });
+    expect(parseValidateArgv(['--scope', 'repo', '--root', './org'])).toMatchObject({ ok: true, scope: 'repo', root: './org' });
+  });
+
+  it('repo scope without --root leaves root undefined (caller defaults to cwd)', () => {
+    expect(parseValidateArgv(['--scope=repo'])).toMatchObject({ ok: true, scope: 'repo', root: undefined });
+  });
+
+  it('rejects an unknown scope', () => {
+    expect(parseValidateArgv(['--scope=bogus'])).toEqual({ ok: false, error: 'bad_scope' });
+  });
+
+  it('signals --scope / --root without a value', () => {
+    expect(parseValidateArgv(['--scope'])).toEqual({ ok: false, error: '--scope_requires_value' });
+    expect(parseValidateArgv(['--root'])).toEqual({ ok: false, error: '--root_requires_value' });
+  });
+
+  it('still surfaces --ext parsing through to file scope', () => {
+    const r = parseValidateArgv(['--ext=.foo', 'x.foo']);
+    expect(r).toMatchObject({ ok: true, scope: 'file' });
+    if (r.ok) expect(r.extList).toEqual(['.foo']);
+  });
+
+  it('passes --help through as wantsHelp', () => {
+    expect(parseValidateArgv(['--scope=repo', '--help'])).toMatchObject({ ok: true, wantsHelp: true });
   });
 });
 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -7,6 +7,6 @@
     "sourceMap": true
   },
   "include": ["src/**/*.ts"],
-  "_comment_export_compliance": "src/export-compliance.ts is excluded here: it imports @transitrix/diagrams source, which cannot be emitted under rootDir:src. It is type-checked by `npm run compile` and loaded by cli.ts via a runtime dynamic import (tsx transpiles it).",
-  "exclude": ["extension", "src/export-compliance.ts"]
+  "_comment_export_compliance": "src/export-compliance.ts and src/repo-validate.ts are excluded here: they import @transitrix/diagrams source, which cannot be emitted under rootDir:src. They are type-checked by `npm run compile` and loaded by cli.ts via a runtime dynamic import (tsx transpiles them).",
+  "exclude": ["extension", "src/export-compliance.ts", "src/repo-validate.ts"]
 }


### PR DESCRIPTION
## What

Adds an explicit `scope` axis to `transitrix validate`, converging validation onto one runtime per the methodology ADR `2026-06-11-validation-two-axis-model` (Studio referencing ADR `docs/decisions/2026-06-11-validation-runtime-convergence.md`, #142):

- `--scope=file` (default) — unchanged per-file BPMN validation.
- `--scope=repo [--root <dir>]` — whole-`canon/` checks, ported from the methodology's Python `.validators/lint.py` onto the shared `@transitrix/diagrams` model.

Resolves #141.

## Repo-scope checks

Parity reference: the **acme_corp** worked example, which lint.py passes with **zero** findings — `validate --scope=repo` also reports zero on it.

| Check | Behaviour |
|---|---|
| YAML syntax | Unparseable canon file → finding; graph checks skipped (mirrors lint.py phase 1). |
| ID uniqueness | Same `id` defined in >1 file. |
| Atomicity | Element file carrying an inline `relations:` section. |
| Referential integrity | Relation endpoint (`from`/`to`, or legacy `source`/`target`) not resolving to a known element. |
| Policy | `Active`/`Production` element (`metadata.status`) with no `metadata.owner`. |
| ArchiMate layer-semantics | **Deferred** — lint.py ships a no-op stub; ported faithfully as a no-op (named hook + comment) until the methodology defines the rules. |

Findings stay shaped `{ scope, id, message }` — the `target`/`category` taxonomy is **deferred** per the ADR. Any repo-scope finding exits non-zero (the CI gate).

## Where the code lives

- **Pure validator + types** in `packages/diagrams/src/repo-validate/` — the standing rule: validation logic lives in `@transitrix/diagrams`, consumed by the CLI.
- **Filesystem walk** (`canon/elements/**` + `canon/relations/**`, skipping `.templates`/`.validators`) in `src/repo-validate.ts`, lazily imported by `cli.ts` — same pattern as `export-compliance`; excluded from the rootDir-restricted emit build (`tsconfig.build.json`).
- `parseValidateArgv()` handles `--scope` / `--root` (equals and spaced forms); default scope `file` keeps `validate <file>` back-compatible.

## Verification

- `validate --scope=repo` over both the in-repo and methodology `acme_corp` → zero findings (lint.py parity).
- A dirty fixture surfaces duplicate-id, dangling-reference and policy findings and exits 1.
- File-scope `validate <file>` unchanged (verified against a BPMN example).
- `npm test`: full build + **763** diagrams tests + core tests green; `npm run compile` clean.

## Notes

In-family cross-repo (methodology + transitrix-studio); local ADRs, not a hub matter. The methodology-side "collapse to one validator / retire lint.py" task is unblocked once this reaches parity. Valerii gates the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)