### PR TITLE
docs(intellij): add change-notes to plugin.xml

### DIFF
--- a/intellij/src/main/resources/META-INF/plugin.xml
+++ b/intellij/src/main/resources/META-INF/plugin.xml
@@ -24,6 +24,20 @@
         <p>Built on ArchiMate 3.2. Open source, MIT licensed.</p>
     ]]></description>
 
+    <change-notes><![CDATA[
+        <h3>0.1.0 — Initial release</h3>
+        <ul>
+            <li>Live notation preview for all Transitrix YAML formats: Goals trees,
+            FGCA / FGA chains, activity networks, BPMN processes, capability maps,
+            process blueprints, activity cards, and more.</li>
+            <li>Preview panel opens automatically on <code>*.transitrix.yaml</code> files,
+            or on demand via right-click → <b>Transitrix: Preview Notation</b>.</li>
+            <li>Powered by the shared <code>@transitrix/diagrams</code> engine —
+            identical output to the VS Code extension.</li>
+            <li>Open source, MIT licensed.</li>
+        </ul>
+    ]]></change-notes>
+
     <depends>com.intellij.modules.platform</depends>
 
     <extensions defaultExtensionNs="com.intellij">


### PR DESCRIPTION
## Problem

JetBrains Marketplace shows \"Unfortunately, Transitrix didn't leave any update notes.\" because `plugin.xml` has no `<change-notes>` element at all.

## Change

Adds `<change-notes>` block with v0.1.0 release notes (HTML, as JetBrains requires).

**Note on retroactivity:** v0.1.0 was already published without notes — JetBrains captures change-notes at publish time, so the existing listing won't change. The next published version will correctly show its notes. The v0.1.0 notes in this PR establish the format for the release runbook.

## Going forward

For each future release, update `<change-notes>` with a new `<h3>` block before publishing to JetBrains Marketplace. Prepend the new version's notes (keep the previous ones below for history).