### PR TITLE
feat(compliance): pending_owner assertion status + owner_to_confirm field

### DIFF
--- a/extension/src/compliance-impact-preview.ts
+++ b/extension/src/compliance-impact-preview.ts
@@ -41,8 +41,8 @@ const DEFAULT_ORDER_ROWS_BY = 'id' as const;
 const DEFAULT_NO_OBLIGATION_LABEL = 'No mapped obligation (current model)';
 const DEFAULT_NO_OBLIGATION_APPLIES_LABEL = 'No obligation applies';
 
-const ADMITTED_STATUSES = new Set<string>(['compliant', 'partial', 'non_compliant', 'under_review', 'n_a']);
-const ALL_STATUSES: AssertionStatus[] = ['compliant', 'partial', 'non_compliant', 'under_review', 'n_a'];
+const ADMITTED_STATUSES = new Set<string>(['compliant', 'partial', 'non_compliant', 'under_review', 'pending_owner', 'n_a']);
+const ALL_STATUSES: AssertionStatus[] = ['compliant', 'partial', 'non_compliant', 'under_review', 'pending_owner', 'n_a'];
 const ALL_SEVERITIES = ['high', 'medium', 'low'];
 
 const STATUS_LABELS: Record<AssertionStatus, string> = {
@@ -50,6 +50,7 @@ const STATUS_LABELS: Record<AssertionStatus, string> = {
   partial: 'Partial',
   non_compliant: 'Non-compliant',
   under_review: 'Under review',
+  pending_owner: 'Pending owner',
   n_a: 'N/A',
 };
 
@@ -660,8 +661,10 @@ export class ComplianceImpactPreview {
 
             const firstAssertion = cell.assertions[0];
             const fsPath = firstAssertion ? this.canon?.pathById.get(firstAssertion.id) : undefined;
+            const ownerToConfirm = cell.assertions.find(a => a.owner_to_confirm)?.owner_to_confirm;
             const metaParts = [
               STATUS_LABELS[status],
+              ownerToConfirm ? 'owner to confirm: ' + ownerToConfirm : null,
               firstAssertion?.assessed_at ? 'assessed ' + firstAssertion.assessed_at : null,
               firstAssertion?.next_review_at ? 'review by ' + firstAssertion.next_review_at : null,
               cell.assertions.length > 1 ? '+' + (cell.assertions.length - 1) + ' more' : null,
@@ -752,6 +755,8 @@ body { padding: 0; }
 .ci-badge-non_compliant { color: var(--ts-status-error-fg, #991b1b); background: var(--ts-status-error-bg, #fee2e2); }
 .ci-under_review { background: var(--ts-status-info-bg, #e0f2fe); }
 .ci-badge-under_review { color: var(--ts-status-info-fg, #0c4a6e); background: var(--ts-status-info-bg, #e0f2fe); }
+.ci-pending_owner { background: #f3e8ff; }
+.ci-badge-pending_owner { color: #6b21a8; background: #f3e8ff; }
 .ci-empty { padding: 40px 24px; color: var(--ts-text-muted, #64748b); max-width: 640px; }
 .ci-empty code { background: var(--ts-bg-subtle, #f1f5f9); padding: 1px 4px; border-radius: 3px; }
 .ci-skipped-hint { cursor: help; color: var(--ts-text-muted, #64748b); font-size: 10px; vertical-align: super; }

--- a/extension/src/compliance-matrix-preview.ts
+++ b/extension/src/compliance-matrix-preview.ts
@@ -26,6 +26,7 @@ const STATUS_LABELS: Record<AssertionStatus, string> = {
   partial: 'Partial',
   non_compliant: 'Non-compliant',
   under_review: 'Under review',
+  pending_owner: 'Pending owner',
   n_a: 'N/A',
 };
 const ALL_STATUSES: AssertionStatus[] = ['compliant', 'partial', 'non_compliant', 'under_review', 'n_a'];

--- a/extension/src/compliance-render.ts
+++ b/extension/src/compliance-render.ts
@@ -14,6 +14,7 @@ export const STATUS_LABELS: Record<AssertionStatus, string> = {
   partial: 'Partial',
   non_compliant: 'Non-compliant',
   under_review: 'Under review',
+  pending_owner: 'Pending owner',
   n_a: 'N/A',
 };
 

--- a/packages/diagrams/src/assertion/types.ts
+++ b/packages/diagrams/src/assertion/types.ts
@@ -4,10 +4,10 @@
 import type { GateChecks } from '../requirement/types.js';
 
 /** Compliance status vocabulary (16-assertion.md §3). */
-export type AssertionStatus = 'compliant' | 'partial' | 'non_compliant' | 'under_review' | 'n_a';
+export type AssertionStatus = 'compliant' | 'partial' | 'non_compliant' | 'under_review' | 'pending_owner' | 'n_a';
 
 export const ASSERTION_STATUSES: readonly AssertionStatus[] = [
-  'compliant', 'partial', 'non_compliant', 'under_review', 'n_a',
+  'compliant', 'partial', 'non_compliant', 'under_review', 'pending_owner', 'n_a',
 ];
 
 /** TYPEs a `subject` may resolve to (16-assertion.md §2, ASSERT-003). */
@@ -45,6 +45,8 @@ export interface Assertion {
   assessed_at?: string;
   assessed_by?: string;
   next_review_at?: string;
+  /** ID or name of the party who must confirm this assertion (pending-owner state). */
+  owner_to_confirm?: string;
 
   // Admission record (CONTRACT.md §6).
   zone: 'canon';

--- a/packages/diagrams/src/compliance/__tests__/classify.test.ts
+++ b/packages/diagrams/src/compliance/__tests__/classify.test.ts
@@ -37,6 +37,20 @@ describe('ingestComplianceDoc', () => {
     expect(canon.subjects[0]).toEqual({ id: 'CAPABILITY-X-1', name: 'CAPABILITY-X-1' });
   });
 
+  it('captures owner_to_confirm on pending_owner assertions', () => {
+    const canon = emptyCanon();
+    ingestComplianceDoc(canon, {
+      notation: 'assertion', id: 'ASSERTION-PO-1',
+      about: 'REQUIREMENT-1', subject: 'PRODUCT-1',
+      status: 'pending_owner', owner_to_confirm: 'alice@example.com',
+    });
+    expect(canon.assertions[0]).toMatchObject({
+      id: 'ASSERTION-PO-1',
+      status: 'pending_owner',
+      owner_to_confirm: 'alice@example.com',
+    });
+  });
+
   it('returns null for non-artefacts, missing id, and malformed assertions', () => {
     const canon = emptyCanon();
     expect(ingestComplianceDoc(canon, { notation: 'goals', id: 'X-1' })).toBeNull();

--- a/packages/diagrams/src/compliance/__tests__/coverage-metric.test.ts
+++ b/packages/diagrams/src/compliance/__tests__/coverage-metric.test.ts
@@ -233,6 +233,15 @@ describe('buildCoverageMatrix', () => {
     expect(matrix.rows[0].coveredCount).toBe(2);
   });
 
+  it('counts pending_owner separately and does not include it in coveredCount', () => {
+    const canon = makeCanon();
+    ingestComplianceDoc(canon, { notation: 'assertion', id: 'ASSERTION-PO', about: 'REQ-3', subject: 'PRODUCT-1', status: 'pending_owner', owner_to_confirm: 'alice' });
+    const matrix = buildCoverageMatrix(canon, makeConfig());
+    expect(matrix.rows[0].pending_owner).toBe(1);
+    expect(matrix.rows[0].gap).toBe(0);
+    expect(matrix.rows[0].coveredCount).toBe(2);
+  });
+
   // ── regimes.filter ───────────────────────────────────────────────────────────
 
   it('resolves codex via regimes.filter.jurisdiction', () => {

--- a/packages/diagrams/src/compliance/__tests__/impact.test.ts
+++ b/packages/diagrams/src/compliance/__tests__/impact.test.ts
@@ -250,6 +250,43 @@ describe('renderImpactMarkdown', () => {
     expect(matrix.columns[0].subjectName).toBe('Product A');
     expect(matrix.columns[1].subjectName).toBe('CRM');
   });
+
+  it('pending_owner cell renders as bound with PENDING status', () => {
+    const canon = emptyCanon();
+    canon.products.push({ id: 'PRODUCT-A-1', name: 'Product A' });
+    canon.requirements.push({ id: 'REQUIREMENT-PO-1', name: 'PO req' });
+    canon.assertions.push({
+      id: 'ASSERTION-PO-1',
+      about: 'REQUIREMENT-PO-1',
+      subject: 'PRODUCT-A-1',
+      status: 'pending_owner',
+      owner_to_confirm: 'alice@example.com',
+    });
+    const matrix = buildImpactMatrix(canon, {
+      id: 'V-PO', name: 'PO Test',
+      subjects: { products: ['PRODUCT-A-1'] },
+      obligations: {},
+    });
+    expect(matrix.cells[0][0].kind).toBe('bound');
+    expect(matrix.cells[0][0].status).toBe('pending_owner');
+    expect(matrix.cells[0][0].assertions[0].owner_to_confirm).toBe('alice@example.com');
+  });
+
+  it('pending_owner loses to partial in aggregation', () => {
+    const canon = emptyCanon();
+    canon.products.push({ id: 'PRODUCT-A-1', name: 'Product A' });
+    canon.requirements.push({ id: 'REQUIREMENT-PO-2', name: 'PO req 2' });
+    canon.assertions.push(
+      { id: 'ASSERTION-PO-2a', about: 'REQUIREMENT-PO-2', subject: 'PRODUCT-A-1', status: 'partial' },
+      { id: 'ASSERTION-PO-2b', about: 'REQUIREMENT-PO-2', subject: 'PRODUCT-A-1', status: 'pending_owner' },
+    );
+    const matrix = buildImpactMatrix(canon, {
+      id: 'V-PO2', name: 'PO Agg',
+      subjects: { products: ['PRODUCT-A-1'] },
+      obligations: {},
+    });
+    expect(matrix.cells[0][0].status).toBe('partial');
+  });
 });
 
 // ── parseImpactViewConfig ───────────────────────────────────────────────────

--- a/packages/diagrams/src/compliance/classify.ts
+++ b/packages/diagrams/src/compliance/classify.ts
@@ -88,6 +88,7 @@ export function ingestComplianceDoc(canon: ComplianceCanon, doc: unknown): strin
       evidenceCount: Array.isArray(d.evidence) ? d.evidence.length : 0,
       admitted_at: str(d.admitted_at),
       realised_via: strArray(d.realised_via),
+      owner_to_confirm: str(d.owner_to_confirm),
     });
     return id;
   }

--- a/packages/diagrams/src/compliance/coverage-metric.ts
+++ b/packages/diagrams/src/compliance/coverage-metric.ts
@@ -72,6 +72,8 @@ export interface CoverageRow {
   partial: number;
   non_compliant: number;
   under_review: number;
+  /** Requirements with at least one pending-owner assertion and no stronger binding. */
+  pending_owner: number;
   /** Requirements with no admitted assertion for the scoped products. */
   gap: number;
   /** compliant + partial. */
@@ -258,20 +260,24 @@ function migrateLegacyScope(v: Record<string, unknown>): {
 
 // ── Builder ───────────────────────────────────────────────────────────────────
 
-const ADMITTED: Set<AssertionStatus> = new Set(['compliant', 'partial', 'non_compliant', 'under_review', 'n_a']);
+const ADMITTED: Set<AssertionStatus> = new Set(['compliant', 'partial', 'non_compliant', 'under_review', 'pending_owner', 'n_a']);
 
-/** Worst-case aggregate across multiple assertions (excludes n_a when others exist). */
+/** Worst-case aggregate across multiple assertions (excludes n_a when others exist).
+ *  Precedence: non_compliant > partial > pending_owner > under_review > compliant > n_a. */
 function aggregateStatus(assertions: IndexAssertion[]): AssertionStatus {
   let sawPartial = false;
+  let sawPendingOwner = false;
   let sawUnderReview = false;
   let sawCompliant = false;
   for (const a of assertions) {
     if (a.status === 'non_compliant') return 'non_compliant';
     if (a.status === 'partial') sawPartial = true;
+    else if (a.status === 'pending_owner') sawPendingOwner = true;
     else if (a.status === 'under_review') sawUnderReview = true;
     else if (a.status === 'compliant') sawCompliant = true;
   }
   if (sawPartial) return 'partial';
+  if (sawPendingOwner) return 'pending_owner';
   if (sawUnderReview) return 'under_review';
   if (sawCompliant) return 'compliant';
   return 'n_a';
@@ -339,6 +345,7 @@ export function buildCoverageMatrix(
     let partial = 0;
     let non_compliant = 0;
     let under_review = 0;
+    let pending_owner = 0;
     let gap = 0;
 
     for (const req of reqs) {
@@ -361,6 +368,7 @@ export function buildCoverageMatrix(
       else if (status === 'partial') partial++;
       else if (status === 'non_compliant') non_compliant++;
       else if (status === 'under_review') under_review++;
+      else if (status === 'pending_owner') pending_owner++;
       else gap++;
     }
 
@@ -376,6 +384,7 @@ export function buildCoverageMatrix(
       partial,
       non_compliant,
       under_review,
+      pending_owner,
       gap,
       coveredCount,
       coveragePct,

--- a/packages/diagrams/src/compliance/html.ts
+++ b/packages/diagrams/src/compliance/html.ts
@@ -22,6 +22,7 @@ const STATUS_LABELS: Record<AssertionStatus, string> = {
   partial: 'Partial',
   non_compliant: 'Non-compliant',
   under_review: 'Under review',
+  pending_owner: 'Pending owner',
   n_a: 'N/A',
 };
 
@@ -73,6 +74,7 @@ code, .cmp-id { font-family: "Menlo", "Consolas", monospace; font-size: 9pt; col
 .cmp-partial { background: #fef9c3; color: #854d0e; }
 .cmp-non_compliant { background: #fee2e2; color: #991b1b; }
 .cmp-under_review { background: #e0f2fe; color: #0c4a6e; }
+.cmp-pending_owner { background: #f3e8ff; color: #6b21a8; }
 .cmp-n_a { background: #f1f5f9; color: #64748b; }
 .cmp-cell-gap { color: #94a3b8; text-align: center; }
 .cmp-req { border: 0.5pt solid #cbd5e1; border-radius: 3pt; margin-bottom: 8pt; page-break-inside: avoid; }
@@ -240,7 +242,7 @@ export interface ImpactMatrixHtmlOptions {
 export function renderImpactMatrixHtml(matrix: ImpactMatrix, options: ImpactMatrixHtmlOptions = {}): string {
   const STATUS_GLYPH: Partial<Record<string, string>> = {
     compliant: 'OK', partial: 'PARTIAL', non_compliant: 'FAIL',
-    under_review: 'REVIEW', n_a: 'N/A',
+    under_review: 'REVIEW', pending_owner: 'PENDING', n_a: 'N/A',
   };
   const statusClass = (s: string | null) => s ?? 'gap';
 
@@ -269,6 +271,7 @@ td.cmp-row-label { text-align: left; font-size: 8.5pt; max-width: 180pt; white-s
 .cmp-partial { background: #fef9c3; color: #854d0e; font-weight: 700; }
 .cmp-non_compliant { background: #fee2e2; color: #991b1b; font-weight: 700; }
 .cmp-under_review { background: #e0f2fe; color: #0c4a6e; }
+.cmp-pending_owner { background: #f3e8ff; color: #6b21a8; }
 .cmp-gap { background: #f8fafc; color: #94a3b8; font-size: 8pt; }
 .cmp-na { background: #f1f5f9; color: #94a3b8; font-size: 8pt; }
 .cmp-dl { color: #b45309; font-size: 8pt; }`;

--- a/packages/diagrams/src/compliance/impact.ts
+++ b/packages/diagrams/src/compliance/impact.ts
@@ -124,9 +124,9 @@ export interface ImpactViewConfig {
  * are auditable ("what I assumed").
  */
 export const COMPLIANCE_IMPACT_DEFAULTS = {
-  /** Accept all four active statuses + n_a in cell aggregation. */
+  /** Accept all active statuses + n_a in cell aggregation. */
   status_display: {
-    show: ['compliant', 'partial', 'non_compliant', 'under_review', 'n_a'] as AssertionStatus[],
+    show: ['compliant', 'partial', 'non_compliant', 'under_review', 'pending_owner', 'n_a'] as AssertionStatus[],
   },
   /** Order rows by canonical REQUIREMENT ID (lexicographic). */
   order_rows_by: 'id' as const,
@@ -383,18 +383,22 @@ function orderRows(rows: IndexRequirement[], key: 'id' | 'name' | undefined): In
 }
 
 /** Aggregate multiple matching assertions into one cell value, per §5.2 step 4.
+ *  Precedence: non_compliant > partial > pending_owner > under_review > compliant > n_a.
  *  Assumes at least one assertion matches an allowed status; caller filters. */
 function aggregateStatus(assertions: IndexAssertion[]): AssertionStatus {
   let sawPartial = false;
+  let sawPendingOwner = false;
   let sawUnderReview = false;
   let sawCompliant = false;
   for (const a of assertions) {
     if (a.status === 'non_compliant') return 'non_compliant';
     if (a.status === 'partial') sawPartial = true;
+    else if (a.status === 'pending_owner') sawPendingOwner = true;
     else if (a.status === 'under_review') sawUnderReview = true;
     else if (a.status === 'compliant') sawCompliant = true;
   }
   if (sawPartial) return 'partial';
+  if (sawPendingOwner) return 'pending_owner';
   if (sawUnderReview) return 'under_review';
   if (sawCompliant) return 'compliant';
   return 'n_a';
@@ -480,7 +484,7 @@ export function buildImpactMatrix(
     : buildProductColumns(config, [...(canon.products ?? []), ...(canon.subjects ?? [])]);
 
   const allowedStatuses = new Set<AssertionStatus>(
-    config.status_display?.show ?? ['compliant', 'partial', 'non_compliant', 'under_review', 'n_a'],
+    config.status_display?.show ?? ['compliant', 'partial', 'non_compliant', 'under_review', 'pending_owner', 'n_a'],
   );
 
   const rowIndex = new Set(obligations.map(r => r.id));
@@ -625,6 +629,7 @@ const STATUS_GLYPH: Record<AssertionStatus, string> = {
   partial: 'PARTIAL',
   non_compliant: 'FAIL',
   under_review: 'REVIEW',
+  pending_owner: 'PENDING',
   n_a: 'N/A',
 };
 
@@ -678,7 +683,7 @@ export function renderImpactMarkdown(matrix: ImpactMatrix): string {
   lines.push('');
   lines.push('## Legend');
   lines.push('');
-  lines.push('- **OK / PARTIAL / FAIL / REVIEW / N/A** — aggregated `ASSERTION.status` per §5.2.');
+  lines.push('- **OK / PARTIAL / FAIL / REVIEW / PENDING / N/A** — aggregated `ASSERTION.status` per §5.2.');
   lines.push(`- **${escMd(matrix.emptyLabels.no_obligation_label)}** — modelling gap; no admitted ASSERTION binds this (obligation, subject) pair.`);
   lines.push(`- **${escMd(matrix.emptyLabels.no_obligation_applies_label)}** — modelled fact; an admitted ASSERTION with status \`n_a\` excludes this pair.`);
 

--- a/packages/diagrams/src/compliance/markdown.ts
+++ b/packages/diagrams/src/compliance/markdown.ts
@@ -14,6 +14,7 @@ const STATUS_LABELS: Record<AssertionStatus, string> = {
   partial: 'Partial',
   non_compliant: 'Non-compliant',
   under_review: 'Under review',
+  pending_owner: 'Pending owner',
   n_a: 'N/A',
 };
 

--- a/packages/diagrams/src/compliance/types.ts
+++ b/packages/diagrams/src/compliance/types.ts
@@ -54,6 +54,8 @@ export interface IndexAssertion {
    * stage-grouped matrix cells.
    */
   realised_via?: string[];
+  /** ID or name of the party who must confirm this assertion (pending-owner state). */
+  owner_to_confirm?: string;
 }
 
 // ── Stage grouping (CV-3a) ──────────────────────────────────────────────────

--- a/packages/diagrams/src/process-blueprint/types.ts
+++ b/packages/diagrams/src/process-blueprint/types.ts
@@ -29,7 +29,7 @@ export interface ComplianceLaneAssertion {
   /** Requirement ID this assertion is about. */
   about: string;
   /** Compliance realisation status. */
-  status: 'compliant' | 'partial' | 'non_compliant' | 'under_review' | 'n_a';
+  status: 'compliant' | 'partial' | 'non_compliant' | 'under_review' | 'pending_owner' | 'n_a';
   /**
    * Typed IDs of stages / process steps where the requirement is realised.
    * When empty/absent, the assertion covers the entire subject, not a specific stage.


### PR DESCRIPTION
## Summary

- Adds `pending_owner` as a first-class `AssertionStatus` — for assertions filed but awaiting owner confirmation before being treated as binding
- `owner_to_confirm?: string` field on `Assertion` and `IndexAssertion`, captured by `ingestComplianceDoc`
- Aggregation precedence: `non_compliant > partial > pending_owner > under_review > compliant > n_a` (both impact matrix and coverage metric)
- `CoverageRow.pending_owner` counter (not included in `coveredCount` — pending confirmation isn't coverage)
- Compliance-impact matrix preview: purple cell style, `owner_to_confirm` surfaced in cell tooltip
- All `STATUS_LABELS` / `STATUS_GLYPH` maps updated (impact, html, markdown, compliance-render, compliance-matrix preview)
- `ComplianceLaneAssertion.status` union extended for process-blueprint compat

## Test plan

- [ ] `classify.test.ts`: `owner_to_confirm` captured from YAML doc
- [ ] `impact.test.ts`: `pending_owner` cell is `kind: 'bound'`, `status: 'pending_owner'`; `owner_to_confirm` accessible on assertion; loses to `partial` in aggregation
- [ ] `coverage-metric.test.ts`: `pending_owner` counted in its own field, not in `coveredCount`
- [ ] Full suite: 858 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)