### PR TITLE
docs(marketplace): IntelliJ as shipped + de-Cervin the listing copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Download the `.vsix` file from [GitHub Releases](https://github.com/transitrix/t
 code --install-extension transitrix-studio-1.0.0.vsix
 ```
 
-A separate IntelliJ IDEA plugin is in development (see [`intellij/`](intellij/)).
+A companion IntelliJ IDEA plugin is available on the JetBrains Marketplace — install it from **Settings → Plugins → Marketplace** and search for *Transitrix Studio* (source under [`intellij/`](intellij/)).
 
 ## Quick start — BPMN
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -52,7 +52,7 @@ Transitrix and Mermaid are **complementary, not competing**. Use **Mermaid** for
 
 Recognised BPMN file suffixes are configurable in **Settings → Transitrix Studio**.
 
-> **Editors:** the extension ships to the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=transitrix.transitrix-studio) (VS Code) and to the [Open VSX Registry](https://open-vsx.org/extension/transitrix/transitrix-studio) (Cursor, VSCodium, Windsurf). The artefact is identical; pick whichever Extensions panel ships with your editor. A separate IntelliJ IDEA plugin is in development.
+> **Editors:** the extension ships to the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=transitrix.transitrix-studio) (VS Code) and to the [Open VSX Registry](https://open-vsx.org/extension/transitrix/transitrix-studio) (Cursor, VSCodium, Windsurf). The artefact is identical; pick whichever Extensions panel ships with your editor. **JetBrains IDEs** (IntelliJ IDEA and the rest) have a companion **Transitrix Studio** plugin — install it from **Settings → Plugins → Marketplace** and search for *Transitrix Studio*.
 
 ## Settings
 
@@ -60,13 +60,8 @@ Configure under **Settings → Transitrix Studio**. The canonical keys are `tran
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `transitrix.fileExtensions` | `[".cervin.yaml", ".bpmn.transitrix.yaml"]` | File suffixes recognised as Transitrix BPMN source files (leading dot required). |
+| `transitrix.fileExtensions` | `[".bpmn.transitrix.yaml"]` | File suffixes recognised as Transitrix BPMN source files (leading dot required). |
 | `transitrix.exportEnabled` | `false` | Show the experimental BPMN/SVG/PNG export commands. |
-
-> **Deprecated:** the legacy `cervin.fileExtensions` and `cervin.exportEnabled` keys
-> are still read as a fallback when their `transitrix.*` counterpart is unset, but are
-> deprecated and will be removed in **2.0.0**. Rename them to `transitrix.*`. If a
-> legacy key is in effect you'll see a one-time migration notice on activation.
 
 ## Learn more
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
   "version": "1.4.3",
-  "description": "Architecture-as-code for the modern enterprise. Author 13 notations — goals, processes, capabilities, BPMN, applications, more — as plain YAML, get live diagrams in VS Code. Diffable in git. AI-friendly. Open source. Built on ArchiMate 3.2 and BPMN 2.0.",
+  "description": "Architecture-as-code for the modern enterprise. Author 17 notations — goals, processes, capabilities, BPMN, applications, more — as plain YAML, get live diagrams in VS Code. Diffable in git. AI-friendly. Open source. Built on ArchiMate 3.2 and BPMN 2.0.",
   "license": "MIT",
   "icon": "icon.png",
   "homepage": "https://github.com/transitrix/transitrix-studio#readme",
@@ -88,24 +88,6 @@
           "type": "boolean",
           "default": false,
           "description": "Show experimental BPMN/SVG/PNG export commands (not finished yet)."
-        },
-        "cervin.fileExtensions": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [
-            ".cervin.yaml",
-            ".bpmn.transitrix.yaml"
-          ],
-          "description": "Deprecated — use transitrix.fileExtensions. Read as a fallback through 1.x; removed in 2.0.0.",
-          "deprecationMessage": "Deprecated: use transitrix.fileExtensions instead. This key is read as a fallback through the 1.x line and removed in 2.0.0."
-        },
-        "cervin.exportEnabled": {
-          "type": "boolean",
-          "default": false,
-          "description": "Deprecated — use transitrix.exportEnabled. Read as a fallback through 1.x; removed in 2.0.0.",
-          "deprecationMessage": "Deprecated: use transitrix.exportEnabled instead. This key is read as a fallback through the 1.x line and removed in 2.0.0."
         },
         "transitrix.theme": {
           "type": "string",

--- a/intellij/README.md
+++ b/intellij/README.md
@@ -1,4 +1,4 @@
-# Transitrix Studio — IntelliJ IDEA plugin (MVP)
+# Transitrix Studio — IntelliJ IDEA plugin
 
 Read-only previews of Transitrix notations inside IntelliJ IDEA, parallel to
 the existing VS Code extension under [`../extension/`](../extension/).
@@ -110,12 +110,15 @@ deliberately touches only the VS Code side).
 
 ## Status
 
-MVP packaging is complete. Out of scope for this MVP (deferred per the epic):
+Available on the **JetBrains Marketplace** — install via **Settings → Plugins →
+Marketplace** and search for *Transitrix Studio*. The from-disk `.zip` above
+stays available for local builds and pre-release testing.
+
+Still deferred (tracked under the epic):
 
 - Editor-title parity with the VS Code extension.
 - Auto-refresh on save outside the active preview.
-- JetBrains Marketplace publication, signing, multi-IDE `verifyPlugin`.
 - PNG export (resvg-js native binary path).
 
 Follow epic [`vkgeorgia/strategy#135`](https://github.com/vkgeorgia/strategy/issues/135)
-for any post-MVP work.
+for any post-release work.

--- a/intellij/src/main/resources/META-INF/plugin.xml
+++ b/intellij/src/main/resources/META-INF/plugin.xml
@@ -4,19 +4,24 @@
     <vendor url="https://github.com/transitrix/transitrix-studio">Transitrix</vendor>
 
     <description><![CDATA[
-        Read-only previews for Transitrix notations inside IntelliJ IDEA.
+        <p><b>Architecture-as-code for the modern enterprise</b> — live notation
+        previews inside IntelliJ IDEA and the other JetBrains IDEs.</p>
 
-        Renders the same diagrams the VS Code extension produces — goals, FGCA,
-        FGA, activities, blocks, applications, products, process maps, scenarios,
-        capability maps, process blueprints, activity cards, issues, BPMN — by
-        bundling the shared <code>@transitrix/diagrams</code> library and loading
-        it into a JCEF webview.
+        <p>Describe your organisation in plain YAML and Transitrix Studio renders
+        the diagram right in the editor: goals trees, FGCA / FGA chains, activity
+        networks, nested blocks, applications, products, process maps, scenarios,
+        capability maps, process blueprints, activity cards, and full BPMN 2.0.
+        These are the same diagrams the
+        <a href="https://marketplace.visualstudio.com/items?itemName=transitrix.transitrix-studio">VS Code extension</a>
+        produces, rendered through the shared <code>@transitrix/diagrams</code>
+        engine in a JCEF webview.</p>
 
-        MVP: read-only previews + SVG export. Editing, marketplace publication,
-        and PNG export are out of scope.
+        <p>Open any <code>*.transitrix.yaml</code> file, or right-click and choose
+        <b>Transitrix: Preview Notation</b>. Your architecture lives in text —
+        diff it, version it, and review it like code. Previews are read-only;
+        you author in YAML.</p>
 
-        See <code>docs/adr/0001-intellij-mvp-tech-choice.md</code> for the
-        rendering and validation technology decision.
+        <p>Built on ArchiMate 3.2 and BPMN 2.0. Open source, MIT licensed.</p>
     ]]></description>
 
     <depends>com.intellij.modules.platform</depends>


### PR DESCRIPTION
Refreshes the marketplace-facing descriptions per Valerii (2026-06-14): (1) treat the IntelliJ IDEA plugin as shipped to the JetBrains Marketplace, (2) stop writing about Cervin / the fallback in the listings (text-only — the functional fallback is untouched).

## Changes
- **VS Code / Open VSX** — `extension/README.md`, `extension/package.json`:
  - removed the deprecated `cervin.fileExtensions` / `cervin.exportEnabled` **settings declarations** (this is what hides them from the marketplace Settings tab) and the "Deprecated … fallback … removed in 2.0.0" note from the README;
  - stopped showcasing `.cervin.yaml` in the documented default;
  - fixed the notation count **13 → 17** (matches the README header);
  - added a JetBrains-IDEs install pointer.
- **JetBrains** — `intellij/src/main/resources/META-INF/plugin.xml`: rewrote the `<description>` as live end-user marketplace copy; dropped the **MVP / "marketplace publication out of scope" / internal ADR** notes and the **retired `issues`** notation.
- `intellij/README.md` + root `README.md`: reflect the plugin as available on the JetBrains Marketplace.

## Scope boundary (deliberate)
**Text-only de-mention — non-breaking.** The functional Cervin fallback stays: the `cervin.*` **command aliases**, the `.cervin.yaml` **language association + activation event**, and the `.cervin.yaml` entry in the `transitrix.fileExtensions` **default**. The extension reads `cervin.*` via `getConfiguration` regardless of the dropped *settings* declarations, so recognition and the alias commands still work. Full removal remains the **2.0.0** breaking change tracked in vkgeorgia/strategy#191.

> Honest residual: because the fallback stays, the marketplace **Contributions** tab will still list the `cervin.*` commands + the `cervin-yaml` language, and the `transitrix.fileExtensions` default still contains `.cervin.yaml`. Those clear in the 2.0.0 cleanup.

## ⚠️ Merge-timing gate
- The "**available on the JetBrains Marketplace**" wording must not go live before the plugin is actually listed. **Hold merge until the listing resolves** (the copy uses a *Settings → Plugins → Marketplace* search, no fragile URL, so it won't 404 — but the claim shouldn't precede the listing).
- The VS Code / Open VSX **listing only updates on the next extension publish** (version bump + republish) — this PR changes the source copy; it does not republish.
- If the in-flight IntelliJ-finishing branch also edits `plugin.xml`, expect a trivial rebase on the `<description>` block.

Ties vkgeorgia/strategy#135 (IntelliJ) and #191/#232 (Cervin). Valerii-gated.