### PR TITLE
docs(release): document manual npm publish runbook (#199)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Docs
 - **CLI usage outside VS Code** — new [`docs/cli.md`](docs/cli.md) and a rewritten README CLI section explain how to get the `transitrix` CLI on `PATH` from a clone (`npm install && npm run build && npm link`), how to run it without a global install, and how a script/skill should auto-detect it. Clarifies the CLI is not yet on npm and the VS Code extension does not ship a PATH binary (unblocks scripted/CI/skill use — strategy #187).
+- **npm release runbook** — new [`docs/release-runbook.md`](docs/release-runbook.md) codifies the manual `npm publish` procedure for `@transitrix/diagrams` (first) and `@transitrix/cli` (second), per the 2026-06-10 publish decisions on strategy #199. Prerequisites, pre-flight checklist, per-package publish steps with `--access public` + 2FA, post-publish verification, tagging, and the unpublish/deprecate guidance. CI publish-on-tag automation is a deferred follow-up.
 
 ### Deprecated
 - **`cervin` CLI is deprecated, use `transitrix`.** The `cervin` bin is kept as a compatibility alias (no removal in this release; slated for 2.0.0). Invoking the tool under the `cervin` name prints a one-line deprecation notice to stderr. First phase of the Cervin → Transitrix CLI rename (CLAUDE.md §Cervin naming, P1).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -12,7 +12,8 @@ deprecated alias of the same binary and will be removed in 2.0.0.
 > The CLI is **not yet published to npm** (`npm install -g transitrix` /
 > `@transitrix/cli` will 404). The VS Code extension bundles the rendering
 > library for previews — it does **not** put a runnable CLI on your `PATH`.
-> Until a published package lands, install from a clone:
+> Until a published package lands, install from a clone (the publish
+> procedure itself is tracked in [`docs/release-runbook.md`](release-runbook.md)):
 
 ```bash
 git clone https://github.com/transitrix/transitrix-studio

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -1,0 +1,153 @@
+# Release runbook — npm
+
+How to publish Transitrix's npm packages by hand. This is the manual procedure
+agreed in strategy hub issue `vkgeorgia/strategy#199`; CI publish-on-tag
+automation is a deferred follow-up.
+
+The VS Code extension `.vsix` flow is a separate pipeline — see
+[`docs/packaging.md`](packaging.md).
+
+## Packages
+
+Two scoped packages live on the `@transitrix/*` namespace:
+
+| Package | Source | Bin | Notes |
+|---|---|---|---|
+| `@transitrix/diagrams` | `packages/diagrams/` | — | Shared rendering / validation / pure-mutation library. Consumed by the CLI, the VS Code extension, and downstream tools. |
+| `@transitrix/cli` | slim package — own `package.json` with `bin` + `files` allowlist, `dist/cli.js` + runtime deps only (not the whole repo) | `transitrix` only (no `cervin` alias — the new package is born in the 2.0 era, see `#191`) | First release `1.0.0`, independent of the extension version line. |
+
+**Publish order matters: `@transitrix/diagrams` first, then `@transitrix/cli`** —
+the CLI depends on diagrams; npm has to be able to resolve it.
+
+## Prerequisites (one-time, Valerii action)
+
+These steps are outside the agent scope and must be done before the first
+publish session:
+
+1. **Create the `transitrix` npm organisation** at <https://www.npmjs.com/org/create>.
+2. **Enable 2FA for `@transitrix/*` writes** (org settings → "Require 2FA for write actions").
+3. Confirm `npm whoami` shows the publishing account is a member of the org with
+   publish permission on the scope.
+4. (Optional, recommended) Reserve the unscoped `transitrix` name on npm so a
+   future squatter can't grab it — even if we ship under `@transitrix/cli`.
+
+A registry token is **not** needed for manual publishes; `npm publish` uses the
+interactive 2FA OTP. A token is only required when CI publish-on-tag is wired
+up later.
+
+## Pre-flight checklist (run for every release)
+
+Run from a clean checkout of the tag/commit being released:
+
+- [ ] `git status` clean; on the exact commit being shipped (no local edits).
+- [ ] `npm ci` (not `npm install`) — reproducible install from `package-lock.json`.
+- [ ] `npm run build` succeeds for the root package, emitting `dist/`.
+- [ ] `npm --workspace packages/diagrams run build` succeeds, emitting
+      `packages/diagrams/dist/`.
+- [ ] `npm test` is green (root core tests + diagrams workspace tests).
+- [ ] `npm run compile && npm run compile:extension` are green
+      (catches type regressions the test suite doesn't exercise).
+- [ ] `CHANGELOG.md` has an entry for the version being shipped (move
+      `[Unreleased]` items to a dated heading; bump the version header).
+- [ ] The version field in the package being published matches the CHANGELOG
+      heading.
+- [ ] `npm whoami` returns the expected publishing account and is a member of
+      the `transitrix` org with publish permission on the scope.
+
+## Publishing `@transitrix/diagrams`
+
+1. **Flip the publish flag.** In `packages/diagrams/package.json` ensure
+   `"private": false` (or the field is absent). Add `homepage`, `repository`,
+   and `bugs` fields pointing at the monorepo if missing — npm shows these on
+   the package page.
+2. **Set the version.** First release: `1.0.0` per the published-package
+   versioning decision. Subsequent releases follow semver from there
+   (independent of the extension version line).
+3. **Dry-run the pack** to inspect the tarball contents:
+   ```bash
+   npm --workspace packages/diagrams pack --dry-run
+   ```
+   Verify the listed files match the `"files"` allowlist
+   (`dist/`, `src/`) — nothing extraneous, no secrets, no `node_modules`.
+4. **Publish:**
+   ```bash
+   npm --workspace packages/diagrams publish --access public
+   ```
+   - `--access public` is required for the first publish of a scoped package;
+     the default is `restricted`.
+   - npm prompts for the 2FA OTP interactively.
+5. **Verify** the package appeared on the registry:
+   ```bash
+   npm view @transitrix/diagrams version
+   ```
+
+## Publishing `@transitrix/cli`
+
+The slim CLI package is *assembled* — it owns its `package.json`, `bin`, and
+`files` allowlist, ships `dist/cli.js` + runtime deps only, and does **not**
+include the rest of the monorepo. The exact assembly script is tracked under
+issue `#199` and will be filled in here as it lands; the procedure below is
+the steady-state shape.
+
+1. **Prepare the publishable directory.** Build the slim package per its
+   `prepublishOnly` (or equivalent) script: `dist/cli.js` is emitted from the
+   root `npm run build`; the slim `package.json` declares `bin: { transitrix:
+   "./dist/cli.js" }`, the runtime `dependencies` (no `devDependencies`), and
+   `engines.node >= 20`. No `cervin` bin alias — see the per-package table above.
+2. **Confirm the dependency on `@transitrix/diagrams`** in the slim
+   `package.json` points at a version range that includes the version just
+   published in the previous step (e.g. `"^1.0.0"`).
+3. **Dry-run:**
+   ```bash
+   npm pack --dry-run --workspace packages/cli   # path subject to change
+   ```
+   Confirm the tarball contains exactly `dist/cli.js` (+ any auxiliaries it
+   loads), the slim `package.json`, `README.md`, `LICENSE` — and nothing else.
+4. **Publish:**
+   ```bash
+   npm publish --access public --workspace packages/cli
+   ```
+   npm prompts for the 2FA OTP.
+5. **Verify on a clean machine / fresh directory:**
+   ```bash
+   npm i -g @transitrix/cli
+   transitrix --help                  # canonical
+   transitrix compile <sample>.yaml out.bpmn
+   ```
+   On Windows: `where.exe transitrix`. On macOS / Linux: `which transitrix`.
+
+## Post-publish
+
+- **Tag the git commit** for traceability (matches the version published):
+  ```bash
+  git tag -s diagrams-v1.0.0 -m "Release @transitrix/diagrams 1.0.0"
+  git tag -s cli-v1.0.0      -m "Release @transitrix/cli 1.0.0"
+  git push --tags
+  ```
+- **Update consumer docs.** [`docs/cli.md`](cli.md) currently states "the CLI
+  is not yet published to npm" — promote `npm i -g @transitrix/cli` to the
+  primary install path and demote the `npm link`-from-a-clone instructions to
+  a "from source" subsection.
+- **Update strategy hub issue `#199`** with the published versions and a link
+  to the npm pages; close when the acceptance criteria are met.
+- **Notify downstream consumer skills** (e.g. win-claude's compliance
+  renderer) that they can switch from the clone+`npm link` recipe to
+  `npm i -g @transitrix/cli`.
+
+## Unpublish / yank
+
+npm only permits unpublish within 72 hours of publish for non-trivial
+packages, and even within that window it's disruptive (cached installs break
+for downstream consumers). Prefer a **patch release with a fix** over an
+unpublish. If a published version is genuinely broken, mark it deprecated:
+
+```bash
+npm deprecate @transitrix/diagrams@1.0.0 "Broken — use 1.0.1+"
+```
+
+## Relates
+
+- Strategy hub: [`vkgeorgia/strategy#199`](https://github.com/vkgeorgia/strategy/issues/199) — the npm-publish task, including the decisions this runbook codifies.
+- [`docs/cli.md`](cli.md) — current install-from-clone instructions (to be updated post-publish).
+- [`docs/packaging.md`](packaging.md) — VS Code extension `.vsix` packaging (separate pipeline).
+- `CLAUDE.md` §Cervin naming — explains why `@transitrix/cli` ships with no `cervin` bin alias.


### PR DESCRIPTION
## Summary

- Add `docs/release-runbook.md` codifying the manual `npm publish` procedure agreed in strategy hub `#199` (2026-06-10 decision comment): `@transitrix/diagrams` first, `@transitrix/cli` second, manual publish with `--access public` + interactive 2FA OTP, CI publish-on-tag deferred.
- Cross-link from `docs/cli.md` (which currently states the CLI is not yet on npm).
- CHANGELOG entry under **Docs**.

Closes one of the acceptance criteria of strategy hub `#199` ("(If feasible) … a documented manual release runbook") — single-concern PR, the slim-CLI-package and the publish itself remain open under the same issue.

## What the runbook covers

- **Prerequisites** (one-time, outside agent scope): create the `transitrix` npm org, enable 2FA for `@transitrix/*` writes, confirm membership / publish permission, optional unscoped-name reservation.
- **Pre-flight checklist**: clean tree, `npm ci`, root + diagrams workspace builds, full test suite, both typechecks, CHANGELOG up to date, version field matches CHANGELOG, expected `npm whoami`.
- **`@transitrix/diagrams` publish** — flip `private: false`, start at `1.0.0`, `pack --dry-run`, `publish --access public`, `npm view` verification.
- **`@transitrix/cli` publish** — slim package shape (own `package.json`, `bin: { transitrix }` only — no `cervin` alias per the 2.0-era decision and #191), version range pin to the just-published diagrams version, dry-run + publish + clean-machine `npm i -g` verification.
- **Post-publish** — signed git tags `diagrams-v1.0.0` / `cli-v1.0.0`, update `docs/cli.md` to promote `npm i -g` over the clone+link recipe, notify downstream consumer skills.
- **Unpublish / yank** — `npm deprecate` instead of unpublish; patch-release-with-fix is preferred.

## Out of scope (still open under #199)

- Flipping `packages/diagrams/package.json` to `"private": false` + bumping to `1.0.0` + filling `homepage`/`bugs`/`repository`.
- Creating the slim `@transitrix/cli` package (own `package.json`, `bin` + `files` allowlist, assembly script).
- The publish itself (Valerii action — requires the npm org + 2FA that haven't been set up yet).

## Test plan

- [x] `npm run compile` — clean.
- [x] `npm run compile:extension` — clean.
- [x] `npm test` — 764 tests green.
- [x] Reread `docs/release-runbook.md` end-to-end; cross-links to `docs/cli.md`, `docs/packaging.md`, CLAUDE.md §Cervin naming, and strategy hub `#199` resolve to existing targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)