### PR TITLE
fix(ci): extend hygiene guard to read HYGIENE_BLOCKLIST_HUB

### DIFF
--- a/.github/workflows/public-surface-hygiene.yml
+++ b/.github/workflows/public-surface-hygiene.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Run hygiene check
         env:
           HYGIENE_BLOCKLIST: ${{ secrets.HYGIENE_BLOCKLIST }}
+          HYGIENE_BLOCKLIST_HUB: ${{ secrets.HYGIENE_BLOCKLIST_HUB }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}

--- a/scripts/ci-hygiene-check.mjs
+++ b/scripts/ci-hygiene-check.mjs
@@ -15,11 +15,14 @@ if (!blocklist || blocklist.trim() === '') {
   process.exit(0);
 }
 
+const blocklistHub = process.env.HYGIENE_BLOCKLIST_HUB;
+const combined = blocklistHub && blocklistHub.trim() ? `${blocklist}|${blocklistHub}` : blocklist;
+
 let pattern;
 try {
-  pattern = new RegExp(blocklist, 'i');
+  pattern = new RegExp(combined, 'i');
 } catch {
-  console.error('[hygiene] HYGIENE_BLOCKLIST is not a valid JavaScript regex.');
+  console.error('[hygiene] HYGIENE_BLOCKLIST (combined) is not a valid JavaScript regex.');
   process.exit(2);
 }
 


### PR DESCRIPTION
Closes part of #259 (studio half of #233).

## What

The existing guard reads only `HYGIENE_BLOCKLIST`. The new `HYGIENE_BLOCKLIST_HUB` secret (added 2026-06-17) blocks references to the private strategy hub in PR/commit surfaces. This PR wires it in.

## Changes

- `.github/workflows/public-surface-hygiene.yml` — expose `HYGIENE_BLOCKLIST_HUB` in `env:`
- `scripts/ci-hygiene-check.mjs` — combine both secrets into one regex: `BLOCKLIST|BLOCKLIST_HUB` (hub half is additive; guard still skips cleanly when main blocklist is absent, e.g. fork PRs)

## Behaviour

- If `HYGIENE_BLOCKLIST_HUB` is unset: pattern falls back to `HYGIENE_BLOCKLIST` only (no regression for fork PRs)
- Existing committed files with hub refs are grandfathered (fail only when next touched in a PR diff)