### PR TITLE
ci(openvsx): drop darwin-x64 (Intel macOS) from the publish matrix

### DIFF
--- a/.github/workflows/openvsx-publish.yml
+++ b/.github/workflows/openvsx-publish.yml
@@ -14,6 +14,12 @@ name: Open VSX — multi-platform publish
 #
 # win32-arm64 is not in the matrix: no GA GitHub-hosted Windows ARM runner
 # exists at time of writing. Add it when one becomes available.
+#
+# darwin-x64 (Intel macOS) is intentionally NOT in the matrix: the macos-13
+# (Intel) hosted runner is chronically unschedulable on this account (jobs sat
+# queued for ~18h), and Apple Silicon (darwin-arm64) covers current Macs. Intel
+# Mac is a shrinking segment; if it ever needs coverage, re-add a `macos-13`
+# entry or publish that target manually. Tracked on strategy #184.
 
 on:
   release:
@@ -35,8 +41,6 @@ jobs:
             target: linux-x64
           - runner: ubuntu-24.04-arm
             target: linux-arm64
-          - runner: macos-13
-            target: darwin-x64
           - runner: macos-latest
             target: darwin-arm64
           - runner: windows-latest


### PR DESCRIPTION
## What
Removes the `darwin-x64` (Intel macOS) entry from the Open VSX multi-platform publish matrix; documents the exclusion next to `win32-arm64`.

## Why
The `macos-13` (Intel) GitHub-hosted runner is chronically unschedulable on this account — `darwin-x64` jobs sat **queued ~18h** across two `workflow_dispatch` runs and never started, while every other platform finished. Apple Silicon (`darwin-arm64`) already covers current Macs; Intel Mac is a shrinking segment not worth blocking publish runs on.

## Effect
Publish matrix becomes: `linux-x64`, `linux-arm64`, `darwin-arm64`, `win32-x64` — all of which build and publish. Runs stop hanging on the unschedulable Intel runner. Re-add a `macos-13` entry (or publish that target manually) if Intel coverage is ever needed.