### PR TITLE
docs(repo-layout): neutralize internal-tooling reference in .archive/ row

### DIFF
--- a/docs/repo-layout.md
+++ b/docs/repo-layout.md
@@ -51,7 +51,7 @@ This document maps **top-level folders** to **roles** so you know where to look 
 | [`scripts/`](../scripts/) | Build and dev tooling: `build-compiler-bundle.mjs`, `build-webview.mjs`, `build-extension-bundle.mjs`, `bump-extension-version.mjs`, `measure-baseline.mjs`, `ci-metrics-diff.mjs`. |
 | [`docs/`](../docs/) | **Project documentation**: this layout map, [`cli.md`](cli.md) (CLI usage outside VS Code), glossary, metrics baselines, validation notes. |
 | [`output/`](../output/) | **Build output** for `build-extension.bat` — packaged `.vsix` files. Gitignored. |
-| [`.archive/`](../.archive/) | **Superseded trees, agent-bus, agent-run logs, accepted-task records.** Gitignored. Canonical archive root — use this in all new prompts, scripts, and docs. Move content here instead of deleting. |
+| [`.archive/`](../.archive/) | **Superseded trees, maintainer tooling state, run logs, and accepted-task records.** Gitignored. Canonical archive root — use this in all new prompts, scripts, and docs. Move content here instead of deleting. |
 | `0. archive/` *(legacy)* | Former archive root (leading space in the folder name). Still gitignored and still works if content remains there; migrate to `.archive/` when convenient. |
 | [`intellij/`](../intellij/) | **IntelliJ plugin** packaging and install docs (optional IDE surface; separate from the VS Code extension). |
 


### PR DESCRIPTION
## Summary

Closes the last tracked acceptance item under hub task `vkgeorgia/strategy#233` — the CI guard and `docs/release-runbook.md:133` fix from PR #156 are already in. This PR addresses the remaining bullet in that issue.

- `docs/repo-layout.md:54` — replaced internal-coordination vocabulary with maintainer-neutral wording per CLAUDE.md's public-surface hygiene rule. The row still describes the contents of `.archive/` (superseded trees, maintainer tooling state, run logs, accepted-task records).
- No code or behavior changes; docs-only single-line edit.

## Anti-recursion note

Per the issue's anti-recursion clause, this PR body refers to the change by file + line only and does not echo the removed substrings. The committed file remains the source of truth for the previous wording.

## Test plan

- [ ] CI public-surface hygiene check passes on this PR (no blocklist hit in diff or body).
- [ ] `docs/repo-layout.md` still reads correctly and the `.archive/` row still describes its contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)