### PR TITLE
feat(extension): extract shared canon-loader module (VP-1)

### DIFF
--- a/extension/src/activity-card-preview.ts
+++ b/extension/src/activity-card-preview.ts
@@ -11,6 +11,12 @@ import {
   type ActivityCardLayout,
 } from '../../packages/diagrams/src/activity-card/index.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
+import {
+  type CanonDocs,
+  findCanonRoot,
+  isUnderCanon,
+  loadCanon,
+} from './canon-loader.js';
 import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
 
 // The Activity Card is the first MULTI-DOCUMENT Studio preview. The card YAML
@@ -18,10 +24,8 @@ import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
 // and the child activities are pulled BY REFERENCE from the canonical ELEMENT
 // and RELATION store — never from other view documents (view-purity: a view is
 // a projection over elements + relations, methodology ELEMENT_PRIMITIVES.md
-// §1). This preview owns the filesystem half of that resolution: it locates the
-// org's `canon/` root above the card and reads every `canon/elements/**` and
-// `canon/relations/**` document; the pure resolver in `@transitrix/diagrams`
-// does the rest.
+// §1). The filesystem half of that resolution is now in canon-loader.ts;
+// the pure resolver in `@transitrix/diagrams` does the rest.
 
 const CARD_SUFFIX = '.activity-card.transitrix.yaml';
 
@@ -32,71 +36,6 @@ function escXml(s: string): string {
 function truncate(text: string, maxChars: number): string {
   if (text.length <= maxChars) return text;
   return text.slice(0, Math.max(0, maxChars - 1)) + '…';
-}
-
-interface CanonDocs {
-  elements: unknown[];
-  relations: unknown[];
-  warnings: string[];
-}
-
-/**
- * Walk up from the card file to the nearest ancestor directory literally named
- * `canon` (the canon-zone root that holds `elements/` and `relations/`).
- */
-function findCanonRoot(cardUri: vscode.Uri): vscode.Uri | undefined {
-  let dir = path.dirname(cardUri.fsPath);
-  for (let i = 0; i < 16; i++) {
-    if (path.basename(dir) === 'canon') return vscode.Uri.file(dir);
-    const parent = path.dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
-  }
-  return undefined;
-}
-
-/** Recursively read + parse every `*.yaml` document under `root` into `out`. */
-async function readYamlDocsUnder(root: vscode.Uri, out: unknown[], warnings: string[]): Promise<void> {
-  let entries: [string, vscode.FileType][];
-  try {
-    entries = await vscode.workspace.fs.readDirectory(root);
-  } catch {
-    return; // missing subtree (e.g. no relations/) is not an error
-  }
-  for (const [name, type] of entries) {
-    const child = vscode.Uri.joinPath(root, name);
-    if (type === vscode.FileType.Directory) {
-      await readYamlDocsUnder(child, out, warnings);
-    } else if (type === vscode.FileType.File && name.endsWith('.yaml')) {
-      try {
-        const bytes = await vscode.workspace.fs.readFile(child);
-        out.push(coerceDatesToIsoStrings(yaml.load(Buffer.from(bytes).toString('utf-8')) as unknown));
-      } catch (e) {
-        warnings.push(`Skipped ${name}: ${(e as Error).message ?? 'parse error'}`);
-      }
-    }
-  }
-}
-
-/** Read the canon element + relation store for the org owning this card. */
-async function readCanonSources(cardUri: vscode.Uri): Promise<CanonDocs> {
-  const elements: unknown[] = [];
-  const relations: unknown[] = [];
-  const warnings: string[] = [];
-
-  const canonRoot = findCanonRoot(cardUri);
-  if (!canonRoot) {
-    warnings.push('Could not locate a canon/ root above this card — project, motivation chain, and child activities cannot resolve.');
-    return { elements, relations, warnings };
-  }
-
-  await readYamlDocsUnder(vscode.Uri.joinPath(canonRoot, 'elements'), elements, warnings);
-  await readYamlDocsUnder(vscode.Uri.joinPath(canonRoot, 'relations'), relations, warnings);
-
-  if (elements.length === 0) {
-    warnings.push('No element documents found under canon/elements — project + child activities cannot resolve.');
-  }
-  return { elements, relations, warnings };
 }
 
 const ARROW_DEF = `<defs><marker id="ac-arrow" markerWidth="8" markerHeight="8" refX="8" refY="3" orient="auto"><path d="M0,0 L0,6 L8,3 z" class="arrow-fill"/></marker></defs>`;
@@ -283,18 +222,14 @@ export class ActivityCardPreview {
     const cardUri = vscode.Uri.parse(this.trackedUri);
     const canonRoot = findCanonRoot(cardUri);
     if (!canonRoot) return;
-    // Only re-render for saves inside this card's canon element/relation store.
-    const savedDir = path.dirname(doc.uri.fsPath);
-    const elementsRoot = path.join(canonRoot.fsPath, 'elements');
-    const relationsRoot = path.join(canonRoot.fsPath, 'relations');
-    if (!savedDir.startsWith(elementsRoot) && !savedDir.startsWith(relationsRoot)) return;
+    if (!isUnderCanon(canonRoot, doc.uri)) return;
     const cardDoc = await vscode.workspace.openTextDocument(cardUri);
     await this.pushDocument(cardDoc);
   }
 
   private async pushDocument(doc: vscode.TextDocument): Promise<void> {
     if (!this.panel) return;
-    const sources = await readCanonSources(doc.uri);
+    const sources = await loadCanon(doc.uri);
     this.panel.webview.html = this.buildHtml(doc.getText(), path.basename(doc.fileName), sources);
   }
 

--- a/extension/src/canon-loader.ts
+++ b/extension/src/canon-loader.ts
@@ -1,0 +1,213 @@
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+import yaml from 'js-yaml';
+import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
+
+// Shared filesystem layer for the canon/ element + relation store.
+//
+// Every Studio preview that reads canonical data (VP-* series) uses the same
+// approach: walk up from the active file to the nearest ancestor directory
+// named `canon/`, then recursively load canon/elements/** and
+// canon/relations/**. This module owns that shared FS half; the per-notation
+// resolvers in `@transitrix/diagrams` own the semantic half.
+//
+// Two tiers of exports:
+//   1. vscode.Uri-based public API (findCanonRoot, loadCanon, isUnderCanon)
+//   2. Pure path-string helpers (*Path variants) — used internally and in
+//      unit tests (no vscode runtime needed).
+
+/** A raw YAML document loaded from canon/elements/**. */
+export interface CanonElement {
+  notation: string;
+  id: string;
+  [key: string]: unknown;
+}
+
+/** A raw YAML document loaded from canon/relations/**. */
+export interface CanonRelation {
+  notation: 'relation';
+  id: string;
+  type: string;
+  from: string;
+  to: string;
+  [key: string]: unknown;
+}
+
+/** Raw docs loaded from a canon/ tree. */
+export interface CanonDocs {
+  elements: unknown[];
+  relations: unknown[];
+  warnings: string[];
+}
+
+/** Indexed view over a CanonDocs store for efficient lookups. */
+export interface CanonIndex {
+  /** Elements by id. */
+  elementById: Map<string, CanonElement>;
+  /** Elements grouped by notation type. */
+  elementsByNotation: Map<string, CanonElement[]>;
+  /** All typed relations. */
+  relations: CanonRelation[];
+}
+
+// ── Path-pure helpers (no vscode runtime — directly unit-testable) ─────────
+
+/**
+ * Walk up from `filePath` up to 16 ancestor levels looking for a directory
+ * literally named `canon`. Returns the absolute path of that directory, or
+ * undefined when no such ancestor exists.
+ */
+export function findCanonRootPath(filePath: string): string | undefined {
+  let dir = path.dirname(filePath);
+  for (let i = 0; i < 16; i++) {
+    if (path.basename(dir) === 'canon') return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return undefined;
+}
+
+/**
+ * Returns true when `savedFilePath` is inside the `elements/` or `relations/`
+ * subtrees of `canonRootPath`.
+ */
+export function isUnderCanonPath(canonRootPath: string, savedFilePath: string): boolean {
+  const elementsRoot = path.join(canonRootPath, 'elements');
+  const relationsRoot = path.join(canonRootPath, 'relations');
+  const savedDir = path.dirname(savedFilePath);
+  return savedDir.startsWith(elementsRoot) || savedDir.startsWith(relationsRoot);
+}
+
+// ── vscode.Uri wrappers ────────────────────────────────────────────────────
+
+/**
+ * Walk up from `fileUri` to find the nearest ancestor directory named `canon/`.
+ */
+export function findCanonRoot(fileUri: vscode.Uri): vscode.Uri | undefined {
+  const p = findCanonRootPath(fileUri.fsPath);
+  return p ? vscode.Uri.file(p) : undefined;
+}
+
+/**
+ * Returns true when `savedUri` is inside the `elements/` or `relations/`
+ * subtrees of `canonRoot`. Use to gate multi-document re-renders: only
+ * re-render when the saved file touches the owning canon store.
+ */
+export function isUnderCanon(canonRoot: vscode.Uri, savedUri: vscode.Uri): boolean {
+  return isUnderCanonPath(canonRoot.fsPath, savedUri.fsPath);
+}
+
+// ── FS loader ─────────────────────────────────────────────────────────────
+
+/** Recursively read + parse every `*.yaml` document under `root` into `out`. */
+export async function readYamlDocsUnder(
+  root: vscode.Uri,
+  out: unknown[],
+  warnings: string[],
+): Promise<void> {
+  let entries: [string, vscode.FileType][];
+  try {
+    entries = await vscode.workspace.fs.readDirectory(root);
+  } catch {
+    return; // missing subtree (e.g. no relations/ yet) is not an error
+  }
+  for (const [name, type] of entries) {
+    const child = vscode.Uri.joinPath(root, name);
+    if (type === vscode.FileType.Directory) {
+      await readYamlDocsUnder(child, out, warnings);
+    } else if (type === vscode.FileType.File && name.endsWith('.yaml')) {
+      try {
+        const bytes = await vscode.workspace.fs.readFile(child);
+        out.push(coerceDatesToIsoStrings(yaml.load(Buffer.from(bytes).toString('utf-8')) as unknown));
+      } catch (e) {
+        warnings.push(`Skipped ${name}: ${(e as Error).message ?? 'parse error'}`);
+      }
+    }
+  }
+}
+
+/**
+ * Load the canon element + relation store for the owning canon/ root of `fileUri`.
+ * Returns an empty store with a warning when no canon/ root is found.
+ */
+export async function loadCanon(fileUri: vscode.Uri): Promise<CanonDocs> {
+  const elements: unknown[] = [];
+  const relations: unknown[] = [];
+  const warnings: string[] = [];
+
+  const canonRoot = findCanonRoot(fileUri);
+  if (!canonRoot) {
+    warnings.push(
+      'Could not locate a canon/ root above this file — element and relation references cannot resolve.',
+    );
+    return { elements, relations, warnings };
+  }
+
+  await readYamlDocsUnder(vscode.Uri.joinPath(canonRoot, 'elements'), elements, warnings);
+  await readYamlDocsUnder(vscode.Uri.joinPath(canonRoot, 'relations'), relations, warnings);
+
+  if (elements.length === 0) {
+    warnings.push('No element documents found under canon/elements — element references cannot resolve.');
+  }
+  return { elements, relations, warnings };
+}
+
+// ── Index & lookup helpers ─────────────────────────────────────────────────
+
+function isElement(doc: unknown): doc is CanonElement {
+  if (doc === null || typeof doc !== 'object') return false;
+  const r = doc as Record<string, unknown>;
+  return typeof r['notation'] === 'string' && r['notation'] !== 'relation' && typeof r['id'] === 'string';
+}
+
+function isRelation(doc: unknown): doc is CanonRelation {
+  if (doc === null || typeof doc !== 'object') return false;
+  const r = doc as Record<string, unknown>;
+  return (
+    r['notation'] === 'relation' &&
+    typeof r['id'] === 'string' &&
+    typeof r['type'] === 'string' &&
+    typeof r['from'] === 'string' &&
+    typeof r['to'] === 'string'
+  );
+}
+
+/**
+ * Build a lookup index over a loaded CanonDocs store.
+ * Malformed documents are silently skipped — callers should check `docs.warnings`.
+ */
+export function buildCanonIndex(docs: CanonDocs): CanonIndex {
+  const elementById = new Map<string, CanonElement>();
+  const elementsByNotation = new Map<string, CanonElement[]>();
+  const relations: CanonRelation[] = [];
+
+  for (const doc of docs.elements) {
+    if (!isElement(doc)) continue;
+    elementById.set(doc.id, doc);
+    const bucket = elementsByNotation.get(doc.notation) ?? [];
+    bucket.push(doc);
+    elementsByNotation.set(doc.notation, bucket);
+  }
+  for (const doc of docs.relations) {
+    if (!isRelation(doc)) continue;
+    relations.push(doc);
+  }
+
+  return { elementById, elementsByNotation, relations };
+}
+
+/** All relations of a given type (e.g. `'activity_goal'`). */
+export function relationsOfType(index: CanonIndex, type: string): CanonRelation[] {
+  return index.relations.filter(r => r.type === type);
+}
+
+/** All relations where `from === sourceId`. */
+export function relationsFrom(index: CanonIndex, sourceId: string): CanonRelation[] {
+  return index.relations.filter(r => r.from === sourceId);
+}
+
+/** All relations where `to === targetId`. */
+export function relationsTo(index: CanonIndex, targetId: string): CanonRelation[] {
+  return index.relations.filter(r => r.to === targetId);
+}

--- a/tests/canon-loader.test.ts
+++ b/tests/canon-loader.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+
+// The pure functions under test (findCanonRootPath, isUnderCanonPath,
+// buildCanonIndex, relation helpers) do not call any vscode API at runtime.
+// This stub satisfies the static import so vitest can load the module.
+vi.mock('vscode', () => ({}));
+import { join, sep } from 'node:path';
+import yaml from 'js-yaml';
+import {
+  findCanonRootPath,
+  isUnderCanonPath,
+  buildCanonIndex,
+  relationsOfType,
+  relationsFrom,
+  relationsTo,
+  type CanonDocs,
+} from '../extension/src/canon-loader.js';
+
+// Helpers to load fixture docs using Node.js fs (no vscode runtime needed).
+
+function readYamlFilesUnder(dir: string): unknown[] {
+  const out: unknown[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const child = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...readYamlFilesUnder(child));
+    } else if (entry.isFile() && entry.name.endsWith('.yaml')) {
+      out.push(yaml.load(readFileSync(child, 'utf-8')));
+    }
+  }
+  return out;
+}
+
+const FIXTURE_CANON = join(
+  import.meta.dirname ?? __dirname,
+  'fixtures',
+  'notation-corpus',
+  'activity-card',
+  'canon',
+);
+
+function makeFixtureDocs(): CanonDocs {
+  return {
+    elements: readYamlFilesUnder(join(FIXTURE_CANON, 'elements')),
+    relations: readYamlFilesUnder(join(FIXTURE_CANON, 'relations')),
+    warnings: [],
+  };
+}
+
+// ── findCanonRootPath ────────────────────────────────────────────────────────
+
+describe('findCanonRootPath', () => {
+  it('returns the canon/ directory when the file is inside it', () => {
+    const filePath = ['', 'org', 'canon', 'elements', 'activities', 'ACT-1.yaml'].join(sep);
+    expect(findCanonRootPath(filePath)).toBe(['', 'org', 'canon'].join(sep));
+  });
+
+  it('finds canon/ several levels above the file', () => {
+    const filePath = ['', 'org', 'canon', 'elements', 'a', 'b', 'c', 'ACT-1.yaml'].join(sep);
+    expect(findCanonRootPath(filePath)).toBe(['', 'org', 'canon'].join(sep));
+  });
+
+  it('returns undefined when no ancestor is named canon/', () => {
+    const filePath = ['', 'org', 'views', 'activity-card', 'my-card.yaml'].join(sep);
+    expect(findCanonRootPath(filePath)).toBeUndefined();
+  });
+
+  it('does not confuse a non-canon directory named similarly', () => {
+    const filePath = ['', 'org', 'canonical', 'elements', 'ACT-1.yaml'].join(sep);
+    expect(findCanonRootPath(filePath)).toBeUndefined();
+  });
+});
+
+// ── isUnderCanonPath ─────────────────────────────────────────────────────────
+
+describe('isUnderCanonPath', () => {
+  const canonRoot = ['', 'org', 'canon'].join(sep);
+
+  it('returns true for a file inside elements/', () => {
+    const saved = join(canonRoot, 'elements', 'activities', 'ACT-1.yaml');
+    expect(isUnderCanonPath(canonRoot, saved)).toBe(true);
+  });
+
+  it('returns true for a file inside relations/', () => {
+    const saved = join(canonRoot, 'relations', 'REL-1.yaml');
+    expect(isUnderCanonPath(canonRoot, saved)).toBe(true);
+  });
+
+  it('returns false for a file outside elements/ and relations/', () => {
+    const saved = join(canonRoot, 'cards', 'my-card.yaml');
+    expect(isUnderCanonPath(canonRoot, saved)).toBe(false);
+  });
+
+  it('returns false for a sibling of canon/', () => {
+    const saved = ['', 'org', 'views', 'my-card.yaml'].join(sep);
+    expect(isUnderCanonPath(canonRoot, saved)).toBe(false);
+  });
+});
+
+// ── buildCanonIndex ──────────────────────────────────────────────────────────
+
+describe('buildCanonIndex', () => {
+  it('indexes all elements by id', () => {
+    const index = buildCanonIndex(makeFixtureDocs());
+    expect(index.elementById.has('ACTIVITY-EU-PROGRAMME-1')).toBe(true);
+    expect(index.elementById.has('GOAL-EU-MARKET-1')).toBe(true);
+    expect(index.elementById.has('FACTOR-EU-MDR-1')).toBe(true);
+    expect(index.elementById.has('CHANGE-EU-COMPLIANCE-1')).toBe(true);
+  });
+
+  it('groups elements by notation', () => {
+    const index = buildCanonIndex(makeFixtureDocs());
+    expect(index.elementsByNotation.has('activity')).toBe(true);
+    expect(index.elementsByNotation.has('goal')).toBe(true);
+    const activities = index.elementsByNotation.get('activity') ?? [];
+    expect(activities.some(a => a.id === 'ACTIVITY-EU-PROGRAMME-1')).toBe(true);
+  });
+
+  it('indexes relations', () => {
+    const index = buildCanonIndex(makeFixtureDocs());
+    expect(index.relations.length).toBeGreaterThan(0);
+    expect(index.relations.some(r => r.id === 'REL-EU-PROGRAMME-GOAL-EU-MARKET-1')).toBe(true);
+  });
+
+  it('skips elements without an id', () => {
+    const docs: CanonDocs = {
+      elements: [{ notation: 'activity' }, { notation: 'activity', id: 'ACT-1' }],
+      relations: [],
+      warnings: [],
+    };
+    const index = buildCanonIndex(docs);
+    expect(index.elementById.size).toBe(1);
+    expect(index.elementById.has('ACT-1')).toBe(true);
+  });
+
+  it('skips malformed relation documents', () => {
+    const docs: CanonDocs = {
+      elements: [],
+      relations: [
+        { notation: 'relation', id: 'REL-1', type: 'link', from: 'A', to: 'B' },
+        { notation: 'relation', id: 'REL-BAD' }, // missing type/from/to
+        null,
+      ],
+      warnings: [],
+    };
+    const index = buildCanonIndex(docs);
+    expect(index.relations).toHaveLength(1);
+    expect(index.relations[0].id).toBe('REL-1');
+  });
+});
+
+// ── relation lookup helpers ──────────────────────────────────────────────────
+
+describe('relationsOfType', () => {
+  it('returns only relations of the given type', () => {
+    const index = buildCanonIndex(makeFixtureDocs());
+    const links = relationsOfType(index, 'activity_goal');
+    expect(links.length).toBeGreaterThan(0);
+    expect(links.every(r => r.type === 'activity_goal')).toBe(true);
+  });
+
+  it('returns empty array for an unknown type', () => {
+    const index = buildCanonIndex(makeFixtureDocs());
+    expect(relationsOfType(index, 'nonexistent_type')).toHaveLength(0);
+  });
+});
+
+describe('relationsFrom', () => {
+  it('returns relations where from matches the sourceId', () => {
+    const index = buildCanonIndex(makeFixtureDocs());
+    const rels = relationsFrom(index, 'ACTIVITY-EU-PROGRAMME-1');
+    expect(rels.length).toBeGreaterThan(0);
+    expect(rels.every(r => r.from === 'ACTIVITY-EU-PROGRAMME-1')).toBe(true);
+  });
+
+  it('returns empty array for an unknown source', () => {
+    const index = buildCanonIndex(makeFixtureDocs());
+    expect(relationsFrom(index, 'DOES-NOT-EXIST')).toHaveLength(0);
+  });
+});
+
+describe('relationsTo', () => {
+  it('returns relations where to matches the targetId', () => {
+    const index = buildCanonIndex(makeFixtureDocs());
+    const rels = relationsTo(index, 'GOAL-EU-MARKET-1');
+    expect(rels.length).toBeGreaterThan(0);
+    expect(rels.every(r => r.to === 'GOAL-EU-MARKET-1')).toBe(true);
+  });
+
+  it('returns empty array for an unknown target', () => {
+    const index = buildCanonIndex(makeFixtureDocs());
+    expect(relationsTo(index, 'DOES-NOT-EXIST')).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Introduces `extension/src/canon-loader.ts` — a shared FS layer for all Studio previews that read from a `canon/` element + relation store (view-purity foundation, VP-1)
- Extracts `findCanonRoot`, `readYamlDocsUnder`, `readCanonSources` out of `activity-card-preview.ts` into the new shared module; behaviour-identical refactor
- Adds pure path-string variants (`findCanonRootPath`, `isUnderCanonPath`) alongside the `vscode.Uri` wrappers — unit-testable without the VS Code runtime
- Adds `buildCanonIndex`, `relationsOfType`, `relationsFrom`, `relationsTo` for efficient element/relation lookups in downstream VP-* migrations
- `activity-card-preview.ts` now delegates to the new module; its own local definitions are removed

## Exports

| Function | Description |
|---|---|
| `findCanonRootPath(filePath)` | Pure: walk up to nearest `canon/` ancestor |
| `findCanonRoot(uri)` | `vscode.Uri` wrapper |
| `isUnderCanonPath(root, file)` | Pure: true when file is under `elements/` or `relations/` |
| `isUnderCanon(root, uri)` | `vscode.Uri` wrapper |
| `readYamlDocsUnder(root, …)` | Recursive YAML loader via `vscode.workspace.fs` |
| `loadCanon(fileUri)` | Full canon load (elements + relations + warnings) |
| `buildCanonIndex(docs)` | Index by id and by notation type |
| `relationsOfType / relationsFrom / relationsTo` | Typed relation lookup helpers |

## Test plan

- [ ] 358 tests pass (`npx vitest run`)
- [ ] Extension type-checks clean (`tsc --noEmit`)
- [ ] Activity Card preview still renders correctly in IDE (behaviour-identical refactor)
- [ ] 19 new unit tests cover `findCanonRootPath`, `isUnderCanonPath`, `buildCanonIndex`, relation helpers

🤖 Generated with [Claude Code](https://claude.com/claude-code)