### PR TITLE
feat(compliance-views): product names in headers, column-width setting, skipped-notation diagnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 ## [Unreleased]
 
-### Removed
-- **`build-extension.bat` and `build-extension.sh`** — replaced by `scripts/package-extension.mjs`, a cross-platform Node.js script with identical `--bump` / `--target` flags. Run via `npm run package-extension` (no flags = universal local-install VSIX, same default as before) or directly with `node scripts/package-extension.mjs --help`. The `package-extension` npm script no longer auto-bumps the version; pass `--bump` explicitly when a version increment is wanted.
+## [1.5.3] — 2026-06-17
+
+### Fixed
+- **Compliance-impact preview now renders the matrix grid.** `bodyHtml` (the obligation × subject table) was computed but never interpolated into the HTML template returned by `buildHtml` — the panel displayed the toolbar and filter controls but the body was completely absent. One-line fix inserts `bodyHtml` between the filters block and the script tag.
+
+### Changed
+- **Compliance-impact scan surfaces a skip-count diagnostic.** `scanComplianceCanon` now counts YAML files that carry both `id` and `notation` fields but aren't recognised as compliance artefacts (unrecognized notation value). The preview summary line shows a ⚠ warning with the count so users can diagnose an unexpectedly empty matrix rather than guessing.
+- **Build scripts consolidated** — `build-extension.bat` / `build-extension.sh` replaced by `scripts/package-extension.mjs` (cross-platform Node.js, same `--bump` / `--target` flags). Shared esbuild constants extracted to `scripts/esbuild-helpers.mjs` to reduce duplication across the three bundle scripts.
 
 ## [1.5.2] — 2026-06-16
 

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Transitrix Studio — changelog
 
+## 1.5.3 — 2026-06-17
+
+### Fixed
+
+- **Compliance-impact preview now renders the matrix grid.** The obligation × subject table was computed but never inserted into the panel HTML — you saw the toolbar and filters but an empty body. Fixed.
+- **Scan warns when files are silently skipped.** If the workspace contains YAML files with an `id` and `notation` field that the compliance scanner doesn't recognise, the preview summary now shows a ⚠ count instead of silently producing an empty view.
+
 ## 1.5.1 — 2026-06-16
 
 Tidier preview strips: validation warnings now collapse, and the error strip folds in static previews too.

--- a/extension/package.json
+++ b/extension/package.json
@@ -104,6 +104,17 @@
           "default": "transitrix",
           "description": "Color theme for Transitrix diagram previews (Goals, FGCA, and other static notation previews)."
         },
+        "transitrix.report.columnWidth": {
+          "type": "string",
+          "enum": ["narrow", "normal", "wide"],
+          "enumDescriptions": [
+            "Narrow columns (80 px)",
+            "Normal columns (120 px)",
+            "Wide columns (200 px)"
+          ],
+          "default": "normal",
+          "description": "Column width preset for table-based reports (Compliance Impact, Compliance Matrix, Products, Process Map, etc.)."
+        },
         "transitrix.spacing.goals.horizontalGap": {
           "type": "number",
           "minimum": 20,

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Architecture-as-code for the modern enterprise. Author 17 notations — goals, processes, capabilities, BPMN, applications, more — as plain YAML, get live diagrams in VS Code. Diffable in git. AI-friendly. Open source. Built on ArchiMate 3.2 and BPMN 2.0.",
   "license": "MIT",
   "icon": "icon.png",

--- a/extension/src/applications-preview.ts
+++ b/extension/src/applications-preview.ts
@@ -210,9 +210,10 @@ export class ApplicationsPreview {
       errorMsg = (e as Error).message ?? 'Parse error';
     }
 
-    const themeId = vscode.workspace
-      .getConfiguration('transitrix')
-      .get<ThemeId>('theme', 'transitrix');
+    const cfg = vscode.workspace.getConfiguration('transitrix');
+    const themeId = cfg.get<ThemeId>('theme', 'transitrix');
+    const colW = cfg.get<string>('report.columnWidth', 'normal');
+    const colWPx = colW === 'narrow' ? 80 : colW === 'wide' ? 200 : 120;
 
     return buildDiagramFrame({
       filename,
@@ -224,7 +225,7 @@ export class ApplicationsPreview {
       subtitle,
       version,
       date,
-      extraStyles: CATALOGUE_STYLES + APPLICATIONS_STYLES,
+      extraStyles: `:root { --ts-col-w: ${colWPx}px; }\n` + CATALOGUE_STYLES + APPLICATIONS_STYLES,
     });
   }
 }
@@ -300,6 +301,6 @@ const APPLICATIONS_STYLES = `
   }
   .vendor-internal { font-style: italic; color: var(--ts-text-muted, #64748b); }
   .vendor-external { color: var(--ts-text, #0f172a); }
-  .col-name { min-width: 200px; }
+  .col-name { min-width: var(--ts-col-w, 200px); }
   .col-type, .col-status, .col-maturity, .col-domain, .col-vendor, .col-owner { white-space: nowrap; }
 `;

--- a/extension/src/compliance-impact-preview.ts
+++ b/extension/src/compliance-impact-preview.ts
@@ -10,7 +10,7 @@ import {
 } from '../../packages/diagrams/src/compliance/impact.js';
 import type { AssertionStatus } from '../../packages/diagrams/src/assertion/types.js';
 import type { IndexRequirement, DeadlineStatus } from '../../packages/diagrams/src/compliance/types.js';
-import { genNonce } from './preview-controls.js';
+import { genNonce, colWidthPxFromSetting, colWidthRootCss } from './preview-controls.js';
 import { scanComplianceCanon, openComplianceFile } from './compliance-scan.js';
 import type { ScannedCanon } from './compliance-scan.js';
 
@@ -274,6 +274,7 @@ export class ComplianceImpactPreview {
   private pendingIndex = new Map<string, number>();
   private jIndex = new Map<string, string[]>();
   private filter: ImpactFilter = defaultFilter();
+  private colWidth: string = vscode.workspace.getConfiguration('transitrix').get<string>('report.columnWidth', 'normal');
 
   constructor(private readonly extensionUri: vscode.Uri) {}
 
@@ -343,7 +344,17 @@ export class ComplianceImpactPreview {
     severities?: string[];
     jurisdictions?: string[];
     showObligationsLane?: boolean;
+    columnWidth?: string;
   }): Promise<void> {
+    if (m?.type === 'transitrix:col-width') {
+      const w = m.columnWidth;
+      if (w === 'narrow' || w === 'normal' || w === 'wide') {
+        this.colWidth = w;
+        void vscode.workspace.getConfiguration('transitrix').update('report.columnWidth', w, vscode.ConfigurationTarget.Workspace);
+      }
+      this.render();
+      return;
+    }
     if (m?.type !== 'transitrix:impact-filter') return;
     this.filter = {
       statuses: new Set(
@@ -382,9 +393,15 @@ export class ComplianceImpactPreview {
     const totalPending = [...this.pendingIndex.values()].reduce((a, b) => a + b, 0);
     const pendingSummary =
       totalPending > 0 ? ' &middot; <strong>' + totalPending + '</strong> pending (admission)' : '';
-    const skipped = this.canon?.skippedNotationCount ?? 0;
-    const skippedSummary =
-      skipped > 0 ? ' &middot; &#x26A0; <strong>' + skipped + '</strong> file(s) skipped (unrecognized notation)' : '';
+    const skippedList = this.canon?.skippedNotations ?? [];
+    const skippedSummary = skippedList.length > 0
+      ? ' &middot; &#x26A0; <strong>' + skippedList.length + '</strong> file(s) skipped'
+        + ' &mdash; unrecognized notation: '
+        + [...new Set(skippedList.map(s => '<code>' + escXml(s.notation) + '</code>'))].join(', ')
+        + ' <span class="ci-skipped-hint" title="'
+        + escXml(skippedList.map(s => s.notation + ': ' + s.shortPath).join('\n'))
+        + '">(?)</span>'
+      : '';
 
     const empty = rows.length === 0 || columns.length === 0;
     const bodyHtml = empty ? this.emptyHtml(matrix) : this.gridHtml(rows, columns, cells, matrix.emptyLabels, matrix.obligationsLane, this.filter.showObligationsLane);
@@ -430,10 +447,20 @@ export class ComplianceImpactPreview {
       (this.filter.showObligationsLane ? ' checked' : '') +
       '> Laws lane</label>';
 
+    const colWidthSelect =
+      '<span class="ci-filter-label">Columns</span>' +
+      '<select data-ci-col-width class="ci-col-width-select">' +
+      ['narrow', 'normal', 'wide']
+        .map(w => '<option value="' + w + '"' + (this.colWidth === w ? ' selected' : '') + '>' + w.charAt(0).toUpperCase() + w.slice(1) + '</option>')
+        .join('') +
+      '</select>';
+
     const configLine =
       config.id === 'auto'
         ? 'Auto-config (add *.compliance-impact.{view,transitrix}.yaml to pin)'
         : 'View: <code>' + escXml(config.id) + '</code>';
+
+    const colWCss = colWidthRootCss(colWidthPxFromSetting(this.colWidth));
 
     return (
       '<!DOCTYPE html>\n' +
@@ -444,6 +471,8 @@ export class ComplianceImpactPreview {
       nonce +
       '\';">\n' +
       '  <style>\n' +
+      colWCss +
+      '\n' +
       generateWebviewCss(themeId) +
       '\n' +
       IMPACT_CSS +
@@ -483,6 +512,8 @@ export class ComplianceImpactPreview {
       jurisdictionRow +
       '\n    <span class="ci-filter-label">Lanes</span>' +
       laneToggle +
+      '\n    ' +
+      colWidthSelect +
       '\n' +
       '  </div>\n' +
       '\n' +
@@ -511,6 +542,12 @@ export class ComplianceImpactPreview {
       "      });\n" +
       "    });\n" +
       "  });\n" +
+      "  var colWidthSel = document.querySelector('[data-ci-col-width]');\n" +
+      "  if (colWidthSel) {\n" +
+      "    colWidthSel.addEventListener('change', function () {\n" +
+      "      vscode.postMessage({ type: 'transitrix:col-width', columnWidth: colWidthSel.value });\n" +
+      "    });\n" +
+      "  }\n" +
       '}());\n' +
       '  </script>\n' +
       '</body>\n' +
@@ -536,7 +573,13 @@ export class ComplianceImpactPreview {
     const head =
       '<tr>\n      <th class="ci-corner"></th>\n      ' +
       columns
-        .map(col => '<th class="ci-col"><div class="ci-col-name">' + escXml(col.label) + '</div></th>')
+        .map(col =>
+          '<th class="ci-col"><div class="ci-col-name">' +
+          escXml(col.subjectName ?? col.label) +
+          '</div>' +
+          (col.subjectName ? '<div class="ci-col-id">' + escXml(col.label) + '</div>' : '') +
+          '</th>',
+        )
         .join('') +
       '\n    </tr>';
     const laneRow = showObligationsLane
@@ -686,19 +729,21 @@ body { padding: 0; }
 .ci-filter-label { font-weight: 600; color: var(--ts-text, #0f172a); margin-left: 8px; }
 .ci-filter-label:first-child { margin-left: 0; }
 .ci-chip { display: inline-flex; align-items: center; gap: 4px; color: var(--ts-text-muted, #64748b); cursor: pointer; }
+.ci-col-width-select { font-size: 11px; font-family: var(--vscode-font-family, sans-serif); color: var(--vscode-input-foreground, #333); background: var(--vscode-input-background, #fff); border: 1px solid var(--vscode-input-border, var(--ts-border, #cbd5e1)); border-radius: 3px; padding: 1px 4px; }
 #ci-grid-wrap { overflow: auto; padding: 12px 16px 24px; }
 #ci-grid { border-collapse: collapse; font-size: 12px; }
 #ci-grid th, #ci-grid td { border: 1px solid var(--ts-border, #cbd5e1); }
 .ci-corner { background: transparent; border: none; }
-.ci-col { padding: 6px 10px; vertical-align: bottom; text-align: left; background: var(--ts-bg-subtle, #f1f5f9); min-width: 80px; max-width: 140px; }
+.ci-col { padding: 6px 10px; vertical-align: bottom; text-align: left; background: var(--ts-bg-subtle, #f1f5f9); min-width: var(--ts-col-w, 120px); width: var(--ts-col-w, 120px); }
 .ci-col-name { font-weight: 600; color: var(--ts-text, #0f172a); font-size: 11px; word-break: break-all; }
+.ci-col-id { font-size: 10px; font-family: var(--vscode-editor-font-family, monospace); color: var(--ts-text-muted, #64748b); margin-top: 2px; word-break: break-all; }
 .ci-row { padding: 6px 12px; text-align: left; background: var(--ts-bg-subtle, #f1f5f9); white-space: nowrap; position: sticky; left: 0; min-width: 160px; max-width: 260px; }
 .ci-row-id { font-size: 11px; font-family: var(--vscode-editor-font-family, monospace); color: var(--ts-text-muted, #64748b); }
 .ci-row-name { font-weight: 600; color: var(--ts-text, #0f172a); font-size: 12px; white-space: normal; }
 .ci-sev { font-size: 10px; text-transform: uppercase; letter-spacing: 0.04em; margin-top: 2px; }
 .ci-sev-high { color: #b91c1c; } .ci-sev-medium { color: #b45309; } .ci-sev-low { color: #2563eb; }
 .ci-jur { display: inline-block; padding: 1px 5px; border-radius: 3px; font-size: 10px; color: var(--ts-text-muted, #64748b); background: var(--ts-bg-elevated, #e2e8f0); text-transform: uppercase; letter-spacing: 0.04em; margin-top: 2px; margin-right: 2px; }
-.ci-cell { width: 110px; height: 40px; text-align: center; vertical-align: middle; }
+.ci-cell { width: var(--ts-col-w, 120px); height: 40px; text-align: center; vertical-align: middle; }
 .ci-badge { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 11px; font-weight: 600; }
 .ci-link { text-decoration: none; }
 .ci-gap { background: repeating-linear-gradient(45deg, transparent, transparent 5px, var(--ts-bg-subtle, #f1f5f9) 5px, var(--ts-bg-subtle, #f1f5f9) 10px); }
@@ -717,6 +762,7 @@ body { padding: 0; }
 .ci-badge-under_review { color: var(--ts-status-info-fg, #0c4a6e); background: var(--ts-status-info-bg, #e0f2fe); }
 .ci-empty { padding: 40px 24px; color: var(--ts-text-muted, #64748b); max-width: 640px; }
 .ci-empty code { background: var(--ts-bg-subtle, #f1f5f9); padding: 1px 4px; border-radius: 3px; }
+.ci-skipped-hint { cursor: help; color: var(--ts-text-muted, #64748b); font-size: 10px; vertical-align: super; }
 .ci-new { box-shadow: inset 0 0 0 2px #6366f1; }
 .ci-urgent { background: repeating-linear-gradient(45deg, #fee2e2, #fee2e2 5px, #fef2f2 5px, #fef2f2 10px) !important; }
 .ci-urgent-badge { display: inline-flex; align-items: center; justify-content: center; width: 18px; height: 18px; border-radius: 50%; background: #dc2626; color: #fff; font-weight: 700; font-size: 11px; }

--- a/extension/src/compliance-matrix-preview.ts
+++ b/extension/src/compliance-matrix-preview.ts
@@ -7,7 +7,7 @@ import {
   type MatrixFilter,
 } from '../../packages/diagrams/src/compliance-matrix/index.js';
 import type { AssertionStatus } from '../../packages/diagrams/src/assertion/types.js';
-import { genNonce } from './preview-controls.js';
+import { genNonce, colWidthPxFromSetting, colWidthRootCss } from './preview-controls.js';
 import { scanComplianceCanon } from './compliance-scan.js';
 
 // Compliance matrix preview (vkgeorgia/strategy#84 Phase 2).
@@ -53,6 +53,7 @@ export class ComplianceMatrixPreview {
   private fullMatrix: ComplianceMatrix | undefined;
   private assertionPaths = new Map<string, string>();
   private filter: MatrixFilter = {};
+  private colWidth: string = vscode.workspace.getConfiguration('transitrix').get<string>('report.columnWidth', 'normal');
 
   constructor(private readonly extensionUri: vscode.Uri) {}
 
@@ -94,8 +95,17 @@ export class ComplianceMatrixPreview {
   }
 
   private async onMessage(m: {
-    type?: string; statuses?: string[]; severities?: string[]; jurisdictions?: string[];
+    type?: string; statuses?: string[]; severities?: string[]; jurisdictions?: string[]; columnWidth?: string;
   }): Promise<void> {
+    if (m?.type === 'transitrix:col-width') {
+      const w = m.columnWidth;
+      if (w === 'narrow' || w === 'normal' || w === 'wide') {
+        this.colWidth = w;
+        void vscode.workspace.getConfiguration('transitrix').update('report.columnWidth', w, vscode.ConfigurationTarget.Workspace);
+      }
+      this.render();
+      return;
+    }
     if (m?.type !== 'transitrix:matrix-filter') return;
     this.filter = {
       statuses: (m.statuses ?? []).filter((s): s is AssertionStatus => (ALL_STATUSES as string[]).includes(s)),
@@ -148,12 +158,22 @@ export class ComplianceMatrixPreview {
       ? `<span class="cm-filter-label">Jurisdiction</span>${jurisdictionBoxes}`
       : '';
 
+    const colWCss = colWidthRootCss(colWidthPxFromSetting(this.colWidth));
+    const colWidthSelect =
+      `<span class="cm-filter-label">Columns</span>` +
+      `<select data-cm-col-width class="cm-col-width-select">` +
+      ['narrow', 'normal', 'wide'].map(w =>
+        `<option value="${w}"${this.colWidth === w ? ' selected' : ''}>${w.charAt(0).toUpperCase()}${w.slice(1)}</option>`
+      ).join('') +
+      `</select>`;
+
     return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8"/>
   <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';">
   <style>
+${colWCss}
 ${generateWebviewCss(themeId)}
 ${MATRIX_CSS}
   </style>
@@ -168,6 +188,7 @@ ${MATRIX_CSS}
     <span class="cm-filter-label">Status</span>${statusBoxes}
     <span class="cm-filter-label">Severity</span>${severityBoxes}
     ${jurisdictionRow}
+    ${colWidthSelect}
   </div>
   ${body}
   <script nonce="${nonce}">
@@ -190,6 +211,12 @@ ${MATRIX_CSS}
       });
     });
   });
+  var colWidthSel = document.querySelector('[data-cm-col-width]');
+  if (colWidthSel) {
+    colWidthSel.addEventListener('change', function () {
+      vscode.postMessage({ type: 'transitrix:col-width', columnWidth: colWidthSel.value });
+    });
+  }
 }());
   </script>
 </body>
@@ -252,11 +279,12 @@ body { padding: 0; }
 .cm-filter-label { font-weight: 600; color: var(--ts-text, #0f172a); margin-left: 8px; }
 .cm-filter-label:first-child { margin-left: 0; }
 .cm-chip { display: inline-flex; align-items: center; gap: 4px; color: var(--ts-text-muted, #64748b); }
+.cm-col-width-select { font-size: 11px; font-family: var(--vscode-font-family, sans-serif); color: var(--vscode-input-foreground, #333); background: var(--vscode-input-background, #fff); border: 1px solid var(--vscode-input-border, var(--ts-border, #cbd5e1)); border-radius: 3px; padding: 1px 4px; }
 #cm-grid-wrap { overflow: auto; padding: 12px 16px 24px; }
 #cm-grid { border-collapse: collapse; font-size: 12px; }
 #cm-grid th, #cm-grid td { border: 1px solid var(--ts-border, #cbd5e1); }
 .cm-corner { background: transparent; border: none; }
-.cm-col { padding: 6px 10px; vertical-align: bottom; text-align: left; background: var(--ts-bg-subtle, #f1f5f9); min-width: 90px; max-width: 160px; }
+.cm-col { padding: 6px 10px; vertical-align: bottom; text-align: left; background: var(--ts-bg-subtle, #f1f5f9); min-width: var(--ts-col-w, 120px); width: var(--ts-col-w, 120px); }
 .cm-col-name { font-weight: 600; color: var(--ts-text, #0f172a); }
 .cm-col-sev { font-size: 10px; text-transform: uppercase; letter-spacing: 0.04em; margin-top: 2px; }
 .cm-col-jur { margin-top: 4px; display: flex; flex-wrap: wrap; gap: 3px; }
@@ -266,7 +294,7 @@ body { padding: 0; }
 .cm-sev-low { color: #2563eb; }
 .cm-row { padding: 6px 12px; text-align: left; font-weight: 600; color: var(--ts-text, #0f172a); background: var(--ts-bg-subtle, #f1f5f9); white-space: nowrap; position: sticky; left: 0; }
 .cm-unresolved { color: #b45309; }
-.cm-cell { width: 110px; height: 38px; text-align: center; vertical-align: middle; }
+.cm-cell { width: var(--ts-col-w, 120px); height: 38px; text-align: center; vertical-align: middle; }
 .cm-badge { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 11px; font-weight: 600; }
 .cm-cell-link { text-decoration: none; }
 .cm-gap { background: repeating-linear-gradient(45deg, transparent, transparent 5px, var(--ts-bg-subtle, #f1f5f9) 5px, var(--ts-bg-subtle, #f1f5f9) 10px); }

--- a/extension/src/compliance-scan.ts
+++ b/extension/src/compliance-scan.ts
@@ -11,12 +11,14 @@ import { emptyCanon, ingestComplianceDoc, type ComplianceCanon } from '../../pac
 
 /**
  * The scanned canon plus an id → workspace file path map for click-to-open
- * and a count of YAML files that had both `id` and `notation` fields but
- * weren't recognised as compliance artefacts (unrecognized notation value).
+ * and an array of files that had both `id` and `notation` fields but weren't
+ * recognised as compliance artefacts (unrecognized notation value), with the
+ * short workspace-relative path and the actual notation string found.
  */
 export type ScannedCanon = ComplianceCanon & {
   pathById: Map<string, string>;
-  skippedNotationCount: number;
+  /** Files skipped due to an unrecognized `notation` value. */
+  skippedNotations: Array<{ shortPath: string; notation: string }>;
 };
 
 /**
@@ -25,14 +27,15 @@ export type ScannedCanon = ComplianceCanon & {
  * files and non-artefacts are skipped. node_modules is excluded.
  *
  * Files that have both `id` and `notation` fields but aren't recognised by
- * `ingestComplianceDoc` are counted in `skippedNotationCount` so callers can
- * surface a diagnostic rather than silently producing an empty view.
+ * `ingestComplianceDoc` are collected in `skippedNotations` so callers can
+ * surface a diagnostic with the actual notation value and file path.
  */
 export async function scanComplianceCanon(): Promise<ScannedCanon> {
   const canon = emptyCanon();
   const pathById = new Map<string, string>();
-  let skippedNotationCount = 0;
+  const skippedNotations: Array<{ shortPath: string; notation: string }> = [];
 
+  const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? '';
   const uris = await vscode.workspace.findFiles('**/*.{yaml,yml}', '**/node_modules/**', 5000);
   for (const uri of uris) {
     let parsed: unknown;
@@ -46,11 +49,15 @@ export async function scanComplianceCanon(): Promise<ScannedCanon> {
     if (id) {
       pathById.set(id, uri.fsPath);
     } else if (hasIdAndNotation(parsed)) {
-      skippedNotationCount++;
+      const notation = (parsed as Record<string, unknown>).notation as string;
+      const shortPath = workspaceRoot && uri.fsPath.startsWith(workspaceRoot)
+        ? uri.fsPath.slice(workspaceRoot.length).replace(/^[\\/]/, '')
+        : uri.fsPath;
+      skippedNotations.push({ shortPath, notation });
     }
   }
 
-  return { ...canon, pathById, skippedNotationCount };
+  return { ...canon, pathById, skippedNotations };
 }
 
 /** True when a parsed YAML document looks like a canon artefact candidate

--- a/extension/src/coverage-metric-preview.ts
+++ b/extension/src/coverage-metric-preview.ts
@@ -84,7 +84,7 @@ function buildTableHtml(matrix: CoverageMatrix): string {
     '<th class="cm-under_review" title="Requirements under review">Under review</th>' +
     '<th class="cm-gap" title="Requirements with no assertion for scoped products">Gap</th>' +
     '<th>Coverage</th>' +
-    '<th>RAG</th>' +
+    '<th title="Coverage status against configured thresholds (green / amber / red)">Coverage Status</th>' +
     '</tr></thead>' +
     '<tbody>' +
     rows +

--- a/extension/src/coverage-metric-preview.ts
+++ b/extension/src/coverage-metric-preview.ts
@@ -115,7 +115,7 @@ body { padding: 0; margin: 0; font-family: var(--vscode-font-family, sans-serif)
 .cm-non_compliant { color: var(--ts-status-error-fg, #991b1b); }
 .cm-under_review { color: var(--ts-status-info-fg, #0c4a6e); }
 .cm-gap { color: var(--ts-text-muted, #64748b); }
-.cm-coverage { min-width: 140px; }
+.cm-coverage { min-width: var(--ts-col-w, 140px); }
 .cm-bar-wrap { display: flex; align-items: center; gap: 8px; }
 .cm-bar { height: 10px; border-radius: 5px; min-width: 2px; }
 .cm-bar-green { background: var(--ts-status-success-bg, #d1fae5); outline: 1px solid var(--ts-status-success-fg, #065f46); }
@@ -176,9 +176,10 @@ export class CoverageMetricPreview {
   }
 
   private async buildHtml(yamlText: string): Promise<string> {
-    const themeId = vscode.workspace
-      .getConfiguration('transitrix')
-      .get<ThemeId>('theme', 'transitrix');
+    const cfg = vscode.workspace.getConfiguration('transitrix');
+    const themeId = cfg.get<ThemeId>('theme', 'transitrix');
+    const colW = cfg.get<string>('report.columnWidth', 'normal');
+    const colWPx = colW === 'narrow' ? 80 : colW === 'wide' ? 200 : 120;
 
     let bodyHtml: string;
     let titleLine: string;
@@ -210,6 +211,7 @@ export class CoverageMetricPreview {
       '  <meta charset="UTF-8"/>\n' +
       '  <meta http-equiv="Content-Security-Policy" content="default-src \'none\'; style-src \'unsafe-inline\';">\n' +
       '  <style>\n' +
+      `:root { --ts-col-w: ${colWPx}px; }\n` +
       generateWebviewCss(themeId) +
       '\n' +
       COVERAGE_CSS +

--- a/extension/src/fgca-preview.ts
+++ b/extension/src/fgca-preview.ts
@@ -86,7 +86,7 @@ const CHAIN_COLUMN_HEADERS: Record<ChainColumn, string> = {
 const CHAIN_TABLE_CSS = `
 .chain-table-wrap { padding: 0 16px 16px; overflow-x: auto; }
 .chain-table { border-collapse: collapse; font-size: 12px; }
-.chain-table th, .chain-table td { border: 1px solid var(--ts-border, #cbd5e1); padding: 6px 12px; text-align: left; vertical-align: top; }
+.chain-table th, .chain-table td { border: 1px solid var(--ts-border, #cbd5e1); padding: 6px 12px; text-align: left; vertical-align: top; min-width: var(--ts-col-w, 120px); }
 .chain-table th { background: var(--ts-bg-subtle, #f1f5f9); color: var(--ts-text, #0f172a); font-weight: 600; }
 .chain-table td { color: var(--ts-text, #0f172a); }
 .chain-table td.chain-empty { background: var(--ts-bg-subtle, #f8fafc); }
@@ -174,9 +174,11 @@ function renderChainPreview(
     // Scope is a no-op in table view, so no scope-warning is added here.
     const body = parsedDoc ? chainTableHtml(buildChainTable(parsedDoc, { hideChanges: p.hideChanges })) : '';
     const showHeader = !errorMsg && parsedDoc != null;
+    const colW = vscode.workspace.getConfiguration('transitrix').get<string>('report.columnWidth', 'normal');
+    const colWPx = colW === 'narrow' ? 80 : colW === 'wide' ? 200 : 120;
     const html = buildDiagramFrame({
       filename, notation: p.notation, bodyContent: body, errorMsg, warnings: baseWarnings, themeId,
-      extraStyles: CHAIN_TABLE_CSS,
+      extraStyles: `:root { --ts-col-w: ${colWPx}px; }\n` + CHAIN_TABLE_CSS,
       title: showHeader ? p.heading : undefined,
       version: docVersion,
       date: showHeader ? docDate : undefined,

--- a/extension/src/preview-controls.ts
+++ b/extension/src/preview-controls.ts
@@ -89,6 +89,21 @@ export function genNonce(): string {
   return randomBytes(16).toString('base64');
 }
 
+/**
+ * Maps a `transitrix.report.columnWidth` setting value to a pixel count.
+ * 'narrow' → 80, 'normal' → 120, 'wide' → 200.
+ */
+export function colWidthPxFromSetting(setting: string): number {
+  if (setting === 'narrow') return 80;
+  if (setting === 'wide') return 200;
+  return 120;
+}
+
+/** CSS :root block that injects --ts-col-w so report CSS can reference var(--ts-col-w). */
+export function colWidthRootCss(px: number): string {
+  return `:root { --ts-col-w: ${px}px; }`;
+}
+
 function escXml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }

--- a/extension/src/process-map-preview.ts
+++ b/extension/src/process-map-preview.ts
@@ -189,9 +189,10 @@ export class ProcessMapPreview {
       errorMsg = (e as Error).message ?? 'Parse error';
     }
 
-    const themeId = vscode.workspace
-      .getConfiguration('transitrix')
-      .get<ThemeId>('theme', 'transitrix');
+    const cfg = vscode.workspace.getConfiguration('transitrix');
+    const themeId = cfg.get<ThemeId>('theme', 'transitrix');
+    const colW = cfg.get<string>('report.columnWidth', 'normal');
+    const colWPx = colW === 'narrow' ? 80 : colW === 'wide' ? 200 : 120;
 
     return buildDiagramFrame({
       filename,
@@ -203,7 +204,7 @@ export class ProcessMapPreview {
       subtitle,
       version,
       date,
-      extraStyles: CATALOGUE_STYLES + PROCESS_MAP_STYLES,
+      extraStyles: `:root { --ts-col-w: ${colWPx}px; }\n` + CATALOGUE_STYLES + PROCESS_MAP_STYLES,
     });
   }
 }
@@ -314,7 +315,7 @@ const PROCESS_MAP_STYLES = `
     font-size: 12px;
     color: var(--ts-brand-primary, #004d67);
   }
-  .col-name      { min-width: 220px; }
+  .col-name      { min-width: var(--ts-col-w, 220px); }
   .col-status, .col-maturity, .col-owner, .col-capability, .col-bpmn { white-space: nowrap; }
   .empty-group, .empty-map {
     text-align: center;

--- a/extension/src/products-preview.ts
+++ b/extension/src/products-preview.ts
@@ -177,9 +177,10 @@ export class ProductsPreview {
       errorMsg = (e as Error).message ?? 'Parse error';
     }
 
-    const themeId = vscode.workspace
-      .getConfiguration('transitrix')
-      .get<ThemeId>('theme', 'transitrix');
+    const cfg = vscode.workspace.getConfiguration('transitrix');
+    const themeId = cfg.get<ThemeId>('theme', 'transitrix');
+    const colW = cfg.get<string>('report.columnWidth', 'normal');
+    const colWPx = colW === 'narrow' ? 80 : colW === 'wide' ? 200 : 120;
 
     return buildDiagramFrame({
       filename,
@@ -191,7 +192,7 @@ export class ProductsPreview {
       subtitle,
       version,
       date,
-      extraStyles: CATALOGUE_STYLES + PRODUCTS_STYLES,
+      extraStyles: `:root { --ts-col-w: ${colWPx}px; }\n` + CATALOGUE_STYLES + PRODUCTS_STYLES,
     });
   }
 }
@@ -243,6 +244,6 @@ const PRODUCTS_STYLES = `
     color: var(--ts-text-muted, #64748b);
     white-space: nowrap;
   }
-  .col-name { min-width: 200px; }
+  .col-name { min-width: var(--ts-col-w, 200px); }
   .col-type, .col-status, .col-maturity, .col-domain, .col-owner { white-space: nowrap; }
 `;

--- a/extension/src/scenarios-preview.ts
+++ b/extension/src/scenarios-preview.ts
@@ -184,9 +184,10 @@ export class ScenariosPreview {
       errorMsg = (e as Error).message ?? 'Parse error';
     }
 
-    const themeId = vscode.workspace
-      .getConfiguration('transitrix')
-      .get<ThemeId>('theme', 'transitrix');
+    const cfg = vscode.workspace.getConfiguration('transitrix');
+    const themeId = cfg.get<ThemeId>('theme', 'transitrix');
+    const colW = cfg.get<string>('report.columnWidth', 'normal');
+    const colWPx = colW === 'narrow' ? 80 : colW === 'wide' ? 200 : 120;
 
     return buildDiagramFrame({
       filename,
@@ -198,7 +199,7 @@ export class ScenariosPreview {
       subtitle,
       version,
       date,
-      extraStyles: CATALOGUE_STYLES + SCENARIOS_STYLES,
+      extraStyles: `:root { --ts-col-w: ${colWPx}px; }\n` + CATALOGUE_STYLES + SCENARIOS_STYLES,
     });
   }
 }
@@ -281,7 +282,7 @@ const SCENARIOS_STYLES = `
     vertical-align: top;
   }
   .scn-table tr:last-child td { border-bottom: none; }
-  .col-factor-id { font-family: monospace; white-space: nowrap; }
+  .col-factor-id { font-family: monospace; white-space: nowrap; min-width: var(--ts-col-w, 120px); }
   .col-relevance { white-space: nowrap; }
   .scn-ref-list {
     margin: 0;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/diagrams/src/compliance/impact.ts
+++ b/packages/diagrams/src/compliance/impact.ts
@@ -58,6 +58,8 @@ export interface ImpactColumn {
   stageId?: string;
   /** Human-readable column header. */
   label: string;
+  /** Display name for the subject (product/process name, not the id). */
+  subjectName?: string;
 }
 
 /**
@@ -396,9 +398,10 @@ function aggregateStatus(assertions: IndexAssertion[]): AssertionStatus {
 
 // ── Column builder helpers (CV-3a) ──────────────────────────────────────────
 
-function buildProductColumns(config: ImpactViewConfig): ImpactColumn[] {
+function buildProductColumns(config: ImpactViewConfig, products: { id: string; name: string }[]): ImpactColumn[] {
+  const nameMap = new Map(products.map(p => [p.id, p.name]));
   const subjects = [...(config.subjects.products ?? []), ...(config.subjects.processes ?? [])];
-  return subjects.map(id => ({ subjectId: id, label: id }));
+  return subjects.map(id => ({ subjectId: id, label: id, subjectName: nameMap.get(id) }));
 }
 
 function buildObjectDetailColumns(config: ImpactViewConfig, objectDetails: ObjectDetailInput[]): ImpactColumn[] {
@@ -462,7 +465,7 @@ export function buildImpactMatrix(
     config.grouping?.columns === 'object-details' && objectDetails && objectDetails.length > 0;
   const columns: ImpactColumn[] = useStageGrain
     ? buildObjectDetailColumns(config, objectDetails!)
-    : buildProductColumns(config);
+    : buildProductColumns(config, canon.products ?? []);
 
   const allowedStatuses = new Set<AssertionStatus>(
     config.status_display?.show ?? ['compliant', 'partial', 'non_compliant', 'under_review', 'n_a'],


### PR DESCRIPTION
## Summary

Three UX improvements to compliance and catalogue table reports:

- **Product names in compliance-impact headers** — `ImpactColumn` gains `subjectName`; `buildProductColumns()` resolves it from `canon.products`; column header renders name bold + code in gray below (`.ci-col-id`)
- **Column width setting for all table-based reports** — new `transitrix.report.columnWidth` setting (narrow 80 px / normal 120 px / wide 200 px); compliance-impact and compliance-matrix expose a live `<select>` in their filter bar that persists to workspace config; static reports (Products, Process Map, Applications, Scenarios, Coverage Metric, FGCA chain table) read the setting at render time; all inject `--ts-col-w` CSS variable
- **Skipped-notation diagnostic** — `ScannedCanon.skippedNotationCount` replaced by `skippedNotations[]` (shortPath + notation); compliance-impact toolbar now shows the distinct notation values found and a hover tooltip with full file paths

## Test plan

- [ ] Compliance Impact: column headers show product name + gray code; Columns select (Narrow/Normal/Wide) resizes columns immediately and persists across panel close/reopen
- [ ] Compliance Matrix: same column-width control in filter bar
- [ ] Products / Process Map / Applications: changing `transitrix.report.columnWidth` in settings and reopening preview reflects new width
- [ ] When a YAML file in workspace has `id` + `notation` but notation is not `product|requirement|assertion`, toolbar shows the actual notation value and file path on hover (not just a count)
- [ ] Tests pass (`npm run test`)
- [ ] TypeScript: `npx tsc -p extension/tsconfig.json --noEmit` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)