### PR TITLE
fix(intellij): make :buildPlugin compile, package, and run on a real host (#135)

### DIFF
--- a/intellij/.gitignore
+++ b/intellij/.gitignore
@@ -1,6 +1,7 @@
 .gradle/
 build/
 out/
+.intellijPlatform/
 .idea/
 *.iml
 local.properties

--- a/intellij/build.gradle.kts
+++ b/intellij/build.gradle.kts
@@ -19,6 +19,10 @@ dependencies {
     intellijPlatform {
         intellijIdeaCommunity(providers.gradleProperty("platformVersion"))
         testFramework(TestFrameworkType.Platform)
+        // Required by the IntelliJ Platform Gradle Plugin v2 for the
+        // `instrumentCode` task (form/NotNull bytecode instrumentation);
+        // without it the build fails with "No Java Compiler dependency found".
+        instrumentationTools()
     }
 }
 
@@ -32,7 +36,10 @@ intellijPlatform {
 }
 
 kotlin {
-    jvmToolchain(17)
+    // IntelliJ Platform 2024.2 (platformVersion) runs on JBR 21 and requires
+    // sourceCompatibility 21; building against an older toolchain fails
+    // instrumentCode. Keep this in lockstep with platformVersion in gradle.properties.
+    jvmToolchain(21)
 }
 
 // Pull the browser-safe `@transitrix/diagrams` bundle produced by
@@ -44,12 +51,18 @@ kotlin {
 val webviewBundleDir = rootProject.layout.projectDirectory
     .dir("../packages/diagrams/dist/webview")
 
+// Dedicated output dir for the synced bundle. Kept OUT of build/generated —
+// the IntelliJ Platform plugin's compileJava/instrumentation also writes under
+// build/generated, and sharing it makes processResources consume compileJava's
+// output without a declared dependency (Gradle 8.x validation error).
+val webviewResourcesDir = layout.buildDirectory.dir("webview-resources")
+
 val syncWebviewBundle by tasks.registering(Copy::class) {
     description = "Copy the @transitrix/diagrams webview bundle into the plugin resources."
     from(webviewBundleDir) {
         include("transitrix-render.js", "transitrix-render.css")
     }
-    into(layout.buildDirectory.dir("generated/webview"))
+    into(webviewResourcesDir.map { it.dir("webview") })
     // Fail loudly if the bundle hasn't been built yet — the Node side owns
     // the build (node scripts/build-webview-bundle.mjs) and Gradle simply
     // packages the outputs. Surfacing the cause beats a silent empty jar.
@@ -69,7 +82,7 @@ val syncWebviewBundle by tasks.registering(Copy::class) {
 sourceSets {
     named("main") {
         resources {
-            srcDir(layout.buildDirectory.dir("generated"))
+            srcDir(webviewResourcesDir)
         }
     }
 }

--- a/scripts/package-intellij-plugin.mjs
+++ b/scripts/package-intellij-plugin.mjs
@@ -57,10 +57,16 @@ if (argv.includes('-h') || argv.includes('--help')) {
 const skipBundle = argv.includes('--skip-bundle');
 
 function run(command, args, options = {}) {
+  // Windows: spawning a `.bat`/`.cmd` (e.g. gradlew.bat) requires `shell: true`.
+  // Since Node 18.20.2 / 20.12.0 (CVE-2024-27980) a direct `spawn` of a batch
+  // file throws `EINVAL`. Route only batch commands through the shell, and quote
+  // the command so a repo path containing spaces survives — other commands
+  // (node via process.execPath, itself a spaced path) keep spawning directly.
+  const isBatch = process.platform === 'win32' && /\.(bat|cmd)$/i.test(command);
   return new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
+    const child = spawn(isBatch ? `"${command}"` : command, args, {
       stdio: 'inherit',
-      shell: false,
+      shell: isBatch,
       ...options,
     });
     child.on('error', reject);


### PR DESCRIPTION
## Summary

The IntelliJ MVP (epic #135) landed across five phases (#93/#97/#98/#99/#101/#102) **without the Gradle build ever being exercised on a host** — every phase carried an explicit *"`:buildPlugin` not run here"* caveat. Running it for the first time on a JDK 21 + Gradle 8.10.2 host surfaced three defects that blocked the artifact, plus a Windows-only bug in the packaging script. This PR fixes all four so the plugin actually builds and packages.

## Defects fixed

**`intellij/build.gradle.kts`**
1. **Missing `instrumentationTools()`** — the IntelliJ Platform Gradle Plugin v2 requires it for `instrumentCode`; without it the build dies with *"No Java Compiler dependency found"*.
2. **Toolchain 17 → 21** — Platform `2024.2` runs on JBR 21 and requires `sourceCompatibility=21`; the `jvmToolchain(17)` failed `verifyPluginProjectConfiguration`.
3. **Resource/compile output collision** — the synced webview bundle was written under `build/generated`, where the plugin's `compileJava` also writes, so `processResources` consumed `compileJava`'s output without a declared dependency (Gradle 8.x validation error). Moved to a dedicated `build/webview-resources` dir; jar layout (`webview/…`) is unchanged.

**`scripts/package-intellij-plugin.mjs`**
4. **Windows `spawn EINVAL`** — since Node 18.20.2 / 20.12.0 (CVE-2024-27980), a direct `spawn` of a `.bat`/`.cmd` throws `EINVAL`, so the documented `node scripts/package-intellij-plugin.mjs` path never worked on Windows (it spawns `gradlew.bat`). Now routes batch commands through `shell: true` with a quoted command; non-batch commands (the spaced `node.exe` path) still spawn directly.

**`intellij/.gitignore`** — ignore `.intellijPlatform/` (the Platform cache dir the plugin warns about).

## Verification

On a JDK 21 + Gradle 8.10.2 host:

- `./gradlew :buildPlugin` → **BUILD SUCCESSFUL**, produces `intellij/build/distributions/transitrix-intellij-0.1.0.zip` (≈70 KB).
- Jar contents confirmed: `META-INF/plugin.xml`, the Kotlin classes (`PreviewAction`, `TransitrixNotation`, `TransitrixPreviewDialog`, `WebviewBundle`), `webview/host.html`, `webview/transitrix-render.css`, and the **260 KB `webview/transitrix-render.js`** rendering bundle.
- `node scripts/package-intellij-plugin.mjs --skip-bundle` drives the same build end-to-end on Windows (no `EINVAL`) and prints the artifact + install hint.

## Still open (human-only)

The final MVP acceptance step — installing the `.zip` into a clean **IntelliJ IDEA Community 2024.2** and visually confirming each notation preview renders (and malformed input shows the error panel) — still needs a human with an IDE. This PR closes the *build/packaging* half of the verification gap that was carried across phases 3–5.

Refs: strategy hub #135.
