### PR TITLE
feat(ci): multi-platform Open VSX publish workflow (#184)

### DIFF
--- a/.github/workflows/openvsx-publish.yml
+++ b/.github/workflows/openvsx-publish.yml
@@ -1,0 +1,79 @@
+name: Open VSX — multi-platform publish
+
+# Triggered on every GitHub Release to publish platform-specific VSIXs to the
+# Open VSX Registry (the registry Cursor, VSCodium, and Windsurf read).
+#
+# A workflow_dispatch trigger is available for manual re-runs or to publish a
+# specific branch/tag without creating a new release.
+#
+# Prerequisites (one-time maintainer setup — see docs/openvsx-publish-runbook.md):
+#   - OVSX_PAT repo Actions secret set to an Open VSX personal access token
+#     issued for the `transitrix` namespace.
+#   - The `ubuntu-24.04-arm` runner requires a GitHub-hosted ARM64 runner seat
+#     (available on Team / Enterprise plans, or via GitHub's larger runners).
+#
+# win32-arm64 is not in the matrix: no GA GitHub-hosted Windows ARM runner
+# exists at time of writing. Add it when one becomes available.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish (${{ matrix.target }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            target: linux-x64
+          - runner: ubuntu-24.04-arm
+            target: linux-arm64
+          - runner: macos-13
+            target: darwin-x64
+          - runner: macos-latest
+            target: darwin-arm64
+          - runner: windows-latest
+            target: win32-x64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install root dependencies
+        run: npm ci
+
+      - name: Build extension bundle
+        # extension:prep installs the extension runtime deps (including the
+        # platform-specific @resvg/resvg-js-* binary) into a clean temp dir,
+        # then moves node_modules into extension/. Each runner therefore picks
+        # up the correct native binary for its OS/arch.
+        run: npm run extension:prep
+
+      - name: Verify extension packaging
+        run: npm run verify-extension-packaging
+
+      - name: Package VSIX (${{ matrix.target }})
+        working-directory: extension
+        run: npx vsce package --target ${{ matrix.target }} --out ../output/
+
+      - name: Publish to Open VSX
+        shell: bash
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+        run: |
+          vsix=$(ls output/*.vsix | head -n 1)
+          echo "Publishing: $vsix"
+          npx ovsx publish "$vsix" --pat "$OVSX_PAT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- **Open VSX CI publish workflow** — `.github/workflows/openvsx-publish.yml` runs on every GitHub Release and publishes per-platform VSIXs to Open VSX in parallel across five runners (`linux-x64`, `linux-arm64`, `darwin-x64`, `darwin-arm64`, `win32-x64`). Each runner installs the platform-specific `@resvg/resvg-js-*` native binary during `npm run extension:prep`, so every VSIX carries the correct binary for its target. `OVSX_PAT` is read from the repo Actions secret. A `workflow_dispatch` trigger allows manual re-runs. `win32-arm64` not yet in matrix (no GA GitHub-hosted Windows ARM runner). Runbook `docs/openvsx-publish-runbook.md` updated to document the CI path as the recommended sync procedure (strategy #184).
 - **`.transitrixrc` project config** — canonical replacement for `.cervinrc`. `loadTransitrixrc()` reads `.transitrixrc` first and falls back to `.cervinrc` (one-time deprecation notice) when absent; ships `transitrixrc.schema.json` (root + extension `schemas/`). `.cervinrc` keeps working through 1.x (removed in 2.0.0). Fourth phase of the Cervin → Transitrix rename (CLAUDE.md §Cervin naming, P4).
 - **`transitrix` CLI binary** — the primary command is now `transitrix`; it is added as a `bin` entry (and an `npm run transitrix` script) pointing at the same `dist/cli.js`. `--help` and usage text recommend `transitrix`.
 - **VS Code settings `transitrix.fileExtensions` / `transitrix.exportEnabled`** — canonical replacements for the legacy `cervin.*` keys, registered in the extension's `contributes.configuration`.

--- a/docs/openvsx-publish-runbook.md
+++ b/docs/openvsx-publish-runbook.md
@@ -131,19 +131,46 @@ verification step needed beyond a spot check.
 ## Keeping Open VSX in sync on future releases
 
 The Open VSX publish is a **second hop** after every VS Code
-Marketplace release. The steady-state procedure is:
+Marketplace release.
 
-1. Publish to the Marketplace per [`packaging.md`](packaging.md) and
-   the existing release process.
-2. From the same runners (or rebuilt VSIXs on matching OS/arch), run
-   `ovsx publish <vsix>` for each target — see above.
-3. Confirm the Open VSX version field matches the Marketplace listing
-   before announcing the release.
+### CI path (recommended)
 
-When CI publish-on-tag automation lands, the same matrix that runs
-`vsce publish` should run `ovsx publish` next to it with `OVSX_PAT`
-injected from the repo Actions secret. Until then, both hops are
-manual.
+The `.github/workflows/openvsx-publish.yml` workflow runs automatically
+on every GitHub Release (`release: types: [published]`) and publishes
+five platform VSIXs in parallel:
+
+| Runner | Target |
+|--------|--------|
+| `ubuntu-latest` | `linux-x64` |
+| `ubuntu-24.04-arm` | `linux-arm64` |
+| `macos-13` | `darwin-x64` |
+| `macos-latest` | `darwin-arm64` |
+| `windows-latest` | `win32-x64` |
+
+The workflow reads `OVSX_PAT` from the repo Actions secret. Each runner
+installs the platform-specific `@resvg/resvg-js-*` native binary during
+`npm run extension:prep`, so every VSIX carries the correct binary for
+its target.
+
+`win32-arm64` is not yet in the matrix — no GA GitHub-hosted Windows
+ARM runner is available at time of writing. Add it to the matrix when
+one becomes available.
+
+### Manual fallback
+
+To publish a single target by hand (e.g. to fill a CI gap or re-publish
+a failed job), follow the steps in the **Publishing** section above with
+a matching local build environment. You can also trigger the full matrix
+manually via the **workflow_dispatch** button in the Actions tab.
+
+After every publish (CI or manual):
+
+1. Confirm the Open VSX version field matches the Marketplace listing:
+   ```bash
+   curl -s https://open-vsx.org/api/transitrix/transitrix-studio | jq '.version'
+   ```
+2. Spot-check the listing in Cursor's Extensions panel before announcing
+   the release.
 
 ## Unpublish / yank
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/openvsx-publish.yml`: triggers on GitHub Release (`release: types: [published]`) and publishes per-platform VSIXs to Open VSX in parallel across five runners.
- Updates `docs/openvsx-publish-runbook.md`: replaces the "until then, both hops are manual" note with the CI-as-recommended-path documentation, including the runner/target table and the manual fallback procedure.
- CHANGELOG entry under Unreleased / Added.

## Platforms covered by this workflow

| Runner | Target |
|--------|--------|
| `ubuntu-latest` | `linux-x64` |
| `ubuntu-24.04-arm` | `linux-arm64` |
| `macos-13` | `darwin-x64` |
| `macos-latest` | `darwin-arm64` |
| `windows-latest` | `win32-x64` |

`win32-arm64` is not in the matrix — no GA GitHub-hosted Windows ARM runner is available. The comment in the workflow flags this for a future addition.

## How it works

Each runner runs `npm run extension:prep`, which internally installs the platform-specific `@resvg/resvg-js-*` native binary (via a temp-dir isolated `npm install --omit=dev`). This is the same mechanism the metrics-regression CI uses (`npm install --prefix extension`). The resulting VSIX carries the correct binary for the target platform. `vsce package --target <target>` tags the VSIX appropriately. `npx ovsx publish` submits it to Open VSX.

## Prerequisites (one-time maintainer action)

`OVSX_PAT` repo Actions secret must be set (already noted in the runbook). The `transitrix` Open VSX namespace is already claimed (created during the 2026-06-13 manual publish session).

The `ubuntu-24.04-arm` runner requires a GitHub-hosted ARM64 runner seat (Team / Enterprise plan or larger runners).

## Test plan

- [ ] Review `openvsx-publish.yml` matrix and step logic
- [ ] Confirm `extension:prep` correctly handles the `@resvg/resvg-js-*` binary installation on each runner type
- [ ] Trigger `workflow_dispatch` on a test tag to verify the pipeline; check Open VSX listing for each new target

Relates: strategy#184

🤖 Generated with [Claude Code](https://claude.com/claude-code)