### PR TITLE
chore(cli): emit `transitrix:` not `cervin:` in CLI error/usage messages

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -57,7 +57,7 @@ Examples:
 async function handleCompileCommand(argv: string[]): Promise<void> {
   const parsed = parseCliFileArgv(argv);
   if (!parsed.ok) {
-    console.error('cervin: --ext requires a comma-separated list of suffixes.');
+    console.error('transitrix: --ext requires a comma-separated list of suffixes.');
     process.exit(1);
   }
 
@@ -71,14 +71,14 @@ async function handleCompileCommand(argv: string[]): Promise<void> {
 
   const [src, dst] = positional;
   if (!src || !dst) {
-    console.error('cervin compile: missing input or output file');
-    console.error(`usage: cervin compile <input.yaml> <output.bpmn>`);
+    console.error('transitrix compile: missing input or output file');
+    console.error(`usage: transitrix compile <input.yaml> <output.bpmn>`);
     process.exit(1);
   }
 
   if (!inputMatchesExtension(src, exts)) {
     console.error(
-      `cervin: input file must end with one of: ${exts.join(', ')} (or pass --ext)`,
+      `transitrix: input file must end with one of: ${exts.join(', ')} (or pass --ext)`,
     );
     process.exit(1);
   }
@@ -190,13 +190,13 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
   const parsed = parseValidateArgv(argv);
   if (!parsed.ok) {
     if (parsed.error === 'bad_scope') {
-      console.error('cervin validate: --scope must be "file" or "repo".');
+      console.error('transitrix validate: --scope must be "file" or "repo".');
     } else if (parsed.error === '--scope_requires_value') {
-      console.error('cervin validate: --scope requires a value (file|repo).');
+      console.error('transitrix validate: --scope requires a value (file|repo).');
     } else if (parsed.error === '--root_requires_value') {
-      console.error('cervin validate: --root requires a directory path.');
+      console.error('transitrix validate: --root requires a directory path.');
     } else {
-      console.error('cervin: --ext requires a comma-separated list of suffixes.');
+      console.error('transitrix: --ext requires a comma-separated list of suffixes.');
     }
     process.exit(1);
   }
@@ -238,14 +238,14 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
   // ----- file scope (existing behaviour) -----
   const [src] = positional;
   if (!src) {
-    console.error('cervin validate: missing input file');
-    console.error(`usage: cervin validate <input.yaml> [--json]`);
+    console.error('transitrix validate: missing input file');
+    console.error(`usage: transitrix validate <input.yaml> [--json]`);
     process.exit(1);
   }
 
   if (!inputMatchesExtension(src, exts)) {
     console.error(
-      `cervin: input file must end with one of: ${exts.join(', ')} (or pass --ext)`,
+      `transitrix: input file must end with one of: ${exts.join(', ')} (or pass --ext)`,
     );
     process.exit(1);
   }
@@ -333,7 +333,7 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
 async function handleMetricsCommand(argv: string[]): Promise<void> {
   const parsed = parseCliFileArgv(argv);
   if (!parsed.ok) {
-    console.error('cervin: --ext requires a comma-separated list of suffixes.');
+    console.error('transitrix: --ext requires a comma-separated list of suffixes.');
     process.exit(1);
   }
 
@@ -348,14 +348,14 @@ async function handleMetricsCommand(argv: string[]): Promise<void> {
 
   const [src] = positional;
   if (!src) {
-    console.error('cervin metrics: missing input file');
-    console.error(`usage: cervin metrics <input.yaml> [--json]`);
+    console.error('transitrix metrics: missing input file');
+    console.error(`usage: transitrix metrics <input.yaml> [--json]`);
     process.exit(1);
   }
 
   if (!inputMatchesExtension(src, exts)) {
     console.error(
-      `cervin: input file must end with one of: ${exts.join(', ')} (or pass --ext)`,
+      `transitrix: input file must end with one of: ${exts.join(', ')} (or pass --ext)`,
     );
     process.exit(1);
   }
@@ -435,12 +435,12 @@ try {
       : process.argv.slice(2);
     await handleCompileCommand(compileArgv);
   } else {
-    console.error(`cervin: unknown command '${subcommand}'`);
+    console.error(`transitrix: unknown command '${subcommand}'`);
     printUsage();
     process.exit(1);
   }
 } catch (e) {
   const err = e as Error;
-  console.error(`cervin: unexpected error: ${err.message ?? String(e)}`);
+  console.error(`transitrix: unexpected error: ${err.message ?? String(e)}`);
   process.exit(1);
 }

--- a/src/serve-ui.ts
+++ b/src/serve-ui.ts
@@ -196,7 +196,7 @@ export async function runUiServer(opts: ServeUiOptions): Promise<void> {
       res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' })
       res.end('404 Not Found')
     } catch (e) {
-      console.error('cervin serve: unhandled error', e)
+      console.error('transitrix serve: unhandled error', e)
       res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' })
       res.end('Internal server error')
     }
@@ -214,7 +214,7 @@ export async function runUiServer(opts: ServeUiOptions): Promise<void> {
   console.error(`Transitrix Studio UI → ${url}  (static root: "${rootName}")`)
 }
 
-/** `cervin serve [--port 8765] [--host 127.0.0.1]` — keeps running after start. */
+/** `transitrix serve [--port 8765] [--host 127.0.0.1]` — keeps running after start. */
 export async function cliServeArgv(argv: string[]): Promise<void> {
   let port = 8765
   let host = '127.0.0.1'
@@ -226,7 +226,7 @@ export async function cliServeArgv(argv: string[]): Promise<void> {
       if (v) {
         const parsed = Number.parseInt(v, 10)
         if (!Number.isFinite(parsed)) {
-          console.error(`cervin serve: --port requires a numeric value, got: ${v}`)
+          console.error(`transitrix serve: --port requires a numeric value, got: ${v}`)
           process.exitCode = 1
           process.exit(1)
         }
@@ -238,7 +238,7 @@ export async function cliServeArgv(argv: string[]): Promise<void> {
       const v = a.slice('--port='.length)
       const parsed = Number.parseInt(v, 10)
       if (!Number.isFinite(parsed)) {
-        console.error(`cervin serve: --port requires a numeric value, got: ${v}`)
+        console.error(`transitrix serve: --port requires a numeric value, got: ${v}`)
         process.exitCode = 1
         process.exit(1)
       }
@@ -252,7 +252,7 @@ export async function cliServeArgv(argv: string[]): Promise<void> {
     }
     if (a === '--help' || a === '-h') {
       // eslint-disable-next-line no-console
-      console.error(`usage: cervin serve [--port 8765] [--host 127.0.0.1]
+      console.error(`usage: transitrix serve [--port 8765] [--host 127.0.0.1]
 
 Local web UI: YAML on the left, BPMN preview on the right.
 Compiles through the server (same pipeline as the CLI / VS Code extension for BPMN).
@@ -267,7 +267,7 @@ Before first run:
 
   if (!Number.isFinite(port) || port < 1 || port > 65535) {
     // eslint-disable-next-line no-console
-    console.error('cervin serve: invalid --port')
+    console.error('transitrix serve: invalid --port')
     process.exitCode = 1
     process.exit(1)
   }


### PR DESCRIPTION
## What

User-facing error and usage strings in the CLI still prefixed every line with the legacy `cervin:` name — `cervin compile:`, `usage: cervin validate …`, `cervin serve: …` — even when the binary is invoked as `transitrix`. For scripted / CI adopters running the CLI **outside VS Code** (the adoption path in vkgeorgia/strategy#187), this contradicts `docs/cli.md`, which documents `transitrix` as the canonical command.

## Change

Repoint all ~19 emitted message prefixes in `src/cli.ts` and `src/serve-ui.ts` to `transitrix`.

**Preserved deliberately** (not message prefixes):
- `invokedAsCervin` identifier and the one-line deprecation notice keyed to the legacy bin name
- `.cervin.yaml` accepted-extension references (separate file-extension deprecation track)
- the help line noting `cervin` is a deprecated alias of `transitrix`

No behaviour change — string-only. Aligns with the Cervin→Transitrix deprecation principle *"accept old, emit new."*

## Verification

- `npm run compile` (typecheck) — clean
- `tests/cli.test.ts` + `tests/serve-ui.test.ts` — 14 passed
- Manual: `transitrix: unknown command …`, `transitrix validate: missing input file`, `transitrix serve: --port requires a numeric value` all confirmed

## Context

vkgeorgia/strategy#187's Studio-side minimum (docs + `--help` exit 0) already landed in #140; this is incremental adoption-UX polish in the same spirit. Out-of-repo items (skill launcher, npm publish) remain tracked on the hub issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)