### PR TITLE
chore(activity-card): drop internal tracker ref from resolver comment

### DIFF
--- a/packages/diagrams/src/activity-card/resolver.ts
+++ b/packages/diagrams/src/activity-card/resolver.ts
@@ -154,7 +154,7 @@ export function resolveActivityCard(
   // one ACTIVITY TYPE and `activity_type` references an ActivityType element,
   // so a missing/non-literal value is acceptable; only an explicit, clearly
   // non-project marker is flagged. (Canonical project-identification semantics
-  // are tracked as a follow-up — see win-claude/tasks.md.)
+  // are tracked as a follow-up internally.)
   const activityType = str(projectRec['activity_type']);
   if (activityType !== undefined && activityType !== 'Project' && activityType !== 'project') {
     errors.push({


### PR DESCRIPTION
## What

The PC-002 comment in `resolveActivityCard` (`packages/diagrams/src/activity-card/resolver.ts`) referenced a private orchestration path that shouldn't appear in public source. Reworded to note the follow-up is tracked internally, without leaking the path.

One-line comment change; no behaviour, no test impact.