### PR TITLE
feat(diagrams): export SCHEMA_VERSION; pin package methodologyVersion (SV-1 PR1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "enterprise-architecture"
   ],
   "type": "module",
+  "transitrix": {
+    "methodologyVersion": "0.5.0"
+  },
   "engines": {
     "node": ">=20"
   },

--- a/packages/diagrams/src/index.ts
+++ b/packages/diagrams/src/index.ts
@@ -15,6 +15,7 @@ export * from "./process-map/index";
 export * from "./products/index";
 export * from "./requirement/index";
 export * from "./scenarios/index";
+export { SCHEMA_VERSION } from "./schema-version";
 export * from "./theme/index";
 export * from "./typed-id";
 export * from "./validation-types";

--- a/packages/diagrams/src/schema-version.ts
+++ b/packages/diagrams/src/schema-version.ts
@@ -1,0 +1,16 @@
+/**
+ * SCHEMA_VERSION — the methodology release whose notation schemas and validation
+ * rules this `@transitrix/diagrams` build conforms to (SV-1).
+ *
+ * Source of truth: the methodology `methodology_version`, declared in an adopter
+ * repository's `transitrix.yaml` per the methodology `notations/MANIFEST.md`
+ * (single source of truth for a repo's conformance). The current methodology
+ * release is **0.5.0**.
+ *
+ * This constant is kept in lockstep with the project manifest's
+ * `transitrix.methodologyVersion` (`package.json`); the
+ * `tests/schema-version.test.ts` unit test asserts the two are equal. A CI guard
+ * that additionally asserts both equal the methodology's published SoT lands
+ * separately (SV-1 PR2) — do not bundle it here.
+ */
+export const SCHEMA_VERSION = '0.5.0';

--- a/tests/schema-version.test.ts
+++ b/tests/schema-version.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import * as path from 'node:path';
+
+import { SCHEMA_VERSION } from '../packages/diagrams/src/schema-version.js';
+
+// SV-1: the @transitrix/diagrams SCHEMA_VERSION constant and the project
+// manifest's `transitrix.methodologyVersion` must stay in lockstep — both pin the
+// methodology release this build conforms to (SoT: methodology
+// notations/MANIFEST.md `methodology_version`, currently 0.5.0).
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const pkg = JSON.parse(readFileSync(path.join(repoRoot, 'package.json'), 'utf-8')) as {
+  transitrix?: { methodologyVersion?: string };
+};
+
+describe('SV-1 — schema version pinning', () => {
+  it('package.json declares transitrix.methodologyVersion', () => {
+    expect(pkg.transitrix?.methodologyVersion).toBeTypeOf('string');
+  });
+
+  it('SCHEMA_VERSION equals package.json transitrix.methodologyVersion', () => {
+    expect(SCHEMA_VERSION).toBe(pkg.transitrix?.methodologyVersion);
+  });
+
+  it('uses a semver-shaped version string', () => {
+    expect(SCHEMA_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+});


### PR DESCRIPTION
## What

SV-1 PR1 — a single, explicit pin of the methodology release this build conforms to.

- `@transitrix/diagrams` exports **`SCHEMA_VERSION = '0.5.0'`** — the current methodology release. Source of truth: the methodology `methodology_version` (methodology `notations/MANIFEST.md`, "single source of truth for a repo's conformance").
- Root `package.json` gains **`transitrix.methodologyVersion = '0.5.0'`**.
- `tests/schema-version.test.ts` asserts the two are **equal** (and semver-shaped).

Keeping the library constant and the project manifest in lockstep makes the methodology-version pin verifiable in code.

## Scope

This is **PR1 only**. The CI guard that additionally asserts both equal the methodology's published SoT is **SV-1 PR2** and is intentionally **not** bundled here (per the local ADR sequencing).

## Verification

- `npx vitest run tests/schema-version.test.ts` — 3/3 pass.
- `npm run compile` clean; full `npm test` green (core 262, diagrams 749).

Valerii gates the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)