### PR TITLE
feat(cli): transitrix migrate — methodology version upgrade CLI

### DIFF
--- a/docs/decisions/2026-06-14-migrate-recipe-source.md
+++ b/docs/decisions/2026-06-14-migrate-recipe-source.md
@@ -1,0 +1,51 @@
+# 2026-06-14 — Migrate CLI: recipe-source transport
+
+- **Status:** accepted
+- **Date:** 2026-06-14
+- **Scope:** `transitrix migrate` CLI subcommand
+- **Supersedes / superseded by:** none
+
+## Context
+
+The `transitrix migrate` CLI orchestrates migration recipes that live in the
+methodology repo. Acceptance criterion 3 requires recipes to be "pinned to a
+version (not floating `main`)." Three transport options were evaluated:
+
+1. **`--recipes <dir>` flag**, defaulting to `../methodology/migrations` —
+   decouples the CLI from transport; the caller supplies (or defaults to) a
+   local checkout. Matches the `scripts/sync-examples-from-methodology.mjs`
+   convention already used in this repo.
+2. **Git submodule** pinned to a methodology tag — heavier; touches
+   release-wiring that the issue gates to Valerii; requires a tag to exist.
+3. **Vendored copy** — recipes bundled into the npm CLI package at a recorded
+   methodology version, synced in by a separate step. Self-contained for
+   npm-installed users; adds a vendor/sync mechanism to own.
+
+The methodology side rejected submodule/subtree (methodology PR #216).
+
+## Decision
+
+Use **option 1**: a `--recipes <dir>` flag, defaulting to
+`../methodology/migrations`.
+
+- The CLI is reviewable and fully tested against the `0.5-to-0.6/fixtures`
+  without any transport dependency.
+- Version-pin is satisfied at the data level: the CLI reads `methodology_version`
+  from the adopter's `transitrix.yaml`, cross-checks it against the recipe
+  chain, and writes the new version back on success — migration is always
+  traceable.
+- The `--recipes` flag is the development/override escape hatch; it is not the
+  production path for an npm-installed CLI.
+
+## Consequences
+
+**Short term (this PR):** development users with a sibling `../methodology`
+checkout can run migrations. The integration test uses that path.
+
+**Production transport (deferred, release-wiring gate):** an npm-installed CLI
+has no sibling checkout. The correct production path is **vendored** — recipes
+bundled into the CLI package at a recorded methodology version (option 3). That
+step is a separate release-wiring task, gated by Valerii, and out of scope for
+this PR.
+
+A git submodule/subtree approach is explicitly ruled out by the methodology side.

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -15,3 +15,4 @@ implementation PRs follow) · **superseded** (replaced by a later ADR).
 | Date | Decision | Status | Scope |
 |---|---|---|---|
 | 2026-06-11 | [Validation runtime convergence (Studio side)](2026-06-11-validation-runtime-convergence.md) | accepted | transitrix-studio |
+| 2026-06-14 | [Migrate CLI: recipe-source transport](2026-06-14-migrate-recipe-source.md) | accepted | hub #201 |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,7 @@ import {
   parseValidateArgv,
 } from './cli-parse.js';
 import { compileTransitrixYamlWithLayout } from './compiler.js';
+import { handleMigrateCommand } from './migrate.js';
 import { computeLayoutMetrics } from './metrics.js';
 import type { ValidationReport, ValidationFinding } from './validator-types.js';
 import { parseYamlToIr } from './parser.js';
@@ -28,6 +29,7 @@ function printUsage(): void {
        transitrix validate [--ext=.cervin.yaml,.bpmn.transitrix.yaml] <input.yaml> [--json]
        transitrix validate --scope=repo [--root <dir>] [--json]
        transitrix export-compliance [--format md|pdf] [--scope law:<ID>|product:<ID>|gap] [--output <path>] [--root <dir>]
+       transitrix migrate [--from X.Y] [--to X.Y] [--dry-run] [--recipes <dir>] [target-dir]
 
   ('cervin' is a deprecated alias of 'transitrix'; both run the same CLI.)
 
@@ -41,6 +43,10 @@ function printUsage(): void {
               default; law:/product:/gap scopes). Scans --root (default cwd) for
               requirement/assertion/product/codex canon. PDF rendering requires
               WeasyPrint on PATH (pipx install weasyprint).
+  migrate   — migrate an adopter repo to a newer methodology version by running
+              the ordered recipes from the methodology repo. Reads the current
+              version from transitrix.yaml (or --from X.Y); --dry-run previews
+              without writing; --recipes <dir> overrides the recipe source.
 
   --no-metrics  suppress quality metrics report on compile.
   --no-validate suppress validation warnings (errors always run).
@@ -51,6 +57,8 @@ Examples:
   npm run transitrix -- metrics example.cervin.yaml --json
   npm run transitrix -- validate example.cervin.yaml
   npm run transitrix -- validate example.cervin.yaml --json
+  npm run transitrix -- migrate --dry-run
+  npm run transitrix -- migrate --from 0.5 --to 0.6 /path/to/adopter-repo
 `);
 }
 
@@ -428,6 +436,8 @@ try {
       handleExportComplianceCommand: (argv: string[]) => Promise<void>;
     };
     await handleExportComplianceCommand(process.argv.slice(3));
+  } else if (subcommand === 'migrate') {
+    await handleMigrateCommand(process.argv.slice(3));
   } else if (!subcommand || subcommand === 'compile') {
     // Default: compile
     const compileArgv = subcommand === 'compile'

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -1,0 +1,393 @@
+// transitrix migrate — walks an adopter repo from its current methodology version
+// to a target version by applying the ordered recipes from the methodology repo.
+//
+// Recipe source: --recipes <dir>, default ../methodology/migrations (matching the
+// sync-examples-from-methodology.mjs convention). Transport is decoupled from the
+// CLI; production vendoring is a separate release-wiring step. See
+// docs/decisions/2026-06-14-migrate-recipe-source.md.
+
+import { spawnSync } from 'node:child_process';
+import { cpSync, existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+
+// ── types ──────────────────────────────────────────────────────────────────
+
+interface RecipeStep {
+  from: string;   // major.minor, e.g. "0.5"
+  to: string;     // major.minor, e.g. "0.6"
+  dir: string;    // absolute path to the recipe directory
+}
+
+export interface MigrateArgs {
+  from: string | undefined;
+  to: string | undefined;
+  dryRun: boolean;
+  recipesDir: string;
+  targetDir: string;
+  wantsHelp: boolean;
+}
+
+// ── arg parsing ────────────────────────────────────────────────────────────
+
+export function parseMigrateArgv(argv: string[]): MigrateArgs {
+  let from: string | undefined;
+  let to: string | undefined;
+  let dryRun = false;
+  let recipesDir = '../methodology/migrations';
+  let targetDir = process.cwd();
+  let wantsHelp = false;
+
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--help' || a === '-h') { wantsHelp = true; continue; }
+    if (a === '--dry-run') { dryRun = true; continue; }
+    if (a === '--from') { from = argv[++i]; continue; }
+    if (a.startsWith('--from=')) { from = a.slice('--from='.length); continue; }
+    if (a === '--to') { to = argv[++i]; continue; }
+    if (a.startsWith('--to=')) { to = a.slice('--to='.length); continue; }
+    if (a === '--recipes') { recipesDir = argv[++i]; continue; }
+    if (a.startsWith('--recipes=')) { recipesDir = a.slice('--recipes='.length); continue; }
+    if (!a.startsWith('-')) { targetDir = a; continue; }
+  }
+
+  return { from, to, dryRun, recipesDir, targetDir, wantsHelp };
+}
+
+// ── recipe discovery ───────────────────────────────────────────────────────
+
+function scanRecipes(recipesDir: string): RecipeStep[] {
+  const absDir = resolve(recipesDir);
+  if (!existsSync(absDir)) return [];
+  const versionPat = /^\d+\.\d+$/;
+  return readdirSync(absDir)
+    .filter(ent => {
+      const parts = ent.split('-to-');
+      return parts.length === 2 && versionPat.test(parts[0]) && versionPat.test(parts[1]);
+    })
+    .map(ent => {
+      const [from, to] = ent.split('-to-');
+      return { from, to, dir: join(absDir, ent) };
+    })
+    .filter(r => existsSync(join(r.dir, 'codemod.mjs')));
+}
+
+// ── chain resolution ───────────────────────────────────────────────────────
+
+export function resolveChain(from: string, to: string, recipes: RecipeStep[]): RecipeStep[] | null {
+  if (from === to) return [];
+
+  const graph = new Map<string, RecipeStep[]>();
+  for (const r of recipes) {
+    if (!graph.has(r.from)) graph.set(r.from, []);
+    graph.get(r.from)!.push(r);
+  }
+
+  const queue: Array<{ node: string; path: RecipeStep[] }> = [{ node: from, path: [] }];
+  const visited = new Set<string>([from]);
+
+  while (queue.length) {
+    const item = queue.shift()!;
+    for (const step of graph.get(item.node) ?? []) {
+      const newPath = [...item.path, step];
+      if (step.to === to) return newPath;
+      if (!visited.has(step.to)) {
+        visited.add(step.to);
+        queue.push({ node: step.to, path: newPath });
+      }
+    }
+  }
+
+  return null;
+}
+
+// ── furthest reachable version ─────────────────────────────────────────────
+
+function findFurthestReachable(from: string, recipes: RecipeStep[]): string | undefined {
+  const forward = new Map<string, string>();
+  for (const r of recipes) forward.set(r.from, r.to);
+
+  let current = from;
+  const visited = new Set<string>([from]);
+  while (forward.has(current)) {
+    const next = forward.get(current)!;
+    if (visited.has(next)) break;
+    visited.add(next);
+    current = next;
+  }
+  return current === from ? undefined : current;
+}
+
+// ── version helpers ────────────────────────────────────────────────────────
+
+// "0.5.0" → "0.5",  "0.5" → "0.5"
+export function toMajorMinor(v: string): string {
+  return v.split('.').slice(0, 2).join('.');
+}
+
+// "0.6" → "0.6.0",  "0.6.0" → "0.6.0"
+function toFullSemver(v: string): string {
+  const parts = v.split('.');
+  while (parts.length < 3) parts.push('0');
+  return parts.slice(0, 3).join('.');
+}
+
+// ── transitrix.yaml helpers ────────────────────────────────────────────────
+
+const TRANSITRIX_YAML = 'transitrix.yaml';
+
+export function readMethodologyVersion(dir: string): string | undefined {
+  const yamlPath = join(resolve(dir), TRANSITRIX_YAML);
+  if (!existsSync(yamlPath)) return undefined;
+  const content = readFileSync(yamlPath, 'utf8');
+  const m = content.match(/^methodology_version\s*:\s*["']?([^\s"'\n]+)["']?/m);
+  return m ? m[1] : undefined;
+}
+
+function updateMethodologyVersion(dir: string, version: string): void {
+  const yamlPath = join(resolve(dir), TRANSITRIX_YAML);
+  if (!existsSync(yamlPath)) {
+    writeFileSync(yamlPath, `methodology_version: ${version}\n`);
+    return;
+  }
+  const content = readFileSync(yamlPath, 'utf8');
+  if (/^methodology_version\s*:/m.test(content)) {
+    const updated = content.replace(
+      /^(methodology_version\s*:\s*)["']?[^\s"'\n]+["']?/m,
+      `$1${version}`,
+    );
+    writeFileSync(yamlPath, updated);
+  } else {
+    writeFileSync(yamlPath, `${content.trimEnd()}\nmethodology_version: ${version}\n`);
+  }
+}
+
+// ── file diff helpers ──────────────────────────────────────────────────────
+
+function walkFiles(dir: string, base = dir): string[] {
+  const result: string[] = [];
+  let entries: string[];
+  try { entries = readdirSync(dir); } catch { return result; }
+  for (const ent of entries) {
+    const full = join(dir, ent);
+    let st: ReturnType<typeof statSync>;
+    try { st = statSync(full); } catch { continue; }
+    if (st.isDirectory()) result.push(...walkFiles(full, base));
+    else result.push(relative(base, full).replace(/\\/g, '/'));
+  }
+  return result;
+}
+
+function printDiff(relPath: string, before: string, after: string): void {
+  if (before === after) return;
+  console.log(`--- a/${relPath}`);
+  console.log(`+++ b/${relPath}`);
+  const bLines = before ? before.split('\n') : [];
+  const aLines = after ? after.split('\n') : [];
+  const maxLen = Math.max(bLines.length, aLines.length);
+  let lastHunk = -1;
+  for (let i = 0; i < maxLen; i++) {
+    const bl = i < bLines.length ? bLines[i] : null;
+    const al = i < aLines.length ? aLines[i] : null;
+    if (bl !== al) {
+      if (lastHunk !== i - 1) console.log(`@@ -${i + 1},0 +${i + 1},0 @@`);
+      if (bl !== null) console.log(`-${bl}`);
+      if (al !== null) console.log(`+${al}`);
+      lastHunk = i;
+    }
+  }
+  console.log('');
+}
+
+function showTreeDiff(originalDir: string, modifiedDir: string): boolean {
+  const origFiles = new Set(walkFiles(originalDir));
+  const modFiles = new Set(walkFiles(modifiedDir));
+  const allFiles = new Set([...origFiles, ...modFiles]);
+
+  const changed: string[] = [];
+  for (const f of allFiles) {
+    const origContent = origFiles.has(f) ? readFileSync(join(originalDir, f), 'utf8') : '';
+    const modContent = modFiles.has(f) ? readFileSync(join(modifiedDir, f), 'utf8') : '';
+    if (origContent !== modContent) changed.push(f);
+  }
+
+  if (changed.length === 0) {
+    console.log('  No files would change.');
+    return false;
+  }
+
+  console.log(`  ${changed.length} file(s) would change:\n`);
+  for (const f of changed) {
+    const origContent = origFiles.has(f) ? readFileSync(join(originalDir, f), 'utf8') : '';
+    const modContent = modFiles.has(f) ? readFileSync(join(modifiedDir, f), 'utf8') : '';
+    printDiff(f, origContent, modContent);
+  }
+  return true;
+}
+
+// ── recipe runner ──────────────────────────────────────────────────────────
+
+function runScript(scriptPath: string, args: string[]): { exitCode: number; output: string } {
+  const r = spawnSync(process.execPath, [scriptPath, ...args], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  return { exitCode: r.status ?? 1, output: (r.stdout ?? '') + (r.stderr ?? '') };
+}
+
+// ── dry-run ────────────────────────────────────────────────────────────────
+
+function runDryRun(chain: RecipeStep[], absTarget: string, toVersion: string): void {
+  const tmpDir = mkdtempSync(join(tmpdir(), 'tx-migrate-'));
+  try {
+    cpSync(absTarget, tmpDir, { recursive: true });
+
+    let overallExit = 0;
+    for (let i = 0; i < chain.length; i++) {
+      const step = chain[i];
+      console.log(`Step ${i + 1}/${chain.length}: ${step.from} → ${step.to}`);
+      const { exitCode, output } = runScript(join(step.dir, 'codemod.mjs'), [tmpDir]);
+      process.stdout.write(output);
+      if (exitCode !== 0) {
+        console.error(`  codemod exited ${exitCode} — would require manual intervention`);
+        overallExit = exitCode;
+      }
+    }
+
+    console.log('\nFile changes:');
+    showTreeDiff(absTarget, tmpDir);
+
+    const currentVersion = readMethodologyVersion(absTarget);
+    console.log(`\nWould update methodology_version: ${currentVersion ?? '(none)'} → ${toFullSemver(toVersion)}`);
+
+    if (overallExit !== 0) {
+      console.error('\nDry-run: some steps would require manual intervention (see above).');
+      process.exit(overallExit);
+    }
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+// ── apply ──────────────────────────────────────────────────────────────────
+
+function runApply(chain: RecipeStep[], absTarget: string, toVersion: string): void {
+  for (let i = 0; i < chain.length; i++) {
+    const step = chain[i];
+    console.log(`Step ${i + 1}/${chain.length}: ${step.from} → ${step.to}`);
+
+    const codemodPath = join(step.dir, 'codemod.mjs');
+    const { exitCode: codemodExit, output: codemodOut } = runScript(codemodPath, [absTarget]);
+    process.stdout.write(codemodOut);
+
+    if (codemodExit !== 0) {
+      console.error(`\ntransitrix migrate: codemod ${step.from}→${step.to} exited ${codemodExit}.`);
+      console.error(`  Manual intervention required (see output above).`);
+      console.error(`  Fix the flagged files, then re-run from step ${i + 1}:`);
+      console.error(`  transitrix migrate --from ${step.from} --to ${toVersion} [target-dir]`);
+      process.exit(codemodExit);
+    }
+
+    const validatePath = join(step.dir, 'validate.mjs');
+    if (existsSync(validatePath)) {
+      const { exitCode: valExit, output: valOut } = runScript(validatePath, [absTarget]);
+      process.stdout.write(valOut);
+      if (valExit !== 0) {
+        console.error(`\ntransitrix migrate: post-step validation failed for ${step.from}→${step.to}.`);
+        console.error(`  Fix the issues above, then re-run from step ${i + 1}:`);
+        console.error(`  transitrix migrate --from ${step.from} --to ${toVersion} [target-dir]`);
+        process.exit(valExit);
+      }
+    }
+
+    console.log(`  ✓ step complete\n`);
+  }
+
+  const newVersion = toFullSemver(toVersion);
+  updateMethodologyVersion(absTarget, newVersion);
+  console.log(`✓ Migration complete: ${newVersion}`);
+  console.log(`  Updated methodology_version in ${join(absTarget, TRANSITRIX_YAML)}`);
+  console.log(`  Review and commit when ready.`);
+}
+
+// ── main handler ───────────────────────────────────────────────────────────
+
+export async function handleMigrateCommand(argv: string[]): Promise<void> {
+  const { from: rawFrom, to: rawTo, dryRun, recipesDir, targetDir, wantsHelp } = parseMigrateArgv(argv);
+
+  if (wantsHelp) {
+    console.error('usage: transitrix migrate [--from X.Y] [--to X.Y] [--dry-run] [--recipes <dir>] [target-dir]');
+    console.error('');
+    console.error('  Migrates an adopter repository from one methodology version to another');
+    console.error('  by running the ordered recipes from the methodology repo.');
+    console.error('');
+    console.error('  --from X.Y         Source version (default: methodology_version in transitrix.yaml)');
+    console.error('  --to X.Y           Target version (default: latest available recipe target)');
+    console.error('  --dry-run          Preview changes; no files written');
+    console.error('  --recipes <dir>    Path to recipes dir (default: ../methodology/migrations)');
+    console.error('  target-dir         Adopter repo root (default: current directory)');
+    process.exit(0);
+  }
+
+  const absTarget = resolve(targetDir);
+  if (!existsSync(absTarget)) {
+    console.error(`transitrix migrate: target directory does not exist: ${absTarget}`);
+    process.exit(1);
+  }
+
+  const recipes = scanRecipes(recipesDir);
+  if (recipes.length === 0) {
+    console.error(`transitrix migrate: no recipes found in ${resolve(recipesDir)}`);
+    console.error(`  Expected subdirectories named X.Y-to-X.Y containing a codemod.mjs.`);
+    process.exit(1);
+  }
+
+  // Resolve --from
+  const fromVersion = rawFrom
+    ? toMajorMinor(rawFrom)
+    : (() => {
+        const v = readMethodologyVersion(absTarget);
+        if (!v) {
+          console.error(`transitrix migrate: cannot determine source version.`);
+          console.error(`  Add methodology_version: X.Y.Z to ${join(absTarget, TRANSITRIX_YAML)}`);
+          console.error(`  or pass --from X.Y`);
+          process.exit(1);
+        }
+        return toMajorMinor(v);
+      })();
+
+  // Resolve --to
+  const toVersion = rawTo
+    ? toMajorMinor(rawTo)
+    : (() => {
+        const v = findFurthestReachable(fromVersion, recipes);
+        if (!v) {
+          console.error(`transitrix migrate: no recipes available from version ${fromVersion}`);
+          console.error(`  Available: ${recipes.map(r => `${r.from}-to-${r.to}`).join(', ')}`);
+          process.exit(1);
+        }
+        return v;
+      })();
+
+  const chain = resolveChain(fromVersion, toVersion, recipes);
+  if (!chain) {
+    console.error(`transitrix migrate: no migration path from ${fromVersion} to ${toVersion}`);
+    console.error(`  Available: ${recipes.map(r => `${r.from}-to-${r.to}`).join(', ')}`);
+    process.exit(1);
+  }
+
+  if (chain.length === 0) {
+    console.log(`transitrix migrate: already at ${toVersion} — nothing to do.`);
+    return;
+  }
+
+  console.log(`transitrix migrate: ${fromVersion} → ${toVersion} (${chain.length} step${chain.length === 1 ? '' : 's'})`);
+  if (dryRun) console.log(`  (dry-run — no files will be written)\n`);
+  else console.log('');
+
+  if (dryRun) {
+    runDryRun(chain, absTarget, toVersion);
+  } else {
+    runApply(chain, absTarget, toVersion);
+  }
+}

--- a/tests/cli-migrate.test.ts
+++ b/tests/cli-migrate.test.ts
@@ -1,0 +1,280 @@
+import { spawnSync } from 'node:child_process';
+import { cpSync, existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { parseMigrateArgv, readMethodologyVersion, resolveChain, toMajorMinor } from '../src/migrate.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliPath = join(__dirname, '..', 'dist', 'cli.js');
+
+// Recipes are in the sibling methodology repo (dev environment only).
+const recipesDir = resolve(__dirname, '../../methodology/migrations');
+const fixtureBase = join(recipesDir, '0.5-to-0.6', 'fixtures');
+const hasRecipes = existsSync(join(recipesDir, '0.5-to-0.6', 'codemod.mjs'));
+
+function runCli(args: string[]): { status: number; stdout: string; stderr: string } {
+  const r = spawnSync(process.execPath, [cliPath, ...args], { encoding: 'utf8' });
+  return { status: r.status ?? 1, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+
+// ── unit tests (no external deps) ─────────────────────────────────────────
+
+describe('parseMigrateArgv', () => {
+  it('parses --from and --to', () => {
+    const r = parseMigrateArgv(['--from', '0.5', '--to', '0.6']);
+    expect(r.from).toBe('0.5');
+    expect(r.to).toBe('0.6');
+  });
+
+  it('parses --from=X.Y form', () => {
+    const r = parseMigrateArgv(['--from=0.4', '--to=0.5']);
+    expect(r.from).toBe('0.4');
+    expect(r.to).toBe('0.5');
+  });
+
+  it('parses --dry-run', () => {
+    expect(parseMigrateArgv(['--dry-run']).dryRun).toBe(true);
+    expect(parseMigrateArgv([]).dryRun).toBe(false);
+  });
+
+  it('parses --recipes', () => {
+    const r = parseMigrateArgv(['--recipes', '/some/path']);
+    expect(r.recipesDir).toBe('/some/path');
+  });
+
+  it('treats positional as targetDir', () => {
+    const r = parseMigrateArgv(['/my/repo']);
+    expect(r.targetDir).toBe('/my/repo');
+  });
+
+  it('sets wantsHelp for --help / -h', () => {
+    expect(parseMigrateArgv(['--help']).wantsHelp).toBe(true);
+    expect(parseMigrateArgv(['-h']).wantsHelp).toBe(true);
+  });
+});
+
+describe('toMajorMinor', () => {
+  it('strips patch from full semver', () => {
+    expect(toMajorMinor('0.5.0')).toBe('0.5');
+    expect(toMajorMinor('1.2.3')).toBe('1.2');
+  });
+
+  it('leaves major.minor unchanged', () => {
+    expect(toMajorMinor('0.6')).toBe('0.6');
+  });
+});
+
+describe('resolveChain', () => {
+  const recipes = [
+    { from: '0.4', to: '0.5', dir: '/r/0.4-to-0.5' },
+    { from: '0.5', to: '0.6', dir: '/r/0.5-to-0.6' },
+  ];
+
+  it('returns empty chain for same version', () => {
+    expect(resolveChain('0.5', '0.5', recipes)).toEqual([]);
+  });
+
+  it('resolves a single step', () => {
+    const chain = resolveChain('0.5', '0.6', recipes);
+    expect(chain).toHaveLength(1);
+    expect(chain![0].from).toBe('0.5');
+    expect(chain![0].to).toBe('0.6');
+  });
+
+  it('resolves a multi-step chain', () => {
+    const chain = resolveChain('0.4', '0.6', recipes);
+    expect(chain).toHaveLength(2);
+    expect(chain![0].from).toBe('0.4');
+    expect(chain![1].to).toBe('0.6');
+  });
+
+  it('returns null when no path exists', () => {
+    expect(resolveChain('0.6', '0.4', recipes)).toBeNull();
+    expect(resolveChain('0.3', '0.6', recipes)).toBeNull();
+  });
+});
+
+describe('readMethodologyVersion', () => {
+  it('returns undefined when transitrix.yaml is absent', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'tx-mv-test-'));
+    try {
+      expect(readMethodologyVersion(tmp)).toBeUndefined();
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('reads methodology_version from transitrix.yaml', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'tx-mv-test-'));
+    try {
+      writeFileSync(join(tmp, 'transitrix.yaml'), 'methodology_version: 0.5.0\n');
+      expect(readMethodologyVersion(tmp)).toBe('0.5.0');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+// ── CLI integration tests (require methodology repo at ../methodology) ─────
+
+// The fixture YAML files are committed with CRLF line endings on this machine.
+// The codemod regexes use `$` which in JS doesn't match before `\r`, so lines
+// with inline comments fail to match in CRLF mode. Normalising to LF before
+// running the recipes makes the codemod behave the same as on a POSIX host.
+function normalizeLf(dir: string): void {
+  const walk = (d: string): string[] => {
+    const r: string[] = [];
+    for (const e of readdirSync(d)) {
+      const f = join(d, e);
+      if (statSync(f).isDirectory()) r.push(...walk(f));
+      else r.push(f);
+    }
+    return r;
+  };
+  for (const f of walk(dir)) {
+    const c = readFileSync(f, 'utf8');
+    if (c.includes('\r\n')) writeFileSync(f, c.replace(/\r\n/g, '\n'));
+  }
+}
+
+const lf = (s: string) => s.replace(/\r\n/g, '\n');
+
+describe.skipIf(!hasRecipes)('transitrix migrate (requires methodology repo)', () => {
+  const temps: string[] = [];
+
+  afterEach(() => {
+    for (const t of temps) rmSync(t, { recursive: true, force: true });
+    temps.length = 0;
+  });
+
+  function makeTempRepo(fromVersion = '0.5.0'): string {
+    const tmp = mkdtempSync(join(tmpdir(), 'tx-migrate-'));
+    temps.push(tmp);
+    cpSync(join(fixtureBase, 'before'), tmp, { recursive: true });
+    normalizeLf(tmp);
+    writeFileSync(join(tmp, 'transitrix.yaml'), `methodology_version: ${fromVersion}\n`);
+    return tmp;
+  }
+
+  it('shows help with --help', () => {
+    const { status, stderr } = runCli(['migrate', '--help']);
+    expect(status).toBe(0);
+    expect(stderr).toContain('transitrix migrate');
+  });
+
+  it('migrate --help appears in top-level usage', () => {
+    const { stderr } = runCli(['--help']);
+    expect(stderr).toContain('migrate');
+  });
+
+  it('migrates 0.5→0.6: activities file matches fixtures/after', () => {
+    const tmp = makeTempRepo('0.5.0');
+    const { status } = runCli(['migrate', '--recipes', recipesDir, tmp]);
+    expect(status).toBe(0);
+
+    const got = lf(readFileSync(join(tmp, 'canon/views/launch.activities.transitrix.yaml'), 'utf8'));
+    const want = lf(readFileSync(join(fixtureBase, 'after/canon/views/launch.activities.transitrix.yaml'), 'utf8'));
+    expect(got).toBe(want);
+  });
+
+  it('migrates 0.5→0.6: role file matches fixtures/after', () => {
+    const tmp = makeTempRepo('0.5.0');
+    runCli(['migrate', '--recipes', recipesDir, tmp]);
+
+    const got = lf(readFileSync(join(tmp, 'canon/elements/02_business/roles/ROLE-OPS-1.yaml'), 'utf8'));
+    const want = lf(readFileSync(join(fixtureBase, 'after/canon/elements/02_business/roles/ROLE-OPS-1.yaml'), 'utf8'));
+    expect(got).toBe(want);
+  });
+
+  it('migrates 0.5→0.6: project-card renamed to activity-card', () => {
+    const tmp = makeTempRepo('0.5.0');
+    runCli(['migrate', '--recipes', recipesDir, tmp]);
+
+    expect(existsSync(join(tmp, 'canon/views/eu.project-card.transitrix.yaml'))).toBe(false);
+    expect(existsSync(join(tmp, 'canon/views/eu.activity-card.transitrix.yaml'))).toBe(true);
+
+    const got = lf(readFileSync(join(tmp, 'canon/views/eu.activity-card.transitrix.yaml'), 'utf8'));
+    const want = lf(readFileSync(join(fixtureBase, 'after/canon/views/eu.activity-card.transitrix.yaml'), 'utf8'));
+    expect(got).toBe(want);
+  });
+
+  it('updates transitrix.yaml methodology_version on success', () => {
+    const tmp = makeTempRepo('0.5.0');
+    const { status } = runCli(['migrate', '--recipes', recipesDir, tmp]);
+    expect(status).toBe(0);
+
+    const yaml = readFileSync(join(tmp, 'transitrix.yaml'), 'utf8');
+    expect(yaml).toContain('methodology_version: 0.6.0');
+  });
+
+  it('auto-detects from-version from transitrix.yaml', () => {
+    const tmp = makeTempRepo('0.5.0');
+    const { status } = runCli(['migrate', '--recipes', recipesDir, '--to', '0.6', tmp]);
+    expect(status).toBe(0);
+    expect(readFileSync(join(tmp, 'transitrix.yaml'), 'utf8')).toContain('0.6.0');
+  });
+
+  it('honours explicit --from / --to flags', () => {
+    const tmp = makeTempRepo('0.5.0');
+    const { status } = runCli(['migrate', '--recipes', recipesDir, '--from', '0.5', '--to', '0.6', tmp]);
+    expect(status).toBe(0);
+  });
+
+  it('exits 0 with "nothing to do" when already at target', () => {
+    const tmp = makeTempRepo('0.6.0');
+    const { status, stdout } = runCli(['migrate', '--recipes', recipesDir, '--from', '0.6', '--to', '0.6', tmp]);
+    expect(status).toBe(0);
+    expect(stdout).toContain('nothing to do');
+  });
+
+  it('--dry-run: files are not modified', () => {
+    const tmp = makeTempRepo('0.5.0');
+    const beforeContent = readFileSync(join(tmp, 'canon/views/launch.activities.transitrix.yaml'), 'utf8');
+
+    const { status } = runCli(['migrate', '--dry-run', '--recipes', recipesDir, tmp]);
+    expect(status).toBe(0);
+
+    const afterContent = readFileSync(join(tmp, 'canon/views/launch.activities.transitrix.yaml'), 'utf8');
+    expect(afterContent).toBe(beforeContent);
+  });
+
+  it('--dry-run: transitrix.yaml is not updated', () => {
+    const tmp = makeTempRepo('0.5.0');
+    const { status } = runCli(['migrate', '--dry-run', '--recipes', recipesDir, tmp]);
+    expect(status).toBe(0);
+    expect(readFileSync(join(tmp, 'transitrix.yaml'), 'utf8')).toContain('0.5.0');
+  });
+
+  it('--dry-run: output mentions files that would change', () => {
+    const tmp = makeTempRepo('0.5.0');
+    const { stdout } = runCli(['migrate', '--dry-run', '--recipes', recipesDir, tmp]);
+    expect(stdout).toContain('would change');
+  });
+
+  it('fails clearly when no transitrix.yaml and no --from', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'tx-migrate-no-yaml-'));
+    temps.push(tmp);
+    cpSync(join(fixtureBase, 'before'), tmp, { recursive: true });
+
+    const { status, stderr } = runCli(['migrate', '--recipes', recipesDir, tmp]);
+    expect(status).not.toBe(0);
+    expect(stderr).toContain('methodology_version');
+  });
+
+  it('fails clearly when recipes dir does not exist', () => {
+    const tmp = makeTempRepo();
+    const { status, stderr } = runCli(['migrate', '--recipes', '/nonexistent/path', tmp]);
+    expect(status).not.toBe(0);
+    expect(stderr).toContain('no recipes found');
+  });
+
+  it('fails clearly when no migration path exists', () => {
+    const tmp = makeTempRepo('0.6.0');
+    const { status, stderr } = runCli(['migrate', '--recipes', recipesDir, '--from', '0.6', '--to', '0.5', tmp]);
+    expect(status).not.toBe(0);
+    expect(stderr).toContain('no migration path');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `transitrix migrate [--from X.Y] [--to X.Y] [--dry-run] [--recipes <dir>] [target-dir]` subcommand that walks an adopter repository from its current methodology version to a target by running the ordered recipes from the methodology repo
- **Recipe source:** `--recipes <dir>`, defaulting to `../methodology/migrations` (matches the `sync-examples-from-methodology.mjs` convention); production transport (vendored recipes in the npm package) is deferred to a separate release-wiring step
- **Chain resolver:** BFS over available recipe dirs, supports multi-hop migrations (e.g. 0.4→0.5→0.6)
- **Version tracking:** reads `methodology_version` from the adopter's `transitrix.yaml` for `--from`; writes the new full semver back on success; never commits
- **`--dry-run`:** copies the tree to a temp dir, runs codemods, prints a file diff, exits without writing
- **Apply mode:** re-validates after each codemod step; stops on first failure with "fix this, then re-run from step N"; updates `transitrix.yaml` on success
- **ADR:** `docs/decisions/2026-06-14-migrate-recipe-source.md` records the recipe-source transport decision (submodule/subtree rejected; `--recipes` flag now; vendored production path deferred)

## Test plan

- [x] 29 new tests in `tests/cli-migrate.test.ts`
  - Unit: arg parsing, `toMajorMinor`, `resolveChain`, `readMethodologyVersion`
  - Integration (skipped if methodology repo absent): drives `migrations/0.5-to-0.6/fixtures/before` through `transitrix migrate` and asserts all output files match `fixtures/after`; covers dry-run, auto-detect, error paths
- [x] 298/298 core tests pass (`npm run test:core`)
- [x] 834/834 diagrams tests pass (`npm run test:diagrams`)
- [x] `tsc --noEmit` clean

## Notes

- **CRLF fixture files (Windows-only):** the methodology 0.5-to-0.6 codemod regex uses `$` which in JS does not match before `\r`. On Windows, fixture files checked out with CRLF line endings cause lines with inline comments to silently skip transformation. The integration test normalises fixture line endings to LF before running — matching POSIX behaviour. This is a known limitation of the codemod on Windows; tracked as a methodology-side issue, not a Studio CLI issue.
- **Transport TODO:** a vendored-recipes step is needed before the npm-published CLI can run migrations without a sibling methodology checkout. That is a separate task, gated by maintainer review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)