### PR TITLE
fix(preview): group validation warnings into a collapsible strip

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Transitrix Studio — changelog
 
+## Unreleased
+
+### Changed
+
+- **Validation warnings now collapse.** The preview's non-fatal warning advisories (e.g. ACT-011 "no duration", ACT-019 "Gantt view will not render") are grouped into one collapsible strip with a count ("N warnings") and start **collapsed**, so they no longer crowd the diagram. Click the summary to expand. Folds with no scripting, like the error strip.
+
+### Fixed
+
+- **Error strip collapses in static previews.** The red "N errors" strip now folds when its summary is clicked in every notation preview; it previously stayed open in the `enableScripts: false` (static) previews because it relied on a native `<details>`.
+
 ## 1.5.0 — 2026-06-16
 
 Sharper in-editor validation, a tidier error strip, and the Cervin → Transitrix settings/command rename.

--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -180,6 +180,24 @@ const ERROR_BLOCK_CSS = `
 .tx-err-toggle-cb:checked ~ .tx-err .tx-err-body{display:none;}
 `;
 
+// Collapsible warnings strip. Same script-free checkbox+label+`:checked ~`
+// mechanism as the error strip, in the warning colour. Non-fatal advisories
+// (e.g. ACT-011 "no duration", ACT-019 "Gantt view will not render") can pile
+// up and crowd the canvas, so — unlike the error strip — this one is COLLAPSED
+// by default (checkbox starts `checked`); the count stays visible in the
+// summary and the user expands to read.
+const WARN_BLOCK_CSS = `
+.tx-warn-toggle-cb{position:absolute;left:-9999px;width:1px;height:1px;opacity:0;}
+.tx-warn{margin:8px 16px;border:1px solid var(--vscode-editorWarning-foreground,#c07030);border-radius:6px;}
+.tx-warn-summary{display:block;cursor:pointer;user-select:none;padding:6px 10px;font-size:12px;font-weight:600;color:var(--vscode-editorWarning-foreground,#c07030);}
+.tx-warn-summary::before{content:"\\25BE\\00a0";}
+.tx-warn-toggle-cb:checked ~ .tx-warn .tx-warn-summary::before{content:"\\25B8\\00a0";}
+.tx-warn-toggle-cb:focus-visible ~ .tx-warn .tx-warn-summary{outline:1px dashed var(--vscode-editorWarning-foreground,#c07030);outline-offset:2px;}
+.tx-warn-body{padding:0 6px 8px;}
+.tx-warn-item{color:var(--vscode-editorWarning-foreground,#c07030);font-size:11px;padding:2px 12px;}
+.tx-warn-toggle-cb:checked ~ .tx-warn .tx-warn-body{display:none;}
+`;
+
 const FRAME_HEADER_CSS = `
 .frame-header{padding:16px 20px 20px;}
 .frame-title{font-size:18px;font-weight:700;color:var(--ts-text,#0f172a);margin-bottom:4px;}
@@ -360,10 +378,16 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
 </div>`
     : '';
 
+  // Warnings collapse via the same hidden-checkbox mechanism, but start
+  // COLLAPSED (checkbox `checked`) — advisories shouldn't crowd the canvas.
+  const warnToggleInput = warnings.length > 0
+    ? `<input type="checkbox" id="ts-warn-toggle" class="tx-warn-toggle-cb" checked>`
+    : '';
   const warnBlock = warnings.length > 0
-    ? warnings.map(w =>
-        `<div style="color:#c07030;font-size:11px;padding:2px 12px;">${escXml(w)}</div>`
-      ).join('')
+    ? `<div class="tx-warn">
+  <label for="ts-warn-toggle" class="tx-warn-summary">⚠ ${warnings.length === 1 ? '1 warning' : `${warnings.length} warnings`}</label>
+  <div class="tx-warn-body">${warnings.map(w => `<div class="tx-warn-item">${escXml(w)}</div>`).join('')}</div>
+</div>`
     : '';
 
   const metaParts = [version ? `v${escXml(version)}` : null, date ? escXml(date) : null].filter(Boolean);
@@ -458,6 +482,7 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
 ${generateWebviewCss(themeId)}
 ${FIX_PROMPT_CSS}
 ${ERROR_BLOCK_CSS}
+${WARN_BLOCK_CSS}
 ${FRAME_HEADER_CSS}
 ${TITLE_TOGGLE_CSS}
 ${ZOOM_CONTROL_CSS}
@@ -469,6 +494,7 @@ ${extraStyles}
   ${toggleInput}
   ${zoomInputs}
   ${errToggleInput}
+  ${warnToggleInput}
   <div id="toolbar"><span class="toolbar-label">${escXml(notation)}: ${escXml(filename)}</span>${toolbarRight}</div>
   ${controlsPanel}
   ${errBlock}${fixPromptBlock}${warnBlock}

--- a/tests/diagram-frame.test.ts
+++ b/tests/diagram-frame.test.ts
@@ -39,3 +39,39 @@ describe('buildDiagramFrame error strip', () => {
     expect(html).not.toContain('<div class="tx-err">');
   });
 });
+
+describe('buildDiagramFrame warnings strip', () => {
+  it('renders warnings in a collapsible strip, collapsed by default', () => {
+    const html = buildDiagramFrame({
+      ...base,
+      svgContent: '<svg/>',
+      warnings: ['ACT-011: no duration', 'ACT-019: Gantt will not render'],
+    });
+    // Same checkbox+label mechanism as the error strip — but `checked` so the
+    // strip starts collapsed (advisories shouldn't crowd the canvas).
+    expect(html).toContain('<input type="checkbox" id="ts-warn-toggle" class="tx-warn-toggle-cb" checked>');
+    expect(html).toContain('<label for="ts-warn-toggle" class="tx-warn-summary">');
+    expect(html).toContain('.tx-warn-toggle-cb:checked ~ .tx-warn .tx-warn-body{display:none;}');
+    // Each warning is an item inside the collapsible body, count in the summary.
+    expect(html).toContain('2 warnings');
+    expect(html).toContain('<div class="tx-warn-item">ACT-011: no duration</div>');
+    // The old flat, un-collapsible inline-styled divs are gone.
+    expect(html).not.toContain('style="color:#c07030');
+  });
+
+  it('counts a single warning as "1 warning"', () => {
+    const html = buildDiagramFrame({ ...base, svgContent: '<svg/>', warnings: ['only one'] });
+    expect(html).toContain('1 warning<');
+  });
+
+  it('emits no warnings control when there are no warnings', () => {
+    const html = buildDiagramFrame({ ...base, svgContent: '<svg/>' });
+    expect(html).not.toContain('ts-warn-toggle');
+    expect(html).not.toContain('<div class="tx-warn">');
+  });
+
+  it('escapes warning text', () => {
+    const html = buildDiagramFrame({ ...base, svgContent: '<svg/>', warnings: ['<script>x</script>'] });
+    expect(html).toContain('&lt;script&gt;x&lt;/script&gt;');
+  });
+});


### PR DESCRIPTION
## What the screenshot showed

The "red error messages that won't collapse" turned out to be **warnings**, not errors — orange advisories (`ACT-011: … has no duration`, `ACT-019: Gantt view will not render…`) in the Activities preview. The document is valid; there's no error strip.

`#185` made the **error** strip collapsible, but **warnings** (`warnBlock`) were rendered as a flat list of inline-styled `<div>`s with **no fold control at all** — so they piled up above the diagram and could never be collapsed.

## Fix

Group warnings into one collapsible strip using the **same script-free mechanism** as the error strip (hidden checkbox + `<label>` summary + `:checked ~ .tx-warn .tx-warn-body { display:none }`), in the warning colour.

- Unlike errors, the strip starts **collapsed** (checkbox `checked`) with the count in the summary (`N warnings`) — advisories shouldn't crowd the canvas; click to expand.
- No scripting, so it folds in static (`enableScripts: false`) previews too.

## Verification

- Chromium: `.tx-warn-body` computed display is `none` by default and flips to `block` when the box is unchecked (label clicked).
- `tests/diagram-frame.test.ts` extended with the warnings-strip contract (collapsed-by-default markup, count, escaping, absence when no warnings).
- `npm run test:core` green (339); `tsc -p extension` clean.

## Changelog

Adds an Unreleased section documenting this change **and** the post-1.5.0 error-strip collapse fix (#185), which wasn't yet in the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)