### PR TITLE
fix(intellij): drop BPMN and issues from plugin description (not wired)

### DIFF
--- a/intellij/src/main/resources/META-INF/plugin.xml
+++ b/intellij/src/main/resources/META-INF/plugin.xml
@@ -8,7 +8,7 @@
 
         Renders the same diagrams the VS Code extension produces — goals, FGCA,
         FGA, activities, blocks, applications, products, process maps, scenarios,
-        capability maps, process blueprints, activity cards, issues, BPMN — by
+        capability maps, process blueprints, activity cards — by
         bundling the shared <code>@transitrix/diagrams</code> library and loading
         it into a JCEF webview.
 


### PR DESCRIPTION
## Summary

Found during the #135 hand-test: the IntelliJ plugin description claimed it renders `issues` and `BPMN`, but **neither is wired**. The Preview action does not surface on `*.bpmn.transitrix.yaml`, which the hand-test confirmed.

- `TransitrixNotation.SUFFIX_TO_KIND` and the webview bundle's `SUPPORTED_KINDS` cover exactly **12** notations: goals, FGCA, FGA, activities, blocks, applications, products, process-map, process-blueprint, scenarios, capability-map, activity-card.
- `issues` was retired from the repo; `BPMN` has no host-neutral renderer in `@transitrix/diagrams` (VS Code renders BPMN via a separate path not in the shared bundle).

This trims the description to the 12 notations that actually preview, so the listing copy matches shipped behaviour.

## Change

- `intellij/src/main/resources/META-INF/plugin.xml`: remove `issues, BPMN` from the rendered-notations list. No code change.

## ⚠️ Overlaps with #166

PR #166 also edits this description block and currently rewrites it to **"… activity cards, and full BPMN 2.0."** — which over-claims BPMN support that the plugin does not have. These two PRs conflict on the same lines. Recommend: merge this correction and drop/adjust the BPMN line in #166 (do not ship "full BPMN 2.0" for the IntelliJ plugin until a BPMN renderer is actually wired — a separate follow-up to #135).

Refs: strategy hub #135.