### PR TITLE
refactor(build): extract shared esbuild constants to esbuild-helpers.mjs

### DIFF
--- a/scripts/build-cli-package.mjs
+++ b/scripts/build-cli-package.mjs
@@ -20,6 +20,7 @@ import esbuild from 'esbuild';
 import fs from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { NODE_BUILTIN_EXTERNALS, REQUIRE_BANNER, COMPILER_RUNTIME_EXTERNALS } from './esbuild-helpers.mjs';
 
 const root = resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
 const pkgRoot = resolve(root, 'packages', 'cli');
@@ -31,27 +32,10 @@ await fs.mkdir(distOut, { recursive: true });
 await fs.rm(schemaOut, { recursive: true, force: true });
 await fs.mkdir(schemaOut, { recursive: true });
 
-const NODE_BUILTIN_EXTERNALS = [
-  'node:path', 'node:url', 'node:fs', 'node:fs/promises',
-  'node:child_process', 'node:os', 'node:http', 'node:https',
-  'node:stream', 'node:util', 'node:events', 'node:buffer',
-  'node:crypto', 'node:worker_threads', 'node:module', 'node:process',
-  'path', 'url', 'fs', 'os', 'child_process', 'crypto',
-  'http', 'https', 'stream', 'util', 'events', 'buffer',
-  'worker_threads', 'process',
-];
-
 // Mirrors packages/cli/package.json "dependencies". Kept external so npm
 // resolves them at install time (ajv has dynamic require patterns that
 // esbuild cannot reliably inline).
-const RUNTIME_DEPS_EXTERNAL = [
-  'ajv',
-  'ajv-formats',
-  'bpmn-moddle',
-  'elkjs',
-  'js-yaml',
-  'xmlbuilder2',
-];
+const RUNTIME_DEPS_EXTERNAL = COMPILER_RUNTIME_EXTERNALS;
 
 const sharedBuildOptions = {
   bundle: true,
@@ -61,11 +45,7 @@ const sharedBuildOptions = {
   sourcemap: false,
   logLevel: 'info',
   external: [...NODE_BUILTIN_EXTERNALS, ...RUNTIME_DEPS_EXTERNAL],
-  // Inject createRequire so bundled CJS deps' dynamic `require(...)` calls
-  // resolve via Node's real module resolver instead of esbuild's stub.
-  banner: {
-    js: "import { createRequire as __createRequire__ } from 'node:module'; const require = __createRequire__(import.meta.url);",
-  },
+  banner: REQUIRE_BANNER,
 };
 
 await esbuild.build({

--- a/scripts/build-compiler-bundle.mjs
+++ b/scripts/build-compiler-bundle.mjs
@@ -15,6 +15,7 @@ import os from 'node:os';
 import { execSync } from 'node:child_process';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { NODE_BUILTIN_EXTERNALS, REQUIRE_BANNER, COMPILER_RUNTIME_EXTERNALS } from './esbuild-helpers.mjs';
 
 const root = resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
 const compilerOut = resolve(root, 'extension', 'compiler');
@@ -25,29 +26,11 @@ const extensionRoot = resolve(root, 'extension');
 await fs.rm(compilerOut, { recursive: true, force: true });
 await fs.mkdir(compilerOut, { recursive: true });
 
-const NODE_BUILTIN_EXTERNALS = [
-  'vscode',
-  'node:path', 'node:url', 'node:fs', 'node:fs/promises',
-  'node:child_process', 'node:os', 'node:http', 'node:https',
-  'node:stream', 'node:util', 'node:events', 'node:buffer',
-  'node:crypto', 'node:worker_threads', 'node:module',
-  'path', 'url', 'fs', 'os', 'child_process', 'crypto',
-  'http', 'https', 'stream', 'util', 'events', 'buffer',
-  'worker_threads',
-];
-
 // Runtime npm deps declared in extension/package.json — kept external so the
 // installed extension can resolve them via node_modules at runtime. Some
 // (notably ajv) have dynamic require patterns that esbuild cannot inline
 // reliably; shipping the real packages avoids fighting the bundler.
-const RUNTIME_DEPS_EXTERNAL = [
-  'ajv',
-  'ajv-formats',
-  'elkjs',
-  'js-yaml',
-  'xmlbuilder2',
-  'bpmn-moddle',
-];
+const RUNTIME_DEPS_EXTERNAL = COMPILER_RUNTIME_EXTERNALS;
 
 await esbuild.build({
   entryPoints: [
@@ -56,17 +39,13 @@ await esbuild.build({
   ],
   bundle: true,
   outdir: compilerOut,
-  external: [...NODE_BUILTIN_EXTERNALS, ...RUNTIME_DEPS_EXTERNAL],
+  external: ['vscode', ...NODE_BUILTIN_EXTERNALS, ...RUNTIME_DEPS_EXTERNAL],
   platform: 'node',
   format: 'esm',
   target: 'node18',
   sourcemap: false,
   logLevel: 'info',
-  // Inject createRequire so bundled CJS deps' dynamic `require(...)` calls
-  // resolve via Node's real module resolver instead of esbuild's stub.
-  banner: {
-    js: "import { createRequire as __createRequire__ } from 'node:module'; const require = __createRequire__(import.meta.url);",
-  },
+  banner: REQUIRE_BANNER,
 });
 
 // Sync schemas

--- a/scripts/build-extension-bundle.mjs
+++ b/scripts/build-extension-bundle.mjs
@@ -10,6 +10,7 @@
 import esbuild from 'esbuild';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { NODE_BUILTIN_EXTERNALS, REQUIRE_BANNER } from './esbuild-helpers.mjs';
 
 const root = resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
 
@@ -22,41 +23,12 @@ await esbuild.build({
     // Native module — its platform .node binary cannot be bundled; resolved
     // at runtime from the node_modules shipped inside the VSIX.
     '@resvg/resvg-js',
-    'node:path',
-    'node:url',
-    'node:fs',
-    'node:fs/promises',
-    'node:child_process',
-    'node:os',
-    'node:http',
-    'node:https',
-    'node:stream',
-    'node:util',
-    'node:events',
-    'node:buffer',
-    'node:crypto',
-    'path',
-    'url',
-    'fs',
-    'os',
-    'http',
-    'https',
-    'stream',
-    'util',
-    'events',
-    'buffer',
-    'child_process',
-    'crypto',
+    ...NODE_BUILTIN_EXTERNALS,
   ],
   platform: 'node',
   format: 'esm',
   target: 'node18',
   sourcemap: false,
   logLevel: 'info',
-  // Inject createRequire so any dynamic `require(...)` in bundled CJS
-  // dependencies falls through to Node's real module resolver. Same
-  // pattern as build-compiler-bundle.mjs.
-  banner: {
-    js: "import { createRequire as __createRequire__ } from 'node:module'; const require = __createRequire__(import.meta.url);",
-  },
+  banner: REQUIRE_BANNER,
 });

--- a/scripts/esbuild-helpers.mjs
+++ b/scripts/esbuild-helpers.mjs
@@ -1,0 +1,35 @@
+/**
+ * Shared constants for Node-target esbuild bundle scripts.
+ * Used by build-extension-bundle.mjs, build-compiler-bundle.mjs,
+ * and build-cli-package.mjs.
+ */
+
+// Injects createRequire so bundled CJS dependencies' dynamic require() calls
+// fall through to Node's real module resolver instead of esbuild's stub.
+export const REQUIRE_BANNER = {
+  js: "import { createRequire as __createRequire__ } from 'node:module'; const require = __createRequire__(import.meta.url);",
+};
+
+// Node.js built-in modules — kept external across all Node-target bundles.
+// Includes both `node:` prefixed and bare forms for CJS compatibility.
+export const NODE_BUILTIN_EXTERNALS = [
+  'node:path', 'node:url', 'node:fs', 'node:fs/promises',
+  'node:child_process', 'node:os', 'node:http', 'node:https',
+  'node:stream', 'node:util', 'node:events', 'node:buffer',
+  'node:crypto', 'node:worker_threads', 'node:module', 'node:process',
+  'path', 'url', 'fs', 'os', 'child_process', 'crypto',
+  'http', 'https', 'stream', 'util', 'events', 'buffer',
+  'worker_threads', 'process',
+];
+
+// npm runtime dependencies bundled as externals in both the extension compiler
+// and the CLI package. Kept external so they resolve via node_modules at
+// runtime — notably ajv has dynamic require patterns esbuild cannot inline.
+export const COMPILER_RUNTIME_EXTERNALS = [
+  'ajv',
+  'ajv-formats',
+  'bpmn-moddle',
+  'elkjs',
+  'js-yaml',
+  'xmlbuilder2',
+];


### PR DESCRIPTION
## Summary

`NODE_BUILTIN_EXTERNALS`, `COMPILER_RUNTIME_EXTERNALS`, and `REQUIRE_BANNER` were duplicated across three Node-target bundle scripts (`build-extension-bundle.mjs`, `build-compiler-bundle.mjs`, `build-cli-package.mjs`). Adding a new runtime dependency or Node built-in required edits in multiple files — a silent maintenance risk.

- New `scripts/esbuild-helpers.mjs` exports the three shared constants.
- All three Node-target bundle scripts import from it; browser-target scripts (`build-webview.mjs`, `build-webview-bundle.mjs`) are unchanged.
- `'vscode'` remains explicit in the two scripts that need it (extension bundle, compiler bundle) — it is not part of the generic built-in list.

## Test plan

- [x] `npm run compile` — clean
- [x] `npm test` — 841 pass (56 files)
- [x] `node -e "import './scripts/esbuild-helpers.mjs'"` — imports cleanly
- [ ] `npm run extension:prep` and `npm run build:cli-package` — verify bundle scripts still execute end-to-end (requires full runtime env; CI covers this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)