### PR TITLE
fix(cli): sync Phase B follow-ups — green up repo-views test + Group-B-covered docs

### DIFF
--- a/organizations/acme_corp/AGENTS.md
+++ b/organizations/acme_corp/AGENTS.md
@@ -184,7 +184,7 @@ npx @transitrix/cli validate --scope=repo --json
 
 `--scope=repo` runs the per-notation validators over every file under `canon/views/**` (BPMN via the IR pipeline) **and** the canon cross-reference checks (referential integrity, id uniqueness, atomicity, policy) in a single invocation — the fastest way for the agent to find everything to fix.
 
-Diagram notations covered per file: `goals`, `fgca`, `fga`, `activities`, `activity-card`, `process-blueprint`, `blocks`, and `bpmn`. The remaining notations (e.g. `applications`, `capability-map`, `products`, `scenarios`, `process-map`) are reported as `skipped` (not silently passed) — validate those in the Studio preview for now.
+Diagram notations covered per file: `goals`, `fgca`, `fga`, `activities`, `activity-card`, `process-blueprint`, `blocks`, `applications`, `capability-map`, `products`, `scenarios`, `process-map`, and `bpmn`. Aggregate views that have no single-file validator (`compliance-impact`, `coverage-metric`) are reported as `skipped` (not silently passed) — validate those in the Studio preview for now.
 
 The agent does **not** commit files with `error`-level validation findings. `warning`-level findings are surfaced to the adopter and committed only with explicit acknowledgement. The agent does not auto-suppress validation rules.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -389,10 +389,11 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
       }
       return;
     }
-    // Recognised notation, but no file-scope CLI validator yet (Group B inline
-    // validators, or non-diagram views like compliance-impact). Be honest: don't
-    // claim valid and don't mis-run the BPMN path — say so and exit 0 (the file
-    // itself isn't in error), so an agent loop isn't blocked on it.
+    // Recognised notation, but no file-scope CLI validator yet — aggregate views
+    // like compliance-impact / coverage-metric that derive from other docs rather
+    // than validating standalone. Be honest: don't claim valid and don't mis-run
+    // the BPMN path — say so and exit 0 (the file itself isn't in error), so an
+    // agent loop isn't blocked on it.
     const notice =
       `notation "${probedNotation}" is not yet validated by the CLI — check it in ` +
       `the Transitrix Studio preview, or run whole-canon checks with --scope=repo.`;

--- a/src/repo-validate.ts
+++ b/src/repo-validate.ts
@@ -105,7 +105,8 @@ export interface ViewFinding {
 
 /** Combined repo-scope result: canon cross-reference findings plus per-file
  *  notation findings from canon/views/**, and the view files skipped because
- *  their notation has no file-scope CLI validator yet (Group B / non-diagram). */
+ *  their notation has no single-file validator (aggregate views like
+ *  compliance-impact / coverage-metric). */
 export interface RepoScopeResult {
   canon: RepoFinding[];
   views: ViewFinding[];

--- a/tests/repo-validate-views.test.ts
+++ b/tests/repo-validate-views.test.ts
@@ -36,11 +36,13 @@ describe('repo-scope views sweep (#258)', () => {
   beforeAll(() => {
     root = mkdtempSync(join(tmpdir(), 'tx-views-'));
     // A clean Group A file, a deliberately broken one, a BPMN file (validated via
-    // the IR pipeline), and a Group B file (no file-scope validator yet).
+    // the IR pipeline), a Group B file (now covered too, since #179), and an
+    // aggregate view (coverage-metric) that has no single-file validator → skipped.
     copyCorpus(root, 'canon/views/goals/good.goals.transitrix.yaml', 'goals/strategy-2026.goals.transitrix.yaml');
     write(root, 'canon/views/goals/bad.goals.transitrix.yaml', 'notation: goals\nid: x\nname: Bad\ngoals: []\n');
     copyCorpus(root, 'canon/views/bpmn/ok.bpmn.transitrix.yaml', 'bpmn/simple-approval.bpmn.transitrix.yaml');
     copyCorpus(root, 'canon/views/applications/p.applications.transitrix.yaml', 'applications/portfolio-2026.applications.transitrix.yaml');
+    copyCorpus(root, 'canon/views/coverage-metric/c.coverage-metric.transitrix.yaml', 'coverage-metric/eu-coverage.coverage-metric.transitrix.yaml');
   });
 
   afterAll(() => {
@@ -70,10 +72,17 @@ describe('repo-scope views sweep (#258)', () => {
     expect(findings.filter((f) => f.notation === 'bpmn' && f.severity === 'error')).toEqual([]);
   });
 
-  it('reports Group B notations as skipped, not silently passed', () => {
+  it('validates Group B notations too (covered since #179, not skipped)', () => {
     const { skipped, findings } = runViewValidate(root);
-    expect(skipped.some((s) => s.notation === 'applications')).toBe(true);
-    expect(findings.some((f) => f.notation === 'applications')).toBe(false);
+    expect(skipped.some((s) => s.notation === 'applications')).toBe(false);
+    // The corpus applications catalogue is clean → no error findings.
+    expect(findings.filter((f) => f.notation === 'applications' && f.severity === 'error')).toEqual([]);
+  });
+
+  it('reports notations with no file-scope validator as skipped, not silently passed', () => {
+    const { skipped, findings } = runViewValidate(root);
+    expect(skipped.some((s) => s.notation === 'coverage-metric')).toBe(true);
+    expect(findings.some((f) => f.notation === 'coverage-metric')).toBe(false);
   });
 
   it('runRepoValidate combines canon + views and fails on a view error', () => {
@@ -91,16 +100,18 @@ describe('repo-scope views sweep — clean tree passes (#258)', () => {
     root = mkdtempSync(join(tmpdir(), 'tx-views-clean-'));
     copyCorpus(root, 'canon/views/goals/good.goals.transitrix.yaml', 'goals/strategy-2026.goals.transitrix.yaml');
     copyCorpus(root, 'canon/views/applications/p.applications.transitrix.yaml', 'applications/portfolio-2026.applications.transitrix.yaml');
+    copyCorpus(root, 'canon/views/coverage-metric/c.coverage-metric.transitrix.yaml', 'coverage-metric/eu-coverage.coverage-metric.transitrix.yaml');
   });
 
   afterAll(() => {
     rmSync(root, { recursive: true, force: true });
   });
 
-  it('a Group B file alone does not fail the run (warnings/skips never error)', () => {
+  it('clean Group A + Group B files pass; only uncovered views are skipped', () => {
     const result = runRepoValidate(root);
     expect(result.views.filter((f) => f.severity === 'error')).toEqual([]);
     expect(repoScopeHasErrors(result)).toBe(false);
-    expect(result.skipped.some((s) => s.notation === 'applications')).toBe(true);
+    expect(result.skipped.some((s) => s.notation === 'applications')).toBe(false);
+    expect(result.skipped.some((s) => s.notation === 'coverage-metric')).toBe(true);
   });
 });


### PR DESCRIPTION
Follow-up to **#179**, which moved the Group B notations (`applications`, `capability-map`, `products`, `scenarios`, `process-map`) from `skipped` to **covered** — but left two artefacts from #178 still asserting the old behaviour.

## Why this is needed

**`main` is currently red.** `tests/repo-validate-views.test.ts` (added in #178) asserts Group B notations land in `skipped`. After #179 they validate, so two assertions fail:

```
FAIL  repo-scope views sweep > reports Group B notations as skipped
FAIL  repo-scope views sweep — clean tree passes > a Group B file alone does not fail the run
  AssertionError: expected false to be true  (skipped.some(applications))
```

## Changes (docs/tests only — no behaviour change)

- **`tests/repo-validate-views.test.ts`** — re-point the skip assertions at an aggregate view that genuinely has no single-file validator (`coverage-metric`), and add a positive case proving Group B (`applications`) is now swept, not skipped. 7 tests, green.
- **`organizations/acme_corp/AGENTS.md`** — the covered-notations list now includes all of Group B; only `compliance-impact` / `coverage-metric` are reported as `skipped`.
- **`src/cli.ts` + `src/repo-validate.ts`** — two stale comments described the not-covered branch as "Group B inline validators"; updated to "aggregate views (compliance-impact, coverage-metric)".

## Verification

- Full core suite green again: **332 passed** (single-fork; the multi-worker pool is crashing in this Windows env — infra, unrelated).
- `npm run compile` clean.
- Confirmed live: `validate --scope=repo --root organizations/acme_corp` now skips only `compliance-impact`, `coverage-metric`; Group B files are validated.

With this, the CLI notation-validation series (file-scope dispatch in #177, repo-views sweep in #178, Group B dedup in #179) is complete and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
