### PR TITLE
docs(contributing): document `.transitrixrc` project config (Cervin deprecation P4)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,20 @@ also run by the test workflow) fails the build if a new `*.cervin.yaml` file is
 committed. Existing `.cervin.yaml` fixtures, where any remain, are kept only for
 regression coverage and are not mass-renamed.
 
+## Project config — use the canonical `.transitrixrc`
+
+Project-level rule overrides (enabling/disabling validation rules) are read from a
+**`.transitrixrc`** file at the project root. Its shape is the published JSON schema
+[`schemas/transitrixrc.schema.json`](schemas/transitrixrc.schema.json); the rule-override
+format is documented in [`docs/validation.md`](docs/validation.md).
+
+The legacy **`.cervinrc`** filename is still read as a *fallback* when `.transitrixrc`
+is absent (see CLAUDE.md §Cervin naming, P4), but is **deprecated** — `loadTransitrixrc()`
+prints a one-time deprecation notice when it falls back, and `.cervinrc` support is slated
+for removal in 2.0.0. Use `.transitrixrc` in new repos and **rename** any existing
+`.cervinrc`; do not add new `.cervinrc` files. The legacy `schemas/cervinrc.schema.json`
+is kept only for backward compatibility.
+
 ## Per-user display preferences
 
 The `.transitrix/display-preferences/` folder is the designated home for **per-user,


### PR DESCRIPTION
## What

Completes the last open deliverable of **Cervin→Transitrix deprecation P4** (CLAUDE.md §Cervin naming): *"document in CONTRIBUTING."*

The P4 runtime already shipped in this repo:
- `loadTransitrixrc()` reads `.transitrixrc`, falls back to legacy `.cervinrc` with a one-time deprecation notice (`src/cervinrc.ts`)
- `schemas/transitrixrc.schema.json` shipped (legacy `cervinrc.schema.json` kept)
- in-repo callers use the new name (`src/compiler.ts`); `loadCervinrc` retained only as a `@deprecated` alias
- covered by `tests/cervinrc.test.ts` → `describe('loadTransitrixrc (Cervin deprecation P4)')`

Only the CONTRIBUTING note was missing.

## Change

Add a **"Project config — use the canonical `.transitrixrc`"** section to `CONTRIBUTING.md`, mirroring the existing notation-suffix guidance: canonical `.transitrixrc`, legacy `.cervinrc` as a deprecated fallback (removal slated for 2.0.0), with pointers to the published schema and the rule-override format in `docs/validation.md`.

Docs-only; no code or test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)