### PR TITLE
fix(build): use RUNNER_TEMP for same-device temp dir on Windows runners

### DIFF
--- a/scripts/build-compiler-bundle.mjs
+++ b/scripts/build-compiler-bundle.mjs
@@ -95,7 +95,12 @@ await fs.rm(extNodeModules, { recursive: true, force: true });
 // unreliable — npm 11's --no-workspaces still hits workspace filter logic
 // and silently produces an empty install. The temp-dir approach is
 // workspace-blind, so it works regardless of root configuration.
-const tempInstall = await fs.mkdtemp(resolve(os.tmpdir(), 'tx-ext-install-'));
+//
+// Use RUNNER_TEMP when available (GitHub-hosted Windows runners put it on the
+// same drive as the workspace, avoiding EXDEV on the rename below). Falls back
+// to os.tmpdir() for local development where a single device is the norm.
+const tempBase = process.env.RUNNER_TEMP ?? os.tmpdir();
+const tempInstall = await fs.mkdtemp(resolve(tempBase, 'tx-ext-install-'));
 await fs.copyFile(
   resolve(extensionRoot, 'package.json'),
   resolve(tempInstall, 'package.json'),


### PR DESCRIPTION
## Summary

- `build-compiler-bundle.mjs` creates a temp dir for the isolated `npm install` and then renames `node_modules` into `extension/`. On GitHub-hosted Windows runners the workspace is on `D:` while `os.tmpdir()` resolves to `C:`, causing `fs.rename()` to fail with `EXDEV: cross-device link not permitted`.
- Fix: prefer `process.env.RUNNER_TEMP` (GitHub puts it on the same drive as the checkout) and fall back to `os.tmpdir()` for local development.
- One-line change at `scripts/build-compiler-bundle.mjs:102`; no logic change on Linux/macOS or local Windows where both paths share a device.

Fixes #253 in the project task tracker.

## Test plan

- [ ] 834 unit tests pass locally (`npm test`)
- [ ] TypeScript compiles clean (`npm run compile`)
- [ ] Re-run the failed `win32-x64` job in the Open VSX publish workflow after merge to confirm the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)