### PR TITLE
feat(compliance): unify UI block order across all compliance/table previews

### DIFF
--- a/extension/src/compliance-impact-preview.ts
+++ b/extension/src/compliance-impact-preview.ts
@@ -13,7 +13,7 @@ import type { IndexRequirement, DeadlineStatus } from '../../packages/diagrams/s
 import { genNonce, colWidthPxFromSetting, colWidthRootCss } from './preview-controls.js';
 import { scanComplianceCanon, openComplianceFile } from './compliance-scan.js';
 import type { ScannedCanon } from './compliance-scan.js';
-import { WARN_BLOCK_CSS, buildWarnHtml } from './diagram-frame.js';
+import { WARN_BLOCK_CSS, buildWarnHtml, ERROR_BLOCK_CSS, buildErrorHtml } from './diagram-frame.js';
 
 // Compliance-impact matrix preview -- CV-2 (vkgeorgia/strategy#84).
 //
@@ -277,6 +277,7 @@ export class ComplianceImpactPreview {
   private jIndex = new Map<string, string[]>();
   private filter: ImpactFilter = defaultFilter();
   private colWidth: string = vscode.workspace.getConfiguration('transitrix').get<string>('report.columnWidth', 'normal');
+  private errorMsg = '';
 
   constructor(private readonly extensionUri: vscode.Uri) {}
 
@@ -310,25 +311,29 @@ export class ComplianceImpactPreview {
     if (!this.panel) return;
     this.panel.webview.html = this.buildLoadingHtml();
 
-    const canon = await scanComplianceCanon();
-    this.canon = canon;
-    this.config = await resolveViewConfig(canon);
-    this.pendingIndex = buildPendingIndex(canon);
+    try {
+      const canon = await scanComplianceCanon();
+      this.canon = canon;
+      this.config = await resolveViewConfig(canon);
+      this.pendingIndex = buildPendingIndex(canon);
 
-    // Auto-fill subjects.products if the view config left it empty.
-    const cfg = this.config;
-    const subjectProducts =
-      cfg.subjects.products && cfg.subjects.products.length > 0
-        ? cfg.subjects.products
-        : canon.products.map(p => p.id).sort();
-    const effectiveConfig: ImpactViewConfig = {
-      ...cfg,
-      subjects: { ...cfg.subjects, products: subjectProducts },
-    };
+      // Auto-fill subjects.products if the view config left it empty.
+      const cfg = this.config;
+      const subjectProducts =
+        cfg.subjects.products && cfg.subjects.products.length > 0
+          ? cfg.subjects.products
+          : canon.products.map(p => p.id).sort();
+      const effectiveConfig: ImpactViewConfig = {
+        ...cfg,
+        subjects: { ...cfg.subjects, products: subjectProducts },
+      };
 
-    this.matrix = buildImpactMatrix(canon, effectiveConfig);
-
-    this.jIndex = buildJurisdictionIndex(this.matrix.rows, canon);
+      this.matrix = buildImpactMatrix(canon, effectiveConfig);
+      this.jIndex = buildJurisdictionIndex(this.matrix.rows, canon);
+      this.errorMsg = '';
+    } catch (e) {
+      this.errorMsg = (e as Error).message ?? 'Unknown error';
+    }
     this.render();
   }
 
@@ -364,7 +369,7 @@ export class ComplianceImpactPreview {
   }
 
   private render(): void {
-    if (!this.panel || !this.matrix) return;
+    if (!this.panel) return;
     const themeId = vscode.workspace
       .getConfiguration('transitrix')
       .get<ThemeId>('theme', 'transitrix');
@@ -377,8 +382,27 @@ export class ComplianceImpactPreview {
 
   private buildHtml(themeId: ThemeId): string {
     const nonce = genNonce();
-    const matrix = this.matrix!;
-    const config = this.config!;
+    const { input: errInput, block: errBlock } = buildErrorHtml(this.errorMsg);
+
+    if (!this.matrix || !this.config) {
+      return (
+        '<!DOCTYPE html>\n<html lang="en">\n<head>\n' +
+        '<meta charset="UTF-8"/>\n' +
+        '<meta http-equiv="Content-Security-Policy" content="default-src \'none\'; style-src \'unsafe-inline\';">\n' +
+        '<style>\n' + generateWebviewCss(themeId) + '\n' + IMPACT_CSS + '\n' + ERROR_BLOCK_CSS + '\n</style>\n' +
+        '</head>\n<body data-theme="' + escXml(themeId) + '">\n' +
+        errInput + '\n' +
+        '<div id="ci-toolbar">' +
+        '<div class="ci-title">Compliance Impact Matrix</div>' +
+        '<a href="command:' + REFRESH_COMMAND + '" class="ci-btn" title="Re-scan the workspace and reload view config">Refresh</a>' +
+        '</div>\n' +
+        errBlock + '\n' +
+        '</body>\n</html>'
+      );
+    }
+
+    const matrix = this.matrix;
+    const config = this.config;
 
     const { rows, columns, cells } = applyFilter(matrix, this.filter, this.jIndex);
     const allJurisdictions = collectAllJurisdictions(matrix.rows, this.jIndex);
@@ -464,6 +488,8 @@ export class ComplianceImpactPreview {
       '\n' +
       IMPACT_CSS +
       '\n' +
+      ERROR_BLOCK_CSS +
+      '\n' +
       WARN_BLOCK_CSS +
       '\n' +
       '  </style>\n' +
@@ -471,6 +497,7 @@ export class ComplianceImpactPreview {
       '<body data-theme="' +
       escXml(themeId) +
       '">\n' +
+      errInput +
       warnInput +
       '  <div id="ci-toolbar">\n' +
       '    <div class="ci-title">Compliance Impact Matrix</div>\n' +
@@ -490,6 +517,7 @@ export class ComplianceImpactPreview {
       REFRESH_COMMAND +
       '" class="ci-btn" title="Re-scan the workspace and reload view config">Refresh</a>\n' +
       '  </div>\n' +
+      errBlock +
       warnBlock +
       '  <div id="ci-filters">\n' +
       '    <span class="ci-filter-label">Status</span>' +

--- a/extension/src/compliance-matrix-preview.ts
+++ b/extension/src/compliance-matrix-preview.ts
@@ -9,6 +9,7 @@ import {
 import type { AssertionStatus } from '../../packages/diagrams/src/assertion/types.js';
 import { genNonce, colWidthPxFromSetting, colWidthRootCss } from './preview-controls.js';
 import { scanComplianceCanon } from './compliance-scan.js';
+import { ERROR_BLOCK_CSS, buildErrorHtml, WARN_BLOCK_CSS, buildWarnHtml } from './diagram-frame.js';
 
 // Compliance matrix preview (vkgeorgia/strategy#84 Phase 2).
 //
@@ -29,7 +30,7 @@ const STATUS_LABELS: Record<AssertionStatus, string> = {
   pending_owner: 'Pending owner',
   n_a: 'N/A',
 };
-const ALL_STATUSES: AssertionStatus[] = ['compliant', 'partial', 'non_compliant', 'under_review', 'n_a'];
+const ALL_STATUSES: AssertionStatus[] = ['compliant', 'partial', 'non_compliant', 'under_review', 'pending_owner', 'n_a'];
 const ALL_SEVERITIES = ['high', 'medium', 'low'];
 
 const OPEN_FILE_COMMAND = 'transitrixStudio.openComplianceFile';
@@ -55,6 +56,8 @@ export class ComplianceMatrixPreview {
   private assertionPaths = new Map<string, string>();
   private filter: MatrixFilter = {};
   private colWidth: string = vscode.workspace.getConfiguration('transitrix').get<string>('report.columnWidth', 'normal');
+  private errorMsg = '';
+  private skippedWarnings: string[] = [];
 
   constructor(private readonly extensionUri: vscode.Uri) {}
 
@@ -82,16 +85,25 @@ export class ComplianceMatrixPreview {
   /** Re-scan the workspace and re-render. */
   async refresh(): Promise<void> {
     if (!this.panel) return;
-    const scan = await scanComplianceCanon();
-    this.assertionPaths = scan.pathById;
-    this.fullMatrix = buildComplianceMatrix({
-      products: scan.products,
-      requirements: scan.requirements.map(r => ({
-        id: r.id, name: r.name, severity: r.severity, derived_from: r.derived_from,
-      })),
-      assertions: scan.assertions,
-      codex: scan.codex.map(c => ({ id: c.id, jurisdiction: c.jurisdiction })),
-    });
+    try {
+      const scan = await scanComplianceCanon();
+      this.assertionPaths = scan.pathById;
+      this.skippedWarnings = (scan.skippedNotations ?? []).map(
+        s => 'Skipped — unrecognized notation "' + s.notation + '": ' + s.shortPath,
+      );
+      this.fullMatrix = buildComplianceMatrix({
+        products: scan.products,
+        requirements: scan.requirements.map(r => ({
+          id: r.id, name: r.name, severity: r.severity, derived_from: r.derived_from,
+        })),
+        assertions: scan.assertions,
+        codex: scan.codex.map(c => ({ id: c.id, jurisdiction: c.jurisdiction })),
+      });
+      this.errorMsg = '';
+    } catch (e) {
+      this.errorMsg = (e as Error).message ?? 'Unknown error';
+      this.skippedWarnings = [];
+    }
     this.render();
   }
 
@@ -117,25 +129,29 @@ export class ComplianceMatrixPreview {
   }
 
   private render(): void {
-    if (!this.panel || !this.fullMatrix) return;
+    if (!this.panel) return;
     const themeId = vscode.workspace.getConfiguration('transitrix').get<ThemeId>('theme', 'transitrix');
-    const matrix = filterComplianceMatrix(this.fullMatrix, this.filter);
+    const matrix = this.fullMatrix ? filterComplianceMatrix(this.fullMatrix, this.filter) : undefined;
     this.panel.webview.html = this.buildHtml(matrix, themeId);
   }
 
-  private buildHtml(matrix: ComplianceMatrix, themeId: ThemeId): string {
+  private buildHtml(matrix: ComplianceMatrix | undefined, themeId: ThemeId): string {
     const nonce = genNonce();
-    const { products, requirements, summary } = matrix;
+    const { input: errInput, block: errBlock } = buildErrorHtml(this.errorMsg);
+    const { input: warnInput, block: warnBlock } = buildWarnHtml(this.skippedWarnings);
 
-    const empty = requirements.length === 0 || products.length === 0;
-    const body = empty
+    const summary = matrix?.summary ?? { products: 0, requirements: 0, gaps: 0, assertions: 0 };
+    const empty = !matrix || matrix.requirements.length === 0 || matrix.products.length === 0;
+    const body = this.errorMsg
+      ? '<div class="cm-empty"><p>Scan failed — see error above.</p></div>'
+      : empty
       ? `<div class="cm-empty">
           <p>No compliance matrix to show.</p>
           <p>This view needs <code>notation: product</code>, <code>notation: requirement</code> and
              <code>notation: assertion</code> files in the workspace. None of one or more were found
              (${summary.products} products, ${summary.requirements} requirements).</p>
         </div>`
-      : this.gridHtml(matrix);
+      : this.gridHtml(matrix!);
 
     const filterStatuses = new Set(this.filter.statuses ?? []);
     const filterSeverities = new Set(this.filter.severities ?? []);
@@ -151,7 +167,7 @@ export class ComplianceMatrixPreview {
     // full matrix's columns. Hidden entirely when no requirement resolved one
     // (e.g. no codex files in the workspace) so the toolbar doesn't claim a
     // dimension that has no values.
-    const jurisdictionUniverse = collectJurisdictions(this.fullMatrix!);
+    const jurisdictionUniverse = this.fullMatrix ? collectJurisdictions(this.fullMatrix) : [];
     const jurisdictionBoxes = jurisdictionUniverse.map(j =>
       `<label class="cm-chip"><input type="checkbox" data-cm-jurisdiction="${escXml(j)}"${filterJurisdictions.has(j) ? ' checked' : ''}> ${escXml(j)}</label>`,
     ).join('');
@@ -177,14 +193,18 @@ export class ComplianceMatrixPreview {
 ${colWCss}
 ${generateWebviewCss(themeId)}
 ${MATRIX_CSS}
+${ERROR_BLOCK_CSS}
+${WARN_BLOCK_CSS}
   </style>
 </head>
 <body data-theme="${escXml(themeId)}">
+  ${errInput}${warnInput}
   <div id="cm-toolbar">
     <div class="cm-title">Compliance Matrix</div>
     <div class="cm-summary">${summary.products} products × ${summary.requirements} requirements · <strong>${summary.gaps}</strong> gaps · ${summary.assertions} claims shown</div>
     <a href="command:${REFRESH_COMMAND}" class="cm-btn" title="Re-scan the workspace">Refresh</a>
   </div>
+  ${errBlock}${warnBlock}
   <div id="cm-filters">
     <span class="cm-filter-label">Status</span>${statusBoxes}
     <span class="cm-filter-label">Severity</span>${severityBoxes}
@@ -309,6 +329,8 @@ body { padding: 0; }
 .cm-under_review .cm-badge { color: var(--ts-status-info-fg, #0c4a6e); }
 .cm-n_a { background: var(--ts-bg-subtle, #f1f5f9); }
 .cm-n_a .cm-badge { color: var(--ts-text-muted, #64748b); }
+.cm-pending_owner { background: #f3e8ff; }
+.cm-pending_owner .cm-badge { color: #6b21a8; }
 .cm-empty { padding: 40px 24px; color: var(--ts-text-muted, #64748b); max-width: 640px; }
 .cm-empty code { background: var(--ts-bg-subtle, #f1f5f9); padding: 1px 4px; border-radius: 3px; }
 `;

--- a/extension/src/compliance-render.ts
+++ b/extension/src/compliance-render.ts
@@ -2,6 +2,7 @@ import { generateWebviewCss, type ThemeId } from '../../packages/diagrams/src/th
 import type { AssertionStatus } from '../../packages/diagrams/src/assertion/types.js';
 import type { ViewScore } from '../../packages/diagrams/src/confidence/index.js';
 import { computeDeadlineStatus } from '../../packages/diagrams/src/compliance/impact.js';
+import { ERROR_BLOCK_CSS, buildErrorHtml, WARN_BLOCK_CSS, buildWarnHtml } from './diagram-frame.js';
 
 // Shared HTML rendering for the script-less compliance views — the single-law
 // tree and single-product view (vkgeorgia/strategy#84 Phase 3). These previews
@@ -71,6 +72,7 @@ body { padding: 0; }
 .cmp-non_compliant { background: var(--ts-status-error-bg, #fee2e2); color: var(--ts-status-error-fg, #991b1b); }
 .cmp-under_review { background: var(--ts-status-info-bg, #e0f2fe); color: var(--ts-status-info-fg, #0c4a6e); }
 .cmp-n_a { background: var(--ts-bg-subtle, #f1f5f9); color: var(--ts-text-muted, #64748b); }
+.cmp-pending_owner { background: #f3e8ff; color: #6b21a8; }
 
 /* Tree (single-law) */
 .cmp-req { margin: 0 0 14px; border: 1px solid var(--ts-border, #cbd5e1); border-radius: 6px; overflow: hidden; }
@@ -124,6 +126,10 @@ export interface ComplianceShellOptions {
    * composite to suppress the line entirely.
    */
   confidence?: ViewScore;
+  /** Non-fatal advisory messages. Rendered as a collapsible warnings block below the toolbar. */
+  warnings?: string[];
+  /** Hard error message. Rendered as a collapsible error block below the toolbar. */
+  errorMsg?: string;
 }
 
 /**
@@ -144,6 +150,8 @@ export function confidenceLineHtml(view: ViewScore): string {
 
 /** Full webview document for a script-less compliance view (static CSP). */
 export function complianceShell(opts: ComplianceShellOptions): string {
+  const { input: errInput, block: errBlock } = buildErrorHtml(opts.errorMsg ?? '');
+  const { input: warnInput, block: warnBlock } = buildWarnHtml(opts.warnings ?? []);
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -152,15 +160,19 @@ export function complianceShell(opts: ComplianceShellOptions): string {
   <style>
 ${generateWebviewCss(opts.themeId)}
 ${COMPLIANCE_CSS}
+${ERROR_BLOCK_CSS}
+${WARN_BLOCK_CSS}
   </style>
 </head>
 <body data-theme="${escXml(opts.themeId)}">
+  ${errInput}${warnInput}
   <div id="cmp-toolbar">
     <span class="cmp-title">${escXml(opts.title)}</span>
     ${opts.subtitle ? `<span class="cmp-subtitle">${escXml(opts.subtitle)}</span>` : ''}
     <span class="cmp-toolbar-actions">${(opts.extraButtons ?? []).map(b => `<a href="command:${b.command}" class="cmp-btn" title="${escXml(b.title)}">${escXml(b.label)}</a>`).join('')}<a href="command:${opts.refreshCommand}" class="cmp-btn" title="Re-scan the workspace">Refresh</a></span>
     ${opts.confidence ? confidenceLineHtml(opts.confidence) : ''}
   </div>
+  ${errBlock}${warnBlock}
   <div id="cmp-body">
     ${opts.bodyHtml}
   </div>

--- a/extension/src/coverage-metric-preview.ts
+++ b/extension/src/coverage-metric-preview.ts
@@ -10,7 +10,7 @@ import {
 } from '../../packages/diagrams/src/compliance/coverage-metric.js';
 import { scanComplianceCanon, openComplianceFile } from './compliance-scan.js';
 import type { ScannedCanon } from './compliance-scan.js';
-import { WARN_BLOCK_CSS, buildWarnHtml } from './diagram-frame.js';
+import { WARN_BLOCK_CSS, buildWarnHtml, ERROR_BLOCK_CSS, buildErrorHtml } from './diagram-frame.js';
 
 // Coverage-metric view preview — strategy#185.
 //
@@ -132,7 +132,6 @@ body { padding: 0; margin: 0; font-family: var(--vscode-font-family, sans-serif)
 .cm-thresholds { margin-top: 10px; font-size: 11px; color: var(--ts-text-muted, #64748b); }
 .cm-empty { padding: 40px 24px; color: var(--ts-text-muted, #64748b); }
 .cm-empty code { background: var(--ts-bg-subtle, #f1f5f9); padding: 1px 4px; border-radius: 3px; }
-.cm-error { padding: 16px; color: var(--vscode-errorForeground, #b91c1c); white-space: pre-wrap; font-size: 12px; }
 `;
 
 export class CoverageMetricPreview {
@@ -186,12 +185,14 @@ export class CoverageMetricPreview {
     let titleLine: string;
     let subtitleLine = '';
     let warnings: string[] = [];
+    let errorMsg = '';
 
     try {
       const parsed = yaml.load(yamlText) as unknown;
       const r = parseCoverageMetricConfig(parsed);
       if (!r.ok) {
-        bodyHtml = `<div class="cm-error">Parse errors:\n${r.errors.join('\n')}</div>`;
+        errorMsg = 'Parse errors:\n' + r.errors.join('\n');
+        bodyHtml = '';
         titleLine = 'Coverage Metric — parse error';
       } else {
         const config = r.config;
@@ -203,10 +204,12 @@ export class CoverageMetricPreview {
         bodyHtml = buildTableHtml(matrix);
       }
     } catch (e) {
-      bodyHtml = `<div class="cm-error">${escXml((e as Error).message ?? 'Unknown error')}</div>`;
+      errorMsg = (e as Error).message ?? 'Unknown error';
+      bodyHtml = '';
       titleLine = 'Coverage Metric — error';
     }
 
+    const { input: errInput, block: errBlock } = buildErrorHtml(errorMsg);
     const { input: warnInput, block: warnBlock } = buildWarnHtml(warnings);
 
     return (
@@ -221,16 +224,20 @@ export class CoverageMetricPreview {
       '\n' +
       COVERAGE_CSS +
       '\n' +
+      ERROR_BLOCK_CSS +
+      '\n' +
       WARN_BLOCK_CSS +
       '\n  </style>\n' +
       '</head>\n' +
       '<body>\n' +
+      errInput +
       warnInput +
       '  <div id="cm-toolbar">\n' +
       `    <div class="cm-title">${titleLine}</div>\n` +
       (subtitleLine ? `    <div class="cm-subtitle">${subtitleLine}</div>\n` : '') +
       `    <a href="command:${REFRESH_COMMAND}" class="cm-btn" title="Re-scan the workspace and reload">Refresh</a>\n` +
       '  </div>\n' +
+      errBlock +
       warnBlock +
       bodyHtml +
       '</body>\n</html>'

--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -169,7 +169,7 @@ const FIX_PROMPT_CSS = `
 // user clicks the summary to fold it once read and reclaim the canvas. The
 // checkbox sits at the top of <body> (off-screen but focusable) so the general
 // sibling combinator reaches the strip wherever it renders.
-const ERROR_BLOCK_CSS = `
+export const ERROR_BLOCK_CSS = `
 .tx-err-toggle-cb{position:absolute;left:-9999px;width:1px;height:1px;opacity:0;}
 .tx-err{margin:8px 16px;border:1px solid var(--vscode-inputValidation-errorBorder,var(--vscode-errorForeground,#b91c1c));border-radius:6px;}
 .tx-err-summary{display:block;cursor:pointer;user-select:none;padding:6px 10px;font-size:12px;font-weight:600;color:var(--vscode-errorForeground,#b91c1c);}
@@ -210,6 +210,19 @@ export function buildWarnHtml(warnings: string[]): { input: string; block: strin
   return {
     input: '<input type="checkbox" id="ts-warn-toggle" class="tx-warn-toggle-cb" checked>',
     block: `<div class="tx-warn">\n  <label for="ts-warn-toggle" class="tx-warn-summary">⚠ ${label}</label>\n  <div class="tx-warn-body">${items}</div>\n</div>`,
+  };
+}
+
+/**
+ * Builds the HTML for a collapsible error block (starts expanded).
+ * Requires `ERROR_BLOCK_CSS` to be included in the page stylesheet.
+ * Returns empty strings when `errorMsg` is empty.
+ */
+export function buildErrorHtml(errorMsg: string): { input: string; block: string } {
+  if (!errorMsg) return { input: '', block: '' };
+  return {
+    input: '<input type="checkbox" id="ts-err-toggle" class="tx-err-toggle-cb">',
+    block: `<div class="tx-err">\n  <label for="ts-err-toggle" class="tx-err-summary">✕ Error</label>\n  <pre class="tx-err-body">${escXml(errorMsg)}</pre>\n</div>`,
   };
 }
 


### PR DESCRIPTION
## Summary

- Establishes a single, consistent HTML block order for all four compliance/table previews:
  `[err-input][warn-input]` → toolbar → error block ▼ → warnings block ▸ → filters → body
- Exports `ERROR_BLOCK_CSS` and `buildErrorHtml()` from `diagram-frame.ts` (mirrors the existing `WARN_BLOCK_CSS` / `buildWarnHtml()` pair)
- `compliance-render.ts` (`complianceShell`): gains `warnings?` / `errorMsg?` options; law-tree, gap dashboard, and product views now support error/warn blocks
- `compliance-matrix-preview.ts`: adds `try/catch` in `refresh()` with skipped-notation warnings surfaced; fixes `ALL_STATUSES` missing `pending_owner`; adds `pending_owner` CSS; `buildHtml()` handles undefined matrix for the error state
- `compliance-impact-preview.ts`: `refresh()` wrapped in `try/catch`; `render()` no longer bails on missing matrix; error-only page shown when matrix/config absent; `errBlock` injected after toolbar
- `coverage-metric-preview.ts`: inline `cm-error` div replaced by `buildErrorHtml()`; `errInput`/`errBlock` placed in correct order; unused `.cm-error` CSS removed

## Test plan

- [ ] 339 library tests pass (`npx vitest run`)
- [ ] Extension type-checks clean (`tsc --noEmit`)
- [ ] Open Compliance Impact Matrix — warnings block collapses, error block (if triggered) expands by default
- [ ] Open Coverage Metric — same block order; parse errors show as collapsible error strip
- [ ] Open Compliance Matrix — `pending_owner` filter chip appears; skipped-notation warnings surface
- [ ] Law tree / gap dashboard / product view callers of `complianceShell` still render correctly (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)