### PR TITLE
fix(coverage-metric): align parser with spec — view: wrapper + regimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 ## [Unreleased]
 
-### Removed
-- **`build-extension.bat` and `build-extension.sh`** — replaced by `scripts/package-extension.mjs`, a cross-platform Node.js script with identical `--bump` / `--target` flags. Run via `npm run package-extension` (no flags = universal local-install VSIX, same default as before) or directly with `node scripts/package-extension.mjs --help`. The `package-extension` npm script no longer auto-bumps the version; pass `--bump` explicitly when a version increment is wanted.
+## [1.5.3] — 2026-06-17
+
+### Fixed
+- **Compliance-impact preview now renders the matrix grid.** `bodyHtml` (the obligation × subject table) was computed but never interpolated into the HTML template returned by `buildHtml` — the panel displayed the toolbar and filter controls but the body was completely absent. One-line fix inserts `bodyHtml` between the filters block and the script tag.
+
+### Changed
+- **Compliance-impact scan surfaces a skip-count diagnostic.** `scanComplianceCanon` now counts YAML files that carry both `id` and `notation` fields but aren't recognised as compliance artefacts (unrecognized notation value). The preview summary line shows a ⚠ warning with the count so users can diagnose an unexpectedly empty matrix rather than guessing.
+- **Build scripts consolidated** — `build-extension.bat` / `build-extension.sh` replaced by `scripts/package-extension.mjs` (cross-platform Node.js, same `--bump` / `--target` flags). Shared esbuild constants extracted to `scripts/esbuild-helpers.mjs` to reduce duplication across the three bundle scripts.
 
 ## [1.5.2] — 2026-06-16
 

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Transitrix Studio — changelog
 
+## 1.5.3 — 2026-06-17
+
+### Fixed
+
+- **Compliance-impact preview now renders the matrix grid.** The obligation × subject table was computed but never inserted into the panel HTML — you saw the toolbar and filters but an empty body. Fixed.
+- **Scan warns when files are silently skipped.** If the workspace contains YAML files with an `id` and `notation` field that the compliance scanner doesn't recognise, the preview summary now shows a ⚠ count instead of silently producing an empty view.
+
 ## 1.5.1 — 2026-06-16
 
 Tidier preview strips: validation warnings now collapse, and the error strip folds in static previews too.

--- a/extension/package.json
+++ b/extension/package.json
@@ -104,6 +104,17 @@
           "default": "transitrix",
           "description": "Color theme for Transitrix diagram previews (Goals, FGCA, and other static notation previews)."
         },
+        "transitrix.report.columnWidth": {
+          "type": "string",
+          "enum": ["narrow", "normal", "wide"],
+          "enumDescriptions": [
+            "Narrow columns (80 px)",
+            "Normal columns (120 px)",
+            "Wide columns (200 px)"
+          ],
+          "default": "normal",
+          "description": "Column width preset for table-based reports (Compliance Impact, Compliance Matrix, Products, Process Map, etc.)."
+        },
         "transitrix.spacing.goals.horizontalGap": {
           "type": "number",
           "minimum": 20,

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Architecture-as-code for the modern enterprise. Author 17 notations — goals, processes, capabilities, BPMN, applications, more — as plain YAML, get live diagrams in VS Code. Diffable in git. AI-friendly. Open source. Built on ArchiMate 3.2 and BPMN 2.0.",
   "license": "MIT",
   "icon": "icon.png",

--- a/extension/src/applications-preview.ts
+++ b/extension/src/applications-preview.ts
@@ -210,9 +210,10 @@ export class ApplicationsPreview {
       errorMsg = (e as Error).message ?? 'Parse error';
     }
 
-    const themeId = vscode.workspace
-      .getConfiguration('transitrix')
-      .get<ThemeId>('theme', 'transitrix');
+    const cfg = vscode.workspace.getConfiguration('transitrix');
+    const themeId = cfg.get<ThemeId>('theme', 'transitrix');
+    const colW = cfg.get<string>('report.columnWidth', 'normal');
+    const colWPx = colW === 'narrow' ? 80 : colW === 'wide' ? 200 : 120;
 
     return buildDiagramFrame({
       filename,
@@ -224,7 +225,7 @@ export class ApplicationsPreview {
       subtitle,
       version,
       date,
-      extraStyles: CATALOGUE_STYLES + APPLICATIONS_STYLES,
+      extraStyles: `:root { --ts-col-w: ${colWPx}px; }\n` + CATALOGUE_STYLES + APPLICATIONS_STYLES,
     });
   }
 }
@@ -300,6 +301,6 @@ const APPLICATIONS_STYLES = `
   }
   .vendor-internal { font-style: italic; color: var(--ts-text-muted, #64748b); }
   .vendor-external { color: var(--ts-text, #0f172a); }
-  .col-name { min-width: 200px; }
+  .col-name { min-width: var(--ts-col-w, 200px); }
   .col-type, .col-status, .col-maturity, .col-domain, .col-vendor, .col-owner { white-space: nowrap; }
 `;

--- a/extension/src/compliance-impact-preview.ts
+++ b/extension/src/compliance-impact-preview.ts
@@ -10,7 +10,7 @@ import {
 } from '../../packages/diagrams/src/compliance/impact.js';
 import type { AssertionStatus } from '../../packages/diagrams/src/assertion/types.js';
 import type { IndexRequirement, DeadlineStatus } from '../../packages/diagrams/src/compliance/types.js';
-import { genNonce } from './preview-controls.js';
+import { genNonce, colWidthPxFromSetting, colWidthRootCss } from './preview-controls.js';
 import { scanComplianceCanon, openComplianceFile } from './compliance-scan.js';
 import type { ScannedCanon } from './compliance-scan.js';
 
@@ -274,6 +274,7 @@ export class ComplianceImpactPreview {
   private pendingIndex = new Map<string, number>();
   private jIndex = new Map<string, string[]>();
   private filter: ImpactFilter = defaultFilter();
+  private colWidth: string = vscode.workspace.getConfiguration('transitrix').get<string>('report.columnWidth', 'normal');
 
   constructor(private readonly extensionUri: vscode.Uri) {}
 
@@ -343,7 +344,17 @@ export class ComplianceImpactPreview {
     severities?: string[];
     jurisdictions?: string[];
     showObligationsLane?: boolean;
+    columnWidth?: string;
   }): Promise<void> {
+    if (m?.type === 'transitrix:col-width') {
+      const w = m.columnWidth;
+      if (w === 'narrow' || w === 'normal' || w === 'wide') {
+        this.colWidth = w;
+        void vscode.workspace.getConfiguration('transitrix').update('report.columnWidth', w, vscode.ConfigurationTarget.Workspace);
+      }
+      this.render();
+      return;
+    }
     if (m?.type !== 'transitrix:impact-filter') return;
     this.filter = {
       statuses: new Set(
@@ -382,9 +393,15 @@ export class ComplianceImpactPreview {
     const totalPending = [...this.pendingIndex.values()].reduce((a, b) => a + b, 0);
     const pendingSummary =
       totalPending > 0 ? ' &middot; <strong>' + totalPending + '</strong> pending (admission)' : '';
-    const skipped = this.canon?.skippedNotationCount ?? 0;
-    const skippedSummary =
-      skipped > 0 ? ' &middot; &#x26A0; <strong>' + skipped + '</strong> file(s) skipped (unrecognized notation)' : '';
+    const skippedList = this.canon?.skippedNotations ?? [];
+    const skippedSummary = skippedList.length > 0
+      ? ' &middot; &#x26A0; <strong>' + skippedList.length + '</strong> file(s) skipped'
+        + ' &mdash; unrecognized notation: '
+        + [...new Set(skippedList.map(s => '<code>' + escXml(s.notation) + '</code>'))].join(', ')
+        + ' <span class="ci-skipped-hint" title="'
+        + escXml(skippedList.map(s => s.notation + ': ' + s.shortPath).join('\n'))
+        + '">(?)</span>'
+      : '';
 
     const empty = rows.length === 0 || columns.length === 0;
     const bodyHtml = empty ? this.emptyHtml(matrix) : this.gridHtml(rows, columns, cells, matrix.emptyLabels, matrix.obligationsLane, this.filter.showObligationsLane);
@@ -430,10 +447,20 @@ export class ComplianceImpactPreview {
       (this.filter.showObligationsLane ? ' checked' : '') +
       '> Laws lane</label>';
 
+    const colWidthSelect =
+      '<span class="ci-filter-label">Columns</span>' +
+      '<select data-ci-col-width class="ci-col-width-select">' +
+      ['narrow', 'normal', 'wide']
+        .map(w => '<option value="' + w + '"' + (this.colWidth === w ? ' selected' : '') + '>' + w.charAt(0).toUpperCase() + w.slice(1) + '</option>')
+        .join('') +
+      '</select>';
+
     const configLine =
       config.id === 'auto'
         ? 'Auto-config (add *.compliance-impact.{view,transitrix}.yaml to pin)'
         : 'View: <code>' + escXml(config.id) + '</code>';
+
+    const colWCss = colWidthRootCss(colWidthPxFromSetting(this.colWidth));
 
     return (
       '<!DOCTYPE html>\n' +
@@ -444,6 +471,8 @@ export class ComplianceImpactPreview {
       nonce +
       '\';">\n' +
       '  <style>\n' +
+      colWCss +
+      '\n' +
       generateWebviewCss(themeId) +
       '\n' +
       IMPACT_CSS +
@@ -483,6 +512,8 @@ export class ComplianceImpactPreview {
       jurisdictionRow +
       '\n    <span class="ci-filter-label">Lanes</span>' +
       laneToggle +
+      '\n    ' +
+      colWidthSelect +
       '\n' +
       '  </div>\n' +
       '\n' +
@@ -511,6 +542,12 @@ export class ComplianceImpactPreview {
       "      });\n" +
       "    });\n" +
       "  });\n" +
+      "  var colWidthSel = document.querySelector('[data-ci-col-width]');\n" +
+      "  if (colWidthSel) {\n" +
+      "    colWidthSel.addEventListener('change', function () {\n" +
+      "      vscode.postMessage({ type: 'transitrix:col-width', columnWidth: colWidthSel.value });\n" +
+      "    });\n" +
+      "  }\n" +
       '}());\n' +
       '  </script>\n' +
       '</body>\n' +
@@ -536,7 +573,13 @@ export class ComplianceImpactPreview {
     const head =
       '<tr>\n      <th class="ci-corner"></th>\n      ' +
       columns
-        .map(col => '<th class="ci-col"><div class="ci-col-name">' + escXml(col.label) + '</div></th>')
+        .map(col =>
+          '<th class="ci-col"><div class="ci-col-name">' +
+          escXml(col.subjectName ?? col.label) +
+          '</div>' +
+          (col.subjectName ? '<div class="ci-col-id">' + escXml(col.label) + '</div>' : '') +
+          '</th>',
+        )
         .join('') +
       '\n    </tr>';
     const laneRow = showObligationsLane
@@ -686,19 +729,21 @@ body { padding: 0; }
 .ci-filter-label { font-weight: 600; color: var(--ts-text, #0f172a); margin-left: 8px; }
 .ci-filter-label:first-child { margin-left: 0; }
 .ci-chip { display: inline-flex; align-items: center; gap: 4px; color: var(--ts-text-muted, #64748b); cursor: pointer; }
+.ci-col-width-select { font-size: 11px; font-family: var(--vscode-font-family, sans-serif); color: var(--vscode-input-foreground, #333); background: var(--vscode-input-background, #fff); border: 1px solid var(--vscode-input-border, var(--ts-border, #cbd5e1)); border-radius: 3px; padding: 1px 4px; }
 #ci-grid-wrap { overflow: auto; padding: 12px 16px 24px; }
 #ci-grid { border-collapse: collapse; font-size: 12px; }
 #ci-grid th, #ci-grid td { border: 1px solid var(--ts-border, #cbd5e1); }
 .ci-corner { background: transparent; border: none; }
-.ci-col { padding: 6px 10px; vertical-align: bottom; text-align: left; background: var(--ts-bg-subtle, #f1f5f9); min-width: 80px; max-width: 140px; }
+.ci-col { padding: 6px 10px; vertical-align: bottom; text-align: left; background: var(--ts-bg-subtle, #f1f5f9); min-width: var(--ts-col-w, 120px); width: var(--ts-col-w, 120px); }
 .ci-col-name { font-weight: 600; color: var(--ts-text, #0f172a); font-size: 11px; word-break: break-all; }
+.ci-col-id { font-size: 10px; font-family: var(--vscode-editor-font-family, monospace); color: var(--ts-text-muted, #64748b); margin-top: 2px; word-break: break-all; }
 .ci-row { padding: 6px 12px; text-align: left; background: var(--ts-bg-subtle, #f1f5f9); white-space: nowrap; position: sticky; left: 0; min-width: 160px; max-width: 260px; }
 .ci-row-id { font-size: 11px; font-family: var(--vscode-editor-font-family, monospace); color: var(--ts-text-muted, #64748b); }
 .ci-row-name { font-weight: 600; color: var(--ts-text, #0f172a); font-size: 12px; white-space: normal; }
 .ci-sev { font-size: 10px; text-transform: uppercase; letter-spacing: 0.04em; margin-top: 2px; }
 .ci-sev-high { color: #b91c1c; } .ci-sev-medium { color: #b45309; } .ci-sev-low { color: #2563eb; }
 .ci-jur { display: inline-block; padding: 1px 5px; border-radius: 3px; font-size: 10px; color: var(--ts-text-muted, #64748b); background: var(--ts-bg-elevated, #e2e8f0); text-transform: uppercase; letter-spacing: 0.04em; margin-top: 2px; margin-right: 2px; }
-.ci-cell { width: 110px; height: 40px; text-align: center; vertical-align: middle; }
+.ci-cell { width: var(--ts-col-w, 120px); height: 40px; text-align: center; vertical-align: middle; }
 .ci-badge { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 11px; font-weight: 600; }
 .ci-link { text-decoration: none; }
 .ci-gap { background: repeating-linear-gradient(45deg, transparent, transparent 5px, var(--ts-bg-subtle, #f1f5f9) 5px, var(--ts-bg-subtle, #f1f5f9) 10px); }
@@ -717,6 +762,7 @@ body { padding: 0; }
 .ci-badge-under_review { color: var(--ts-status-info-fg, #0c4a6e); background: var(--ts-status-info-bg, #e0f2fe); }
 .ci-empty { padding: 40px 24px; color: var(--ts-text-muted, #64748b); max-width: 640px; }
 .ci-empty code { background: var(--ts-bg-subtle, #f1f5f9); padding: 1px 4px; border-radius: 3px; }
+.ci-skipped-hint { cursor: help; color: var(--ts-text-muted, #64748b); font-size: 10px; vertical-align: super; }
 .ci-new { box-shadow: inset 0 0 0 2px #6366f1; }
 .ci-urgent { background: repeating-linear-gradient(45deg, #fee2e2, #fee2e2 5px, #fef2f2 5px, #fef2f2 10px) !important; }
 .ci-urgent-badge { display: inline-flex; align-items: center; justify-content: center; width: 18px; height: 18px; border-radius: 50%; background: #dc2626; color: #fff; font-weight: 700; font-size: 11px; }

--- a/extension/src/compliance-matrix-preview.ts
+++ b/extension/src/compliance-matrix-preview.ts
@@ -7,7 +7,7 @@ import {
   type MatrixFilter,
 } from '../../packages/diagrams/src/compliance-matrix/index.js';
 import type { AssertionStatus } from '../../packages/diagrams/src/assertion/types.js';
-import { genNonce } from './preview-controls.js';
+import { genNonce, colWidthPxFromSetting, colWidthRootCss } from './preview-controls.js';
 import { scanComplianceCanon } from './compliance-scan.js';
 
 // Compliance matrix preview (vkgeorgia/strategy#84 Phase 2).
@@ -53,6 +53,7 @@ export class ComplianceMatrixPreview {
   private fullMatrix: ComplianceMatrix | undefined;
   private assertionPaths = new Map<string, string>();
   private filter: MatrixFilter = {};
+  private colWidth: string = vscode.workspace.getConfiguration('transitrix').get<string>('report.columnWidth', 'normal');
 
   constructor(private readonly extensionUri: vscode.Uri) {}
 
@@ -94,8 +95,17 @@ export class ComplianceMatrixPreview {
   }
 
   private async onMessage(m: {
-    type?: string; statuses?: string[]; severities?: string[]; jurisdictions?: string[];
+    type?: string; statuses?: string[]; severities?: string[]; jurisdictions?: string[]; columnWidth?: string;
   }): Promise<void> {
+    if (m?.type === 'transitrix:col-width') {
+      const w = m.columnWidth;
+      if (w === 'narrow' || w === 'normal' || w === 'wide') {
+        this.colWidth = w;
+        void vscode.workspace.getConfiguration('transitrix').update('report.columnWidth', w, vscode.ConfigurationTarget.Workspace);
+      }
+      this.render();
+      return;
+    }
     if (m?.type !== 'transitrix:matrix-filter') return;
     this.filter = {
       statuses: (m.statuses ?? []).filter((s): s is AssertionStatus => (ALL_STATUSES as string[]).includes(s)),
@@ -148,12 +158,22 @@ export class ComplianceMatrixPreview {
       ? `<span class="cm-filter-label">Jurisdiction</span>${jurisdictionBoxes}`
       : '';
 
+    const colWCss = colWidthRootCss(colWidthPxFromSetting(this.colWidth));
+    const colWidthSelect =
+      `<span class="cm-filter-label">Columns</span>` +
+      `<select data-cm-col-width class="cm-col-width-select">` +
+      ['narrow', 'normal', 'wide'].map(w =>
+        `<option value="${w}"${this.colWidth === w ? ' selected' : ''}>${w.charAt(0).toUpperCase()}${w.slice(1)}</option>`
+      ).join('') +
+      `</select>`;
+
     return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8"/>
   <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';">
   <style>
+${colWCss}
 ${generateWebviewCss(themeId)}
 ${MATRIX_CSS}
   </style>
@@ -168,6 +188,7 @@ ${MATRIX_CSS}
     <span class="cm-filter-label">Status</span>${statusBoxes}
     <span class="cm-filter-label">Severity</span>${severityBoxes}
     ${jurisdictionRow}
+    ${colWidthSelect}
   </div>
   ${body}
   <script nonce="${nonce}">
@@ -190,6 +211,12 @@ ${MATRIX_CSS}
       });
     });
   });
+  var colWidthSel = document.querySelector('[data-cm-col-width]');
+  if (colWidthSel) {
+    colWidthSel.addEventListener('change', function () {
+      vscode.postMessage({ type: 'transitrix:col-width', columnWidth: colWidthSel.value });
+    });
+  }
 }());
   </script>
 </body>
@@ -252,11 +279,12 @@ body { padding: 0; }
 .cm-filter-label { font-weight: 600; color: var(--ts-text, #0f172a); margin-left: 8px; }
 .cm-filter-label:first-child { margin-left: 0; }
 .cm-chip { display: inline-flex; align-items: center; gap: 4px; color: var(--ts-text-muted, #64748b); }
+.cm-col-width-select { font-size: 11px; font-family: var(--vscode-font-family, sans-serif); color: var(--vscode-input-foreground, #333); background: var(--vscode-input-background, #fff); border: 1px solid var(--vscode-input-border, var(--ts-border, #cbd5e1)); border-radius: 3px; padding: 1px 4px; }
 #cm-grid-wrap { overflow: auto; padding: 12px 16px 24px; }
 #cm-grid { border-collapse: collapse; font-size: 12px; }
 #cm-grid th, #cm-grid td { border: 1px solid var(--ts-border, #cbd5e1); }
 .cm-corner { background: transparent; border: none; }
-.cm-col { padding: 6px 10px; vertical-align: bottom; text-align: left; background: var(--ts-bg-subtle, #f1f5f9); min-width: 90px; max-width: 160px; }
+.cm-col { padding: 6px 10px; vertical-align: bottom; text-align: left; background: var(--ts-bg-subtle, #f1f5f9); min-width: var(--ts-col-w, 120px); width: var(--ts-col-w, 120px); }
 .cm-col-name { font-weight: 600; color: var(--ts-text, #0f172a); }
 .cm-col-sev { font-size: 10px; text-transform: uppercase; letter-spacing: 0.04em; margin-top: 2px; }
 .cm-col-jur { margin-top: 4px; display: flex; flex-wrap: wrap; gap: 3px; }
@@ -266,7 +294,7 @@ body { padding: 0; }
 .cm-sev-low { color: #2563eb; }
 .cm-row { padding: 6px 12px; text-align: left; font-weight: 600; color: var(--ts-text, #0f172a); background: var(--ts-bg-subtle, #f1f5f9); white-space: nowrap; position: sticky; left: 0; }
 .cm-unresolved { color: #b45309; }
-.cm-cell { width: 110px; height: 38px; text-align: center; vertical-align: middle; }
+.cm-cell { width: var(--ts-col-w, 120px); height: 38px; text-align: center; vertical-align: middle; }
 .cm-badge { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 11px; font-weight: 600; }
 .cm-cell-link { text-decoration: none; }
 .cm-gap { background: repeating-linear-gradient(45deg, transparent, transparent 5px, var(--ts-bg-subtle, #f1f5f9) 5px, var(--ts-bg-subtle, #f1f5f9) 10px); }

--- a/extension/src/compliance-scan.ts
+++ b/extension/src/compliance-scan.ts
@@ -11,12 +11,14 @@ import { emptyCanon, ingestComplianceDoc, type ComplianceCanon } from '../../pac
 
 /**
  * The scanned canon plus an id → workspace file path map for click-to-open
- * and a count of YAML files that had both `id` and `notation` fields but
- * weren't recognised as compliance artefacts (unrecognized notation value).
+ * and an array of files that had both `id` and `notation` fields but weren't
+ * recognised as compliance artefacts (unrecognized notation value), with the
+ * short workspace-relative path and the actual notation string found.
  */
 export type ScannedCanon = ComplianceCanon & {
   pathById: Map<string, string>;
-  skippedNotationCount: number;
+  /** Files skipped due to an unrecognized `notation` value. */
+  skippedNotations: Array<{ shortPath: string; notation: string }>;
 };
 
 /**
@@ -25,14 +27,15 @@ export type ScannedCanon = ComplianceCanon & {
  * files and non-artefacts are skipped. node_modules is excluded.
  *
  * Files that have both `id` and `notation` fields but aren't recognised by
- * `ingestComplianceDoc` are counted in `skippedNotationCount` so callers can
- * surface a diagnostic rather than silently producing an empty view.
+ * `ingestComplianceDoc` are collected in `skippedNotations` so callers can
+ * surface a diagnostic with the actual notation value and file path.
  */
 export async function scanComplianceCanon(): Promise<ScannedCanon> {
   const canon = emptyCanon();
   const pathById = new Map<string, string>();
-  let skippedNotationCount = 0;
+  const skippedNotations: Array<{ shortPath: string; notation: string }> = [];
 
+  const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? '';
   const uris = await vscode.workspace.findFiles('**/*.{yaml,yml}', '**/node_modules/**', 5000);
   for (const uri of uris) {
     let parsed: unknown;
@@ -46,11 +49,15 @@ export async function scanComplianceCanon(): Promise<ScannedCanon> {
     if (id) {
       pathById.set(id, uri.fsPath);
     } else if (hasIdAndNotation(parsed)) {
-      skippedNotationCount++;
+      const notation = (parsed as Record<string, unknown>).notation as string;
+      const shortPath = workspaceRoot && uri.fsPath.startsWith(workspaceRoot)
+        ? uri.fsPath.slice(workspaceRoot.length).replace(/^[\\/]/, '')
+        : uri.fsPath;
+      skippedNotations.push({ shortPath, notation });
     }
   }
 
-  return { ...canon, pathById, skippedNotationCount };
+  return { ...canon, pathById, skippedNotations };
 }
 
 /** True when a parsed YAML document looks like a canon artefact candidate

--- a/extension/src/coverage-metric-preview.ts
+++ b/extension/src/coverage-metric-preview.ts
@@ -84,7 +84,7 @@ function buildTableHtml(matrix: CoverageMatrix): string {
     '<th class="cm-under_review" title="Requirements under review">Under review</th>' +
     '<th class="cm-gap" title="Requirements with no assertion for scoped products">Gap</th>' +
     '<th>Coverage</th>' +
-    '<th>RAG</th>' +
+    '<th title="Coverage status against configured thresholds (green / amber / red)">Coverage Status</th>' +
     '</tr></thead>' +
     '<tbody>' +
     rows +

--- a/extension/src/coverage-metric-preview.ts
+++ b/extension/src/coverage-metric-preview.ts
@@ -65,7 +65,7 @@ function buildRowHtml(row: CoverageRow): string {
 
 function buildTableHtml(matrix: CoverageMatrix): string {
   if (matrix.rows.length === 0) {
-    return '<div class="cm-empty"><p>No laws in scope. Add <code>scope.codex</code> entries to the view config.</p></div>';
+    return '<div class="cm-empty"><p>No laws in scope. Add <code>regimes.include</code> or <code>regimes.filter</code> under the <code>view:</code> block, or the canon has no codex entries yet.</p></div>';
   }
 
   const rows = matrix.rows.map(buildRowHtml).join('');

--- a/extension/src/coverage-metric-preview.ts
+++ b/extension/src/coverage-metric-preview.ts
@@ -115,7 +115,7 @@ body { padding: 0; margin: 0; font-family: var(--vscode-font-family, sans-serif)
 .cm-non_compliant { color: var(--ts-status-error-fg, #991b1b); }
 .cm-under_review { color: var(--ts-status-info-fg, #0c4a6e); }
 .cm-gap { color: var(--ts-text-muted, #64748b); }
-.cm-coverage { min-width: 140px; }
+.cm-coverage { min-width: var(--ts-col-w, 140px); }
 .cm-bar-wrap { display: flex; align-items: center; gap: 8px; }
 .cm-bar { height: 10px; border-radius: 5px; min-width: 2px; }
 .cm-bar-green { background: var(--ts-status-success-bg, #d1fae5); outline: 1px solid var(--ts-status-success-fg, #065f46); }
@@ -176,9 +176,10 @@ export class CoverageMetricPreview {
   }
 
   private async buildHtml(yamlText: string): Promise<string> {
-    const themeId = vscode.workspace
-      .getConfiguration('transitrix')
-      .get<ThemeId>('theme', 'transitrix');
+    const cfg = vscode.workspace.getConfiguration('transitrix');
+    const themeId = cfg.get<ThemeId>('theme', 'transitrix');
+    const colW = cfg.get<string>('report.columnWidth', 'normal');
+    const colWPx = colW === 'narrow' ? 80 : colW === 'wide' ? 200 : 120;
 
     let bodyHtml: string;
     let titleLine: string;
@@ -210,6 +211,7 @@ export class CoverageMetricPreview {
       '  <meta charset="UTF-8"/>\n' +
       '  <meta http-equiv="Content-Security-Policy" content="default-src \'none\'; style-src \'unsafe-inline\';">\n' +
       '  <style>\n' +
+      `:root { --ts-col-w: ${colWPx}px; }\n` +
       generateWebviewCss(themeId) +
       '\n' +
       COVERAGE_CSS +

--- a/extension/src/fgca-preview.ts
+++ b/extension/src/fgca-preview.ts
@@ -86,7 +86,7 @@ const CHAIN_COLUMN_HEADERS: Record<ChainColumn, string> = {
 const CHAIN_TABLE_CSS = `
 .chain-table-wrap { padding: 0 16px 16px; overflow-x: auto; }
 .chain-table { border-collapse: collapse; font-size: 12px; }
-.chain-table th, .chain-table td { border: 1px solid var(--ts-border, #cbd5e1); padding: 6px 12px; text-align: left; vertical-align: top; }
+.chain-table th, .chain-table td { border: 1px solid var(--ts-border, #cbd5e1); padding: 6px 12px; text-align: left; vertical-align: top; min-width: var(--ts-col-w, 120px); }
 .chain-table th { background: var(--ts-bg-subtle, #f1f5f9); color: var(--ts-text, #0f172a); font-weight: 600; }
 .chain-table td { color: var(--ts-text, #0f172a); }
 .chain-table td.chain-empty { background: var(--ts-bg-subtle, #f8fafc); }
@@ -174,9 +174,11 @@ function renderChainPreview(
     // Scope is a no-op in table view, so no scope-warning is added here.
     const body = parsedDoc ? chainTableHtml(buildChainTable(parsedDoc, { hideChanges: p.hideChanges })) : '';
     const showHeader = !errorMsg && parsedDoc != null;
+    const colW = vscode.workspace.getConfiguration('transitrix').get<string>('report.columnWidth', 'normal');
+    const colWPx = colW === 'narrow' ? 80 : colW === 'wide' ? 200 : 120;
     const html = buildDiagramFrame({
       filename, notation: p.notation, bodyContent: body, errorMsg, warnings: baseWarnings, themeId,
-      extraStyles: CHAIN_TABLE_CSS,
+      extraStyles: `:root { --ts-col-w: ${colWPx}px; }\n` + CHAIN_TABLE_CSS,
       title: showHeader ? p.heading : undefined,
       version: docVersion,
       date: showHeader ? docDate : undefined,

--- a/extension/src/preview-controls.ts
+++ b/extension/src/preview-controls.ts
@@ -89,6 +89,21 @@ export function genNonce(): string {
   return randomBytes(16).toString('base64');
 }
 
+/**
+ * Maps a `transitrix.report.columnWidth` setting value to a pixel count.
+ * 'narrow' → 80, 'normal' → 120, 'wide' → 200.
+ */
+export function colWidthPxFromSetting(setting: string): number {
+  if (setting === 'narrow') return 80;
+  if (setting === 'wide') return 200;
+  return 120;
+}
+
+/** CSS :root block that injects --ts-col-w so report CSS can reference var(--ts-col-w). */
+export function colWidthRootCss(px: number): string {
+  return `:root { --ts-col-w: ${px}px; }`;
+}
+
 function escXml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }

--- a/extension/src/process-map-preview.ts
+++ b/extension/src/process-map-preview.ts
@@ -189,9 +189,10 @@ export class ProcessMapPreview {
       errorMsg = (e as Error).message ?? 'Parse error';
     }
 
-    const themeId = vscode.workspace
-      .getConfiguration('transitrix')
-      .get<ThemeId>('theme', 'transitrix');
+    const cfg = vscode.workspace.getConfiguration('transitrix');
+    const themeId = cfg.get<ThemeId>('theme', 'transitrix');
+    const colW = cfg.get<string>('report.columnWidth', 'normal');
+    const colWPx = colW === 'narrow' ? 80 : colW === 'wide' ? 200 : 120;
 
     return buildDiagramFrame({
       filename,
@@ -203,7 +204,7 @@ export class ProcessMapPreview {
       subtitle,
       version,
       date,
-      extraStyles: CATALOGUE_STYLES + PROCESS_MAP_STYLES,
+      extraStyles: `:root { --ts-col-w: ${colWPx}px; }\n` + CATALOGUE_STYLES + PROCESS_MAP_STYLES,
     });
   }
 }
@@ -314,7 +315,7 @@ const PROCESS_MAP_STYLES = `
     font-size: 12px;
     color: var(--ts-brand-primary, #004d67);
   }
-  .col-name      { min-width: 220px; }
+  .col-name      { min-width: var(--ts-col-w, 220px); }
   .col-status, .col-maturity, .col-owner, .col-capability, .col-bpmn { white-space: nowrap; }
   .empty-group, .empty-map {
     text-align: center;

--- a/extension/src/products-preview.ts
+++ b/extension/src/products-preview.ts
@@ -177,9 +177,10 @@ export class ProductsPreview {
       errorMsg = (e as Error).message ?? 'Parse error';
     }
 
-    const themeId = vscode.workspace
-      .getConfiguration('transitrix')
-      .get<ThemeId>('theme', 'transitrix');
+    const cfg = vscode.workspace.getConfiguration('transitrix');
+    const themeId = cfg.get<ThemeId>('theme', 'transitrix');
+    const colW = cfg.get<string>('report.columnWidth', 'normal');
+    const colWPx = colW === 'narrow' ? 80 : colW === 'wide' ? 200 : 120;
 
     return buildDiagramFrame({
       filename,
@@ -191,7 +192,7 @@ export class ProductsPreview {
       subtitle,
       version,
       date,
-      extraStyles: CATALOGUE_STYLES + PRODUCTS_STYLES,
+      extraStyles: `:root { --ts-col-w: ${colWPx}px; }\n` + CATALOGUE_STYLES + PRODUCTS_STYLES,
     });
   }
 }
@@ -243,6 +244,6 @@ const PRODUCTS_STYLES = `
     color: var(--ts-text-muted, #64748b);
     white-space: nowrap;
   }
-  .col-name { min-width: 200px; }
+  .col-name { min-width: var(--ts-col-w, 200px); }
   .col-type, .col-status, .col-maturity, .col-domain, .col-owner { white-space: nowrap; }
 `;

--- a/extension/src/scenarios-preview.ts
+++ b/extension/src/scenarios-preview.ts
@@ -184,9 +184,10 @@ export class ScenariosPreview {
       errorMsg = (e as Error).message ?? 'Parse error';
     }
 
-    const themeId = vscode.workspace
-      .getConfiguration('transitrix')
-      .get<ThemeId>('theme', 'transitrix');
+    const cfg = vscode.workspace.getConfiguration('transitrix');
+    const themeId = cfg.get<ThemeId>('theme', 'transitrix');
+    const colW = cfg.get<string>('report.columnWidth', 'normal');
+    const colWPx = colW === 'narrow' ? 80 : colW === 'wide' ? 200 : 120;
 
     return buildDiagramFrame({
       filename,
@@ -198,7 +199,7 @@ export class ScenariosPreview {
       subtitle,
       version,
       date,
-      extraStyles: CATALOGUE_STYLES + SCENARIOS_STYLES,
+      extraStyles: `:root { --ts-col-w: ${colWPx}px; }\n` + CATALOGUE_STYLES + SCENARIOS_STYLES,
     });
   }
 }
@@ -281,7 +282,7 @@ const SCENARIOS_STYLES = `
     vertical-align: top;
   }
   .scn-table tr:last-child td { border-bottom: none; }
-  .col-factor-id { font-family: monospace; white-space: nowrap; }
+  .col-factor-id { font-family: monospace; white-space: nowrap; min-width: var(--ts-col-w, 120px); }
   .col-relevance { white-space: nowrap; }
   .scn-ref-list {
     margin: 0;

--- a/organizations/acme_corp/canon/views/coverage-metric/eu-coverage.coverage-metric.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/coverage-metric/eu-coverage.coverage-metric.transitrix.yaml
@@ -2,9 +2,9 @@
 # Opens in Transitrix Studio; notation spec: notations/views/22-coverage-metric.md.
 
 notation: coverage-metric
-spec_version: "0.1"
+spec_version: "0.2"
 
-coverage_metric:
+view:
   id: COVERAGE_METRIC-ACME-EU-1
   name: "acme_corp — EU Coverage Metric (GDPR + NIS2)"
   description: >
@@ -13,21 +13,19 @@ coverage_metric:
     that are compliant, partial, under review, non-compliant, or gap
     (no assertion filed).
   date: "2026-06-10"
-  version: "0.1"
+  version: "0.2"
   author: "v.korobeinikov"
 
-  scope:
-    jurisdictions:
-      - eu
-    codex:
+  regimes:
+    include:
       - LAW-GDPR-1
       - LAW-NIS2-1
-    subjects:
-      products:
-        - PRODUCT-ECOMM-1
-        - PRODUCT-SUPPORT-1
+
+  subjects:
+    products:
+      - PRODUCT-ECOMM-1
+      - PRODUCT-SUPPORT-1
 
   thresholds:
     green: 0.80
     amber: 0.50
-    red: 0.00

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/diagrams/src/compliance/__tests__/coverage-metric.test.ts
+++ b/packages/diagrams/src/compliance/__tests__/coverage-metric.test.ts
@@ -16,17 +16,14 @@ describe('parseCoverageMetricConfig', () => {
   });
 
   it('rejects missing id', () => {
-    const r = parseCoverageMetricConfig({ coverage_metric: { name: 'x' } });
+    const r = parseCoverageMetricConfig({ view: { name: 'x' } });
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.errors.some(e => e.includes('id'))).toBe(true);
   });
 
-  it('parses minimal config', () => {
+  it('parses minimal config via view: wrapper', () => {
     const r = parseCoverageMetricConfig({
-      coverage_metric: {
-        id: 'CM-1',
-        name: 'Test',
-      },
+      view: { id: 'CM-1', name: 'Test' },
     });
     expect(r.ok).toBe(true);
     if (r.ok) {
@@ -34,18 +31,91 @@ describe('parseCoverageMetricConfig', () => {
       expect(r.config.name).toBe('Test');
       expect(r.config.thresholds.green).toBe(0.8);
       expect(r.config.thresholds.amber).toBe(0.5);
+      expect(r.config.regimes).toBeUndefined();
     }
   });
 
-  it('parses full config with scope and thresholds', () => {
+  it('parses view: wrapper with regimes.include and subjects', () => {
     const r = parseCoverageMetricConfig({
-      coverage_metric: {
+      view: {
         id: 'CM-2',
         name: 'EU Coverage',
         description: 'desc',
+        regimes: { include: ['LAW-GDPR-1'] },
+        subjects: { products: ['PRODUCT-1'] },
+        thresholds: { green: 0.9, amber: 0.6 },
+      },
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.config.regimes?.include).toEqual(['LAW-GDPR-1']);
+      expect(r.config.subjects?.products).toEqual(['PRODUCT-1']);
+      expect(r.config.thresholds.green).toBe(0.9);
+      expect(r.config.thresholds.amber).toBe(0.6);
+      expect(r.config.warnings).toBeUndefined();
+    }
+  });
+
+  it('parses view: wrapper with regimes.filter', () => {
+    const r = parseCoverageMetricConfig({
+      view: {
+        id: 'CM-3',
+        name: 'EU Filter',
+        regimes: { filter: { jurisdiction: ['EU'], codex_type: ['regulation'] } },
+      },
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.config.regimes?.filter?.jurisdiction).toEqual(['EU']);
+      expect(r.config.regimes?.filter?.codex_type).toEqual(['regulation']);
+      expect(r.config.regimes?.include).toBeUndefined();
+    }
+  });
+
+  it('warns COVMET-007 when both regimes.include and regimes.filter are set', () => {
+    const r = parseCoverageMetricConfig({
+      view: {
+        id: 'CM-4',
+        name: 'Both',
+        regimes: {
+          include: ['LAW-GDPR-1'],
+          filter: { jurisdiction: ['EU'] },
+        },
+      },
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.config.warnings?.some(w => w.includes('COVMET-007'))).toBe(true);
+    }
+  });
+
+  it('accepts bare (unwrapped) object without wrapper warning', () => {
+    const r = parseCoverageMetricConfig({ id: 'CM-5', name: 'Bare' });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.config.warnings?.some(w => w.includes('COVMET-DEPRECATED'))).toBeFalsy();
+    }
+  });
+
+  // ── Backward compatibility: deprecated coverage_metric: wrapper ──────────────
+
+  it('accepts deprecated coverage_metric: wrapper with COVMET-DEPRECATED warning', () => {
+    const r = parseCoverageMetricConfig({
+      coverage_metric: { id: 'CM-6', name: 'Legacy' },
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.config.warnings?.some(w => w.includes('COVMET-DEPRECATED'))).toBe(true);
+    }
+  });
+
+  it('maps deprecated scope.codex to regimes.include', () => {
+    const r = parseCoverageMetricConfig({
+      coverage_metric: {
+        id: 'CM-7',
+        name: 'Legacy Scope',
         scope: {
-          jurisdictions: ['EU'],
-          codex: ['LAW-GDPR-1'],
+          codex: ['LAW-GDPR-1', 'LAW-NIS2-1'],
           subjects: { products: ['PRODUCT-1'] },
         },
         thresholds: { green: 0.9, amber: 0.6 },
@@ -53,16 +123,10 @@ describe('parseCoverageMetricConfig', () => {
     });
     expect(r.ok).toBe(true);
     if (r.ok) {
-      expect(r.config.scope.codex).toEqual(['LAW-GDPR-1']);
-      expect(r.config.scope.subjects?.products).toEqual(['PRODUCT-1']);
+      expect(r.config.regimes?.include).toEqual(['LAW-GDPR-1', 'LAW-NIS2-1']);
+      expect(r.config.subjects?.products).toEqual(['PRODUCT-1']);
       expect(r.config.thresholds.green).toBe(0.9);
-      expect(r.config.thresholds.amber).toBe(0.6);
     }
-  });
-
-  it('accepts bare (unwrapped) object', () => {
-    const r = parseCoverageMetricConfig({ id: 'CM-3', name: 'Bare' });
-    expect(r.ok).toBe(true);
   });
 });
 
@@ -70,15 +134,11 @@ describe('parseCoverageMetricConfig', () => {
 
 function makeCanon(): ComplianceCanon {
   const canon = emptyCanon();
-  // Codex: GDPR law
   ingestComplianceDoc(canon, { id: 'LAW-GDPR-1', name: 'GDPR', zone: 'codex', jurisdiction: 'EU' });
-  // Requirements
   ingestComplianceDoc(canon, { notation: 'requirement', id: 'REQ-1', name: 'Lawful basis', derived_from: ['LAW-GDPR-1'] });
   ingestComplianceDoc(canon, { notation: 'requirement', id: 'REQ-2', name: 'Data minimisation', derived_from: ['LAW-GDPR-1'] });
   ingestComplianceDoc(canon, { notation: 'requirement', id: 'REQ-3', name: 'Breach notification', derived_from: ['LAW-GDPR-1'] });
-  // Products
   ingestComplianceDoc(canon, { notation: 'product', id: 'PRODUCT-1', name: 'E-commerce' });
-  // Assertions
   ingestComplianceDoc(canon, { notation: 'assertion', id: 'ASSERTION-1', about: 'REQ-1', subject: 'PRODUCT-1', status: 'compliant' });
   ingestComplianceDoc(canon, { notation: 'assertion', id: 'ASSERTION-2', about: 'REQ-2', subject: 'PRODUCT-1', status: 'partial' });
   // REQ-3 has no assertion → gap
@@ -89,10 +149,8 @@ function makeConfig(overrides?: Partial<CoverageMetricConfig>): CoverageMetricCo
   return {
     id: 'CM-TEST-1',
     name: 'Test Coverage',
-    scope: {
-      codex: ['LAW-GDPR-1'],
-      subjects: { products: ['PRODUCT-1'] },
-    },
+    regimes: { include: ['LAW-GDPR-1'] },
+    subjects: { products: ['PRODUCT-1'] },
     thresholds: { green: 0.8, amber: 0.5 },
     ...overrides,
   };
@@ -100,10 +158,7 @@ function makeConfig(overrides?: Partial<CoverageMetricConfig>): CoverageMetricCo
 
 describe('buildCoverageMatrix', () => {
   it('returns correct row counts', () => {
-    const canon = makeCanon();
-    const config = makeConfig();
-    const matrix = buildCoverageMatrix(canon, config);
-
+    const matrix = buildCoverageMatrix(makeCanon(), makeConfig());
     expect(matrix.rows).toHaveLength(1);
     const row = matrix.rows[0];
     expect(row.codexId).toBe('LAW-GDPR-1');
@@ -115,20 +170,16 @@ describe('buildCoverageMatrix', () => {
   });
 
   it('computes coverage percentage correctly', () => {
-    const matrix = buildCoverageMatrix(makeCanon(), makeConfig());
-    const row = matrix.rows[0];
-    // 2 covered out of 3 → ~66.7%
+    const row = buildCoverageMatrix(makeCanon(), makeConfig()).rows[0];
     expect(row.coveragePct).toBeCloseTo(2 / 3, 5);
   });
 
   it('assigns amber RAG status for ~67% coverage with green=0.80, amber=0.50', () => {
-    const matrix = buildCoverageMatrix(makeCanon(), makeConfig());
-    expect(matrix.rows[0].ragStatus).toBe('amber');
+    expect(buildCoverageMatrix(makeCanon(), makeConfig()).rows[0].ragStatus).toBe('amber');
   });
 
   it('assigns green RAG when all requirements covered', () => {
     const canon = makeCanon();
-    // Add assertion for REQ-3 so all 3 are covered
     ingestComplianceDoc(canon, { notation: 'assertion', id: 'ASSERTION-3', about: 'REQ-3', subject: 'PRODUCT-1', status: 'compliant' });
     const matrix = buildCoverageMatrix(canon, makeConfig());
     expect(matrix.rows[0].ragStatus).toBe('green');
@@ -137,30 +188,26 @@ describe('buildCoverageMatrix', () => {
 
   it('assigns red RAG when coverage < amber threshold', () => {
     const matrix = buildCoverageMatrix(makeCanon(), makeConfig({ thresholds: { green: 0.9, amber: 0.8 } }));
-    // ~67% < 80% → red
     expect(matrix.rows[0].ragStatus).toBe('red');
   });
 
   it('returns no_data when codex has no requirements', () => {
     const canon = emptyCanon();
     ingestComplianceDoc(canon, { id: 'LAW-EMPTY-1', name: 'Empty Law', zone: 'codex', jurisdiction: 'XX' });
-    const config = makeConfig({ scope: { codex: ['LAW-EMPTY-1'] } });
-    const matrix = buildCoverageMatrix(canon, config);
+    const matrix = buildCoverageMatrix(canon, makeConfig({ regimes: { include: ['LAW-EMPTY-1'] } }));
     expect(matrix.rows[0].ragStatus).toBe('no_data');
     expect(matrix.rows[0].totalRequirements).toBe(0);
   });
 
   it('includes jurisdiction from scanned canon', () => {
-    const matrix = buildCoverageMatrix(makeCanon(), makeConfig());
-    expect(matrix.rows[0].jurisdiction).toBe('EU');
+    expect(buildCoverageMatrix(makeCanon(), makeConfig()).rows[0].jurisdiction).toBe('EU');
   });
 
-  it('handles multiple codex entries', () => {
+  it('handles multiple codex entries via regimes.include', () => {
     const canon = makeCanon();
     ingestComplianceDoc(canon, { id: 'LAW-NIS2-1', name: 'NIS2', zone: 'codex', jurisdiction: 'EU' });
     ingestComplianceDoc(canon, { notation: 'requirement', id: 'REQ-NIS-1', name: 'Incident reporting', derived_from: ['LAW-NIS2-1'] });
-    const config = makeConfig({ scope: { codex: ['LAW-GDPR-1', 'LAW-NIS2-1'] } });
-    const matrix = buildCoverageMatrix(canon, config);
+    const matrix = buildCoverageMatrix(canon, makeConfig({ regimes: { include: ['LAW-GDPR-1', 'LAW-NIS2-1'] } }));
     expect(matrix.rows).toHaveLength(2);
     expect(matrix.rows[1].codexId).toBe('LAW-NIS2-1');
     expect(matrix.rows[1].gap).toBe(1);
@@ -168,11 +215,12 @@ describe('buildCoverageMatrix', () => {
 
   it('respects product scope — ignores assertions for other products', () => {
     const canon = makeCanon();
-    // Add another product with compliant assertion for REQ-3
     ingestComplianceDoc(canon, { notation: 'product', id: 'PRODUCT-2', name: 'Support' });
     ingestComplianceDoc(canon, { notation: 'assertion', id: 'ASSERTION-OUT', about: 'REQ-3', subject: 'PRODUCT-2', status: 'compliant' });
-    // config only scopes PRODUCT-1 → REQ-3 should still be a gap
-    const matrix = buildCoverageMatrix(canon, makeConfig({ scope: { codex: ['LAW-GDPR-1'], subjects: { products: ['PRODUCT-1'] } } }));
+    const matrix = buildCoverageMatrix(canon, makeConfig({
+      regimes: { include: ['LAW-GDPR-1'] },
+      subjects: { products: ['PRODUCT-1'] },
+    }));
     expect(matrix.rows[0].gap).toBe(1);
   });
 
@@ -182,7 +230,62 @@ describe('buildCoverageMatrix', () => {
     const matrix = buildCoverageMatrix(canon, makeConfig());
     expect(matrix.rows[0].non_compliant).toBe(1);
     expect(matrix.rows[0].gap).toBe(0);
-    // non_compliant does not count as covered
     expect(matrix.rows[0].coveredCount).toBe(2);
+  });
+
+  // ── regimes.filter ───────────────────────────────────────────────────────────
+
+  it('resolves codex via regimes.filter.jurisdiction', () => {
+    const canon = makeCanon();
+    ingestComplianceDoc(canon, { id: 'LAW-CCPA-1', name: 'CCPA', zone: 'codex', jurisdiction: 'US' });
+    // regimes.filter: only EU laws → should return LAW-GDPR-1 only
+    const matrix = buildCoverageMatrix(canon, makeConfig({
+      regimes: { filter: { jurisdiction: ['EU'] } },
+    }));
+    expect(matrix.rows.every(r => r.codexId !== 'LAW-CCPA-1')).toBe(true);
+    expect(matrix.rows.some(r => r.codexId === 'LAW-GDPR-1')).toBe(true);
+  });
+
+  it('resolves codex via regimes.filter.codex_type', () => {
+    const canon = emptyCanon();
+    ingestComplianceDoc(canon, { id: 'LAW-A', name: 'Regulation A', zone: 'codex', type: 'regulation' });
+    ingestComplianceDoc(canon, { id: 'LAW-B', name: 'Standard B', zone: 'codex', type: 'standard' });
+    const matrix = buildCoverageMatrix(canon, makeConfig({
+      regimes: { filter: { codex_type: ['regulation'] } },
+    }));
+    expect(matrix.rows.map(r => r.codexId)).toEqual(['LAW-A']);
+  });
+
+  // ── Zero-config: all canon codex entries ─────────────────────────────────────
+
+  it('zero-config (no regimes) enumerates all canon codex', () => {
+    const canon = makeCanon();
+    ingestComplianceDoc(canon, { id: 'LAW-NIS2-1', name: 'NIS2', zone: 'codex', jurisdiction: 'EU' });
+    const matrix = buildCoverageMatrix(canon, makeConfig({ regimes: undefined }));
+    expect(matrix.rows.map(r => r.codexId)).toContain('LAW-GDPR-1');
+    expect(matrix.rows.map(r => r.codexId)).toContain('LAW-NIS2-1');
+  });
+
+  // ── Backward compat: deprecated config still produces correct matrix ─────────
+
+  it('deprecated scope.codex via parseCoverageMetricConfig maps to correct matrix', () => {
+    const r = parseCoverageMetricConfig({
+      coverage_metric: {
+        id: 'CM-LEGACY',
+        name: 'Legacy',
+        scope: {
+          codex: ['LAW-GDPR-1'],
+          subjects: { products: ['PRODUCT-1'] },
+        },
+        thresholds: { green: 0.8, amber: 0.5 },
+      },
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      const matrix = buildCoverageMatrix(makeCanon(), r.config);
+      expect(matrix.rows).toHaveLength(1);
+      expect(matrix.rows[0].codexId).toBe('LAW-GDPR-1');
+      expect(matrix.rows[0].coveredCount).toBe(2);
+    }
   });
 });

--- a/packages/diagrams/src/compliance/coverage-metric.ts
+++ b/packages/diagrams/src/compliance/coverage-metric.ts
@@ -12,14 +12,25 @@ import type { IndexAssertion } from './types.js';
 
 // ── Config types ─────────────────────────────────────────────────────────────
 
-export interface CoverageMetricSubjects {
-  products?: string[];
+/** Declarative filter resolved at build time from the canon's codex catalogue. */
+export interface CoverageMetricRegimesFilter {
+  jurisdiction?: string[];
+  codex_type?: string[];
 }
 
-export interface CoverageMetricScope {
-  jurisdictions?: string[];
-  codex?: string[];
-  subjects?: CoverageMetricSubjects;
+/**
+ * Regime (codex) selection for the coverage view.
+ * - `include`: explicit list of codex IDs — takes precedence over `filter`.
+ * - `filter`: resolved against the workspace canon at render time.
+ * - Omit entirely → all codex artefacts in the canon become regime columns.
+ */
+export interface CoverageMetricRegimes {
+  include?: string[];
+  filter?: CoverageMetricRegimesFilter;
+}
+
+export interface CoverageMetricSubjects {
+  products?: string[];
 }
 
 export interface CoverageMetricThresholds {
@@ -35,8 +46,13 @@ export interface CoverageMetricConfig {
   description?: string;
   date?: string;
   version?: string;
-  scope: CoverageMetricScope;
+  /** Regime (codex) selection. Absent = all canon codex entries. */
+  regimes?: CoverageMetricRegimes;
+  /** Products to scope assertions to. Absent = all products. */
+  subjects?: CoverageMetricSubjects;
   thresholds: CoverageMetricThresholds;
+  /** Non-fatal parse warnings (e.g. deprecated keys). */
+  warnings?: string[];
 }
 
 export type ParseCoverageMetricResult =
@@ -77,10 +93,59 @@ export interface CoverageMatrix {
 
 // ── Parser ───────────────────────────────────────────────────────────────────
 
+function parseRegimes(raw: Record<string, unknown>): { regimes?: CoverageMetricRegimes; warnings: string[] } {
+  const warnings: string[] = [];
+  const rawR = raw.regimes;
+  if (!rawR || typeof rawR !== 'object' || Array.isArray(rawR)) {
+    return { regimes: undefined, warnings };
+  }
+  const r = rawR as Record<string, unknown>;
+
+  const include = Array.isArray(r.include)
+    ? (r.include as unknown[]).filter((x): x is string => typeof x === 'string')
+    : undefined;
+
+  const rawF = r.filter;
+  const filter =
+    rawF && typeof rawF === 'object' && !Array.isArray(rawF)
+      ? (() => {
+          const f = rawF as Record<string, unknown>;
+          return {
+            jurisdiction: Array.isArray(f.jurisdiction)
+              ? (f.jurisdiction as unknown[]).filter((x): x is string => typeof x === 'string')
+              : undefined,
+            codex_type: Array.isArray(f.codex_type)
+              ? (f.codex_type as unknown[]).filter((x): x is string => typeof x === 'string')
+              : undefined,
+          };
+        })()
+      : undefined;
+
+  if (include?.length && filter) {
+    warnings.push('COVMET-007: both regimes.include and regimes.filter are set; include takes precedence');
+  }
+
+  return { regimes: { include, filter }, warnings };
+}
+
+function parseSubjects(raw: Record<string, unknown>): CoverageMetricSubjects | undefined {
+  const s = raw.subjects;
+  if (!s || typeof s !== 'object' || Array.isArray(s)) return undefined;
+  const obj = s as Record<string, unknown>;
+  return {
+    products: Array.isArray(obj.products)
+      ? (obj.products as unknown[]).filter((x): x is string => typeof x === 'string')
+      : undefined,
+  };
+}
+
 /**
- * Validate and normalise a raw (YAML-parsed) document into a
- * `CoverageMetricConfig`. Accepts both the bare top-level object and the
- * wrapped form (`{ coverage_metric: { … } }`).
+ * Parse and validate a raw (YAML-parsed) document into a `CoverageMetricConfig`.
+ *
+ * Accepts:
+ * - `{ view: { id, name, regimes, subjects, thresholds } }` — canonical (new spec)
+ * - `{ coverage_metric: { … } }` — deprecated; `scope.codex` → `regimes.include`
+ * - Bare top-level object — same as deprecated wrapper, no wrapper warning
  */
 export function parseCoverageMetricConfig(raw: unknown): ParseCoverageMetricResult {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
@@ -88,31 +153,49 @@ export function parseCoverageMetricConfig(raw: unknown): ParseCoverageMetricResu
   }
   const top = raw as Record<string, unknown>;
 
-  // Unwrap optional `coverage_metric:` wrapper.
-  const v: Record<string, unknown> =
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  let v: Record<string, unknown>;
+  let regimes: CoverageMetricRegimes | undefined;
+  let subjects: CoverageMetricSubjects | undefined;
+
+  if ('view' in top && top.view && typeof top.view === 'object' && !Array.isArray(top.view)) {
+    // Canonical format: view: { id, name, regimes, subjects, thresholds }
+    v = top.view as Record<string, unknown>;
+    const parsed = parseRegimes(v);
+    regimes = parsed.regimes;
+    warnings.push(...parsed.warnings);
+    subjects = parseSubjects(v);
+
+  } else if (
     'coverage_metric' in top &&
     top.coverage_metric &&
     typeof top.coverage_metric === 'object' &&
     !Array.isArray(top.coverage_metric)
-      ? (top.coverage_metric as Record<string, unknown>)
-      : top;
+  ) {
+    // Deprecated wrapper: coverage_metric: { scope: { codex, jurisdictions, subjects }, … }
+    v = top.coverage_metric as Record<string, unknown>;
+    warnings.push('COVMET-DEPRECATED: coverage_metric: wrapper is deprecated; migrate to view:');
+    const r = migrateLegacyScope(v);
+    regimes = r.regimes;
+    subjects = r.subjects;
 
-  const errors: string[] = [];
+  } else {
+    // Bare object — accept as deprecated shape without extra warning
+    v = top;
+    const r = migrateLegacyScope(v);
+    regimes = r.regimes;
+    subjects = r.subjects;
+  }
+
   if (!v.id || typeof v.id !== 'string') errors.push('coverage_metric.id: required string');
   if (!v.name || typeof v.name !== 'string') errors.push('coverage_metric.name: required string');
   if (errors.length) return { ok: false, errors };
 
-  const rawScope =
-    v.scope && typeof v.scope === 'object' && !Array.isArray(v.scope)
-      ? (v.scope as Record<string, unknown>)
-      : {};
-  const rawSubjects =
-    rawScope.subjects && typeof rawScope.subjects === 'object' && !Array.isArray(rawScope.subjects)
-      ? (rawScope.subjects as Record<string, unknown>)
-      : {};
+  const rawT = v.thresholds;
   const rawThresholds =
-    v.thresholds && typeof v.thresholds === 'object' && !Array.isArray(v.thresholds)
-      ? (v.thresholds as Record<string, unknown>)
+    rawT && typeof rawT === 'object' && !Array.isArray(rawT)
+      ? (rawT as Record<string, unknown>)
       : {};
 
   const greenRaw = typeof rawThresholds.green === 'number' ? rawThresholds.green : 0.8;
@@ -124,26 +207,53 @@ export function parseCoverageMetricConfig(raw: unknown): ParseCoverageMetricResu
     description: typeof v.description === 'string' ? v.description : undefined,
     date: typeof v.date === 'string' ? v.date : undefined,
     version: typeof v.version === 'string' ? v.version : undefined,
-    scope: {
-      jurisdictions: Array.isArray(rawScope.jurisdictions)
-        ? (rawScope.jurisdictions as unknown[]).filter((x): x is string => typeof x === 'string')
-        : undefined,
-      codex: Array.isArray(rawScope.codex)
-        ? (rawScope.codex as unknown[]).filter((x): x is string => typeof x === 'string')
-        : undefined,
-      subjects: {
-        products: Array.isArray(rawSubjects.products)
-          ? (rawSubjects.products as unknown[]).filter((x): x is string => typeof x === 'string')
-          : undefined,
-      },
-    },
+    regimes,
+    subjects,
     thresholds: {
       green: Math.max(0, Math.min(1, greenRaw)),
       amber: Math.max(0, Math.min(1, amberRaw)),
     },
+    warnings: warnings.length > 0 ? warnings : undefined,
   };
 
   return { ok: true, config };
+}
+
+/** Translate old `scope.codex` / `scope.jurisdictions` / `scope.subjects` to new shape. */
+function migrateLegacyScope(v: Record<string, unknown>): {
+  regimes: CoverageMetricRegimes | undefined;
+  subjects: CoverageMetricSubjects | undefined;
+} {
+  const rawScope =
+    v.scope && typeof v.scope === 'object' && !Array.isArray(v.scope)
+      ? (v.scope as Record<string, unknown>)
+      : {};
+
+  const codexList = Array.isArray(rawScope.codex)
+    ? (rawScope.codex as unknown[]).filter((x): x is string => typeof x === 'string')
+    : undefined;
+  const jurisdictionList = Array.isArray(rawScope.jurisdictions)
+    ? (rawScope.jurisdictions as unknown[]).filter((x): x is string => typeof x === 'string')
+    : undefined;
+
+  let regimes: CoverageMetricRegimes | undefined;
+  if (codexList && codexList.length > 0) {
+    regimes = { include: codexList };
+  } else if (jurisdictionList && jurisdictionList.length > 0) {
+    regimes = { filter: { jurisdiction: jurisdictionList } };
+  }
+
+  const rawSubjectsObj =
+    rawScope.subjects && typeof rawScope.subjects === 'object' && !Array.isArray(rawScope.subjects)
+      ? (rawScope.subjects as Record<string, unknown>)
+      : {};
+  const subjects: CoverageMetricSubjects = {
+    products: Array.isArray(rawSubjectsObj.products)
+      ? (rawSubjectsObj.products as unknown[]).filter((x): x is string => typeof x === 'string')
+      : undefined,
+  };
+
+  return { regimes, subjects };
 }
 
 // ── Builder ───────────────────────────────────────────────────────────────────
@@ -175,11 +285,34 @@ function ragFromPct(pct: number, thresholds: CoverageMetricThresholds, hasData: 
 }
 
 /**
+ * Resolve the ordered list of codex IDs from the config's `regimes` field:
+ * - `regimes.include` — explicit list, takes precedence.
+ * - `regimes.filter` — resolved against the canon's codex catalogue.
+ * - No `regimes` — all codex entries in the canon.
+ */
+function resolveCodexList(regimes: CoverageMetricRegimes | undefined, canon: ComplianceCanon): string[] {
+  if (regimes?.include && regimes.include.length > 0) return regimes.include;
+  if (regimes?.filter) {
+    let docs = [...canon.codex];
+    if (regimes.filter.jurisdiction?.length) {
+      const jurs = regimes.filter.jurisdiction;
+      docs = docs.filter(c => c.jurisdiction != null && jurs.includes(c.jurisdiction));
+    }
+    if (regimes.filter.codex_type?.length) {
+      const types = regimes.filter.codex_type;
+      docs = docs.filter(c => c.type != null && types.includes(c.type));
+    }
+    return docs.map(c => c.id);
+  }
+  return canon.codex.map(c => c.id);
+}
+
+/**
  * Compute per-codex coverage statistics.
  *
- * For each law (codex ID) in `config.scope.codex`:
+ * For each law (codex ID) resolved from `config.regimes`:
  *  - Collect requirements whose `derived_from` includes that law.
- *  - Optionally restrict to assertions for `config.scope.subjects.products`.
+ *  - Optionally restrict to assertions for `config.subjects.products`.
  *  - Compute compliant / partial / non_compliant / under_review / gap counts.
  *  - Compute coverage % = (compliant + partial) / total and apply RAG.
  */
@@ -192,8 +325,8 @@ export function buildCoverageMatrix(
     assertions: canon.assertions,
   });
 
-  const codexList = config.scope.codex ?? [];
-  const productList = config.scope.subjects?.products ?? [];
+  const codexList = resolveCodexList(config.regimes, canon);
+  const productList = config.subjects?.products ?? [];
 
   const rows: CoverageRow[] = [];
 
@@ -213,9 +346,8 @@ export function buildCoverageMatrix(
 
       // Filter to admitted statuses, then optionally to scoped products.
       const admitted = allAssertions.filter(a => ADMITTED.has(a.status));
-      const scoped = productList.length > 0
-        ? admitted.filter(a => productList.includes(a.subject))
-        : admitted;
+      const scoped =
+        productList.length > 0 ? admitted.filter(a => productList.includes(a.subject)) : admitted;
 
       // Exclude pure n_a assertions from counting as coverage.
       const active = scoped.filter(a => a.status !== 'n_a');

--- a/packages/diagrams/src/compliance/impact.ts
+++ b/packages/diagrams/src/compliance/impact.ts
@@ -58,6 +58,8 @@ export interface ImpactColumn {
   stageId?: string;
   /** Human-readable column header. */
   label: string;
+  /** Display name for the subject (product/process name, not the id). */
+  subjectName?: string;
 }
 
 /**
@@ -396,9 +398,10 @@ function aggregateStatus(assertions: IndexAssertion[]): AssertionStatus {
 
 // ── Column builder helpers (CV-3a) ──────────────────────────────────────────
 
-function buildProductColumns(config: ImpactViewConfig): ImpactColumn[] {
+function buildProductColumns(config: ImpactViewConfig, products: { id: string; name: string }[]): ImpactColumn[] {
+  const nameMap = new Map(products.map(p => [p.id, p.name]));
   const subjects = [...(config.subjects.products ?? []), ...(config.subjects.processes ?? [])];
-  return subjects.map(id => ({ subjectId: id, label: id }));
+  return subjects.map(id => ({ subjectId: id, label: id, subjectName: nameMap.get(id) }));
 }
 
 function buildObjectDetailColumns(config: ImpactViewConfig, objectDetails: ObjectDetailInput[]): ImpactColumn[] {
@@ -462,7 +465,7 @@ export function buildImpactMatrix(
     config.grouping?.columns === 'object-details' && objectDetails && objectDetails.length > 0;
   const columns: ImpactColumn[] = useStageGrain
     ? buildObjectDetailColumns(config, objectDetails!)
-    : buildProductColumns(config);
+    : buildProductColumns(config, canon.products ?? []);
 
   const allowedStatuses = new Set<AssertionStatus>(
     config.status_display?.show ?? ['compliant', 'partial', 'non_compliant', 'under_review', 'n_a'],

--- a/packages/diagrams/src/compliance/index.ts
+++ b/packages/diagrams/src/compliance/index.ts
@@ -33,7 +33,8 @@ export {
 } from './coverage-metric.js';
 export type {
   CoverageMetricConfig,
-  CoverageMetricScope,
+  CoverageMetricRegimes,
+  CoverageMetricRegimesFilter,
   CoverageMetricSubjects,
   CoverageMetricThresholds,
   CoverageMatrix,

--- a/tests/fixtures/notation-corpus/coverage-metric/eu-coverage.coverage-metric.transitrix.yaml
+++ b/tests/fixtures/notation-corpus/coverage-metric/eu-coverage.coverage-metric.transitrix.yaml
@@ -1,31 +1,26 @@
-# Coverage-metric example — retired stub.
-#
-# The canonical coverage-metric view for the demo now lives at:
-#   transitrix/methodology:
-#   organizations/acme_corp/canon/views/eu-coverage.coverage-metric.transitrix.yaml
-#
-# Open that file in Transitrix Studio to see the coverage gauges.
+# Coverage-metric fixture — tests/fixtures.
+# Spec: notations/views/22-coverage-metric.md
 
 notation: coverage-metric
-spec_version: "0.1"
+spec_version: "0.2"
 
-coverage_metric:
+view:
   id: COVERAGE_METRIC-ACME-EU-1
   name: "acme_corp — EU Coverage Metric (GDPR + NIS2)"
   description: >
     Demo stub — open the canonical view in transitrix/methodology/organizations/acme_corp/
     for the full connected demo.
-  scope:
-    jurisdictions:
-      - eu
-    codex:
+
+  regimes:
+    include:
       - LAW-GDPR-1
       - LAW-NIS2-1
-    subjects:
-      products:
-        - PRODUCT-ECOMM-1
-        - PRODUCT-SUPPORT-1
+
+  subjects:
+    products:
+      - PRODUCT-ECOMM-1
+      - PRODUCT-SUPPORT-1
+
   thresholds:
     green: 0.80
     amber: 0.50
-    red: 0.00


### PR DESCRIPTION
## Summary

- Replaces the incorrect `coverage_metric.scope.codex` shape (COVMET-001) with the spec-canonical `view: { regimes, subjects }` format per methodology spec §22.
- `regimes.include` — explicit codex ID list (takes precedence); `regimes.filter` — resolved against the workspace canon by `jurisdiction` / `codex_type`; no `regimes` — all canon codex entries.
- Backward compat: `coverage_metric:` wrapper still parses; `scope.codex` maps to `regimes.include` with a `COVMET-DEPRECATED` warning.
- COVMET-007 warning when both `include` and `filter` are set.
- 23 unit tests (up from 13), including filter, zero-config, and legacy compat paths.
- Both fixture YAML files migrated to `view:` + `spec_version: "0.2"`.
- Preview empty-state hint updated to reference `regimes.include` / `regimes.filter`.

## Test plan

- [x] `packages/diagrams` test suite: 849 passed
- [x] Root test suite: 339 passed
- [ ] Open `organizations/acme_corp/canon/views/coverage-metric/eu-coverage.coverage-metric.transitrix.yaml` in Studio — verify preview renders without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)