### PR TITLE
chore(release): cut 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+## [1.6.0] — 2026-06-17
+
+### Added
+- **`transitrix.report.columnWidth` setting** — choose between Narrow (80 px), Normal (120 px, default), and Wide (200 px) column widths for all table-based compliance reports: compliance-impact, compliance-matrix, products, process-map, applications, scenarios, coverage-metric, and the FGCA chain table. Interactive reports (compliance-impact, compliance-matrix) expose a live dropdown in the toolbar that persists the choice to the workspace configuration; static reports pick it up at render time.
+- **Product names in compliance-impact column headers.** Each law × subject column now shows the product's display name (e.g. "E-commerce Platform") with the product code in a smaller gray line below, instead of showing only the raw identifier. The name is sourced from the compliance canon product document.
+
+### Changed
+- **Skipped-notation scan diagnostic now surfaces file paths and notation values.** When the compliance scanner skips a YAML file whose `notation` value is not recognised, the preview toolbar now lists every distinct unrecognised notation string (e.g. `scenario`, `unknown-type`) with an expandable tooltip showing the workspace-relative paths of the affected files, replacing the previous bare file count.
+- **Coverage-metric "Coverage Status" column** (was "RAG"). The last column in the coverage-metric report is renamed to avoid confusion with the RAG (Retrieval-Augmented Generation) term that is commonly used in AI-based documentation workflows. A tooltip on the header still explains the green / amber / red threshold semantics.
+
+### Fixed
+- **Coverage-metric parser aligned with the notation spec.** The parser previously expected `coverage_metric.scope.codex` (a key that does not exist in the spec, COVMET-001). It now accepts the canonical `view: { regimes: { include | filter }, subjects }` format. `regimes.include` takes an explicit list of codex IDs; `regimes.filter` resolves from the workspace canon by `jurisdiction` and/or `codex_type`; omitting `regimes` entirely enumerates all codex entries. The deprecated `coverage_metric:` wrapper is still accepted and its `scope.codex` is silently migrated to `regimes.include` (emits a `COVMET-DEPRECATED` warning). Fixture YAML files updated to `view:` + `spec_version: "0.2"`.
+
 ## [1.5.3] — 2026-06-17
 
 ### Fixed

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Transitrix Studio — changelog
 
+## 1.6.0 — 2026-06-17
+
+Column-width controls, product names in impact headers, coverage-metric spec fix.
+
+### Added
+
+- **Column width setting.** `transitrix.report.columnWidth` (Narrow / Normal / Wide) controls the data column width across all table-based reports. Compliance-impact and compliance-matrix offer a live dropdown in the toolbar; all other table reports pick the setting up at render time.
+- **Product names in compliance-impact headers.** Each obligation × subject column now shows the product's display name with the product code below in gray.
+
+### Changed
+
+- **Skipped-notation diagnostic shows paths and notation values** (was a bare count).
+- **Coverage-metric last column renamed to "Coverage Status"** (was "RAG") to avoid confusion with AI retrieval systems.
+
+### Fixed
+
+- **Coverage-metric parser now reads the canonical `view:` / `regimes` spec shape.** Files using the old `coverage_metric.scope.codex` shape still load (backward compat) and produce a deprecation warning.
+
 ## 1.5.3 — 2026-06-17
 
 ### Fixed

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "1.5.3",
+  "version": "1.6.0",
   "description": "Architecture-as-code for the modern enterprise. Author 17 notations — goals, processes, capabilities, BPMN, applications, more — as plain YAML, get live diagrams in VS Code. Diffable in git. AI-friendly. Open source. Built on ArchiMate 3.2 and BPMN 2.0.",
   "license": "MIT",
   "icon": "icon.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "1.5.3",
+  "version": "1.6.0",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
## Release 1.6.0

Version bump + CHANGELOG for the changes landing in #196 and #197.

**Merge order:** #196 → #197 → this PR.

### What's in this release

**Added**
- `transitrix.report.columnWidth` setting (Narrow / Normal / Wide) — live dropdown in compliance-impact & compliance-matrix toolbars, render-time for all other table reports
- Product display names in compliance-impact column headers (code in gray below)

**Changed**
- Skipped-notation diagnostic now lists distinct notation values + file paths (was bare count)
- Coverage-metric last column renamed "Coverage Status" (was "RAG")

**Fixed**
- Coverage-metric parser aligned with spec — canonical `view: { regimes, subjects }` shape; old `coverage_metric.scope.codex` still accepted with deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)