### PR TITLE
feat(cli): sweep canon/views in validate --scope=repo (#258 Phase A.2)

### DIFF
--- a/organizations/acme_corp/AGENTS.md
+++ b/organizations/acme_corp/AGENTS.md
@@ -174,12 +174,17 @@ Every notation file is validated before commit. Two sanctioned paths:
 **The agent validates files itself — it does not wait for a human to read the preview.** The CLI's `validate <file>` routes on the document's `notation:` field to the same per-notation checks the Studio preview runs, so the agent gets the identical findings as structured output. Run the closed loop on every file it touches:
 
 ```sh
-# --json → machine-readable findings; exit 1 when any error-level finding exists.
+# Per file — --json → machine-readable findings; exit 1 on any error-level finding.
 npx @transitrix/cli validate canon/views/goals/eu-strategy.goals.transitrix.yaml --json
 # parse findings → fix the YAML → re-run until exit 0
+
+# Whole repo — one sweep over canon/views/** plus canon cross-reference checks.
+npx @transitrix/cli validate --scope=repo --json
 ```
 
-Diagram notations covered per file: `goals`, `fgca`, `fga`, `activities`, `activity-card`, `process-blueprint`, `blocks`. For the remaining notations (e.g. `applications`, `capability-map`, `products`, `scenarios`, `process-map`), the CLI reports the file as not-yet-covered — validate those in the Studio preview, and run `validate --scope=repo` for whole-canon cross-reference checks.
+`--scope=repo` runs the per-notation validators over every file under `canon/views/**` (BPMN via the IR pipeline) **and** the canon cross-reference checks (referential integrity, id uniqueness, atomicity, policy) in a single invocation — the fastest way for the agent to find everything to fix.
+
+Diagram notations covered per file: `goals`, `fgca`, `fga`, `activities`, `activity-card`, `process-blueprint`, `blocks`, and `bpmn`. The remaining notations (e.g. `applications`, `capability-map`, `products`, `scenarios`, `process-map`) are reported as `skipped` (not silently passed) — validate those in the Studio preview for now.
 
 The agent does **not** commit files with `error`-level validation findings. `warning`-level findings are surfaced to the adopter and committed only with explicit acknowledgement. The agent does not auto-suppress validation rules.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -289,13 +289,28 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
     // rootDir-restricted emit build (see repo-validate.ts header).
     const repoModule = './repo-validate.js';
     type RepoFinding = { scope: 'repo'; id: string; message: string };
-    const { runRepoValidate, reportRepoFindings } = (await import(repoModule)) as {
-      runRepoValidate: (root: string) => RepoFinding[];
-      reportRepoFindings: (root: string, findings: RepoFinding[], useJson: boolean) => void;
+    type ViewFinding = {
+      file: string;
+      notation: string;
+      ruleId: string;
+      severity: 'error' | 'warning';
+      message: string;
     };
-    const findings = runRepoValidate(repoRoot);
-    reportRepoFindings(repoRoot, findings, useJson);
-    if (findings.length > 0) {
+    type RepoScopeResult = {
+      canon: RepoFinding[];
+      views: ViewFinding[];
+      skipped: Array<{ file: string; notation: string }>;
+    };
+    const { runRepoValidate, reportRepoFindings, repoScopeHasErrors } = (await import(
+      repoModule
+    )) as {
+      runRepoValidate: (root: string) => RepoScopeResult;
+      reportRepoFindings: (root: string, result: RepoScopeResult, useJson: boolean) => void;
+      repoScopeHasErrors: (result: RepoScopeResult) => boolean;
+    };
+    const result = runRepoValidate(repoRoot);
+    reportRepoFindings(repoRoot, result, useJson);
+    if (repoScopeHasErrors(result)) {
       process.exit(1);
     }
     return;

--- a/src/repo-validate.ts
+++ b/src/repo-validate.ts
@@ -19,6 +19,14 @@ import {
   type RepoFinding,
   type RepoModelInput,
 } from '../packages/diagrams/src/repo-validate/index.js';
+import {
+  validateNotationDoc,
+  isFileValidatableNotation,
+  notationOf,
+  loadNotationYaml,
+} from './validate-notation.js';
+import { parseYamlToIr } from './parser.js';
+import { validateProcess } from './validator.js';
 
 /** Directory segments that are tooling/scaffolding, never canon content.
  *  Mirrors lint.py, which skips `.templates/` and `.validators/`. */
@@ -81,17 +89,159 @@ export function loadRepoModel(root: string): RepoModelInput {
   return { elements, relations };
 }
 
-/** Load the canon model under `root` and run the repo-scope checks. */
-export function runRepoValidate(root: string): RepoFinding[] {
-  return validateRepoModel(loadRepoModel(root));
+/** A per-file notation finding from sweeping canon/views/** (vkgeorgia/strategy
+ *  #258, Phase A.2). Unlike the frozen `RepoFinding` (canon cross-references),
+ *  this carries the file, notation, and rule code an agent needs to fix it. */
+export interface ViewFinding {
+  /** Source file path, relative to the scanned root. */
+  file: string;
+  /** The document's `notation:` field — '' for a YAML syntax error. */
+  notation: string;
+  /** The validator rule code, e.g. 'GOALS-002'. 'YAML' for a parse failure. */
+  ruleId: string;
+  severity: 'error' | 'warning';
+  message: string;
 }
 
-/** Print findings (human or JSON). Returns nothing; the caller sets exit code. */
-export function reportRepoFindings(root: string, findings: RepoFinding[], useJson: boolean): void {
+/** Combined repo-scope result: canon cross-reference findings plus per-file
+ *  notation findings from canon/views/**, and the view files skipped because
+ *  their notation has no file-scope CLI validator yet (Group B / non-diagram). */
+export interface RepoScopeResult {
+  canon: RepoFinding[];
+  views: ViewFinding[];
+  skipped: Array<{ file: string; notation: string }>;
+}
+
+/** Collect the raw text of every YAML doc under `<root>/canon/views/**`. */
+function loadViewDocs(root: string): Array<{ path: string; text: string }> {
+  const docs: Array<{ path: string; text: string }> = [];
+  let entries: string[] = [];
+  try {
+    entries = readdirSync(path.join(root, 'canon', 'views'), { recursive: true }) as string[];
+  } catch {
+    return docs;
+  }
+  for (const rel of entries) {
+    if (typeof rel !== 'string' || !isYaml(rel) || shouldSkip(rel)) continue;
+    const fullRel = path.join('canon', 'views', rel);
+    let text: string;
+    try {
+      text = readFileSync(path.join(root, fullRel), 'utf-8');
+    } catch {
+      continue;
+    }
+    docs.push({ path: fullRel.replace(/\\/g, '/'), text });
+  }
+  return docs;
+}
+
+/** Validate every Group A notation file under canon/views/** with the same
+ *  per-notation validator the VS Code preview uses, so a repo-scope run surfaces
+ *  the per-file errors an adopter would otherwise read off each preview. */
+export function runViewValidate(root: string): {
+  findings: ViewFinding[];
+  skipped: Array<{ file: string; notation: string }>;
+} {
+  const findings: ViewFinding[] = [];
+  const skipped: Array<{ file: string; notation: string }> = [];
+  for (const doc of loadViewDocs(root)) {
+    let data: unknown;
+    try {
+      data = loadNotationYaml(doc.text);
+    } catch (e) {
+      findings.push({
+        file: doc.path,
+        notation: '',
+        ruleId: 'YAML',
+        severity: 'error',
+        message: (e as Error).message,
+      });
+      continue;
+    }
+    const notation = notationOf(data);
+    if (!notation) continue; // not a notation document — ignore
+
+    // BPMN flow files validate through the IR pipeline (same as file scope),
+    // not the diagram-notation dispatch.
+    if (notation === 'bpmn') {
+      try {
+        const report = validateProcess(parseYamlToIr(doc.text));
+        for (const f of report.findings) {
+          if (f.severity === 'info') continue;
+          findings.push({
+            file: doc.path,
+            notation,
+            ruleId: f.ruleId,
+            severity: f.severity,
+            message: f.message,
+          });
+        }
+      } catch (e) {
+        findings.push({
+          file: doc.path,
+          notation,
+          ruleId: 'PARSE',
+          severity: 'error',
+          message: (e as Error).message,
+        });
+      }
+      continue;
+    }
+
+    if (!isFileValidatableNotation(notation)) {
+      skipped.push({ file: doc.path, notation });
+      continue;
+    }
+    for (const f of validateNotationDoc(notation, data).findings) {
+      if (f.severity === 'info') continue;
+      findings.push({
+        file: doc.path,
+        notation,
+        ruleId: f.ruleId,
+        severity: f.severity,
+        message: f.message,
+      });
+    }
+  }
+  return { findings, skipped };
+}
+
+/** Load the canon model under `root` and run the repo-scope checks: canon
+ *  cross-references plus a per-file notation sweep over canon/views/**. */
+export function runRepoValidate(root: string): RepoScopeResult {
+  const canon = validateRepoModel(loadRepoModel(root));
+  const { findings: views, skipped } = runViewValidate(root);
+  return { canon, views, skipped };
+}
+
+/** True when the run has a blocking finding — a canon finding or a view error.
+ *  View warnings and skipped files do not fail the run. */
+export function repoScopeHasErrors(result: RepoScopeResult): boolean {
+  return result.canon.length > 0 || result.views.some((v) => v.severity === 'error');
+}
+
+/** Print the repo-scope result (human or JSON). Returns nothing; the caller sets
+ *  the exit code via repoScopeHasErrors(). */
+export function reportRepoFindings(root: string, result: RepoScopeResult, useJson: boolean): void {
+  const { canon, views, skipped } = result;
+  const viewErrors = views.filter((v) => v.severity === 'error');
+  const viewWarnings = views.filter((v) => v.severity === 'warning');
+  const valid = canon.length === 0 && viewErrors.length === 0;
+
   if (useJson) {
     console.log(
       JSON.stringify(
-        { scope: 'repo', root, valid: findings.length === 0, findings },
+        {
+          scope: 'repo',
+          root,
+          valid,
+          // Canon cross-reference findings — frozen {scope,id,message} shape.
+          findings: canon,
+          // Per-file notation findings from the canon/views/** sweep.
+          views: { valid: viewErrors.length === 0, findings: views },
+          // View files whose notation has no file-scope CLI validator yet.
+          skipped,
+        },
         null,
         2,
       ),
@@ -99,23 +249,64 @@ export function reportRepoFindings(root: string, findings: RepoFinding[], useJso
     return;
   }
 
-  if (findings.length === 0) {
+  if (valid && skipped.length === 0) {
     console.log(`✓ ${root} — repo-scope validation passed`);
     console.log();
     return;
   }
 
   console.log();
-  console.log(`✗ ${root}`);
+  console.log(`${valid ? '✓' : '✗'} ${root}`);
   console.log();
-  console.log('Repo-scope validation:');
-  for (const f of findings) {
-    const where = f.id ? f.id : '(file)';
-    console.log(`  \x1b[31m✗ ${where}\x1b[0m ${f.message}`);
+
+  if (canon.length > 0) {
+    console.log('Canon (elements / relations):');
+    for (const f of canon) {
+      const where = f.id ? f.id : '(file)';
+      console.log(`  \x1b[31m✗ ${where}\x1b[0m ${f.message}`);
+    }
+    console.log();
   }
-  console.log();
-  console.log(
-    `Repo-scope validation: \x1b[31m${findings.length} finding${findings.length === 1 ? '' : 's'}\x1b[0m`,
-  );
-  console.log();
+
+  if (views.length > 0) {
+    console.log('Views (canon/views):');
+    let currentFile = '';
+    for (const v of views) {
+      if (v.file !== currentFile) {
+        console.log(`  ${v.file} [${v.notation || 'yaml'}]`);
+        currentFile = v.file;
+      }
+      const mark =
+        v.severity === 'error' ? `\x1b[31m✗ ${v.ruleId}\x1b[0m` : `\x1b[33m⚠ ${v.ruleId}\x1b[0m`;
+      console.log(`    ${mark} ${v.message}`);
+    }
+    console.log();
+  }
+
+  if (skipped.length > 0) {
+    console.log(
+      `Skipped — notation not yet validated by the CLI (check in the preview): ${skipped.length} file${skipped.length === 1 ? '' : 's'}`,
+    );
+    for (const s of skipped) {
+      console.log(`  • ${s.file} [${s.notation}]`);
+    }
+    console.log();
+  }
+
+  const parts: string[] = [];
+  if (canon.length > 0) {
+    parts.push(`\x1b[31m${canon.length}\x1b[0m canon`);
+  }
+  if (viewErrors.length > 0) {
+    parts.push(`\x1b[31m${viewErrors.length}\x1b[0m view error${viewErrors.length === 1 ? '' : 's'}`);
+  }
+  if (viewWarnings.length > 0) {
+    parts.push(
+      `\x1b[33m${viewWarnings.length}\x1b[0m view warning${viewWarnings.length === 1 ? '' : 's'}`,
+    );
+  }
+  if (parts.length > 0) {
+    console.log(`Repo-scope validation: ${parts.join(', ')}`);
+    console.log();
+  }
 }

--- a/tests/repo-validate-views.test.ts
+++ b/tests/repo-validate-views.test.ts
@@ -1,0 +1,106 @@
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { afterAll, beforeAll, describe, it, expect } from 'vitest';
+
+import {
+  runViewValidate,
+  runRepoValidate,
+  repoScopeHasErrors,
+} from '../src/repo-validate.js';
+
+// Phase A.2 (vkgeorgia/strategy#258): `validate --scope=repo` sweeps every
+// notation file under canon/views/** with the same validators the preview uses.
+
+const corpus = join(
+  dirname(fileURLToPath(import.meta.url)),
+  'fixtures',
+  'notation-corpus',
+);
+
+function write(root: string, rel: string, body: string): void {
+  const p = join(root, rel);
+  mkdirSync(dirname(p), { recursive: true });
+  writeFileSync(p, body, 'utf8');
+}
+
+function copyCorpus(root: string, rel: string, corpusRel: string): void {
+  write(root, rel, readFileSync(join(corpus, corpusRel), 'utf8'));
+}
+
+describe('repo-scope views sweep (#258)', () => {
+  let root: string;
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), 'tx-views-'));
+    // A clean Group A file, a deliberately broken one, a BPMN file (validated via
+    // the IR pipeline), and a Group B file (no file-scope validator yet).
+    copyCorpus(root, 'canon/views/goals/good.goals.transitrix.yaml', 'goals/strategy-2026.goals.transitrix.yaml');
+    write(root, 'canon/views/goals/bad.goals.transitrix.yaml', 'notation: goals\nid: x\nname: Bad\ngoals: []\n');
+    copyCorpus(root, 'canon/views/bpmn/ok.bpmn.transitrix.yaml', 'bpmn/simple-approval.bpmn.transitrix.yaml');
+    copyCorpus(root, 'canon/views/applications/p.applications.transitrix.yaml', 'applications/portfolio-2026.applications.transitrix.yaml');
+  });
+
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('flags the broken Group A file with its rule code', () => {
+    const { findings } = runViewValidate(root);
+    const bad = findings.filter((f) => f.file.endsWith('bad.goals.transitrix.yaml'));
+    expect(bad.length).toBeGreaterThan(0);
+    expect(bad.every((f) => f.notation === 'goals')).toBe(true);
+    expect(bad.some((f) => f.severity === 'error' && f.ruleId.startsWith('GOALS-'))).toBe(true);
+  });
+
+  it('leaves the clean Group A file error-free', () => {
+    const { findings } = runViewValidate(root);
+    const good = findings.filter(
+      (f) => f.file.endsWith('good.goals.transitrix.yaml') && f.severity === 'error',
+    );
+    expect(good).toEqual([]);
+  });
+
+  it('validates BPMN via the IR pipeline (not skipped)', () => {
+    const { findings, skipped } = runViewValidate(root);
+    expect(skipped.some((s) => s.notation === 'bpmn')).toBe(false);
+    // simple-approval is clean → no BPMN error findings.
+    expect(findings.filter((f) => f.notation === 'bpmn' && f.severity === 'error')).toEqual([]);
+  });
+
+  it('reports Group B notations as skipped, not silently passed', () => {
+    const { skipped, findings } = runViewValidate(root);
+    expect(skipped.some((s) => s.notation === 'applications')).toBe(true);
+    expect(findings.some((f) => f.notation === 'applications')).toBe(false);
+  });
+
+  it('runRepoValidate combines canon + views and fails on a view error', () => {
+    const result = runRepoValidate(root);
+    expect(result.canon).toEqual([]); // no elements/relations in this fixture
+    expect(result.views.some((f) => f.severity === 'error')).toBe(true);
+    expect(repoScopeHasErrors(result)).toBe(true);
+  });
+});
+
+describe('repo-scope views sweep — clean tree passes (#258)', () => {
+  let root: string;
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), 'tx-views-clean-'));
+    copyCorpus(root, 'canon/views/goals/good.goals.transitrix.yaml', 'goals/strategy-2026.goals.transitrix.yaml');
+    copyCorpus(root, 'canon/views/applications/p.applications.transitrix.yaml', 'applications/portfolio-2026.applications.transitrix.yaml');
+  });
+
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('a Group B file alone does not fail the run (warnings/skips never error)', () => {
+    const result = runRepoValidate(root);
+    expect(result.views.filter((f) => f.severity === 'error')).toEqual([]);
+    expect(repoScopeHasErrors(result)).toBe(false);
+    expect(result.skipped.some((s) => s.notation === 'applications')).toBe(true);
+  });
+});


### PR DESCRIPTION
CLI notation-validation series (Phase A.2) — builds on #177 (now on `main`).

## What

`transitrix validate --scope=repo` now runs the **per-notation validators over every file under `canon/views/**`** in addition to the existing canon cross-reference checks. One invocation surfaces every per-file view error an adopter would otherwise read off each preview one at a time — the fastest self-serve path for an agent.

## Coverage

- **Group A** (`goals`, `fgca`, `fga`, `activities`, `activity-card`, `process-blueprint`, `blocks`) → the same validator the preview uses.
- **`bpmn`** → the IR pipeline (`parseYamlToIr` + `validateProcess`), so flow files are checked too (not parked in `skipped`).
- **Group B** (`applications`, `capability-map`, `products`, `scenarios`, `process-map`) and non-diagram views (`compliance-impact`, `coverage-metric`) → reported as `skipped` — **surfaced, never silently passed**. They land in Phase B once their inline validators are deduped.

## Output

The repo-scope JSON keeps `scope`/`root`/`findings` (canon, frozen `{scope,id,message}`) and adds:

```jsonc
{
  "valid": false,                       // false on a canon finding OR a view error
  "findings": [ /* canon cross-refs */ ],
  "views": { "valid": false, "findings": [
    { "file": "canon/views/bpmn/x.bpmn.transitrix.yaml", "notation": "bpmn",
      "ruleId": "SF-007", "severity": "error", "message": "..." }
  ]},
  "skipped": [ { "file": "...", "notation": "applications" } ]
}
```

View warnings and skipped files do **not** fail the run (exit 1 only on a canon finding or a view *error*) — same error/warning split as file scope. The canon `RepoFinding` shape is left untouched per its ADR; the richer per-file fields live only on view findings. Human output groups findings by file with colour-coded codes, lists skipped files, and a summary line.

## Test

- `tests/repo-validate-views.test.ts` (6 tests) over a deterministic temp fixture: broken Group A file flagged with its rule code, clean file error-free, **bpmn validated (not skipped)**, Group B skipped (not passed), and a clean tree passes.
- Full core suite green (**318 passed**). `build` + `compile` clean, no stray `dist/` artifacts. Slim CLI package bundles and runs both scopes end-to-end.

## Surfaced (not fixed here)

Running the sweep on the bundled example `organizations/acme_corp` flagged a **real** error its canon checks missed — `data-subject-erasure.bpmn.transitrix.yaml` has two `SF-007` (a flow with both default marker and a condition). File-scope validate confirms it. Left as a separate example-data decision for you rather than silently edited.

## Remaining (follow-ups)

- **Phase B** — dedup the Group B inline validators against the package versions, then extend the dispatch so they move from `skipped` to covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

