### PR TITLE
fix(intellij): widen plugin until-build to 261.* (IDEA 2026.1)

### DIFF
--- a/intellij/gradle.properties
+++ b/intellij/gradle.properties
@@ -6,7 +6,10 @@ pluginVersion = 0.1.0
 # IntelliJ IDEA Community 2024.2 — JCEF-bearing baseline (JCEF requires 2020.2+).
 platformVersion = 2024.2
 pluginSinceBuild = 242
-pluginUntilBuild = 251.*
+# Upper bound covers IDEA 2026.1 (build 261). The plugin builds against the
+# 2024.2 baseline but uses only stable platform + JCEF APIs, so it loads on
+# later IDEs; widen this as new IDEA majors are validated.
+pluginUntilBuild = 261.*
 
 gradleVersion = 8.10.2
 


### PR DESCRIPTION
## Summary

Follow-up to #163. Hand-testing the built `.zip` on **IntelliJ IDEA Ultimate 2026.1** (build `IU-261.25134.95`) failed to install:

> Plugin 'Transitrix Studio' (version '0.1.0') is not compatible with the current version of the IDE, because it requires build 251.* or older but the current build is IU-261.25134.95

The plugin declared `pluginUntilBuild = 251.*` (IDEA 2025.1). It builds against the 2024.2 baseline but uses only stable platform + JCEF APIs, so it loads on later IDEs. This raises the upper bound to **`261.*`** so 2026.x installs.

## Change

- `intellij/gradle.properties`: `pluginUntilBuild = 251.*` → `261.*` (one line + explanatory comment). No code change.

## Verification

A plugin packaged with this bound installs on IDEA 2026.1 (confirmed by manifest-patching the existing artifact and loading it; full `:buildPlugin` with the bumped bound produces an identical jar otherwise).

Refs: strategy hub #135.