### PR TITLE
chore(ci): public-surface hygiene guard + de-leak runbook line

### DIFF
--- a/.github/workflows/public-surface-hygiene.yml
+++ b/.github/workflows/public-surface-hygiene.yml
@@ -1,0 +1,35 @@
+name: Public-surface hygiene
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  hygiene-check:
+    runs-on: ubuntu-latest
+    name: Diff + PR-metadata blocklist
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run hygiene check
+        env:
+          HYGIENE_BLOCKLIST: ${{ secrets.HYGIENE_BLOCKLIST }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: node scripts/ci-hygiene-check.mjs

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -130,7 +130,7 @@ the steady-state shape.
   a "from source" subsection.
 - **Update strategy hub issue `#199`** with the published versions and a link
   to the npm pages; close when the acceptance criteria are met.
-- **Notify downstream consumer skills** (e.g. win-claude's compliance
+- **Notify downstream consumers** (e.g. the maintainer's compliance
   renderer) that they can switch from the clone+`npm link` recipe to
   `npm i -g @transitrix/cli`.
 

--- a/scripts/ci-hygiene-check.mjs
+++ b/scripts/ci-hygiene-check.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+// Public-surface hygiene check.
+//
+// Fails the PR if the diff (added lines), PR title, or PR body matches a regex
+// blocklist held in the repo Actions secret HYGIENE_BLOCKLIST. The blocklist
+// stays out of source on purpose; this script only reports file:line of hits
+// and never echoes the matched substring (anti-recursion).
+
+import { execSync } from 'node:child_process';
+
+const blocklist = process.env.HYGIENE_BLOCKLIST;
+if (!blocklist || blocklist.trim() === '') {
+  console.warn('[hygiene] HYGIENE_BLOCKLIST secret is not set — skipping check.');
+  console.warn('[hygiene] Set the repo Actions secret HYGIENE_BLOCKLIST to a regex to enable enforcement.');
+  process.exit(0);
+}
+
+let pattern;
+try {
+  pattern = new RegExp(blocklist, 'i');
+} catch {
+  console.error('[hygiene] HYGIENE_BLOCKLIST is not a valid JavaScript regex.');
+  process.exit(2);
+}
+
+const baseSha = process.env.BASE_SHA;
+const headSha = process.env.HEAD_SHA;
+if (!baseSha || !headSha) {
+  console.error('[hygiene] missing BASE_SHA / HEAD_SHA env vars (must be invoked from a pull_request workflow).');
+  process.exit(2);
+}
+
+try {
+  execSync(`git fetch --no-tags --depth=1 origin ${baseSha}`, { stdio: 'pipe' });
+} catch {
+  // Fallback: rely on existing fetch depth from checkout step.
+}
+
+let diff;
+try {
+  diff = execSync(`git diff --unified=0 ${baseSha} ${headSha}`, {
+    encoding: 'utf8',
+    maxBuffer: 128 * 1024 * 1024,
+  });
+} catch (err) {
+  console.error('[hygiene] failed to compute diff:', err.message);
+  process.exit(2);
+}
+
+const hits = [];
+let currentFile = null;
+let currentLine = 0;
+
+for (const line of diff.split('\n')) {
+  if (line.startsWith('+++ b/')) {
+    currentFile = line.slice(6);
+    currentLine = 0;
+    continue;
+  }
+  if (line.startsWith('+++ ') || line.startsWith('--- ')) continue;
+  if (line.startsWith('diff --git')) {
+    currentFile = null;
+    currentLine = 0;
+    continue;
+  }
+  if (line.startsWith('@@')) {
+    const m = line.match(/\+(\d+)(?:,\d+)?/);
+    currentLine = m ? parseInt(m[1], 10) : 0;
+    continue;
+  }
+  if (line.startsWith('+') && currentFile) {
+    if (pattern.test(line.slice(1))) {
+      hits.push({ file: currentFile, line: currentLine });
+    }
+    currentLine++;
+  }
+}
+
+const titleHit = pattern.test(process.env.PR_TITLE || '');
+const bodyHit = pattern.test(process.env.PR_BODY || '');
+
+if (hits.length === 0 && !titleHit && !bodyHit) {
+  console.log('[hygiene] no blocklist matches in diff or PR metadata.');
+  process.exit(0);
+}
+
+console.error('[hygiene] blocklisted vocabulary detected. Replace with neutral wording before merging.');
+console.error('[hygiene] (matched terms are intentionally not printed — repeating them would re-leak them.)');
+if (titleHit) console.error('  - PR title contains a match');
+if (bodyHit) console.error('  - PR body contains a match');
+for (const h of hits) {
+  console.error(`  - ${h.file}:${h.line}`);
+}
+process.exit(1);


### PR DESCRIPTION
## Summary

Closes hub task `vkgeorgia/strategy#233`.

- Adds a new CI workflow `.github/workflows/public-surface-hygiene.yml` that runs on every pull request and fails the build when added diff lines, the PR title, or the PR body match a regex blocklist held in the repo Actions secret `HYGIENE_BLOCKLIST`. The blocklist is intentionally NOT committed; the script only reports `file:line` on hits and never echoes the matched substring (anti-recursion).
- Adds `scripts/ci-hygiene-check.mjs`, the matcher invoked by the workflow. Parses `git diff --unified=0 BASE HEAD`, walks added lines, checks `PR_TITLE` and `PR_BODY` from the workflow event, and exits non-zero with a quiet `file:line` report on any hit. Skips with a warning (exit 0) when the secret is unset so PRs do not fail before Valerii sets it.
- Neutralises one phrase in `docs/release-runbook.md:133` per the task acceptance criteria. The replacement reads `the maintainer's compliance renderer` and `Notify downstream consumers`.

## Operator action (one-time)

After merge, set the repo Actions secret `HYGIENE_BLOCKLIST` to a JavaScript regex (case-insensitive matching is applied). Until that secret is set, the workflow runs but skips with a no-op exit-0, so it cannot block the next PR by accident.

## Local script verification

Three smoke tests against the committed branch tip:

| scenario | expected | actual |
|---|---|---|
| regex matches a string in the added diff | exit 1, report `file:line`, no matched-term echo | ✅ |
| regex matches a substring of `PR_TITLE` only | exit 1, report `PR title contains a match` | ✅ |
| `HYGIENE_BLOCKLIST` unset | exit 0 with skip warning | ✅ |

## Test plan

- [ ] After merge, set the `HYGIENE_BLOCKLIST` secret per the task body.
- [ ] Confirm the new workflow appears in the Actions tab and runs on the next PR.
- [ ] Confirm a probe PR with a deliberately matching string fails the check at `scripts/ci-hygiene-check.mjs` with a `file:line` report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)