### PR TITLE
feat(extension): collapsible warnings block in compliance previews

### DIFF
--- a/extension/src/compliance-impact-preview.ts
+++ b/extension/src/compliance-impact-preview.ts
@@ -13,6 +13,7 @@ import type { IndexRequirement, DeadlineStatus } from '../../packages/diagrams/s
 import { genNonce, colWidthPxFromSetting, colWidthRootCss } from './preview-controls.js';
 import { scanComplianceCanon, openComplianceFile } from './compliance-scan.js';
 import type { ScannedCanon } from './compliance-scan.js';
+import { WARN_BLOCK_CSS, buildWarnHtml } from './diagram-frame.js';
 
 // Compliance-impact matrix preview -- CV-2 (vkgeorgia/strategy#84).
 //
@@ -384,17 +385,10 @@ export class ComplianceImpactPreview {
 
     const totalGaps = matrix.cells.flat().filter(c => c.kind === 'gap').length;
     const totalPending = [...this.pendingIndex.values()].reduce((a, b) => a + b, 0);
-    const pendingSummary =
-      totalPending > 0 ? ' &middot; <strong>' + totalPending + '</strong> pending (admission)' : '';
+    const pendingSummary = totalPending > 0 ? ' &middot; <strong>' + totalPending + '</strong> pending (admission)' : '';
     const skippedList = this.canon?.skippedNotations ?? [];
-    const skippedSummary = skippedList.length > 0
-      ? ' &middot; &#x26A0; <strong>' + skippedList.length + '</strong> file(s) skipped'
-        + ' &mdash; unrecognized notation: '
-        + [...new Set(skippedList.map(s => '<code>' + escXml(s.notation) + '</code>'))].join(', ')
-        + ' <span class="ci-skipped-hint" title="'
-        + escXml(skippedList.map(s => s.notation + ': ' + s.shortPath).join('\n'))
-        + '">(?)</span>'
-      : '';
+    const skippedWarnings = skippedList.map(s => 'Skipped — unrecognized notation "' + s.notation + '": ' + s.shortPath);
+    const { input: warnInput, block: warnBlock } = buildWarnHtml(skippedWarnings);
 
     const empty = rows.length === 0 || columns.length === 0;
     const bodyHtml = empty ? this.emptyHtml(matrix) : this.gridHtml(rows, columns, cells, matrix.emptyLabels, matrix.obligationsLane, this.filter.showObligationsLane);
@@ -470,11 +464,14 @@ export class ComplianceImpactPreview {
       '\n' +
       IMPACT_CSS +
       '\n' +
+      WARN_BLOCK_CSS +
+      '\n' +
       '  </style>\n' +
       '</head>\n' +
       '<body data-theme="' +
       escXml(themeId) +
       '">\n' +
+      warnInput +
       '  <div id="ci-toolbar">\n' +
       '    <div class="ci-title">Compliance Impact Matrix</div>\n' +
       '    <div class="ci-summary">' +
@@ -485,7 +482,6 @@ export class ComplianceImpactPreview {
       totalGaps +
       '</strong> gaps' +
       pendingSummary +
-      skippedSummary +
       '</div>\n' +
       '    <div class="ci-config">' +
       configLine +
@@ -494,6 +490,7 @@ export class ComplianceImpactPreview {
       REFRESH_COMMAND +
       '" class="ci-btn" title="Re-scan the workspace and reload view config">Refresh</a>\n' +
       '  </div>\n' +
+      warnBlock +
       '  <div id="ci-filters">\n' +
       '    <span class="ci-filter-label">Status</span>' +
       statusBoxes +
@@ -759,7 +756,6 @@ body { padding: 0; }
 .ci-badge-pending_owner { color: #6b21a8; background: #f3e8ff; }
 .ci-empty { padding: 40px 24px; color: var(--ts-text-muted, #64748b); max-width: 640px; }
 .ci-empty code { background: var(--ts-bg-subtle, #f1f5f9); padding: 1px 4px; border-radius: 3px; }
-.ci-skipped-hint { cursor: help; color: var(--ts-text-muted, #64748b); font-size: 10px; vertical-align: super; }
 .ci-new { box-shadow: inset 0 0 0 2px #6366f1; }
 .ci-urgent { background: repeating-linear-gradient(45deg, #fee2e2, #fee2e2 5px, #fef2f2 5px, #fef2f2 10px) !important; }
 .ci-urgent-badge { display: inline-flex; align-items: center; justify-content: center; width: 18px; height: 18px; border-radius: 50%; background: #dc2626; color: #fff; font-weight: 700; font-size: 11px; }

--- a/extension/src/coverage-metric-preview.ts
+++ b/extension/src/coverage-metric-preview.ts
@@ -10,6 +10,7 @@ import {
 } from '../../packages/diagrams/src/compliance/coverage-metric.js';
 import { scanComplianceCanon, openComplianceFile } from './compliance-scan.js';
 import type { ScannedCanon } from './compliance-scan.js';
+import { WARN_BLOCK_CSS, buildWarnHtml } from './diagram-frame.js';
 
 // Coverage-metric view preview — strategy#185.
 //
@@ -184,6 +185,7 @@ export class CoverageMetricPreview {
     let bodyHtml: string;
     let titleLine: string;
     let subtitleLine = '';
+    let warnings: string[] = [];
 
     try {
       const parsed = yaml.load(yamlText) as unknown;
@@ -195,6 +197,7 @@ export class CoverageMetricPreview {
         const config = r.config;
         titleLine = escXml(config.name);
         if (config.description) subtitleLine = escXml(config.description.trim());
+        if (config.warnings) warnings = config.warnings;
         const canon: ScannedCanon = await scanComplianceCanon();
         const matrix = buildCoverageMatrix(canon, config);
         bodyHtml = buildTableHtml(matrix);
@@ -203,6 +206,8 @@ export class CoverageMetricPreview {
       bodyHtml = `<div class="cm-error">${escXml((e as Error).message ?? 'Unknown error')}</div>`;
       titleLine = 'Coverage Metric — error';
     }
+
+    const { input: warnInput, block: warnBlock } = buildWarnHtml(warnings);
 
     return (
       '<!DOCTYPE html>\n' +
@@ -215,14 +220,18 @@ export class CoverageMetricPreview {
       generateWebviewCss(themeId) +
       '\n' +
       COVERAGE_CSS +
+      '\n' +
+      WARN_BLOCK_CSS +
       '\n  </style>\n' +
       '</head>\n' +
       '<body>\n' +
+      warnInput +
       '  <div id="cm-toolbar">\n' +
       `    <div class="cm-title">${titleLine}</div>\n` +
       (subtitleLine ? `    <div class="cm-subtitle">${subtitleLine}</div>\n` : '') +
       `    <a href="command:${REFRESH_COMMAND}" class="cm-btn" title="Re-scan the workspace and reload">Refresh</a>\n` +
       '  </div>\n' +
+      warnBlock +
       bodyHtml +
       '</body>\n</html>'
     );

--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -186,7 +186,7 @@ const ERROR_BLOCK_CSS = `
 // up and crowd the canvas, so — unlike the error strip — this one is COLLAPSED
 // by default (checkbox starts `checked`); the count stays visible in the
 // summary and the user expands to read.
-const WARN_BLOCK_CSS = `
+export const WARN_BLOCK_CSS = `
 .tx-warn-toggle-cb{position:absolute;left:-9999px;width:1px;height:1px;opacity:0;}
 .tx-warn{margin:8px 16px;border:1px solid var(--vscode-editorWarning-foreground,#c07030);border-radius:6px;}
 .tx-warn-summary{display:block;cursor:pointer;user-select:none;padding:6px 10px;font-size:12px;font-weight:600;color:var(--vscode-editorWarning-foreground,#c07030);}
@@ -197,6 +197,21 @@ const WARN_BLOCK_CSS = `
 .tx-warn-item{color:var(--vscode-editorWarning-foreground,#c07030);font-size:11px;padding:2px 12px;}
 .tx-warn-toggle-cb:checked ~ .tx-warn .tx-warn-body{display:none;}
 `;
+
+/**
+ * Builds the HTML for a collapsible warnings block (starts collapsed).
+ * Requires `WARN_BLOCK_CSS` to be included in the page stylesheet.
+ * Returns empty strings when `warnings` is empty.
+ */
+export function buildWarnHtml(warnings: string[]): { input: string; block: string } {
+  if (warnings.length === 0) return { input: '', block: '' };
+  const label = warnings.length === 1 ? '1 warning' : `${warnings.length} warnings`;
+  const items = warnings.map(w => `<div class="tx-warn-item">${escXml(w)}</div>`).join('');
+  return {
+    input: '<input type="checkbox" id="ts-warn-toggle" class="tx-warn-toggle-cb" checked>',
+    block: `<div class="tx-warn">\n  <label for="ts-warn-toggle" class="tx-warn-summary">⚠ ${label}</label>\n  <div class="tx-warn-body">${items}</div>\n</div>`,
+  };
+}
 
 const FRAME_HEADER_CSS = `
 .frame-header{padding:16px 20px 20px;}
@@ -380,15 +395,7 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
 
   // Warnings collapse via the same hidden-checkbox mechanism, but start
   // COLLAPSED (checkbox `checked`) — advisories shouldn't crowd the canvas.
-  const warnToggleInput = warnings.length > 0
-    ? `<input type="checkbox" id="ts-warn-toggle" class="tx-warn-toggle-cb" checked>`
-    : '';
-  const warnBlock = warnings.length > 0
-    ? `<div class="tx-warn">
-  <label for="ts-warn-toggle" class="tx-warn-summary">⚠ ${warnings.length === 1 ? '1 warning' : `${warnings.length} warnings`}</label>
-  <div class="tx-warn-body">${warnings.map(w => `<div class="tx-warn-item">${escXml(w)}</div>`).join('')}</div>
-</div>`
-    : '';
+  const { input: warnToggleInput, block: warnBlock } = buildWarnHtml(warnings);
 
   const metaParts = [version ? `v${escXml(version)}` : null, date ? escXml(date) : null].filter(Boolean);
   const headerBlock = title


### PR DESCRIPTION
## Summary

- Extracts `WARN_BLOCK_CSS` + new `buildWarnHtml()` from `diagram-frame.ts` so compliance previews can use the established CSS-only collapsed strip pattern without duplication
- **Coverage-metric preview**: `config.warnings` (e.g. `COVMET-DEPRECATED`, `COVMET-007`) were previously silently dropped — now rendered as a collapsed block below the toolbar
- **Compliance-impact preview**: skipped-file diagnostics moved from inline toolbar summary text into the same collapsible block; removes the ad-hoc `ci-skipped-hint` class

The block starts collapsed with the warning count visible in the summary header, consistent with the diagram-frame pattern for all other diagram types.

## Test plan

- [ ] Open a `*.coverage-metric.transitrix.yaml` with a deprecated `coverage_metric:` wrapper — toolbar shows the matrix, collapsed warning block appears below with "1 warning" label; expand to see `COVMET-DEPRECATED` message
- [ ] Open a compliance-impact view with YAML files using unrecognised notations in the workspace — skipped-file warnings appear in the collapsed block, no longer cluttering the summary line
- [ ] No warnings → no block rendered in either preview
- [ ] 858 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)