### PR TITLE
fix(compliance-impact): inject bodyHtml into webview template + surface skipped-file count

### DIFF
--- a/extension/src/compliance-impact-preview.ts
+++ b/extension/src/compliance-impact-preview.ts
@@ -382,6 +382,9 @@ export class ComplianceImpactPreview {
     const totalPending = [...this.pendingIndex.values()].reduce((a, b) => a + b, 0);
     const pendingSummary =
       totalPending > 0 ? ' &middot; <strong>' + totalPending + '</strong> pending (admission)' : '';
+    const skipped = this.canon?.skippedNotationCount ?? 0;
+    const skippedSummary =
+      skipped > 0 ? ' &middot; &#x26A0; <strong>' + skipped + '</strong> file(s) skipped (unrecognized notation)' : '';
 
     const empty = rows.length === 0 || columns.length === 0;
     const bodyHtml = empty ? this.emptyHtml(matrix) : this.gridHtml(rows, columns, cells, matrix.emptyLabels, matrix.obligationsLane, this.filter.showObligationsLane);
@@ -460,6 +463,7 @@ export class ComplianceImpactPreview {
       totalGaps +
       '</strong> gaps' +
       pendingSummary +
+      skippedSummary +
       '</div>\n' +
       '    <div class="ci-config">' +
       configLine +
@@ -481,6 +485,8 @@ export class ComplianceImpactPreview {
       laneToggle +
       '\n' +
       '  </div>\n' +
+      '\n' +
+      bodyHtml +
       '\n' +
       '  <script nonce="' +
       nonce +

--- a/extension/src/compliance-scan.ts
+++ b/extension/src/compliance-scan.ts
@@ -9,17 +9,29 @@ import { emptyCanon, ingestComplianceDoc, type ComplianceCanon } from '../../pac
 // (also used by the CLI's `export-compliance` scan), so the recognition rules
 // are defined once.
 
-/** The scanned canon plus an id → workspace file path map for click-to-open. */
-export type ScannedCanon = ComplianceCanon & { pathById: Map<string, string> };
+/**
+ * The scanned canon plus an id → workspace file path map for click-to-open
+ * and a count of YAML files that had both `id` and `notation` fields but
+ * weren't recognised as compliance artefacts (unrecognized notation value).
+ */
+export type ScannedCanon = ComplianceCanon & {
+  pathById: Map<string, string>;
+  skippedNotationCount: number;
+};
 
 /**
  * Scans the workspace for compliance canon artefacts (products / requirements /
  * assertions by `notation`, codex by `zone: codex`). Unreadable/unparseable
  * files and non-artefacts are skipped. node_modules is excluded.
+ *
+ * Files that have both `id` and `notation` fields but aren't recognised by
+ * `ingestComplianceDoc` are counted in `skippedNotationCount` so callers can
+ * surface a diagnostic rather than silently producing an empty view.
  */
 export async function scanComplianceCanon(): Promise<ScannedCanon> {
   const canon = emptyCanon();
   const pathById = new Map<string, string>();
+  let skippedNotationCount = 0;
 
   const uris = await vscode.workspace.findFiles('**/*.{yaml,yml}', '**/node_modules/**', 5000);
   for (const uri of uris) {
@@ -31,10 +43,22 @@ export async function scanComplianceCanon(): Promise<ScannedCanon> {
       continue;
     }
     const id = ingestComplianceDoc(canon, parsed);
-    if (id) pathById.set(id, uri.fsPath);
+    if (id) {
+      pathById.set(id, uri.fsPath);
+    } else if (hasIdAndNotation(parsed)) {
+      skippedNotationCount++;
+    }
   }
 
-  return { ...canon, pathById };
+  return { ...canon, pathById, skippedNotationCount };
+}
+
+/** True when a parsed YAML document looks like a canon artefact candidate
+ *  (has `id` + `notation`) but was not recognised by `ingestComplianceDoc`. */
+function hasIdAndNotation(doc: unknown): boolean {
+  if (doc === null || typeof doc !== 'object' || Array.isArray(doc)) return false;
+  const d = doc as Record<string, unknown>;
+  return typeof d.id === 'string' && typeof d.notation === 'string';
 }
 
 /** Opens a canon artefact file beside the active editor — the click-to-open


### PR DESCRIPTION
## Summary

- **Bug fix:** `bodyHtml` (the matrix grid) was computed but never interpolated into the HTML template returned by `buildHtml` in `extension/src/compliance-impact-preview.ts`. The panel displayed the toolbar and filter controls but the body was completely absent. One-line fix: insert `bodyHtml` between the closing `</div>` of the filters block and the `<script>` tag.

- **Diagnostic improvement:** `scanComplianceCanon` silently skipped YAML files that carry both `id` and `notation` fields but aren't recognised by `ingestComplianceDoc` (unrecognized notation value). This could cause an unexpectedly empty matrix with no indication of what went wrong. The scan now counts such files in `skippedNotationCount` (new field on `ScannedCanon`) and the preview summary line shows a ⚠ warning when the count is non-zero.

## Test plan

- [ ] Open a workspace with valid `notation: requirement` / `notation: product` / `notation: assertion` files — compliance-impact preview should render the full matrix grid
- [ ] Introduce a YAML file with `id: TEST-1` + `notation: unknown-value` — summary line should show "1 file(s) skipped (unrecognized notation)"
- [ ] `npm test` — 841 tests, all passing
- [ ] `npx tsc -p extension/tsconfig.json --noEmit` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)