### PR TITLE
fix(intellij): drop BPMN claim from plugin description (not rendered)

### DIFF
--- a/intellij/src/main/resources/META-INF/plugin.xml
+++ b/intellij/src/main/resources/META-INF/plugin.xml
@@ -10,8 +10,8 @@
         <p>Describe your organisation in plain YAML and Transitrix Studio renders
         the diagram right in the editor: goals trees, FGCA / FGA chains, activity
         networks, nested blocks, applications, products, process maps, scenarios,
-        capability maps, process blueprints, activity cards, and full BPMN 2.0.
-        These are the same diagrams the
+        capability maps, process blueprints, and activity cards. These are the
+        same diagrams the
         <a href="https://marketplace.visualstudio.com/items?itemName=transitrix.transitrix-studio">VS Code extension</a>
         produces, rendered through the shared <code>@transitrix/diagrams</code>
         engine in a JCEF webview.</p>
@@ -21,7 +21,7 @@
         diff it, version it, and review it like code. Previews are read-only;
         you author in YAML.</p>
 
-        <p>Built on ArchiMate 3.2 and BPMN 2.0. Open source, MIT licensed.</p>
+        <p>Built on ArchiMate 3.2. Open source, MIT licensed.</p>
     ]]></description>
 
     <depends>com.intellij.modules.platform</depends>


### PR DESCRIPTION
## Summary

The merged #166 listing copy claims the IntelliJ plugin renders **"…activity cards, and full BPMN 2.0"** and is **"Built on ArchiMate 3.2 and BPMN 2.0"** — but the plugin does **not** render BPMN. Confirmed in the #135 hand-test: the **Transitrix: Preview Notation** action does not appear on `*.bpmn.transitrix.yaml`. `TransitrixNotation.SUFFIX_TO_KIND` and the bundle's `SUPPORTED_KINDS` cover exactly 12 notations, none of them BPMN (no host-neutral BPMN renderer in `@transitrix/diagrams`).

This removes both BPMN mentions so the marketplace copy matches shipped behaviour.

## Change

- `intellij/.../plugin.xml`:
  - "…process blueprints, activity cards, **and full BPMN 2.0**." → "…process blueprints, **and activity cards**."
  - "Built on ArchiMate 3.2 **and BPMN 2.0**." → "Built on ArchiMate 3.2."
- No code change.

## Notes

- **Supersedes #168**, which was based on the pre-#166 description and now conflicts. Closing #168 in favour of this.
- BPMN preview in IntelliJ remains a possible follow-up to #135 (needs a host-neutral BPMN renderer in the shared bundle).

Refs: strategy hub #135.