### PR TITLE
feat(preview): entryCurvature — independent arrow entry control (1.5.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [1.5.2] — 2026-06-16
+
+### Added
+- **`transitrix.entryCurvature.<notation>` settings** — independent control over the arrow curvature at the point it enters a target node (`goals`, `fgca`, `fga`, `activities`). Previously the single `curvature` multiplier was applied symmetrically to both the exit and entry control handles; at low `curvature` values this caused the arrival curve to look cramped, especially on edges with large vertical spans. Setting `entryCurvature` higher than `curvature` (e.g. `curvature: 0.4`, `entryCurvature: 1.2`) gives a gentle exit while keeping the arrival smooth. Defaults to `1`; when equal to `curvature`, behaviour is identical to the previous release.
+
 ## [1.5.0] — 2026-06-16
 
 ### Added

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Architecture-as-code for the modern enterprise. Author 17 notations — goals, processes, capabilities, BPMN, applications, more — as plain YAML, get live diagrams in VS Code. Diffable in git. AI-friendly. Open source. Built on ArchiMate 3.2 and BPMN 2.0.",
   "license": "MIT",
   "icon": "icon.png",
@@ -187,6 +187,34 @@
           "maximum": 3,
           "default": 1,
           "description": "Activities preview: CPM dependency-arrow curvature. 0 = straight lines, 1 = default, higher = stronger arc."
+        },
+        "transitrix.entryCurvature.goals": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 3,
+          "default": 1,
+          "description": "Goals preview: curvature of the arrow at the point it enters a node. Defaults to transitrix.curvature.goals when equal to 1."
+        },
+        "transitrix.entryCurvature.fgca": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 3,
+          "default": 1,
+          "description": "FGCA preview: curvature of the arrow at the point it enters a node. Defaults to transitrix.curvature.fgca when equal to 1."
+        },
+        "transitrix.entryCurvature.fga": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 3,
+          "default": 1,
+          "description": "FGA preview: curvature of the arrow at the point it enters a node. Defaults to transitrix.curvature.fga when equal to 1."
+        },
+        "transitrix.entryCurvature.activities": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 3,
+          "default": 1,
+          "description": "Activities preview: curvature of the dependency arrow at the point it enters an activity node. Defaults to transitrix.curvature.activities when equal to 1."
         },
         "transitrix.scope.goals.rootId": {
           "type": "string",

--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -18,7 +18,7 @@ import {
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 import { horizontalCubicEdgePath, DEFAULT_EDGE_CURVATURE } from '../../packages/diagrams/src/edge-path.js';
 import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
-import { readSpacing, readCurvature, applyControlMessage, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND } from './spacing-config.js';
+import { readSpacing, readCurvature, readEntryCurvature, applyControlMessage, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND } from './spacing-config.js';
 import { genNonce, buildControlsPanel, buildControlsScript } from './preview-controls.js';
 
 // Default network (PSND) gaps — must match the layoutActivities defaults
@@ -45,7 +45,7 @@ const N_NODE_W = 200;
 const N_NODE_H = 80;
 const N_PAD = 24;
 
-function networkSvg(doc: ActivityDoc, gaps: ActivitiesLayoutOptions = {}, curvature: number = DEFAULT_EDGE_CURVATURE, heading?: string, filename?: string, date?: string, version?: string): string {
+function networkSvg(doc: ActivityDoc, gaps: ActivitiesLayoutOptions = {}, curvature: number = DEFAULT_EDGE_CURVATURE, entryCurvature?: number, heading?: string, filename?: string, date?: string, version?: string): string {
   const layout: ActivitiesLayout = layoutActivities(doc, gaps);
   if (layout.nodes.length === 0) {
     return '<svg xmlns="http://www.w3.org/2000/svg" width="200" height="60"><text class="text-primary" x="10" y="40">No activities</text></svg>';
@@ -82,7 +82,7 @@ function networkSvg(doc: ActivityDoc, gaps: ActivitiesLayoutOptions = {}, curvat
     const ty = t.y + oy + t.height / 2;
     const cls = e.isCritical ? 'diagram-edge critical-edge' : 'diagram-edge';
     const marker = `url(#${e.isCritical ? 'arrow-crit' : 'arrow'})`;
-    return `<path d="${horizontalCubicEdgePath(sx, sy, tx, ty, curvature)}" class="${cls}" marker-end="${marker}"/>`;
+    return `<path d="${horizontalCubicEdgePath(sx, sy, tx, ty, curvature, entryCurvature)}" class="${cls}" marker-end="${marker}"/>`;
   }).join('\n');
 
   const nodeSvg = layout.nodes.map(n => {
@@ -424,9 +424,9 @@ interface ActivityViews {
   ganttSvg: string;
 }
 
-function buildActivityViews(doc: ActivityDoc, gaps: ActivitiesLayoutOptions, curvature: number, filename: string, date: string, version?: string): ActivityViews {
+function buildActivityViews(doc: ActivityDoc, gaps: ActivitiesLayoutOptions, curvature: number, entryCurvature: number | undefined, filename: string, date: string, version?: string): ActivityViews {
   const networkHeading = 'Network view — Project Schedule Network Diagram (PSND)';
-  const networkSvgStr = networkSvg(doc, gaps, curvature, networkHeading, filename, date, version);
+  const networkSvgStr = networkSvg(doc, gaps, curvature, entryCurvature, networkHeading, filename, date, version);
   const gantt: GanttResult = computeGanttLayout(doc);
 
   // Mirror titleBlockSvg's date line: `v{version} · {date}` when version is set.
@@ -612,6 +612,7 @@ export class ActivitiesPreview {
     const spacingDefaults = { horizontalGap: ACTIVITIES_DEFAULT_H_GAP, verticalGap: ACTIVITIES_DEFAULT_V_GAP };
     const spacing = readSpacing('activities', spacingDefaults);
     const curvature = readCurvature('activities');
+    const entryCurvature = readEntryCurvature('activities');
 
     try {
       const parsed = coerceDatesToIsoStrings(yaml.load(yamlText) as unknown);
@@ -627,7 +628,7 @@ export class ActivitiesPreview {
       if (!v.valid) {
         errorMsg = v.errors.map(e => `${e.code}: ${e.message}`).join('\n');
       } else {
-        const views = buildActivityViews(parsed as ActivityDoc, { horizontalGap: spacing.horizontalGap, verticalGap: spacing.verticalGap }, curvature, filename, docDate, docVersion);
+        const views = buildActivityViews(parsed as ActivityDoc, { horizontalGap: spacing.horizontalGap, verticalGap: spacing.verticalGap }, curvature, entryCurvature, filename, docDate, docVersion);
         bodyContent = buildCanvasContent(views);
         this.lastNetworkSvg = views.networkSvg;
         this.lastGanttSvg = views.ganttSvg;

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -34,6 +34,7 @@ import {
   SPACING_CONFIG_SECTION,
   OPEN_CURVATURE_SETTINGS_COMMAND,
   CURVATURE_CONFIG_SECTION,
+  ENTRY_CURVATURE_CONFIG_SECTION,
   OPEN_SCOPE_SETTINGS_COMMAND,
   SCOPE_CONFIG_SECTION,
   VIEW_CONFIG_SECTION,
@@ -404,6 +405,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       if (
         !e.affectsConfiguration(SPACING_CONFIG_SECTION) &&
         !e.affectsConfiguration(CURVATURE_CONFIG_SECTION) &&
+        !e.affectsConfiguration(ENTRY_CURVATURE_CONFIG_SECTION) &&
         !e.affectsConfiguration(SCOPE_CONFIG_SECTION) &&
         !e.affectsConfiguration(VIEW_CONFIG_SECTION)
       ) return;

--- a/extension/src/fgca-preview.ts
+++ b/extension/src/fgca-preview.ts
@@ -18,7 +18,7 @@ import { buildChainTable, type ChainTable, type ChainColumn } from '../../packag
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 import { checkScopeRoot, type Scope } from '../../packages/diagrams/src/scope.js';
 import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
-import { readSpacing, readCurvature, readScope, readView, applyControlMessage, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND } from './spacing-config.js';
+import { readSpacing, readCurvature, readEntryCurvature, readScope, readView, applyControlMessage, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND } from './spacing-config.js';
 import { genNonce, buildControlsPanel, buildControlsScript, buildViewToggle, type ControlsModel, type ScopeGoalOption } from './preview-controls.js';
 
 // ── Inline render types ─────────────────────────────────────────────────────
@@ -190,6 +190,7 @@ function renderChainPreview(
   const gaps = readSpacing(p.viewNotation, spacingDefaults);
   const scope = readScope(p.viewNotation);
   const curvature = readCurvature(p.viewNotation);
+  const entryCurvature = readEntryCurvature(p.viewNotation);
   const warnings = [...baseWarnings];
   let svg = '';
   let goalOptions: ScopeGoalOption[] = [];
@@ -198,7 +199,7 @@ function renderChainPreview(
     ({ goals: goalOptions, maxLevelPresent } = scopeInputsFromDoc(parsedDoc));
     const scopeWarning = checkScopeRoot(scope, parsedDoc.goals.map(g => g.id));
     if (scopeWarning) warnings.push(`${scopeWarning.code}: ${scopeWarning.message}`);
-    svg = buildSvg(parsedDoc, p.hideChanges, { colGap: gaps.horizontalGap, rowGap: gaps.verticalGap, curvature, scope }, p.heading, filename, docDate, docVersion);
+    svg = buildSvg(parsedDoc, p.hideChanges, { colGap: gaps.horizontalGap, rowGap: gaps.verticalGap, curvature, entryCurvature, scope }, p.heading, filename, docDate, docVersion);
   }
   const model = fgcaControlsModel(gaps, spacingDefaults, curvature, scope, goalOptions, maxLevelPresent);
   const html = buildDiagramFrame({
@@ -217,13 +218,14 @@ function renderChainPreview(
 function buildSvg(
   doc: FGCADoc,
   hideChanges = false,
-  opts: { colGap?: number; rowGap?: number; curvature?: number; scope?: Scope } = {},
+  opts: { colGap?: number; rowGap?: number; curvature?: number; entryCurvature?: number; scope?: Scope } = {},
   heading?: string,
   filename?: string,
   date?: string,
   version?: string,
 ): string {
   const curvature = opts.curvature ?? DEFAULT_EDGE_CURVATURE;
+  const entryCurvature = opts.entryCurvature;
   const { nodes, edges, columns, width, height } = layoutFGCAPreview(doc, {
     hideChanges,
     colGap: opts.colGap,
@@ -244,7 +246,7 @@ function buildSvg(
   // @transitrix/diagrams). `curvature` scales the handle length: 1 = default,
   // 0 = straight, higher = stronger arc (vkgeorgia/strategy#76).
   const edgeSvg = edges.map(e =>
-    `<path d="${horizontalCubicEdgePath(e.sx, e.sy, e.tx, e.ty, curvature)}" class="diagram-edge" marker-end="url(#arrow)"/>`
+    `<path d="${horizontalCubicEdgePath(e.sx, e.sy, e.tx, e.ty, curvature, entryCurvature)}" class="diagram-edge" marker-end="url(#arrow)"/>`
   ).join('\n');
 
   const nodeSvg = nodes.map(n => {

--- a/extension/src/goals-preview.ts
+++ b/extension/src/goals-preview.ts
@@ -13,7 +13,7 @@ import { parseCanonicalGoals } from '../../packages/diagrams/src/goals/parse-can
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 import { horizontalCubicEdgePath, DEFAULT_EDGE_CURVATURE } from '../../packages/diagrams/src/edge-path.js';
 import { checkScopeRoot } from '../../packages/diagrams/src/scope.js';
-import { readSpacing, readCurvature, readScope, applyControlMessage, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND } from './spacing-config.js';
+import { readSpacing, readCurvature, readEntryCurvature, readScope, applyControlMessage, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND } from './spacing-config.js';
 import { genNonce, buildControlsPanel, buildControlsScript, type ControlsModel, type ScopeGoalOption } from './preview-controls.js';
 
 // ── SVG renderer ─────────────────────────────────────────────────────────────
@@ -33,7 +33,7 @@ function escXml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
 
-function layoutToSvg(layout: GoalTreeLayout, treeName: string, filename?: string, date?: string, version?: string, curvature: number = DEFAULT_EDGE_CURVATURE): string {
+function layoutToSvg(layout: GoalTreeLayout, treeName: string, filename?: string, date?: string, version?: string, curvature: number = DEFAULT_EDGE_CURVATURE, entryCurvature?: number): string {
   const pad = 24;
   const showTitle = filename != null && date != null;
   const titleH = showTitle ? TITLE_BLOCK_H : 0;
@@ -55,7 +55,7 @@ function layoutToSvg(layout: GoalTreeLayout, treeName: string, filename?: string
     const sy = s.y + oy + s.height / 2;
     const tx = t.x + ox;
     const ty = t.y + oy + t.height / 2;
-    return horizontalCubicEdgePath(sx, sy, tx, ty, curvature);
+    return horizontalCubicEdgePath(sx, sy, tx, ty, curvature, entryCurvature);
   }
 
   const edgeSvg = layout.edges.map(e =>
@@ -156,6 +156,7 @@ export class GoalsPreview {
     const gaps = readSpacing('goals', spacingDefaults);
     const scope = readScope('goals');
     const curvature = readCurvature('goals');
+    const entryCurvature = readEntryCurvature('goals');
     // Populated on a successful parse — feeds the scope root-picker dropdown
     // and the level-cap upper bound in the interactive control panel.
     let goalOptions: ScopeGoalOption[] = [];
@@ -183,7 +184,7 @@ export class GoalsPreview {
           nodeSep: gaps.verticalGap,
           scope,
         });
-        svgContent = layoutToSvg(layout, treeName, filename, docDate, docVersion, curvature);
+        svgContent = layoutToSvg(layout, treeName, filename, docDate, docVersion, curvature, entryCurvature);
       }
     } catch (e) {
       errorMsg = (e as Error).message ?? 'Parse error';

--- a/extension/src/preview-controls.ts
+++ b/extension/src/preview-controls.ts
@@ -64,7 +64,7 @@ export interface ControlsModel {
 /** Message posted from the webview to the host on every control change. */
 export interface ControlMessage {
   type: 'transitrix:control';
-  control: 'spacing' | 'curvature' | 'scope' | 'view';
+  control: 'spacing' | 'curvature' | 'entryCurvature' | 'scope' | 'view';
   /** spacing: 'horizontalGap'|'verticalGap'; scope: 'rootId'|'maxLevel'|'reset'; view: 'tree'|'table'; absent for curvature. */
   field?: 'horizontalGap' | 'verticalGap' | 'rootId' | 'maxLevel' | 'reset' | 'tree' | 'table';
   /** Numeric for spacing/curvature/maxLevel; string for rootId; absent for reset/view. */

--- a/extension/src/spacing-config.ts
+++ b/extension/src/spacing-config.ts
@@ -54,6 +54,17 @@ export const CURVATURE_CONFIG_SECTION = 'transitrix.curvature';
 /** Command that opens Settings filtered to the curvature controls. */
 export const OPEN_CURVATURE_SETTINGS_COMMAND = 'transitrixStudio.openCurvatureSettings';
 
+// Must match DEFAULT_EDGE_CURVATURE so an unconfigured preview is visually unchanged.
+const DEFAULT_ENTRY_CURVATURE = 1;
+
+/** Reads the user's configured entry curvature for a notation (default 1 = same as exit). */
+export function readEntryCurvature(notation: CurvatureNotation): number {
+  return vscode.workspace.getConfiguration('transitrix').get<number>(`entryCurvature.${notation}`, DEFAULT_ENTRY_CURVATURE);
+}
+
+/** Config section that, when changed, re-renders curvature-aware previews. */
+export const ENTRY_CURVATURE_CONFIG_SECTION = 'transitrix.entryCurvature';
+
 // ── Scope filter (vkgeorgia/strategy#77) ────────────────────────────────────
 //
 // Trim a preview to a subtree root or a level cap. Same PR1 persistence
@@ -132,6 +143,10 @@ export async function applyControlMessage(notation: SpacingNotation, msg: Contro
   }
   if (msg.control === 'curvature') {
     await cfg.update(`curvature.${notation}`, clamp(Number(msg.value), 0, 3), target);
+    return;
+  }
+  if (msg.control === 'entryCurvature') {
+    await cfg.update(`entryCurvature.${notation}`, clamp(Number(msg.value), 0, 3), target);
     return;
   }
   if (msg.control === 'view' && (notation === 'fgca' || notation === 'fga')) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/diagrams/src/__tests__/edge-path.test.ts
+++ b/packages/diagrams/src/__tests__/edge-path.test.ts
@@ -43,4 +43,16 @@ describe('horizontalCubicEdgePath', () => {
     const d = horizontalCubicEdgePath(0, 0, 0, 200, 1);
     expect(d).toBe('M0,0 C160,0 -160,200 0,200');
   });
+
+  it('entryCurvature independently scales the arrival handle', () => {
+    // exit handle = max(64,20,0)*1 = 64; entry handle = max(64,20,0)*2 = 128.
+    const d = horizontalCubicEdgePath(0, 0, 40, 0, 1, 2);
+    expect(d).toBe(`M0,0 C${EDGE_MIN_HANDLE},0 ${40 - EDGE_MIN_HANDLE * 2},0 40,0`);
+  });
+
+  it('omitting entryCurvature gives symmetric handles (historical behaviour)', () => {
+    expect(horizontalCubicEdgePath(0, 0, 40, 0, 0.5)).toBe(
+      horizontalCubicEdgePath(0, 0, 40, 0, 0.5, 0.5),
+    );
+  });
 });

--- a/packages/diagrams/src/edge-path.ts
+++ b/packages/diagrams/src/edge-path.ts
@@ -24,10 +24,14 @@ export const DEFAULT_EDGE_CURVATURE = 1;
  * Builds the SVG `d` for a horizontal-tangent cubic Bézier from (sx,sy) to
  * (tx,ty).
  *
- * `curvature` scales the control-handle length:
- *   - 0   → control points collapse onto the endpoints ⇒ a straight line.
+ * `curvature` scales the exit control-handle (departure from source).
+ * `entryCurvature` scales the entry control-handle (arrival at target);
+ * defaults to `curvature` when omitted so callers that pass one value get
+ * symmetric handles (the historical behaviour).
+ *
+ *   - 0   → handle collapses onto its endpoint ⇒ straight at that end.
  *   - 1   → the historical curve (no visual change from before #76).
- *   - >1  → progressively stronger arc.
+ *   - >1  → progressively stronger arc at that end.
  */
 export function horizontalCubicEdgePath(
   sx: number,
@@ -35,10 +39,12 @@ export function horizontalCubicEdgePath(
   tx: number,
   ty: number,
   curvature: number = DEFAULT_EDGE_CURVATURE,
+  entryCurvature?: number,
 ): string {
   const dx = tx - sx;
   const dy = ty - sy;
   const baseHandle = Math.max(EDGE_MIN_HANDLE, Math.abs(dx) * DX_FACTOR, Math.abs(dy) * DY_FACTOR);
-  const handle = baseHandle * curvature;
-  return `M${sx},${sy} C${sx + handle},${sy} ${tx - handle},${ty} ${tx},${ty}`;
+  const exitHandle = baseHandle * curvature;
+  const entryHandle = baseHandle * (entryCurvature ?? curvature);
+  return `M${sx},${sy} C${sx + exitHandle},${sy} ${tx - entryHandle},${ty} ${tx},${ty}`;
 }

--- a/packages/diagrams/src/webview/render-activities.ts
+++ b/packages/diagrams/src/webview/render-activities.ts
@@ -48,8 +48,10 @@ export interface RenderActivitiesOptions {
   title?: string;
   /** Network column / row gaps. Defaults match `layoutActivities`. */
   gaps?: ActivitiesLayoutOptions;
-  /** Edge curvature; 1 = default, 0 = straight, higher = stronger arc. */
+  /** Exit edge curvature; 1 = default, 0 = straight, higher = stronger arc. */
   curvature?: number;
+  /** Entry curvature at the target node; defaults to `curvature` when omitted. */
+  entryCurvature?: number;
 }
 
 /**
@@ -67,7 +69,7 @@ export interface RenderActivitiesOptions {
  * than short-circuiting.
  */
 export function renderActivitiesSvg(doc: ActivityDoc, options: RenderActivitiesOptions = {}): string {
-  const { title = '', gaps = {}, curvature = DEFAULT_EDGE_CURVATURE } = options;
+  const { title = '', gaps = {}, curvature = DEFAULT_EDGE_CURVATURE, entryCurvature } = options;
 
   const layout: ActivitiesLayout = layoutActivities(doc, gaps);
 
@@ -105,7 +107,7 @@ export function renderActivitiesSvg(doc: ActivityDoc, options: RenderActivitiesO
       const ty = t.y + oy + t.height / 2;
       const cls = e.isCritical ? 'diagram-edge critical-edge' : 'diagram-edge';
       const marker = `url(#${e.isCritical ? 'arrow-crit' : 'arrow'})`;
-      return `<path d="${horizontalCubicEdgePath(sx, sy, tx, ty, curvature)}" class="${cls}" marker-end="${marker}"/>`;
+      return `<path d="${horizontalCubicEdgePath(sx, sy, tx, ty, curvature, entryCurvature)}" class="${cls}" marker-end="${marker}"/>`;
     })
     .join('\n');
 

--- a/packages/diagrams/src/webview/render-fgca.ts
+++ b/packages/diagrams/src/webview/render-fgca.ts
@@ -37,10 +37,14 @@ export interface RenderFgcaOptions {
   variant?: 'fgca' | 'fga';
   /** Optional heading rendered as a left-anchored `text-header` line. */
   title?: string;
+  /** Exit edge curvature; 1 = default, 0 = straight, higher = stronger arc. */
+  curvature?: number;
+  /** Entry curvature at the target node; defaults to `curvature` when omitted. */
+  entryCurvature?: number;
 }
 
 export function renderFgcaSvg(doc: FGCADoc, options: RenderFgcaOptions = {}): string {
-  const { variant = 'fgca', title = '' } = options;
+  const { variant = 'fgca', title = '', curvature = DEFAULT_EDGE_CURVATURE, entryCurvature } = options;
   const hideChanges = variant === 'fga';
 
   const { nodes, edges, columns, width, height } = layoutFGCAPreview(doc, { hideChanges });
@@ -58,13 +62,10 @@ export function renderFgcaSvg(doc: FGCADoc, options: RenderFgcaOptions = {}): st
     )
     .join('\n');
 
-  // Cubic bezier with horizontal control handles (shared geometry in
-  // @transitrix/diagrams). Uses the package default curvature — the
-  // interactive curvature control is a VS Code-only concern.
   const edgeSvg = edges
     .map(
       (e) =>
-        `<path d="${horizontalCubicEdgePath(e.sx, e.sy, e.tx, e.ty, DEFAULT_EDGE_CURVATURE)}" class="diagram-edge" marker-end="url(#arrow)"/>`,
+        `<path d="${horizontalCubicEdgePath(e.sx, e.sy, e.tx, e.ty, curvature, entryCurvature)}" class="diagram-edge" marker-end="url(#arrow)"/>`,
     )
     .join('\n');
 

--- a/packages/diagrams/src/webview/render-goals.ts
+++ b/packages/diagrams/src/webview/render-goals.ts
@@ -34,10 +34,11 @@ function escXml(s: string): string {
 export interface RenderGoalsOptions {
   treeName?: string;
   curvature?: number;
+  entryCurvature?: number;
 }
 
 export function renderGoalsSvg(tree: GoalTree, options: RenderGoalsOptions = {}): string {
-  const { treeName = '', curvature = DEFAULT_EDGE_CURVATURE } = options;
+  const { treeName = '', curvature = DEFAULT_EDGE_CURVATURE, entryCurvature } = options;
 
   const layout: GoalTreeLayout = layoutGoalTree(tree, {
     nodeWidth: NODE_W,
@@ -65,7 +66,7 @@ export function renderGoalsSvg(tree: GoalTree, options: RenderGoalsOptions = {})
     const sy = s.y + oy + s.height / 2;
     const tx = t.x + ox;
     const ty = t.y + oy + t.height / 2;
-    return horizontalCubicEdgePath(sx, sy, tx, ty, curvature);
+    return horizontalCubicEdgePath(sx, sy, tx, ty, curvature, entryCurvature);
   }
 
   const edgeSvg = layout.edges


### PR DESCRIPTION
## Summary

- Adds `transitrix.entryCurvature.<notation>` VS Code settings (`goals`, `fgca`, `fga`, `activities`) to independently control how curved an arrow is as it enters a target node
- Fixes visually cramped arrivals at low `curvature` values, especially on edges with large vertical spans (fan-out diagrams)
- `horizontalCubicEdgePath` gains optional 6th param `entryCurvature`; omitting it keeps symmetric handles — no visual change for existing configs
- 2 new unit tests (8 total in `edge-path.test.ts`); 841/841 tests pass
- Bumps version 1.5.1 → 1.5.2; CHANGELOG entry added

## Usage

Set in VS Code settings:
```json
"transitrix.curvature.activities": 0.4,
"transitrix.entryCurvature.activities": 1.2
```
Arrow exits the source gently, arrives at the target smoothly without cramping.

## Test plan

- [ ] Open an Activities diagram with a fan-out (one source → multiple targets at different heights)
- [ ] Set `transitrix.curvature.activities: 0.3`, confirm arrows previously looked cramped on entry
- [ ] Set `transitrix.entryCurvature.activities: 1.2`, confirm arrivals are now smooth
- [ ] Leave `entryCurvature` at default (1) with default `curvature` (1) — visually identical to 1.5.1
- [ ] Same check for Goals and FGCA notations