### PR TITLE
chore(release): cut 1.5.1

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Transitrix Studio — changelog
 
-## Unreleased
+## 1.5.1 — 2026-06-16
+
+Tidier preview strips: validation warnings now collapse, and the error strip folds in static previews too.
 
 ### Changed
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Architecture-as-code for the modern enterprise. Author 17 notations — goals, processes, capabilities, BPMN, applications, more — as plain YAML, get live diagrams in VS Code. Diffable in git. AI-friendly. Open source. Built on ArchiMate 3.2 and BPMN 2.0.",
   "license": "MIT",
   "icon": "icon.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
## Release 1.5.1

Promotes the CHANGELOG `Unreleased` section to a dated **1.5.1** and bumps the version in `extension/package.json` + root `package.json` (1.5.0 → 1.5.1, via `scripts/bump-extension-version.mjs set 1.5.1`).

### What ships in 1.5.1

Post-1.5.0 preview fixes:
- **Collapsible validation-warnings strip** (#187) — warnings group into one collapsible strip, collapsed by default.
- **Error strip folds in static previews** (#185) — the red "N errors" strip now collapses on click in `enableScripts: false` previews.

### After merge — publish

Per [`docs/vscode-marketplace-publish-runbook.md`](docs/vscode-marketplace-publish-runbook.md), publishing a **GitHub Release tagged `v1.5.1`** triggers `.github/workflows/vscode-marketplace-publish.yml`, which runs `vsce publish` across the platform matrix (win32-x64, darwin-arm64, linux-x64, linux-arm64). Open VSX is a separate workflow.

I have **not** created the tag/Release — that outward-facing publish step is yours to trigger (or confirm and I'll create it after this merges).

### Checks

- `tsc --noEmit` (root + extension) clean; `npm run test:core` green (339).

### Note

The Activity Card fields (#184) are currently listed under the **1.5.0** changelog section. Since marketplace 1.5.0 was tagged before #184 merged, those fields actually first reach users in 1.5.1. Left the 1.5.0 section as-is to avoid rewriting released history — say the word if you'd like them moved/duplicated under 1.5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)