### PR TITLE
feat(cli): Group B notation dispatch + dedup inline validators (#258 Phase B)

### DIFF
--- a/extension/src/applications-preview.ts
+++ b/extension/src/applications-preview.ts
@@ -3,8 +3,9 @@ import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, CATALOGUE_STYLES, type ThemeId } from './diagram-frame.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
+import { validateApplicationsCatalogue } from '../../packages/diagrams/src/applications/validate.js';
 
-// ── Inline types (mirror packages/diagrams/src/applications/types.ts) ─────────
+// ── Types (used by render helpers) ───────────────────────────────────────────
 
 type ApplicationType = 'application' | 'integration' | 'platform' | 'data_store';
 type ApplicationStatus = 'Draft' | 'Active' | 'Deprecated' | 'Decommissioning';
@@ -42,92 +43,6 @@ interface ApplicationsCatalogueHeader {
   version?: string;
   updated_at: string;
   applications: Application[];
-}
-
-interface ValidationError { code: string; message: string; }
-interface ValidationResult { valid: boolean; errors: ValidationError[]; warnings: Array<{ code: string; message: string }> }
-
-// ── Inline validation (mirrors packages/diagrams/src/applications/validate.ts) ─
-
-const VALID_TYPES = new Set<string>(['application', 'integration', 'platform', 'data_store']);
-const VALID_STATUSES = new Set<string>(['Draft', 'Active', 'Deprecated', 'Decommissioning']);
-const VALID_DIRECTIONS = new Set<string>(['inbound', 'outbound', 'bidirectional']);
-const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
-
-function validateApplicationsCatalogue(input: unknown): ValidationResult {
-  const errors: ValidationError[] = [];
-  const warnings: Array<{ code: string; message: string }> = [];
-
-  if (!input || typeof input !== 'object') {
-    return { valid: false, errors: [{ code: 'APP-001', message: 'Input must be an object' }], warnings };
-  }
-  const raw = input as Record<string, unknown>;
-
-  if (!('notation' in raw)) {
-    errors.push({ code: 'APP-001', message: 'Missing required field: notation' });
-  } else if (raw['notation'] !== 'applications') {
-    errors.push({ code: 'APP-001', message: `notation must be "applications", got "${raw['notation']}"` });
-  }
-  if (errors.length > 0) return { valid: false, errors, warnings };
-
-  if (!raw['applications_catalogue'] || typeof raw['applications_catalogue'] !== 'object') {
-    errors.push({ code: 'APP-002', message: 'Missing required field: applications_catalogue' });
-    return { valid: false, errors, warnings };
-  }
-  const cat = raw['applications_catalogue'] as Record<string, unknown>;
-
-  if (!cat['id'] || typeof cat['id'] !== 'string' || !(cat['id'] as string).trim())
-    errors.push({ code: 'APP-002', message: 'applications_catalogue.id is required' });
-  if (!cat['name'] || typeof cat['name'] !== 'string' || !(cat['name'] as string).trim())
-    errors.push({ code: 'APP-002', message: 'applications_catalogue.name is required' });
-  if (!cat['updated_at'] || typeof cat['updated_at'] !== 'string')
-    errors.push({ code: 'APP-002', message: 'applications_catalogue.updated_at is required' });
-  if (errors.length > 0) return { valid: false, errors, warnings };
-
-  if (!DATE_RE.test(cat['updated_at'] as string))
-    errors.push({ code: 'APP-007', message: `applications_catalogue.updated_at must be YYYY-MM-DD, got "${cat['updated_at']}"` });
-
-  const applications = cat['applications'];
-  if (!Array.isArray(applications)) {
-    errors.push({ code: 'APP-002', message: 'applications_catalogue.applications must be an array' });
-    return { valid: false, errors, warnings };
-  }
-
-  const seenIds = new Set<string>();
-  for (let i = 0; i < applications.length; i++) {
-    const a = applications[i] as Record<string, unknown>;
-    const idx = `applications[${i}]`;
-
-    if (!a['app_id'] || typeof a['app_id'] !== 'string' || !(a['app_id'] as string).trim()) {
-      errors.push({ code: 'APP-003', message: `${idx}: app_id is required` });
-    } else {
-      const aid = a['app_id'] as string;
-      if (seenIds.has(aid)) errors.push({ code: 'APP-008', message: `Duplicate app_id: "${aid}"` });
-      seenIds.add(aid);
-    }
-    if (!a['name'] || typeof a['name'] !== 'string' || !(a['name'] as string).trim())
-      errors.push({ code: 'APP-003', message: `${idx}: name is required` });
-    if (!a['type']) errors.push({ code: 'APP-003', message: `${idx}: type is required` });
-    if (!a['status']) errors.push({ code: 'APP-003', message: `${idx}: status is required` });
-    if (a['type'] && !VALID_TYPES.has(a['type'] as string))
-      errors.push({ code: 'APP-004', message: `${idx}: type "${a['type']}" must be one of: application, integration, platform, data_store` });
-    if (a['status'] && !VALID_STATUSES.has(a['status'] as string))
-      errors.push({ code: 'APP-005', message: `${idx}: status "${a['status']}" must be one of: Draft, Active, Deprecated, Decommissioning` });
-    if (a['maturity'] !== undefined) {
-      const m = a['maturity'];
-      if (typeof m !== 'number' || !Number.isInteger(m) || m < 1 || m > 5)
-        errors.push({ code: 'APP-006', message: `${idx}: maturity must be an integer 1–5, got "${m}"` });
-    }
-    if (Array.isArray(a['integrations'])) {
-      const intgs = a['integrations'] as Record<string, unknown>[];
-      for (let j = 0; j < intgs.length; j++) {
-        const intg = intgs[j];
-        if (intg['direction'] !== undefined && !VALID_DIRECTIONS.has(intg['direction'] as string))
-          errors.push({ code: 'APP-009', message: `${idx}.integrations[${j}]: direction "${intg['direction']}" must be one of: inbound, outbound, bidirectional` });
-      }
-    }
-  }
-  return { valid: errors.length === 0, errors, warnings };
 }
 
 // ── HTML table render helpers ─────────────────────────────────────────────────

--- a/extension/src/capability-map-preview.ts
+++ b/extension/src/capability-map-preview.ts
@@ -3,8 +3,9 @@ import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, CATALOGUE_STYLES, type ThemeId } from './diagram-frame.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
+import { validateCapabilityMap } from '../../packages/diagrams/src/capability-map/validate.js';
 
-// ── Inline types (mirror packages/diagrams/src/capability-map/types.ts) ───────
+// ── Types (used by render helpers) ───────────────────────────────────────────
 
 type CapabilityType = 'domain' | 'supporting';
 
@@ -28,101 +29,6 @@ interface CapabilityMapHeader {
   description?: string;
   assessment_date: string;
   capabilities: CapabilityNode[];
-}
-
-interface ValidationError { code: string; message: string; }
-interface ValidationResult { valid: boolean; errors: ValidationError[]; warnings: Array<{ code: string; message: string }> }
-
-// ── Inline validation (mirrors capability-map/validate.ts) ────────────────────
-
-const VALID_TYPES = new Set<string>(['domain', 'supporting']);
-const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
-const CAP_ID_RE = /^(V|H)\d+(\.\d+)*$/;
-
-function validateTree(nodes: unknown[], pathPrefix: string, errors: ValidationError[], seen: Set<string>): void {
-  for (let i = 0; i < nodes.length; i++) {
-    const node = nodes[i] as Record<string, unknown>;
-    const p = `${pathPrefix}[${i}]`;
-    if (!node['id'] || typeof node['id'] !== 'string' || !(node['id'] as string).trim()) {
-      errors.push({ code: 'CMAP-003', message: `${p}: id is required` });
-    } else {
-      const id = node['id'] as string;
-      if (seen.has(id)) errors.push({ code: 'CMAP-008', message: `Duplicate capability id: "${id}"` });
-      seen.add(id);
-      if (!CAP_ID_RE.test(id))
-        errors.push({ code: 'CMAP-009', message: `${p}: id "${id}" must match V[n] or H[n] with optional .n segments` });
-    }
-    if (!node['name'] || typeof node['name'] !== 'string' || !(node['name'] as string).trim())
-      errors.push({ code: 'CMAP-003', message: `${p}: name is required` });
-    if (node['current_maturity'] === undefined) {
-      errors.push({ code: 'CMAP-003', message: `${p}: current_maturity is required` });
-    } else {
-      const cm = node['current_maturity'];
-      if (typeof cm !== 'number' || !Number.isInteger(cm) || cm < 1 || cm > 5)
-        errors.push({ code: 'CMAP-005', message: `${p}: current_maturity must be 1–5, got "${cm}"` });
-    }
-    if (node['target_maturity'] !== undefined) {
-      const tm = node['target_maturity'];
-      if (typeof tm !== 'number' || !Number.isInteger(tm) || tm < 1 || tm > 5)
-        errors.push({ code: 'CMAP-006', message: `${p}: target_maturity must be 1–5, got "${tm}"` });
-    }
-    if (node['type'] !== undefined && !VALID_TYPES.has(node['type'] as string))
-      errors.push({ code: 'CMAP-004', message: `${p}: type "${node['type']}" must be one of: domain, supporting` });
-    if (node['target_date'] !== undefined) {
-      if (typeof node['target_date'] !== 'string' || !DATE_RE.test(node['target_date'] as string))
-        errors.push({ code: 'CMAP-007', message: `${p}: target_date must be YYYY-MM-DD, got "${node['target_date']}"` });
-    }
-    if (node['applications'] !== undefined && !Array.isArray(node['applications']))
-      errors.push({ code: 'CMAP-003', message: `${p}: applications must be an array` });
-    if (node['children'] !== undefined) {
-      if (!Array.isArray(node['children'])) {
-        errors.push({ code: 'CMAP-003', message: `${p}: children must be an array` });
-      } else {
-        validateTree(node['children'] as unknown[], `${p}.children`, errors, seen);
-      }
-    }
-  }
-}
-
-function validateCapabilityMap(input: unknown): ValidationResult {
-  const errors: ValidationError[] = [];
-  const warnings: Array<{ code: string; message: string }> = [];
-  if (!input || typeof input !== 'object') {
-    return { valid: false, errors: [{ code: 'CMAP-001', message: 'Input must be an object' }], warnings };
-  }
-  const raw = input as Record<string, unknown>;
-  if (!('notation' in raw)) {
-    errors.push({ code: 'CMAP-001', message: 'Missing required field: notation' });
-  } else if (raw['notation'] !== 'capability-map') {
-    errors.push({ code: 'CMAP-001', message: `notation must be "capability-map", got "${raw['notation']}"` });
-  }
-  if (errors.length > 0) return { valid: false, errors, warnings };
-
-  const map = raw['capability_map'];
-  if (!map || typeof map !== 'object') {
-    errors.push({ code: 'CMAP-002', message: 'Missing required field: capability_map' });
-    return { valid: false, errors, warnings };
-  }
-  const m = map as Record<string, unknown>;
-
-  if (!m['id'] || typeof m['id'] !== 'string' || !(m['id'] as string).trim())
-    errors.push({ code: 'CMAP-002', message: 'capability_map.id is required' });
-  if (!m['name'] || typeof m['name'] !== 'string' || !(m['name'] as string).trim())
-    errors.push({ code: 'CMAP-002', message: 'capability_map.name is required' });
-  if (!m['assessment_date'] || typeof m['assessment_date'] !== 'string')
-    errors.push({ code: 'CMAP-002', message: 'capability_map.assessment_date is required' });
-  if (errors.length > 0) return { valid: false, errors, warnings };
-
-  if (!DATE_RE.test(m['assessment_date'] as string))
-    errors.push({ code: 'CMAP-007', message: `capability_map.assessment_date must be YYYY-MM-DD, got "${m['assessment_date']}"` });
-
-  const caps = m['capabilities'];
-  if (!Array.isArray(caps)) {
-    errors.push({ code: 'CMAP-002', message: 'capability_map.capabilities must be an array' });
-    return { valid: false, errors, warnings };
-  }
-  validateTree(caps, 'capabilities', errors, new Set<string>());
-  return { valid: errors.length === 0, errors, warnings };
 }
 
 // ── HTML render helpers ───────────────────────────────────────────────────────

--- a/extension/src/process-map-preview.ts
+++ b/extension/src/process-map-preview.ts
@@ -3,8 +3,9 @@ import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, CATALOGUE_STYLES, type ThemeId } from './diagram-frame.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
+import { validateProcessMap } from '../../packages/diagrams/src/process-map/validate.js';
 
-// ── Inline types (mirror packages/diagrams/src/process-map/types.ts) ──────────
+// ── Types (used by render helpers) ───────────────────────────────────────────
 
 type ProcessGroupType = 'operating' | 'supporting' | 'management';
 type ProcessStatus = 'Draft' | 'Active' | 'Deprecated';
@@ -35,108 +36,6 @@ interface ProcessMapHeader {
   version?: string;
   updated_at: string;
   groups: ProcessGroup[];
-}
-
-interface ValidationError { code: string; message: string; }
-interface ValidationResult { valid: boolean; errors: ValidationError[]; warnings: Array<{ code: string; message: string }> }
-
-// ── Inline validation (mirrors packages/diagrams/src/process-map/validate.ts) ─
-
-const VALID_GROUP_TYPES = new Set<string>(['operating', 'supporting', 'management']);
-const VALID_STATUSES = new Set<string>(['Draft', 'Active', 'Deprecated']);
-const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
-
-function validateProcessMap(input: unknown): ValidationResult {
-  const errors: ValidationError[] = [];
-  const warnings: Array<{ code: string; message: string }> = [];
-
-  if (!input || typeof input !== 'object') {
-    return { valid: false, errors: [{ code: 'PMAP-001', message: 'Input must be an object' }], warnings };
-  }
-  const raw = input as Record<string, unknown>;
-
-  if (!('notation' in raw)) {
-    errors.push({ code: 'PMAP-001', message: 'Missing required field: notation' });
-  } else if (raw['notation'] !== 'process-map') {
-    errors.push({ code: 'PMAP-001', message: `notation must be "process-map", got "${raw['notation']}"` });
-  }
-  if (errors.length > 0) return { valid: false, errors, warnings };
-
-  const map = raw['process_map'];
-  if (!map || typeof map !== 'object') {
-    errors.push({ code: 'PMAP-002', message: 'Missing required field: process_map' });
-    return { valid: false, errors, warnings };
-  }
-  const m = map as Record<string, unknown>;
-
-  if (!m['id'] || typeof m['id'] !== 'string' || !(m['id'] as string).trim())
-    errors.push({ code: 'PMAP-002', message: 'process_map.id is required' });
-  if (!m['name'] || typeof m['name'] !== 'string' || !(m['name'] as string).trim())
-    errors.push({ code: 'PMAP-002', message: 'process_map.name is required' });
-  if (!m['updated_at'] || typeof m['updated_at'] !== 'string')
-    errors.push({ code: 'PMAP-002', message: 'process_map.updated_at is required' });
-  if (errors.length > 0) return { valid: false, errors, warnings };
-
-  if (!DATE_RE.test(m['updated_at'] as string))
-    errors.push({ code: 'PMAP-008', message: `process_map.updated_at must be YYYY-MM-DD, got "${m['updated_at']}"` });
-
-  const groups = m['groups'];
-  if (!Array.isArray(groups)) {
-    errors.push({ code: 'PMAP-002', message: 'process_map.groups must be an array' });
-    return { valid: false, errors, warnings };
-  }
-
-  const seenGroupIds = new Set<string>();
-  const seenProcessIds = new Set<string>();
-  for (let gi = 0; gi < groups.length; gi++) {
-    const g = groups[gi] as Record<string, unknown>;
-    const gIdx = `groups[${gi}]`;
-    if (!g['id'] || typeof g['id'] !== 'string' || !(g['id'] as string).trim()) {
-      errors.push({ code: 'PMAP-003', message: `${gIdx}: id is required` });
-    } else {
-      const gid = g['id'] as string;
-      if (seenGroupIds.has(gid)) errors.push({ code: 'PMAP-010', message: `Duplicate group id: "${gid}"` });
-      seenGroupIds.add(gid);
-    }
-    if (!g['name'] || typeof g['name'] !== 'string' || !(g['name'] as string).trim())
-      errors.push({ code: 'PMAP-003', message: `${gIdx}: name is required` });
-    if (!g['type']) {
-      errors.push({ code: 'PMAP-003', message: `${gIdx}: type is required` });
-    } else if (!VALID_GROUP_TYPES.has(g['type'] as string)) {
-      errors.push({ code: 'PMAP-004', message: `${gIdx}: type "${g['type']}" must be one of: operating, supporting, management` });
-    }
-
-    const processes = g['processes'];
-    if (processes !== undefined && !Array.isArray(processes)) {
-      errors.push({ code: 'PMAP-003', message: `${gIdx}: processes must be an array` });
-      continue;
-    }
-    const list = (processes ?? []) as unknown[];
-    for (let pi = 0; pi < list.length; pi++) {
-      const p = list[pi] as Record<string, unknown>;
-      const pIdx = `${gIdx}.processes[${pi}]`;
-      if (!p['process_id'] || typeof p['process_id'] !== 'string' || !(p['process_id'] as string).trim()) {
-        errors.push({ code: 'PMAP-005', message: `${pIdx}: process_id is required` });
-      } else {
-        const pid = p['process_id'] as string;
-        if (seenProcessIds.has(pid)) errors.push({ code: 'PMAP-009', message: `Duplicate process_id: "${pid}"` });
-        seenProcessIds.add(pid);
-      }
-      if (!p['name'] || typeof p['name'] !== 'string' || !(p['name'] as string).trim())
-        errors.push({ code: 'PMAP-005', message: `${pIdx}: name is required` });
-      if (!p['status']) {
-        errors.push({ code: 'PMAP-005', message: `${pIdx}: status is required` });
-      } else if (!VALID_STATUSES.has(p['status'] as string)) {
-        errors.push({ code: 'PMAP-006', message: `${pIdx}: status "${p['status']}" must be one of: Draft, Active, Deprecated` });
-      }
-      if (p['maturity'] !== undefined) {
-        const mat = p['maturity'];
-        if (typeof mat !== 'number' || !Number.isInteger(mat) || mat < 1 || mat > 5)
-          errors.push({ code: 'PMAP-007', message: `${pIdx}: maturity must be an integer 1–5, got "${mat}"` });
-      }
-    }
-  }
-  return { valid: errors.length === 0, errors, warnings };
 }
 
 // ── HTML render helpers ───────────────────────────────────────────────────────

--- a/extension/src/products-preview.ts
+++ b/extension/src/products-preview.ts
@@ -3,8 +3,9 @@ import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, CATALOGUE_STYLES, type ThemeId } from './diagram-frame.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
+import { validateProductsCatalogue } from '../../packages/diagrams/src/products/validate.js';
 
-// ── Inline types (mirror packages/diagrams/src/products/types.ts) ─────────────
+// ── Types (used by render helpers) ───────────────────────────────────────────
 
 type ProductType = 'digital_product' | 'service' | 'platform' | 'bundle';
 type ProductStatus = 'Draft' | 'Active' | 'Deprecated';
@@ -30,81 +31,6 @@ interface ProductsCatalogueHeader {
   version?: string;
   updated_at: string;
   products: Product[];
-}
-
-interface ValidationError { code: string; message: string; }
-interface ValidationResult { valid: boolean; errors: ValidationError[]; warnings: Array<{ code: string; message: string }> }
-
-// ── Inline validation (mirrors packages/diagrams/src/products/validate.ts) ────
-
-const VALID_TYPES = new Set<string>(['digital_product', 'service', 'platform', 'bundle']);
-const VALID_STATUSES = new Set<string>(['Draft', 'Active', 'Deprecated']);
-const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
-
-function validateProductsCatalogue(input: unknown): ValidationResult {
-  const errors: ValidationError[] = [];
-  const warnings: Array<{ code: string; message: string }> = [];
-
-  if (!input || typeof input !== 'object') {
-    return { valid: false, errors: [{ code: 'PROD-001', message: 'Input must be an object' }], warnings };
-  }
-  const raw = input as Record<string, unknown>;
-
-  if (!('notation' in raw)) {
-    errors.push({ code: 'PROD-001', message: 'Missing required field: notation' });
-  } else if (raw['notation'] !== 'products') {
-    errors.push({ code: 'PROD-001', message: `notation must be "products", got "${raw['notation']}"` });
-  }
-  if (errors.length > 0) return { valid: false, errors, warnings };
-
-  const cat = (raw['products_catalogue'] ?? {}) as Record<string, unknown>;
-  if (!raw['products_catalogue'] || typeof raw['products_catalogue'] !== 'object') {
-    errors.push({ code: 'PROD-002', message: 'Missing required field: products_catalogue' });
-    return { valid: false, errors, warnings };
-  }
-  if (!cat['id'] || typeof cat['id'] !== 'string' || !(cat['id'] as string).trim())
-    errors.push({ code: 'PROD-002', message: 'products_catalogue.id is required' });
-  if (!cat['name'] || typeof cat['name'] !== 'string' || !(cat['name'] as string).trim())
-    errors.push({ code: 'PROD-002', message: 'products_catalogue.name is required' });
-  if (!cat['updated_at'] || typeof cat['updated_at'] !== 'string')
-    errors.push({ code: 'PROD-002', message: 'products_catalogue.updated_at is required' });
-  if (errors.length > 0) return { valid: false, errors, warnings };
-
-  if (!DATE_RE.test(cat['updated_at'] as string))
-    errors.push({ code: 'PROD-007', message: `products_catalogue.updated_at must be YYYY-MM-DD, got "${cat['updated_at']}"` });
-
-  const products = cat['products'];
-  if (!Array.isArray(products)) {
-    errors.push({ code: 'PROD-002', message: 'products_catalogue.products must be an array' });
-    return { valid: false, errors, warnings };
-  }
-
-  const seenIds = new Set<string>();
-  for (let i = 0; i < products.length; i++) {
-    const p = products[i] as Record<string, unknown>;
-    const idx = `products[${i}]`;
-    if (!p['product_id'] || typeof p['product_id'] !== 'string' || !(p['product_id'] as string).trim()) {
-      errors.push({ code: 'PROD-003', message: `${idx}: product_id is required` });
-    } else {
-      const pid = p['product_id'] as string;
-      if (seenIds.has(pid)) errors.push({ code: 'PROD-008', message: `Duplicate product_id: "${pid}"` });
-      seenIds.add(pid);
-    }
-    if (!p['name'] || typeof p['name'] !== 'string' || !(p['name'] as string).trim())
-      errors.push({ code: 'PROD-003', message: `${idx}: name is required` });
-    if (!p['type']) errors.push({ code: 'PROD-003', message: `${idx}: type is required` });
-    if (!p['status']) errors.push({ code: 'PROD-003', message: `${idx}: status is required` });
-    if (p['type'] && !VALID_TYPES.has(p['type'] as string))
-      errors.push({ code: 'PROD-004', message: `${idx}: type "${p['type']}" must be one of: digital_product, service, platform, bundle` });
-    if (p['status'] && !VALID_STATUSES.has(p['status'] as string))
-      errors.push({ code: 'PROD-005', message: `${idx}: status "${p['status']}" must be one of: Draft, Active, Deprecated` });
-    if (p['maturity'] !== undefined) {
-      const m = p['maturity'];
-      if (typeof m !== 'number' || !Number.isInteger(m) || m < 1 || m > 5)
-        errors.push({ code: 'PROD-006', message: `${idx}: maturity must be an integer 1–5, got "${m}"` });
-    }
-  }
-  return { valid: errors.length === 0, errors, warnings };
 }
 
 // ── HTML table render helpers ─────────────────────────────────────────────────

--- a/extension/src/scenarios-preview.ts
+++ b/extension/src/scenarios-preview.ts
@@ -3,8 +3,9 @@ import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, CATALOGUE_STYLES, type ThemeId } from './diagram-frame.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
+import { validateScenario } from '../../packages/diagrams/src/scenarios/validate.js';
 
-// ── Inline types (mirror packages/diagrams/src/scenarios/types.ts) ────────────
+// ── Types (used by render helpers) ───────────────────────────────────────────
 
 type ScenarioStatus = 'Draft' | 'Active' | 'Archived';
 type FactorRelevance = 'High' | 'Medium' | 'Low';
@@ -25,109 +26,6 @@ interface ScenarioHeader {
   products?: Array<{ product_id: string }>;
   processes?: Array<{ process_id: string }>;
   applications?: Array<{ app_id: string }>;
-}
-
-interface ValidationError { code: string; message: string; }
-interface ValidationResult { valid: boolean; errors: ValidationError[]; warnings: Array<{ code: string; message: string }> }
-
-// ── Inline validation (mirrors packages/diagrams/src/scenarios/validate.ts) ───
-
-const VALID_STATUSES = new Set<string>(['Draft', 'Active', 'Archived']);
-const VALID_RELEVANCE = new Set<string>(['High', 'Medium', 'Low']);
-const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
-
-const REF_SPECS = [
-  { field: 'goals',        idField: 'goal_id',       errorCode: 'SCN-007' },
-  { field: 'capabilities', idField: 'capability_id', errorCode: 'SCN-008' },
-  { field: 'activities',   idField: 'activity_id',   errorCode: 'SCN-009' },
-  { field: 'products',     idField: 'product_id',    errorCode: 'SCN-010' },
-  { field: 'processes',    idField: 'process_id',    errorCode: 'SCN-011' },
-  { field: 'applications', idField: 'app_id',        errorCode: 'SCN-012' },
-] as const;
-
-function validateScenario(input: unknown): ValidationResult {
-  const errors: ValidationError[] = [];
-  const warnings: Array<{ code: string; message: string }> = [];
-
-  if (!input || typeof input !== 'object') {
-    return { valid: false, errors: [{ code: 'SCN-001', message: 'Input must be an object' }], warnings };
-  }
-  const raw = input as Record<string, unknown>;
-
-  if (!('notation' in raw)) {
-    errors.push({ code: 'SCN-001', message: 'Missing required field: notation' });
-  } else if (raw['notation'] !== 'scenarios') {
-    errors.push({ code: 'SCN-001', message: `notation must be "scenarios", got "${raw['notation']}"` });
-  }
-  if (errors.length > 0) return { valid: false, errors, warnings };
-
-  const scn = raw['scenario'];
-  if (!scn || typeof scn !== 'object') {
-    errors.push({ code: 'SCN-002', message: 'Missing required field: scenario' });
-    return { valid: false, errors, warnings };
-  }
-  const s = scn as Record<string, unknown>;
-
-  if (!s['id'] || typeof s['id'] !== 'string' || !(s['id'] as string).trim())
-    errors.push({ code: 'SCN-002', message: 'scenario.id is required' });
-  if (!s['name'] || typeof s['name'] !== 'string' || !(s['name'] as string).trim())
-    errors.push({ code: 'SCN-002', message: 'scenario.name is required' });
-  if (!s['status']) {
-    errors.push({ code: 'SCN-002', message: 'scenario.status is required' });
-  } else if (!VALID_STATUSES.has(s['status'] as string)) {
-    errors.push({ code: 'SCN-003', message: `scenario.status "${s['status']}" must be one of: Draft, Active, Archived` });
-  }
-  if (errors.length > 0) return { valid: false, errors, warnings };
-
-  if (s['created_at'] !== undefined) {
-    if (typeof s['created_at'] !== 'string' || !DATE_RE.test(s['created_at'] as string))
-      errors.push({ code: 'SCN-004', message: `scenario.created_at must be YYYY-MM-DD, got "${s['created_at']}"` });
-  }
-
-  if (s['factors_view'] !== undefined) {
-    if (!Array.isArray(s['factors_view'])) {
-      errors.push({ code: 'SCN-005', message: 'scenario.factors_view must be an array' });
-    } else {
-      const seen = new Set<string>();
-      const fv = s['factors_view'] as unknown[];
-      for (let i = 0; i < fv.length; i++) {
-        const f = fv[i] as Record<string, unknown>;
-        const idx = `factors_view[${i}]`;
-        if (!f['factor_id'] || typeof f['factor_id'] !== 'string' || !(f['factor_id'] as string).trim()) {
-          errors.push({ code: 'SCN-005', message: `${idx}: factor_id is required` });
-        } else {
-          const fid = f['factor_id'] as string;
-          if (seen.has(fid)) errors.push({ code: 'SCN-013', message: `Duplicate factor_id: "${fid}"` });
-          seen.add(fid);
-        }
-        if (f['relevance'] !== undefined && !VALID_RELEVANCE.has(f['relevance'] as string))
-          errors.push({ code: 'SCN-006', message: `${idx}: relevance "${f['relevance']}" must be one of: High, Medium, Low` });
-      }
-    }
-  }
-
-  for (const spec of REF_SPECS) {
-    const list = s[spec.field];
-    if (list === undefined) continue;
-    if (!Array.isArray(list)) {
-      errors.push({ code: spec.errorCode, message: `scenario.${spec.field} must be an array` });
-      continue;
-    }
-    const seen = new Set<string>();
-    for (let i = 0; i < list.length; i++) {
-      const item = list[i] as Record<string, unknown>;
-      const idx = `${spec.field}[${i}]`;
-      const id = item?.[spec.idField];
-      if (!id || typeof id !== 'string' || !(id as string).trim()) {
-        errors.push({ code: spec.errorCode, message: `${idx}: ${spec.idField} is required` });
-      } else {
-        const sid = id as string;
-        if (seen.has(sid)) errors.push({ code: spec.errorCode, message: `${idx}: duplicate ${spec.idField} "${sid}"` });
-        seen.add(sid);
-      }
-    }
-  }
-  return { valid: errors.length === 0, errors, warnings };
 }
 
 // ── HTML render helpers ───────────────────────────────────────────────────────

--- a/src/validate-notation.ts
+++ b/src/validate-notation.ts
@@ -1,4 +1,4 @@
-// File-scope validation for diagram notations (vkgeorgia/strategy#258, Phase A).
+// File-scope validation for diagram notations (vkgeorgia/strategy#258).
 //
 // The VS Code preview renders its red error block from per-notation validators
 // in @transitrix/diagrams. This module exposes those same validators to the CLI
@@ -12,13 +12,14 @@
 // loaded by cli.ts via a runtime dynamic import (tsx in dev), and bundled into
 // the slim CLI package by scripts/build-cli-package.mjs.
 //
-// Scope — "Group A": notations whose validator already lives in the shared
-// package AND is the one the preview calls, so parity is exact by construction.
-// Group B (applications, capability-map, products, scenarios, process-map) keep
-// an inline validator copy in the extension; folding those in needs a dedup
-// first and is deferred. activity-card runs only its single-file structural
-// stage here — cross-document resolution (resolveActivityCard) needs the whole
-// canon and belongs to repo scope.
+// Group A: notations whose validator already lived in the shared package AND was
+// the one the preview called — parity by construction from Phase A.
+// Group B (applications, capability-map, products, scenarios, process-map):
+// previously kept inline copies in the extension preview files. Phase B deduped
+// them — the extension now imports the package validator — so CLI parity is
+// guaranteed for all notations listed here.
+// activity-card runs only its single-file structural stage here — cross-document
+// resolution (resolveActivityCard) needs the whole canon and belongs to repo scope.
 
 import yaml from 'js-yaml';
 import type { ValidationReport, ValidationFinding } from './validator-types.js';
@@ -32,8 +33,13 @@ import { validateActivities } from '../packages/diagrams/src/activities/validate
 import { validateActivityCard } from '../packages/diagrams/src/activity-card/validate.js';
 import { validateProcessBlueprint } from '../packages/diagrams/src/process-blueprint/validate.js';
 import { validateNestedBlocks } from '../packages/diagrams/src/blocks/validate.js';
+import { validateApplicationsCatalogue } from '../packages/diagrams/src/applications/validate.js';
+import { validateCapabilityMap } from '../packages/diagrams/src/capability-map/validate.js';
+import { validateProductsCatalogue } from '../packages/diagrams/src/products/validate.js';
+import { validateScenario } from '../packages/diagrams/src/scenarios/validate.js';
+import { validateProcessMap } from '../packages/diagrams/src/process-map/validate.js';
 
-/** The shape every Group A validator returns: code/message findings split into
+/** The shape every notation validator returns: code/message findings split into
  *  blocking errors and advisory warnings. The concrete result types carry extra
  *  fields (parsed model, etc.) — structurally assignable to this. */
 interface NotationValidationResult {
@@ -47,6 +53,7 @@ type NotationValidator = (input: unknown) => NotationValidationResult;
 // Keyed by the document's `notation:` field value — see the corpus under
 // tests/fixtures/notation-corpus/<notation>/.
 const VALIDATORS: Record<string, NotationValidator> = {
+  // Group A — validator lives in the shared package and is the one the preview calls.
   goals: parseCanonicalGoals,
   fgca: parseCanonicalFGCA,
   fga: parseCanonicalFGA,
@@ -54,9 +61,15 @@ const VALIDATORS: Record<string, NotationValidator> = {
   'activity-card': validateActivityCard,
   'process-blueprint': validateProcessBlueprint,
   blocks: validateNestedBlocks,
+  // Group B — deduped from inline preview copies in Phase B; package is now canonical.
+  applications: validateApplicationsCatalogue,
+  'capability-map': validateCapabilityMap,
+  products: validateProductsCatalogue,
+  scenarios: validateScenario,
+  'process-map': validateProcessMap,
 };
 
-/** Notation field values the CLI can validate per file (Group A). */
+/** Notation field values the CLI can validate per file. */
 export const FILE_VALIDATABLE_NOTATIONS = Object.keys(VALIDATORS);
 
 /** True when `transitrix validate <file>` has a per-notation validator for this

--- a/tests/validate-notation.test.ts
+++ b/tests/validate-notation.test.ts
@@ -14,10 +14,15 @@ import {
 // Imported directly to prove the CLI dispatch mirrors the validator the VS Code
 // preview uses — same findings, no drift (vkgeorgia/strategy#258).
 import { parseCanonicalGoals } from '../packages/diagrams/src/goals/parse-canonical.js';
+import { validateApplicationsCatalogue } from '../packages/diagrams/src/applications/validate.js';
+import { validateCapabilityMap } from '../packages/diagrams/src/capability-map/validate.js';
+import { validateProductsCatalogue } from '../packages/diagrams/src/products/validate.js';
+import { validateScenario } from '../packages/diagrams/src/scenarios/validate.js';
+import { validateProcessMap } from '../packages/diagrams/src/process-map/validate.js';
 
 const corpusRoot = join(dirname(fileURLToPath(import.meta.url)), 'fixtures', 'notation-corpus');
 
-// Group A — notations the CLI validates per file by routing on the notation field.
+// Group A — shared package validators already used by the preview before Phase B.
 const GROUP_A = [
   'goals',
   'fgca',
@@ -28,6 +33,17 @@ const GROUP_A = [
   'blocks',
 ];
 
+// Group B — deduped from extension inline copies in Phase B; package is now canonical.
+const GROUP_B = [
+  'applications',
+  'capability-map',
+  'products',
+  'scenarios',
+  'process-map',
+];
+
+const ALL_NOTATIONS = [...GROUP_A, ...GROUP_B];
+
 function fixtures(notation: string): string[] {
   return readdirSync(join(corpusRoot, notation))
     .filter((f) => f.endsWith('.transitrix.yaml'))
@@ -35,22 +51,13 @@ function fixtures(notation: string): string[] {
 }
 
 describe('validate-notation — dispatch (#258)', () => {
-  it('recognises exactly the Group A notations', () => {
-    for (const n of GROUP_A) expect(isFileValidatableNotation(n)).toBe(true);
-    expect([...FILE_VALIDATABLE_NOTATIONS].sort()).toEqual([...GROUP_A].sort());
+  it('recognises all Group A and Group B notations', () => {
+    for (const n of ALL_NOTATIONS) expect(isFileValidatableNotation(n)).toBe(true);
+    expect([...FILE_VALIDATABLE_NOTATIONS].sort()).toEqual([...ALL_NOTATIONS].sort());
   });
 
-  it('does not claim BPMN, Group B, or unknown notations', () => {
-    for (const n of [
-      'bpmn',
-      'applications',
-      'capability-map',
-      'products',
-      'scenarios',
-      'process-map',
-      'compliance-impact',
-      'nonsense',
-    ]) {
+  it('does not claim BPMN, non-diagram views, or unknown notations', () => {
+    for (const n of ['bpmn', 'compliance-impact', 'coverage-metric', 'nonsense']) {
       expect(isFileValidatableNotation(n)).toBe(false);
     }
   });
@@ -65,7 +72,7 @@ describe('validate-notation — dispatch (#258)', () => {
 });
 
 describe('validate-notation — the notation corpus validates clean (#258)', () => {
-  for (const notation of GROUP_A) {
+  for (const notation of ALL_NOTATIONS) {
     for (const file of fixtures(notation)) {
       const name = file.slice(corpusRoot.length + 1).replace(/\\/g, '/');
       it(`${name} → valid`, () => {
@@ -106,5 +113,56 @@ describe('validate-notation — parity with the preview validator (#258)', () =>
       .filter((f) => f.severity === 'warning')
       .map((f) => f.ruleId);
     expect(warningCodes).toEqual(raw.warnings.map((w) => w.code));
+  });
+
+  // Group B parity — CLI dispatch calls the same package function the extension now imports.
+  it('applications: CLI findings mirror validateApplicationsCatalogue exactly', () => {
+    const broken = { notation: 'applications' };
+    const raw = validateApplicationsCatalogue(broken);
+    const report = validateNotationDoc('applications', broken);
+    expect(report.isValid).toBe(raw.valid);
+    expect(report.isValid).toBe(false);
+    expect(report.findings.filter((f) => f.severity === 'error').map((f) => f.ruleId))
+      .toEqual(raw.errors.map((e) => e.code));
+  });
+
+  it('capability-map: CLI findings mirror validateCapabilityMap exactly', () => {
+    const broken = { notation: 'capability-map' };
+    const raw = validateCapabilityMap(broken);
+    const report = validateNotationDoc('capability-map', broken);
+    expect(report.isValid).toBe(raw.valid);
+    expect(report.isValid).toBe(false);
+    expect(report.findings.filter((f) => f.severity === 'error').map((f) => f.ruleId))
+      .toEqual(raw.errors.map((e) => e.code));
+  });
+
+  it('products: CLI findings mirror validateProductsCatalogue exactly', () => {
+    const broken = { notation: 'products' };
+    const raw = validateProductsCatalogue(broken);
+    const report = validateNotationDoc('products', broken);
+    expect(report.isValid).toBe(raw.valid);
+    expect(report.isValid).toBe(false);
+    expect(report.findings.filter((f) => f.severity === 'error').map((f) => f.ruleId))
+      .toEqual(raw.errors.map((e) => e.code));
+  });
+
+  it('scenarios: CLI findings mirror validateScenario exactly', () => {
+    const broken = { notation: 'scenarios' };
+    const raw = validateScenario(broken);
+    const report = validateNotationDoc('scenarios', broken);
+    expect(report.isValid).toBe(raw.valid);
+    expect(report.isValid).toBe(false);
+    expect(report.findings.filter((f) => f.severity === 'error').map((f) => f.ruleId))
+      .toEqual(raw.errors.map((e) => e.code));
+  });
+
+  it('process-map: CLI findings mirror validateProcessMap exactly', () => {
+    const broken = { notation: 'process-map' };
+    const raw = validateProcessMap(broken);
+    const report = validateNotationDoc('process-map', broken);
+    expect(report.isValid).toBe(raw.valid);
+    expect(report.isValid).toBe(false);
+    expect(report.findings.filter((f) => f.severity === 'error').map((f) => f.ruleId))
+      .toEqual(raw.errors.map((e) => e.code));
   });
 });


### PR DESCRIPTION
Phase B of vkgeorgia/strategy#258 — builds on Phase A.1 (#177, merged) and is independent of Phase A.2 (#178, pending).

## What

Five notations (applications, capability-map, products, scenarios, process-map) previously kept **inline validator copies** inside the extension preview files while authoritative validators also existed in `@transitrix/diagrams`. The copies had drifted: `capability-map-preview.ts` only accepted the bare `V1` capability-id form, while the package validator also accepts the canonical `CAPABILITY-V1` prefix.

This PR:

- **Dedupes the extension** — each of the five preview files now imports the package validator (`../../packages/diagrams/src/<notation>/validate.js`) and removes its inline function + supporting const-sets (~490 lines deleted). CLI and preview now share exactly one validator per notation, so finding parity is structural.
- **Extends the CLI dispatch** — `src/validate-notation.ts` registers all five Group B validators in `VALIDATORS`; `isFileValidatableNotation()` and `FILE_VALIDATABLE_NOTATIONS` now cover all 12 supported notations.
- **Expands tests** — `tests/validate-notation.test.ts`: corpus round-trip now runs over Group B fixtures; parity assertions added per Group B notation (CLI findings == package output); dispatch test updated to reflect the full set.

## Coverage after this PR

| Notation | Before | After |
|---|---|---|
| goals, fgca, fga, activities, activity-card, process-blueprint, blocks | CLI ✓ | CLI ✓ |
| applications, capability-map, products, scenarios, process-map | CLI — (skipped as "not-yet-covered") | **CLI ✓** |
| bpmn | IR pipeline | IR pipeline (unchanged) |

## Capability-map parity fix

The inline validator used `CAP_ID_RE = /^(V|H)\d+(\.\d+)*$/` (bare form only). The package uses `/^(CAPABILITY-)?(V|H)\d+(\.\d+)*$/` (also accepts the canonical-prefix form). After this PR the extension and CLI agree on the authoritative regex and error messages.

## Tests

- **325 core tests pass** (17 test files); validate-notation suite grows from 14 to 27 tests.
- **834 diagrams package tests pass** (56 test files).
- `compile` (tsc --noEmit) clean; `build` clean.

## Remaining on strategy#258

None — Phase B completes the issue's acceptance criteria. Group B notations move from `skipped` to covered in the repo-scope sweep once Phase A.2 (#178) merges (the sweep already calls `isFileValidatableNotation()`, which now returns true for Group B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)