### PR TITLE
chore(release): cut 1.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 ## [Unreleased]
 
-### Removed
-- **`build-extension.bat` and `build-extension.sh`** — replaced by `scripts/package-extension.mjs`, a cross-platform Node.js script with identical `--bump` / `--target` flags. Run via `npm run package-extension` (no flags = universal local-install VSIX, same default as before) or directly with `node scripts/package-extension.mjs --help`. The `package-extension` npm script no longer auto-bumps the version; pass `--bump` explicitly when a version increment is wanted.
+## [1.5.3] — 2026-06-17
+
+### Fixed
+- **Compliance-impact preview now renders the matrix grid.** `bodyHtml` (the obligation × subject table) was computed but never interpolated into the HTML template returned by `buildHtml` — the panel displayed the toolbar and filter controls but the body was completely absent. One-line fix inserts `bodyHtml` between the filters block and the script tag.
+
+### Changed
+- **Compliance-impact scan surfaces a skip-count diagnostic.** `scanComplianceCanon` now counts YAML files that carry both `id` and `notation` fields but aren't recognised as compliance artefacts (unrecognized notation value). The preview summary line shows a ⚠ warning with the count so users can diagnose an unexpectedly empty matrix rather than guessing.
+- **Build scripts consolidated** — `build-extension.bat` / `build-extension.sh` replaced by `scripts/package-extension.mjs` (cross-platform Node.js, same `--bump` / `--target` flags). Shared esbuild constants extracted to `scripts/esbuild-helpers.mjs` to reduce duplication across the three bundle scripts.
 
 ## [1.5.2] — 2026-06-16
 

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Transitrix Studio — changelog
 
+## 1.5.3 — 2026-06-17
+
+### Fixed
+
+- **Compliance-impact preview now renders the matrix grid.** The obligation × subject table was computed but never inserted into the panel HTML — you saw the toolbar and filters but an empty body. Fixed.
+- **Scan warns when files are silently skipped.** If the workspace contains YAML files with an `id` and `notation` field that the compliance scanner doesn't recognise, the preview summary now shows a ⚠ count instead of silently producing an empty view.
+
 ## 1.5.1 — 2026-06-16
 
 Tidier preview strips: validation warnings now collapse, and the error strip folds in static previews too.

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Architecture-as-code for the modern enterprise. Author 17 notations — goals, processes, capabilities, BPMN, applications, more — as plain YAML, get live diagrams in VS Code. Diffable in git. AI-friendly. Open source. Built on ArchiMate 3.2 and BPMN 2.0.",
   "license": "MIT",
   "icon": "icon.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
## What's in this release

**Fixed**
- Compliance-impact preview now renders the matrix grid — `bodyHtml` was computed but never inserted into the panel HTML (PR #194)
- Compliance-impact scan surfaces a ⚠ skip-count diagnostic for files with unrecognized notation values (PR #194)

**Changed**
- Build scripts consolidated: `build-extension.bat/.sh` → `scripts/package-extension.mjs`; shared esbuild constants extracted to `scripts/esbuild-helpers.mjs` (PRs #191, #192)
- CI hygiene guard extended to read `HYGIENE_BLOCKLIST_HUB` (PR #193)

## Checklist

- [ ] Merge this PR
- [ ] Create GitHub Release with tag `v1.5.3` — CI automatically builds platform-specific VSIXs and publishes to VS Code Marketplace + Open VSX

🤖 Generated with [Claude Code](https://claude.com/claude-code)