### PR TITLE
chore(diagrams): prepare @transitrix/diagrams 1.0.0 for first npm publish (#199)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - **VS Code settings `transitrix.fileExtensions` / `transitrix.exportEnabled`** — canonical replacements for the legacy `cervin.*` keys, registered in the extension's `contributes.configuration`.
 - **VS Code commands `transitrix.openPreview` / `transitrix.exportSvg` / `transitrix.exportPng` / `transitrix.exportBpmn`** — canonical replacements for the `cervin.*` commands. The editor-title preview button now invokes `transitrix.openPreview`.
 
+### Changed
+- **`@transitrix/diagrams` prepared for first npm publish (1.0.0)** — `packages/diagrams/package.json` drops `private: true`, bumps to `1.0.0`, and adds `homepage`, `bugs`, and `repository` (with `directory`) fields per the release runbook prep step. Package now ships a `README.md` and `LICENSE` so the npm tarball is complete. No source or API change. Package is consumed only as a workspace inside this repo, so the version bump has no downstream effect; the actual `npm publish` is a manual maintainer action gated on the `transitrix` npm organisation (strategy #199).
+
 ### Docs
 - **CLI usage outside VS Code** — new [`docs/cli.md`](docs/cli.md) and a rewritten README CLI section explain how to get the `transitrix` CLI on `PATH` from a clone (`npm install && npm run build && npm link`), how to run it without a global install, and how a script/skill should auto-detect it. Clarifies the CLI is not yet on npm and the VS Code extension does not ship a PATH binary (unblocks scripted/CI/skill use — strategy #187).
 - **npm release runbook** — new [`docs/release-runbook.md`](docs/release-runbook.md) codifies the manual `npm publish` procedure for `@transitrix/diagrams` (first) and `@transitrix/cli` (second), per the 2026-06-10 publish decisions on strategy #199. Prerequisites, pre-flight checklist, per-package publish steps with `--access public` + 2FA, post-publish verification, tagging, and the unpublish/deprecate guidance. CI publish-on-tag automation is a deferred follow-up.

--- a/packages/diagrams/LICENSE
+++ b/packages/diagrams/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023-2026 Valerii Korobeinikov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/diagrams/README.md
+++ b/packages/diagrams/README.md
@@ -1,0 +1,47 @@
+# @transitrix/diagrams
+
+Shared rendering, validation, and pure mutations for Transitrix custom diagram
+formats (BPMN, Goals, FGCA, Capability Map, Process Blueprint, and the rest of
+the Transitrix notation family).
+
+This package is the runtime library used by the **Transitrix Studio** VS Code
+extension, the `@transitrix/cli`, and downstream tools that need to read,
+validate, or render Transitrix diagrams.
+
+## Install
+
+```bash
+npm install @transitrix/diagrams
+```
+
+`react` and `reactflow` are declared as peer dependencies — install them in the
+host application if you use the React renderers; pure validation / mutation
+APIs do not require them.
+
+## What's inside
+
+The package re-exports the per-notation modules under one entry point:
+
+- Activities, Activity Card, Applications, Assertion, Blocks, Capability Map,
+  Compliance + Compliance Matrix, Confidence, FGCA, Goals, Process Blueprint,
+  Process Map, Products, Requirement, Scenarios.
+- Shared primitives: `geometry`, `typed-id`, `validation-types`,
+  `yaml-normalize`, `SCHEMA_VERSION`, theme tokens, repository-level validators.
+
+See the source layout under [`src/`](./src) and the per-module `index.ts`
+exports for the public surface.
+
+## Versioning
+
+`@transitrix/diagrams` ships on its own version line, independent of the
+Transitrix Studio extension version. The first published release is `1.0.0`.
+
+## License
+
+MIT — see [`LICENSE`](./LICENSE).
+
+## Links
+
+- Monorepo: <https://github.com/transitrix/transitrix-studio>
+- Issues: <https://github.com/transitrix/transitrix-studio/issues>
+- Methodology spec: <https://github.com/transitrix/methodology>

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,10 +1,18 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "0.1.0",
-  "private": true,
+  "version": "1.0.0",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",
+  "homepage": "https://github.com/transitrix/transitrix-studio/tree/main/packages/diagrams#readme",
+  "bugs": {
+    "url": "https://github.com/transitrix/transitrix-studio/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/transitrix/transitrix-studio.git",
+    "directory": "packages/diagrams"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [


### PR DESCRIPTION
## Summary

Prep step for the manual `npm publish` session that closes the first half
of [strategy hub `#199`](https://github.com/vkgeorgia/strategy/issues/199)
("Publish Transitrix CLI to npm"). Per the publish runbook at
`docs/release-runbook.md` §"Publishing `@transitrix/diagrams`", the
package needs three things in `package.json` before it can be published:
drop `private`, set the version to `1.0.0`, and add `homepage`, `bugs`,
`repository`.

This PR does exactly that, plus the two files an npm package needs to look
honest on the registry — a package-local `LICENSE` and a `README.md`.

## Changes

- `packages/diagrams/package.json`
  - Drop `"private": true`.
  - `version` `0.1.0` → `1.0.0` (first publish under the published-package
    version line, per the 2026-06-10 decision on strategy `#199`).
  - Add `homepage`, `bugs`, `repository` (with `directory:
    "packages/diagrams"` so the npm page links into the monorepo).
- `packages/diagrams/LICENSE` — MIT, copied from the repo root LICENSE
  (`license: "MIT"` was already declared in the manifest; the tarball now
  actually ships the text).
- `packages/diagrams/README.md` — short overview, install line, peer-dep
  note, link to monorepo + methodology spec.
- `CHANGELOG.md` — entry under Unreleased / Changed.

No source or API change. The package is consumed only as a workspace
inside this repo (`grep` for `@transitrix/diagrams` outside the package
finds no `dependencies:` reference), so the version bump cannot affect
any downstream build.

The actual `npm publish` is **not** done by this PR — it is a manual
maintainer action gated on the `transitrix` npm organisation setup
(prerequisite documented in the release runbook).

## Verification

- `npm run compile` ✅
- `npm run compile:extension` ✅
- `npm --workspace packages/diagrams run build` ✅
- `npm --workspace packages/diagrams test` ✅ (764 tests)
- `npm run test:core` ✅ (269 tests)
- `npm --workspace packages/diagrams pack --dry-run` — tarball is
  534 kB / 478 files, contains `dist/` + `src/` + `LICENSE` +
  `README.md` only; no `node_modules`, no secrets, no extraneous paths.

## Test plan

- [ ] Maintainer reviews the three `package.json` URL fields and the
      `README.md` wording.
- [ ] Maintainer runs the runbook pre-flight checklist before the publish
      session (clean checkout, `npm ci`, build, tests, CHANGELOG).
- [ ] Maintainer runs `npm --workspace packages/diagrams publish
      --access public` once the `transitrix` npm org is in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)