### PR TITLE
docs: redact internal agent codename from public feature-list

### DIFF
--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -1,7 +1,7 @@
 ---
 title: "Transitrix Feature List"
 doc_type: living-design-doc
-established_by: "Win-Claude"
+established_by: "Valerii Korobeinikov"
 last_updated: "2026-06-10"
 scope: "transitrix-methodology, transitrix-studio"
 ---


### PR DESCRIPTION
## Why

`docs/feature-list.md` (public) carried `established_by: "Win-Claude"` in its
frontmatter — an internal agent codename on a world-readable surface. Same class
of issue as the 2026-06-06 agent-name-redaction decision (ADR Deciders line).

## What

One-line frontmatter change: `established_by: "Win-Claude"` →
`established_by: "Valerii Korobeinikov"`. Nothing else touched (diff is +10 bytes).

## Note on ADRs staying public

Recommendation: **keep ADRs / design docs public** — they're part of the
architecture-as-code, open-methodology posture; making them private would
undercut that. The fix is to redact internal *agent identifiers* from public
surfaces, not to hide the decisions. This was the only confirmed public
agent-name leak in the markdown of the two public repos (methodology + studio);
dsm and swarm are private.

Valerii gates the merge.