### PR TITLE
chore(release): cut 1.5.0 for marketplace re-publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.5.0] — 2026-06-16
+
 ### Added
 - **Open VSX CI publish workflow** — `.github/workflows/openvsx-publish.yml` runs on every GitHub Release and publishes per-platform VSIXs to Open VSX in parallel across five runners (`linux-x64`, `linux-arm64`, `darwin-x64`, `darwin-arm64`, `win32-x64`). Each runner installs the platform-specific `@resvg/resvg-js-*` native binary during `npm run extension:prep`, so every VSIX carries the correct binary for its target. `OVSX_PAT` is read from the repo Actions secret. A `workflow_dispatch` trigger allows manual re-runs. `win32-arm64` not yet in matrix (no GA GitHub-hosted Windows ARM runner). Runbook `docs/openvsx-publish-runbook.md` updated to document the CI path as the recommended sync procedure (strategy #184).
 - **`.transitrixrc` project config** — canonical replacement for `.cervinrc`. `loadTransitrixrc()` reads `.transitrixrc` first and falls back to `.cervinrc` (one-time deprecation notice) when absent; ships `transitrixrc.schema.json` (root + extension `schemas/`). `.cervinrc` keeps working through 1.x (removed in 2.0.0). Fourth phase of the Cervin → Transitrix rename (CLAUDE.md §Cervin naming, P4).

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "description": "Architecture-as-code for the modern enterprise. Author 17 notations — goals, processes, capabilities, BPMN, applications, more — as plain YAML, get live diagrams in VS Code. Diffable in git. AI-friendly. Open source. Built on ArchiMate 3.2 and BPMN 2.0.",
   "license": "MIT",
   "icon": "icon.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
Cuts **1.5.0** so today's Marketplace / Open VSX re-publish carries everything accumulated on `main` since the published **1.4.3** VSIX.

## What changed in this PR
- `package.json` + `extension/package.json`: `1.4.3 → 1.5.0` (via `scripts/bump-extension-version.mjs set 1.5.0`).
- `CHANGELOG.md`: closed `[Unreleased]` into a dated `[1.5.0] — 2026-06-16` heading; fresh empty `[Unreleased]` kept on top.

No source changes — this is a release-cut commit only.

## User-facing highlights shipping in 1.5.0
- **Collapsible red error strip** in the notation preview.
- **Per-element validators** (CHANGE / ACTOR / STAKEHOLDER / FACTOR / TARGET_STATE).
- **Notation-aware inline validation** (Group A + Group B) now shared one-for-one between the CLI `validate` path and the extension preview — parity is structural, not coincidental.
- Accumulated Cervin → Transitrix rename phases, `.transitrixrc` config, npm-package prep, and the Open VSX CI publish workflow (previously staged in `[Unreleased]`).

## Verification
- `compile` + `compile:extension` — green
- `check:no-cervin-yaml` + `verify-extension-packaging` — green
- core + diagrams suites — green (834 diagrams tests)

## Notes
- Compliance render (hub #252) is **not** in this release — it is date-gated to after the 2026-06-17 demo and depends on T1/T3.
- Heads-up for the publish step: `npm run package-extension` runs a `patch` `bump-extension-version` of its own; with the version already at 1.5.0 it would bump to 1.5.1 before packaging. Package/publish from this committed 1.5.0 accordingly (or skip the auto-bump) so the VSIX version matches the CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)