### PR TITLE
fix(preview): make the error strip actually collapse in static previews

### DIFF
--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -156,18 +156,28 @@ const FIX_PROMPT_CSS = `
 `;
 
 // Collapsible error strip (vkgeorgia/strategy view-testing idea). Mirrors the
-// `.tx-ctl` controls panel look so the preview reads consistently: a native
-// <details>/<summary> with the same arrow marker. Native <details> needs no
-// script, so the strip collapses in static (enableScripts: false) previews too.
-// Open by default — a hard error must never be silently folded away; the user
-// can collapse it once read to get the diagram canvas back.
+// `.tx-ctl` controls panel look so the preview reads consistently.
+//
+// Collapse is driven by a hidden checkbox + a <label> summary + a `:checked ~`
+// sibling selector — the SAME CSS-only mechanism the Title toggle and Zoom
+// control use (see TITLE_TOGGLE_CSS / ZOOM_CONTROL_CSS). A previous revision
+// used a native <details>/<summary>, but that did not collapse in the static
+// (`enableScripts: false`) previews where the strip most often appears, so the
+// strip is wired the same script-free way as every other preview affordance.
+//
+// Expanded by default — a hard error must never be silently folded away; the
+// user clicks the summary to fold it once read and reclaim the canvas. The
+// checkbox sits at the top of <body> (off-screen but focusable) so the general
+// sibling combinator reaches the strip wherever it renders.
 const ERROR_BLOCK_CSS = `
+.tx-err-toggle-cb{position:absolute;left:-9999px;width:1px;height:1px;opacity:0;}
 .tx-err{margin:8px 16px;border:1px solid var(--vscode-inputValidation-errorBorder,var(--vscode-errorForeground,#b91c1c));border-radius:6px;}
-.tx-err > summary{cursor:pointer;user-select:none;list-style:none;padding:6px 10px;font-size:12px;font-weight:600;color:var(--vscode-errorForeground,#b91c1c);}
-.tx-err > summary::-webkit-details-marker{display:none;}
-.tx-err > summary::before{content:"\\25B8\\00a0";}
-.tx-err[open] > summary::before{content:"\\25BE\\00a0";}
-.tx-err > pre{margin:0;color:var(--vscode-errorForeground,#b91c1c);white-space:pre-wrap;padding:2px 16px 12px;}
+.tx-err-summary{display:block;cursor:pointer;user-select:none;padding:6px 10px;font-size:12px;font-weight:600;color:var(--vscode-errorForeground,#b91c1c);}
+.tx-err-summary::before{content:"\\25BE\\00a0";}
+.tx-err-toggle-cb:checked ~ .tx-err .tx-err-summary::before{content:"\\25B8\\00a0";}
+.tx-err-toggle-cb:focus-visible ~ .tx-err .tx-err-summary{outline:1px dashed var(--vscode-errorForeground,#b91c1c);outline-offset:2px;}
+.tx-err-body{margin:0;color:var(--vscode-errorForeground,#b91c1c);white-space:pre-wrap;padding:2px 16px 12px;}
+.tx-err-toggle-cb:checked ~ .tx-err .tx-err-body{display:none;}
 `;
 
 const FRAME_HEADER_CSS = `
@@ -331,11 +341,16 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
   // `v.errors.map(...).join('\n')`); a bare parse failure is a single line.
   // Counting non-empty lines gives a meaningful summary count for both.
   const errCount = errorMsg ? errorMsg.split('\n').filter(l => l.trim() !== '').length : 0;
+  // Hidden checkbox drives the CSS-only collapse (see ERROR_BLOCK_CSS); only
+  // emitted alongside an actual error so there's no orphan control.
+  const errToggleInput = errorMsg
+    ? `<input type="checkbox" id="ts-err-toggle" class="tx-err-toggle-cb">`
+    : '';
   const errBlock = errorMsg
-    ? `<details class="tx-err" open>
-  <summary>⚠ ${errCount === 1 ? '1 error' : `${errCount} errors`}</summary>
-  <pre>${escXml(errorMsg)}</pre>
-</details>`
+    ? `<div class="tx-err">
+  <label for="ts-err-toggle" class="tx-err-summary">⚠ ${errCount === 1 ? '1 error' : `${errCount} errors`}</label>
+  <pre class="tx-err-body">${escXml(errorMsg)}</pre>
+</div>`
     : '';
 
   const fixPromptBlock = fixPrompt
@@ -453,6 +468,7 @@ ${extraStyles}
 <body data-theme="${escXml(themeId)}">
   ${toggleInput}
   ${zoomInputs}
+  ${errToggleInput}
   <div id="toolbar"><span class="toolbar-label">${escXml(notation)}: ${escXml(filename)}</span>${toolbarRight}</div>
   ${controlsPanel}
   ${errBlock}${fixPromptBlock}${warnBlock}

--- a/tests/diagram-frame.test.ts
+++ b/tests/diagram-frame.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { buildDiagramFrame } from '../extension/src/diagram-frame.js';
+
+// The shared preview shell. `buildDiagramFrame` is a pure string builder (no
+// `vscode`), so the error-strip markup/CSS contract is testable here.
+
+const base = { filename: 'demo.goals.transitrix.yaml', notation: 'Goal tree' };
+
+describe('buildDiagramFrame error strip', () => {
+  it('renders a collapsible error strip driven by the CSS-only checkbox+label', () => {
+    const html = buildDiagramFrame({
+      ...base,
+      svgContent: '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"></svg>',
+      errorMsg: 'GL-001: broke\nGL-002: also broke',
+    });
+    // Hidden checkbox + label summary + body — the same script-free mechanism
+    // the Title/Zoom toggles use, so it collapses in enableScripts:false
+    // previews (a native <details> did not).
+    expect(html).toContain('<input type="checkbox" id="ts-err-toggle" class="tx-err-toggle-cb">');
+    expect(html).toContain('<label for="ts-err-toggle" class="tx-err-summary">');
+    expect(html).toContain('class="tx-err-body"');
+    // The `:checked ~` sibling rule that actually folds the body away.
+    expect(html).toContain('.tx-err-toggle-cb:checked ~ .tx-err .tx-err-body{display:none;}');
+    // The old native-<details> strip (which didn't collapse in static previews) is gone.
+    expect(html).not.toContain('<details class="tx-err"');
+    expect(html).toContain('2 errors');
+  });
+
+  it('counts a single error as "1 error"', () => {
+    const html = buildDiagramFrame({ ...base, errorMsg: 'GL-001: just one' });
+    expect(html).toContain('1 error<');
+  });
+
+  it('emits no error control when there is no error', () => {
+    const html = buildDiagramFrame({ ...base, svgContent: '<svg/>' });
+    // The CSS lives in the <style> block unconditionally; assert no error
+    // *markup* (the checkbox control + the strip div) is emitted.
+    expect(html).not.toContain('ts-err-toggle');
+    expect(html).not.toContain('<div class="tx-err">');
+  });
+});


### PR DESCRIPTION
## Problem

Testing 1.5.0: in view-notation previews the red error strip **doesn't collapse** when you click its header.

The collapsible strip (PR #176) used a native `<details>`/`<summary>` and assumed it would toggle without scripts. But the view-notation previews are created with `enableScripts: false`, and in that script-less context clicking the summary didn't fold the error away — the strip just stayed open.

## Fix

Rewire the strip with the **same script-free mechanism the Title toggle and Zoom control already use** in these previews: a hidden checkbox + a `<label>` summary + a `:checked ~ .tx-err .tx-err-body { display:none }` sibling rule.

- `label`↔`checkbox` association and the sibling selector are pure HTML/CSS — no scripting — so the strip collapses in **both** static (`enableScripts:false`) and interactive previews.
- Expanded by default is preserved (a hard error is never silently folded); clicking the summary folds it once read.
- The checkbox is emitted only when an error is present, so clean renders carry no orphan control.

## Verification

- Reproduced the CSS mechanism in Chromium (the webview engine): `getComputedStyle('.tx-err-body').display` flips `block → none` when the checkbox is checked (i.e. when the label is clicked).
- New `tests/diagram-frame.test.ts` pins the markup/CSS contract (`buildDiagramFrame` is a pure string builder, no `vscode`).
- `npm run test:core` green (335); `tsc -p extension` clean.

## Notes

- Native `<details>` is still used elsewhere (catalogue previews, the `.tx-ctl` controls panel) and is left as-is — those either run with scripts or keep the default marker; only the error strip needed the script-free treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)