### PR TITLE
feat(cli): notation-aware validate so agents self-serve view errors (#258 Phase A)

### DIFF
--- a/organizations/acme_corp/AGENTS.md
+++ b/organizations/acme_corp/AGENTS.md
@@ -171,6 +171,16 @@ Every notation file is validated before commit. Two sanctioned paths:
 - **Transitrix Studio (VS Code extension)** — install from the Marketplace (`transitrix.transitrix-studio`). The extension validates on save and shows error annotations in the editor.
 - **Transitrix CLI** — `npx @transitrix/cli validate path/to/your.fgca.transitrix.yaml`. Use in CI or when working without VS Code.
 
+**The agent validates files itself — it does not wait for a human to read the preview.** The CLI's `validate <file>` routes on the document's `notation:` field to the same per-notation checks the Studio preview runs, so the agent gets the identical findings as structured output. Run the closed loop on every file it touches:
+
+```sh
+# --json → machine-readable findings; exit 1 when any error-level finding exists.
+npx @transitrix/cli validate canon/views/goals/eu-strategy.goals.transitrix.yaml --json
+# parse findings → fix the YAML → re-run until exit 0
+```
+
+Diagram notations covered per file: `goals`, `fgca`, `fga`, `activities`, `activity-card`, `process-blueprint`, `blocks`. For the remaining notations (e.g. `applications`, `capability-map`, `products`, `scenarios`, `process-map`), the CLI reports the file as not-yet-covered — validate those in the Studio preview, and run `validate --scope=repo` for whole-canon cross-reference checks.
+
 The agent does **not** commit files with `error`-level validation findings. `warning`-level findings are surfaced to the adopter and committed only with explicit acknowledgement. The agent does not auto-suppress validation rules.
 
 Every notation spec carries its own validation-codes table (e.g. `FGCA-001..015`, `GOALS-001..013`, `BL-001..009`, `ISS-001..006`). When surfacing a validation error to the adopter, the agent includes the canonical code so the rule is traceable to the spec.

--- a/scripts/build-cli-package.mjs
+++ b/scripts/build-cli-package.mjs
@@ -7,13 +7,14 @@
  *   packages/cli/dist/cli.js                 — bundled entry (shebang preserved)
  *   packages/cli/dist/repo-validate.js       — bundled `validate --scope=repo` handler
  *   packages/cli/dist/export-compliance.js   — bundled `export-compliance` handler
+ *   packages/cli/dist/validate-notation.js   — bundled per-notation `validate <file>` dispatch
  *   packages/cli/schemas/bpmn-dsl.schema.json — copied from root schemas/
  *
  * Runtime npm dependencies are kept external; they are declared in
  * packages/cli/package.json and resolved by npm at install time. The
- * Transitrix diagrams *source* (imported by repo-validate.ts and
- * export-compliance.ts) is bundled in — the slim package does not list
- * @transitrix/diagrams as a runtime dependency.
+ * Transitrix diagrams *source* (imported by repo-validate.ts,
+ * export-compliance.ts and validate-notation.ts) is bundled in — the slim
+ * package does not list @transitrix/diagrams as a runtime dependency.
  */
 import esbuild from 'esbuild';
 import fs from 'node:fs/promises';
@@ -82,6 +83,12 @@ await esbuild.build({
 await esbuild.build({
   ...sharedBuildOptions,
   entryPoints: { 'export-compliance': resolve(root, 'src', 'export-compliance.ts') },
+  outdir: distOut,
+});
+
+await esbuild.build({
+  ...sharedBuildOptions,
+  entryPoints: { 'validate-notation': resolve(root, 'src', 'validate-notation.ts') },
   outdir: distOut,
 });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,8 @@
 import { writeFileSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 
+import jsyaml from 'js-yaml';
+
 import {
   CERVIN_DEPRECATION_NOTICE,
   DEFAULT_CERVIN_FILE_EXTENSIONS,
@@ -37,8 +39,11 @@ function printUsage(): void {
   <compile> — YAML → BPMN 2.0 XML with layout metrics.
   metrics   — layout quality metrics (with --json for CI).
   validate  — validation only (no XML output; exit 1 on errors). Default scope
-              is a single file; --scope=repo runs whole-canon checks
-              (referential integrity, atomicity, id uniqueness, policy).
+              is a single file: BPMN, or a diagram notation (goals, fgca, fga,
+              activities, activity-card, process-blueprint, blocks) routed by its
+              notation: field — the same checks the Studio preview shows.
+              --scope=repo runs whole-canon checks (referential integrity,
+              atomicity, id uniqueness, policy).
   export-compliance — Markdown or PDF report of the compliance views (matrix by
               default; law:/product:/gap scopes). Scans --root (default cwd) for
               requirement/assertion/product/codex canon. PDF rendering requires
@@ -194,6 +199,56 @@ function printValidationReport(src: string, validation: ValidationReport, suppre
   console.log();
 }
 
+/** Cheap probe of a document's `notation:` field, used to route diagram
+ *  notations to their own validator before the BPMN/IR path. Returns undefined
+ *  for non-object YAML, a missing/non-string notation, or a syntax error — in
+ *  every case the chosen downstream path reports the real problem. */
+function probeNotation(text: string): string | undefined {
+  try {
+    const doc = jsyaml.load(text);
+    if (doc && typeof doc === 'object' && !Array.isArray(doc)) {
+      const n = (doc as Record<string, unknown>).notation;
+      if (typeof n === 'string') return n;
+    }
+  } catch {
+    /* malformed YAML — surfaced by parseYamlToIr / loadNotationYaml below */
+  }
+  return undefined;
+}
+
+/** Emit a file-scope ValidationReport as JSON (for CI/agents) or coloured text.
+ *  Shared by the BPMN path and the per-notation path so both speak one schema.
+ *  `notation` is added to the JSON only for diagram-notation validation. */
+function emitFileReport(
+  src: string,
+  report: ValidationReport,
+  useJson: boolean,
+  notation?: string,
+): void {
+  if (useJson) {
+    const output: Record<string, unknown> = {
+      valid: report.isValid,
+      findings: report.findings.map((f: ValidationFinding) => ({
+        ruleId: f.ruleId,
+        severity: f.severity,
+        message: f.message,
+        elementId: f.elementId || null,
+        hint: f.hint || null,
+      })),
+      summary: report.summary,
+    };
+    if (notation) output.notation = notation;
+    console.log(JSON.stringify(output, null, 2));
+    return;
+  }
+  if (report.findings.length === 0) {
+    console.log(`✓ ${src} — valid`);
+    console.log();
+    return;
+  }
+  printValidationReport(src, report, false);
+}
+
 async function handleValidateCommand(argv: string[]): Promise<void> {
   const parsed = parseValidateArgv(argv);
   if (!parsed.ok) {
@@ -218,6 +273,9 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
     console.error(`       transitrix validate --scope=repo [--root <dir>] [--json]`);
     console.error('');
     console.error('file scope — single-file structural/semantic validation (default).');
+    console.error('             BPMN, or a diagram notation routed by its notation: field');
+    console.error('             (goals, fgca, fga, activities, activity-card,');
+    console.error('             process-blueprint, blocks) — same checks as the preview.');
     console.error('repo scope — whole-canon checks (referential integrity, atomicity,');
     console.error('             id uniqueness, policy) over <root> (default: cwd).');
     console.error('Exits with code 1 if any findings.');
@@ -243,7 +301,7 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
     return;
   }
 
-  // ----- file scope (existing behaviour) -----
+  // ----- file scope -----
   const [src] = positional;
   if (!src) {
     console.error('transitrix validate: missing input file');
@@ -251,19 +309,14 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
     process.exit(1);
   }
 
-  if (!inputMatchesExtension(src, exts)) {
-    console.error(
-      `transitrix: input file must end with one of: ${exts.join(', ')} (or pass --ext)`,
-    );
-    process.exit(1);
-  }
-
-  // Read and parse YAML. TX-R004 — file read was outside the try block, so a
-  // missing file surfaced as an unhandled rejection / stack trace instead of
-  // a clean exit-1.
-  let yaml: string;
+  // Read first, so we can probe the `notation:` field before the extension gate:
+  // diagram-notation files (*.goals.transitrix.yaml, …) don't match the default
+  // BPMN/Cervin extension list, and their notation field — not the filename — is
+  // the authoritative signal. TX-R004 — keep the read inside try so a missing
+  // file exits 1 cleanly instead of throwing.
+  let fileText: string;
   try {
-    yaml = await readFile(src, 'utf8');
+    fileText = await readFile(src, 'utf8');
   } catch (e) {
     const err = e as NodeJS.ErrnoException;
     if (useJson) {
@@ -277,9 +330,81 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
     process.exit(1);
   }
 
+  // Diagram-notation routing (vkgeorgia/strategy#258): validate via the same
+  // per-notation validator the VS Code preview uses, so the CLI emits the same
+  // findings the preview shows in red. BPMN / no-notation files fall through to
+  // the IR path below.
+  const probedNotation = probeNotation(fileText);
+  if (probedNotation && probedNotation !== 'bpmn') {
+    // Hand-typed dynamic import (not `typeof import(...)`) so this @transitrix/
+    // diagrams-importing module stays out of the rootDir-restricted emit build —
+    // same pattern as the repo-scope handler above.
+    const nvModule = './validate-notation.js';
+    const nv = (await import(nvModule)) as {
+      isFileValidatableNotation: (notation: string) => boolean;
+      loadNotationYaml: (text: string) => unknown;
+      validateNotationDoc: (notation: string, data: unknown) => ValidationReport;
+    };
+    if (nv.isFileValidatableNotation(probedNotation)) {
+      let data: unknown;
+      try {
+        data = nv.loadNotationYaml(fileText);
+      } catch (e) {
+        const err = e as Error;
+        if (useJson) {
+          console.log(
+            JSON.stringify(
+              { valid: false, notation: probedNotation, message: err.message },
+              null,
+              2,
+            ),
+          );
+        } else {
+          console.error(`✗ ${src}`);
+          console.error();
+          console.error(`Parse error: ${err.message}`);
+          console.error();
+        }
+        process.exit(1);
+      }
+      const report = nv.validateNotationDoc(probedNotation, data);
+      emitFileReport(src, report, useJson, probedNotation);
+      if (!report.isValid) {
+        process.exit(1);
+      }
+      return;
+    }
+    // Recognised notation, but no file-scope CLI validator yet (Group B inline
+    // validators, or non-diagram views like compliance-impact). Be honest: don't
+    // claim valid and don't mis-run the BPMN path — say so and exit 0 (the file
+    // itself isn't in error), so an agent loop isn't blocked on it.
+    const notice =
+      `notation "${probedNotation}" is not yet validated by the CLI — check it in ` +
+      `the Transitrix Studio preview, or run whole-canon checks with --scope=repo.`;
+    if (useJson) {
+      console.log(
+        JSON.stringify({ valid: null, notation: probedNotation, covered: false, message: notice }, null, 2),
+      );
+    } else {
+      console.error(`• ${src}: ${notice}`);
+      console.error();
+    }
+    return;
+  }
+
+  // ----- BPMN / no-notation path -----
+  // The extension gate only applies here; diagram notations are routed above by
+  // their notation field regardless of filename.
+  if (!inputMatchesExtension(src, exts)) {
+    console.error(
+      `transitrix: input file must end with one of: ${exts.join(', ')} (or pass --ext)`,
+    );
+    process.exit(1);
+  }
+
   let ir: ProcessIr;
   try {
-    ir = parseYamlToIr(yaml);
+    ir = parseYamlToIr(fileText);
   } catch (e) {
     const err = e as Error & { errors?: string[] };
     if (useJson) {
@@ -305,34 +430,8 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
     process.exit(1);
   }
 
-  // Run validator
   const report = validateProcess(ir);
-
-  if (useJson) {
-    // JSON output for CI
-    const output = {
-      valid: report.isValid,
-      findings: report.findings.map((f: ValidationFinding) => ({
-        ruleId: f.ruleId,
-        severity: f.severity,
-        message: f.message,
-        elementId: f.elementId || null,
-        hint: f.hint || null,
-      })),
-      summary: report.summary,
-    };
-    console.log(JSON.stringify(output, null, 2));
-  } else {
-    // Human-readable output
-    if (report.findings.length === 0) {
-      console.log(`✓ ${src} — valid`);
-      console.log();
-    } else {
-      printValidationReport(src, report, false);
-    }
-  }
-
-  // Exit with appropriate code
+  emitFileReport(src, report, useJson);
   if (!report.isValid) {
     process.exit(1);
   }

--- a/src/validate-notation.ts
+++ b/src/validate-notation.ts
@@ -1,0 +1,106 @@
+// File-scope validation for diagram notations (vkgeorgia/strategy#258, Phase A).
+//
+// The VS Code preview renders its red error block from per-notation validators
+// in @transitrix/diagrams. This module exposes those same validators to the CLI
+// so `transitrix validate <file> --json` emits the SAME findings an adopter
+// currently copies out of the preview by hand — letting an agent run a closed
+// validate → fix → validate loop with no human relaying errors.
+//
+// Separate module — like repo-validate.ts / export-compliance.ts — because it
+// imports @transitrix/diagrams *source*, which the rootDir-restricted emit build
+// (tsconfig.build.json) cannot emit. It is type-checked by `npm run compile`,
+// loaded by cli.ts via a runtime dynamic import (tsx in dev), and bundled into
+// the slim CLI package by scripts/build-cli-package.mjs.
+//
+// Scope — "Group A": notations whose validator already lives in the shared
+// package AND is the one the preview calls, so parity is exact by construction.
+// Group B (applications, capability-map, products, scenarios, process-map) keep
+// an inline validator copy in the extension; folding those in needs a dedup
+// first and is deferred. activity-card runs only its single-file structural
+// stage here — cross-document resolution (resolveActivityCard) needs the whole
+// canon and belongs to repo scope.
+
+import yaml from 'js-yaml';
+import type { ValidationReport, ValidationFinding } from './validator-types.js';
+import { coerceDatesToIsoStrings } from '../packages/diagrams/src/yaml-normalize.js';
+import { parseCanonicalGoals } from '../packages/diagrams/src/goals/parse-canonical.js';
+import {
+  parseCanonicalFGCA,
+  parseCanonicalFGA,
+} from '../packages/diagrams/src/fgca/parse-canonical.js';
+import { validateActivities } from '../packages/diagrams/src/activities/validate.js';
+import { validateActivityCard } from '../packages/diagrams/src/activity-card/validate.js';
+import { validateProcessBlueprint } from '../packages/diagrams/src/process-blueprint/validate.js';
+import { validateNestedBlocks } from '../packages/diagrams/src/blocks/validate.js';
+
+/** The shape every Group A validator returns: code/message findings split into
+ *  blocking errors and advisory warnings. The concrete result types carry extra
+ *  fields (parsed model, etc.) — structurally assignable to this. */
+interface NotationValidationResult {
+  valid: boolean;
+  errors: Array<{ code: string; message: string }>;
+  warnings: Array<{ code: string; message: string }>;
+}
+
+type NotationValidator = (input: unknown) => NotationValidationResult;
+
+// Keyed by the document's `notation:` field value — see the corpus under
+// tests/fixtures/notation-corpus/<notation>/.
+const VALIDATORS: Record<string, NotationValidator> = {
+  goals: parseCanonicalGoals,
+  fgca: parseCanonicalFGCA,
+  fga: parseCanonicalFGA,
+  activities: validateActivities,
+  'activity-card': validateActivityCard,
+  'process-blueprint': validateProcessBlueprint,
+  blocks: validateNestedBlocks,
+};
+
+/** Notation field values the CLI can validate per file (Group A). */
+export const FILE_VALIDATABLE_NOTATIONS = Object.keys(VALIDATORS);
+
+/** True when `transitrix validate <file>` has a per-notation validator for this
+ *  notation — i.e. it can reproduce the preview's error block. */
+export function isFileValidatableNotation(notation: string): boolean {
+  return Object.prototype.hasOwnProperty.call(VALIDATORS, notation);
+}
+
+/** Read the `notation:` field from parsed YAML data, if present. */
+export function notationOf(data: unknown): string | undefined {
+  if (data && typeof data === 'object' && !Array.isArray(data)) {
+    const n = (data as Record<string, unknown>).notation;
+    if (typeof n === 'string') return n;
+  }
+  return undefined;
+}
+
+/** Parse + date-coerce a YAML string exactly as the previews do, so validator
+ *  input — and therefore findings — match the preview. Throws on a YAML syntax
+ *  error (the caller maps that to a parse-error report). */
+export function loadNotationYaml(text: string): unknown {
+  return coerceDatesToIsoStrings(yaml.load(text) as unknown);
+}
+
+/** Run the per-notation validator and shape its result as a ValidationReport, so
+ *  the CLI prints/serialises notation findings through the same path as BPMN
+ *  validation. `notation` must be one isFileValidatableNotation() accepts. */
+export function validateNotationDoc(notation: string, data: unknown): ValidationReport {
+  const result = VALIDATORS[notation](data);
+  const findings: ValidationFinding[] = [
+    ...result.errors.map(
+      (e): ValidationFinding => ({ ruleId: e.code, severity: 'error', message: e.message }),
+    ),
+    ...result.warnings.map(
+      (w): ValidationFinding => ({ ruleId: w.code, severity: 'warning', message: w.message }),
+    ),
+  ];
+  return {
+    isValid: result.valid,
+    findings,
+    summary: {
+      errorCount: findings.filter((f) => f.severity === 'error').length,
+      warningCount: findings.filter((f) => f.severity === 'warning').length,
+      infoCount: 0,
+    },
+  };
+}

--- a/tests/validate-notation.test.ts
+++ b/tests/validate-notation.test.ts
@@ -1,0 +1,110 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  isFileValidatableNotation,
+  validateNotationDoc,
+  loadNotationYaml,
+  notationOf,
+  FILE_VALIDATABLE_NOTATIONS,
+} from '../src/validate-notation.js';
+// Imported directly to prove the CLI dispatch mirrors the validator the VS Code
+// preview uses — same findings, no drift (vkgeorgia/strategy#258).
+import { parseCanonicalGoals } from '../packages/diagrams/src/goals/parse-canonical.js';
+
+const corpusRoot = join(dirname(fileURLToPath(import.meta.url)), 'fixtures', 'notation-corpus');
+
+// Group A — notations the CLI validates per file by routing on the notation field.
+const GROUP_A = [
+  'goals',
+  'fgca',
+  'fga',
+  'activities',
+  'activity-card',
+  'process-blueprint',
+  'blocks',
+];
+
+function fixtures(notation: string): string[] {
+  return readdirSync(join(corpusRoot, notation))
+    .filter((f) => f.endsWith('.transitrix.yaml'))
+    .map((f) => join(corpusRoot, notation, f));
+}
+
+describe('validate-notation — dispatch (#258)', () => {
+  it('recognises exactly the Group A notations', () => {
+    for (const n of GROUP_A) expect(isFileValidatableNotation(n)).toBe(true);
+    expect([...FILE_VALIDATABLE_NOTATIONS].sort()).toEqual([...GROUP_A].sort());
+  });
+
+  it('does not claim BPMN, Group B, or unknown notations', () => {
+    for (const n of [
+      'bpmn',
+      'applications',
+      'capability-map',
+      'products',
+      'scenarios',
+      'process-map',
+      'compliance-impact',
+      'nonsense',
+    ]) {
+      expect(isFileValidatableNotation(n)).toBe(false);
+    }
+  });
+
+  it('reads the notation field defensively', () => {
+    expect(notationOf({ notation: 'goals' })).toBe('goals');
+    expect(notationOf({ notation: 123 })).toBeUndefined();
+    expect(notationOf({})).toBeUndefined();
+    expect(notationOf(null)).toBeUndefined();
+    expect(notationOf([1, 2])).toBeUndefined();
+  });
+});
+
+describe('validate-notation — the notation corpus validates clean (#258)', () => {
+  for (const notation of GROUP_A) {
+    for (const file of fixtures(notation)) {
+      const name = file.slice(corpusRoot.length + 1).replace(/\\/g, '/');
+      it(`${name} → valid`, () => {
+        const data = loadNotationYaml(readFileSync(file, 'utf8'));
+        const report = validateNotationDoc(notation, data);
+        const errors = report.findings.filter((f) => f.severity === 'error');
+        // Surface the offending findings in the failure message if this regresses.
+        expect(errors, JSON.stringify(errors, null, 2)).toEqual([]);
+        expect(report.isValid).toBe(true);
+        expect(report.summary.errorCount).toBe(0);
+      });
+    }
+  }
+});
+
+describe('validate-notation — parity with the preview validator (#258)', () => {
+  it('goals findings mirror parseCanonicalGoals exactly', () => {
+    // A deliberately malformed goals doc — the CLI must surface the same codes
+    // the preview shows in its red block.
+    const broken = { notation: 'goals', id: 'x', name: 'Broken', goals: [] };
+    const raw = parseCanonicalGoals(broken);
+    const report = validateNotationDoc('goals', broken);
+
+    const reportErrorCodes = report.findings
+      .filter((f) => f.severity === 'error')
+      .map((f) => f.ruleId);
+    expect(reportErrorCodes).toEqual(raw.errors.map((e) => e.code));
+    expect(report.isValid).toBe(raw.valid);
+    expect(report.isValid).toBe(false);
+    expect(reportErrorCodes.length).toBeGreaterThan(0);
+  });
+
+  it('maps validator warnings to advisory findings, not errors', () => {
+    const data = loadNotationYaml(readFileSync(fixtures('goals')[0], 'utf8'));
+    const raw = parseCanonicalGoals(data);
+    const report = validateNotationDoc('goals', data);
+    const warningCodes = report.findings
+      .filter((f) => f.severity === 'warning')
+      .map((f) => f.ruleId);
+    expect(warningCodes).toEqual(raw.warnings.map((w) => w.code));
+  });
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -7,6 +7,6 @@
     "sourceMap": true
   },
   "include": ["src/**/*.ts"],
-  "_comment_export_compliance": "src/export-compliance.ts and src/repo-validate.ts are excluded here: they import @transitrix/diagrams source, which cannot be emitted under rootDir:src. They are type-checked by `npm run compile` and loaded by cli.ts via a runtime dynamic import (tsx transpiles them).",
-  "exclude": ["extension", "src/export-compliance.ts", "src/repo-validate.ts"]
+  "_comment_export_compliance": "src/export-compliance.ts, src/repo-validate.ts and src/validate-notation.ts are excluded here: they import @transitrix/diagrams source, which cannot be emitted under rootDir:src. They are type-checked by `npm run compile` and loaded by cli.ts via a runtime dynamic import (tsx transpiles them).",
+  "exclude": ["extension", "src/export-compliance.ts", "src/repo-validate.ts", "src/validate-notation.ts"]
 }


### PR DESCRIPTION
CLI notation-validation series (Phase A) — let an agent in an adopter repo obtain the **same validation errors the human currently reads off the VS Code preview's red block**, directly, as structured CLI output.

## Problem

Adopters generate notation previews in the Studio extension, see errors in red, and **copy them to an agent by hand**. The errors come from per-notation validators in `@transitrix/diagrams`, but no CLI path exposed them: `validate <file>` only did BPMN, `--scope=repo` only did canon cross-references. So the human was stuck relaying errors.

## Change

`transitrix validate <file>` now probes the document's `notation:` field and routes diagram notations to **the same validator the preview uses**, emitting the identical findings as JSON. The agent runs a closed loop with no human in the middle:

```sh
npx @transitrix/cli validate canon/views/goals/eu-strategy.goals.transitrix.yaml --json
# parse findings → fix YAML → re-run until exit 0
```

Covered per file (**Group A** — validators already shared with the preview, parity exact by construction): `goals`, `fgca`, `fga`, `activities`, `activity-card`, `process-blueprint`, `blocks`.

- **activity-card** runs its single-file structural stage only; cross-document resolution (`resolveActivityCard`) needs the whole canon and belongs to repo scope.
- **Group B** (`applications`, `capability-map`, `products`, `scenarios`, `process-map`) keep an inline validator copy in the extension — reported as **not-yet-covered** (`valid: null, covered: false`, exit 0) rather than silently passed. Folding them in needs a dedup and is deferred (Phase B).

## How

- **New `src/validate-notation.ts`** — `notation → validator` dispatch, shaping each result as the shared `ValidationReport` so notation and BPMN findings speak **one JSON schema**. Imports `@transitrix/diagrams` source, so it's excluded from the rootDir emit build and bundled by the slim CLI packager — mirroring `repo-validate.ts` / `export-compliance.ts` (incl. the hand-typed dynamic import that keeps it out of the tsc program).
- **File-scope `validate` reads the file before the extension gate**, so diagram files (`*.goals.transitrix.yaml`, …) validate on their notation field instead of being rejected for not matching the BPMN/Cervin extension list. The gate still applies to the BPMN/IR path.
- **Adopter `AGENTS.md`** documents the self-serve loop.

## Test

- `tests/validate-notation.test.ts` (14 tests): dispatch table, the whole notation corpus validates clean, and **parity** — CLI findings mirror `parseCanonicalGoals` code-for-code, warnings map to advisory (not error) findings.
- Full core suite green (312 passed). `npm run build` + `npm run compile` clean; no stray `dist/validate-notation.js`.
- Manual smoke: valid goals → `valid:true`/exit 0; broken goals → `valid:false`/exit 1 with `GOALS-*` codes; applications → not-covered notice/exit 0; BPMN unchanged.

## Not in this PR (follow-ups)

- **Phase A.2** — extend `validate --scope=repo` to sweep every notation file under `canon/views/**` (one command → all errors).
- **Phase B** — dedup the Group B inline validators against the package versions, then extend the dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

