### PR TITLE
feat(diagrams): VP-3 — FGCA preview resolver migrated to shared canon-loader

### DIFF
--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -420,6 +420,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       // a projection over canon/elements + canon/relations). Runs before the
       // per-type routing below (which early-returns on a match).
       void activityCardPreview.refreshIfSiblingSaved(doc);
+      void fgcaPreview.refreshIfSiblingSaved(doc);
       // Compliance views are repo-wide: re-scan the open ones whenever a canon
       // artefact (by filename convention) is saved. No-op when no panel is open.
       if (/^(PRODUCT|REQUIREMENT|ASSERTION|LAW|REGULATION|POLICY|INTERNAL_STANDARD)-.*\.ya?ml$/.test(path.basename(doc.fileName))) {

--- a/extension/src/fgca-preview.ts
+++ b/extension/src/fgca-preview.ts
@@ -3,7 +3,9 @@ import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, prepareSvgForExport, type ThemeId } from './diagram-frame.js';
 import { TITLE_BLOCK_H, titleBlockSvg, todayIso } from './svg-title-block.js';
+import { loadCanon, findCanonRoot, isUnderCanon, type CanonDocs } from './canon-loader.js';
 import { parseCanonicalFGCA, parseCanonicalFGA } from '../../packages/diagrams/src/fgca/parse-canonical.js';
+import { resolveFGCA, isFGCAViewDoc } from '../../packages/diagrams/src/fgca/resolver.js';
 import {
   layoutFGCAPreview,
   FGCA_NODE_W as NODE_W,
@@ -345,12 +347,25 @@ export class FGCAPreview {
     await this.pushDocument(doc);
   }
 
-  private async pushDocument(doc: vscode.TextDocument): Promise<void> {
-    if (!this.panel) return;
-    this.panel.webview.html = this.buildHtml(doc.getText(), path.basename(doc.fileName));
+  /** Re-render the tracked document when a sibling canon element/relation saves. */
+  async refreshIfSiblingSaved(doc: vscode.TextDocument): Promise<void> {
+    if (!this.panel || !this.trackedUri) return;
+    if (!doc.fileName.endsWith('.yaml')) return;
+    const fgcaUri = vscode.Uri.parse(this.trackedUri);
+    const canonRoot = findCanonRoot(fgcaUri);
+    if (!canonRoot) return;
+    if (!isUnderCanon(canonRoot, doc.uri)) return;
+    const fgcaDoc = await vscode.workspace.openTextDocument(fgcaUri);
+    await this.pushDocument(fgcaDoc);
   }
 
-  private buildHtml(yamlText: string, filename: string): string {
+  private async pushDocument(doc: vscode.TextDocument): Promise<void> {
+    if (!this.panel) return;
+    const sources = await loadCanon(doc.uri);
+    this.panel.webview.html = this.buildHtml(doc.getText(), path.basename(doc.fileName), sources);
+  }
+
+  private buildHtml(yamlText: string, filename: string, sources: CanonDocs): string {
     let parsedDoc: FGCADoc | null = null;
     let errorMsg = '';
     let warnings: string[] = [];
@@ -362,15 +377,15 @@ export class FGCAPreview {
       const meta = (parsed && typeof parsed === 'object' ? parsed : {}) as { version?: unknown; date?: unknown };
       docVersion = typeof meta.version === 'string' ? meta.version : undefined;
       docDate = typeof meta.date === 'string' ? meta.date : todayIso();
-      const v = parseCanonicalFGCA(parsed);
-      warnings = v.warnings.map(w => `${w.code}: ${w.message}`);
+      // Canon-projection form (VP-3): view_config present, no inline elements.
+      // Fall back to inline parsing for legacy documents that carry factors[]/goals[].
+      const input = isFGCAViewDoc(parsed) ? resolveFGCA(parsed, sources) : parsed;
+      warnings = [...sources.warnings];
+      const v = parseCanonicalFGCA(input);
+      warnings.push(...v.warnings.map(w => `${w.code}: ${w.message}`));
       if (!v.valid || !v.parsed) {
         errorMsg = v.errors.map(e => `${e.code}: ${e.message}`).join('\n');
       } else {
-        // parseCanonicalFGCA returns the strict internal form with numeric
-        // IDs and singular `change.goal_id` / `change.activity_ids`. The
-        // inline FGCADoc / buildSvg here accept both forms (number | string
-        // unions) — pass through.
         parsedDoc = v.parsed as unknown as FGCADoc;
       }
     } catch (e) {

--- a/packages/diagrams/src/fgca/__tests__/resolver.test.ts
+++ b/packages/diagrams/src/fgca/__tests__/resolver.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import yaml from 'js-yaml';
+import { resolveFGCA, isFGCAViewDoc } from '../resolver.js';
+import { parseCanonicalFGCA } from '../parse-canonical.js';
+
+// ── Inline canon element store (mirrors strategy-2026 data split into per-element form) ─
+
+const ELEMENTS = [
+  { notation: 'factor', id: 'FACTOR-1', name: 'Competitive market pressure', type: 'external' },
+  { notation: 'factor', id: 'FACTOR-2', name: 'Digital adoption acceleration', type: 'external' },
+  { notation: 'goal', id: 'GOAL-1', name: 'Grow revenue by 20%', factors: ['FACTOR-1', 'FACTOR-2'] },
+  { notation: 'goal', id: 'GOAL-2', name: 'Reduce operational costs', factors: ['FACTOR-2'] },
+  { notation: 'goal', id: 'GOAL-3', name: 'Improve customer retention', factors: ['FACTOR-1'] },
+  { notation: 'change', id: 'CHANGE-1', name: 'Launch new product line', goals: ['GOAL-1'] },
+  { notation: 'change', id: 'CHANGE-2', name: 'Automate manual processes', goals: ['GOAL-2'] },
+  { notation: 'change', id: 'CHANGE-3', name: 'Enhance support platform', goals: ['GOAL-3'] },
+  { notation: 'activity', id: 'ACTIVITY-1', name: 'Market research', changes: ['CHANGE-1'] },
+  { notation: 'activity', id: 'ACTIVITY-2', name: 'MVP development', changes: ['CHANGE-1'] },
+  { notation: 'activity', id: 'ACTIVITY-3', name: 'Process audit', changes: ['CHANGE-2'] },
+  { notation: 'activity', id: 'ACTIVITY-4', name: 'RPA tooling rollout', changes: ['CHANGE-2'] },
+  { notation: 'activity', id: 'ACTIVITY-5', name: 'CRM implementation', changes: ['CHANGE-3'] },
+];
+
+const SOURCES = { elements: ELEMENTS, relations: [] };
+
+const VIEW_DOC = {
+  notation: 'fgca',
+  id: 'FGCA-STRAT-1',
+  name: 'Strategy 2026 — FGCA chain',
+  spec_version: '0.1',
+  view_config: {
+    goals: { filter: 'all' },
+    factors: { surface: 'derived' },
+    changes: { surface: 'derived' },
+    activities: { surface: 'derived' },
+  },
+};
+
+// ── isFGCAViewDoc ─────────────────────────────────────────────────────────────
+
+describe('isFGCAViewDoc', () => {
+  it('returns true for a view_config-based doc', () => {
+    expect(isFGCAViewDoc(VIEW_DOC)).toBe(true);
+  });
+
+  it('returns false for an inline doc with factors/goals arrays', () => {
+    expect(isFGCAViewDoc({
+      notation: 'fgca', id: 'FGCA-1', name: 'x',
+      factors: [], goals: [], changes: [], activities: [],
+    })).toBe(false);
+  });
+
+  it('returns false for non-objects', () => {
+    expect(isFGCAViewDoc(null)).toBe(false);
+    expect(isFGCAViewDoc('string')).toBe(false);
+    expect(isFGCAViewDoc(42)).toBe(false);
+  });
+});
+
+// ── resolveFGCA — goals.filter=all (default) ──────────────────────────────────
+
+describe('resolveFGCA — goals.filter=all', () => {
+  it('includes all goals, changes, and activities', () => {
+    const doc = resolveFGCA(VIEW_DOC, SOURCES);
+    expect((doc['goals'] as unknown[]).length).toBe(3);
+    expect((doc['changes'] as unknown[]).length).toBe(3);
+    expect((doc['activities'] as unknown[]).length).toBe(5);
+  });
+
+  it('derives factors from all goal.factors[] refs', () => {
+    const doc = resolveFGCA(VIEW_DOC, SOURCES);
+    const factorIds = (doc['factors'] as Array<{ id: string }>).map((f) => f.id);
+    expect(factorIds).toContain('FACTOR-1');
+    expect(factorIds).toContain('FACTOR-2');
+    expect(factorIds.length).toBe(2);
+  });
+
+  it('passes parseCanonicalFGCA and produces a fully valid internal doc', () => {
+    const doc = resolveFGCA(VIEW_DOC, SOURCES);
+    const r = parseCanonicalFGCA(doc);
+    expect(r.valid).toBe(true);
+    expect(r.errors).toEqual([]);
+    expect(r.parsed?.goals).toHaveLength(3);
+    expect(r.parsed?.factors).toHaveLength(2);
+    expect(r.parsed?.changes).toHaveLength(3);
+    expect(r.parsed?.activities).toHaveLength(5);
+  });
+
+  it('carries view doc metadata (id, name, spec_version)', () => {
+    const doc = resolveFGCA(VIEW_DOC, SOURCES);
+    expect(doc['notation']).toBe('fgca');
+    expect(doc['id']).toBe('FGCA-STRAT-1');
+    expect(doc['name']).toBe('Strategy 2026 — FGCA chain');
+    expect(doc['spec_version']).toBe('0.1');
+  });
+});
+
+// ── resolveFGCA — goals.filter=ids ────────────────────────────────────────────
+
+describe('resolveFGCA — goals.filter=ids', () => {
+  it('narrows to the specified goal and its derived changes + activities', () => {
+    const viewDoc = {
+      ...VIEW_DOC,
+      view_config: { goals: { filter: 'ids', ids: ['GOAL-1'] }, factors: { surface: 'derived' }, changes: { surface: 'derived' }, activities: { surface: 'derived' } },
+    };
+    const doc = resolveFGCA(viewDoc, SOURCES);
+    const goalIds = (doc['goals'] as Array<{ id: string }>).map((g) => g.id);
+    expect(goalIds).toEqual(['GOAL-1']);
+    const changeIds = (doc['changes'] as Array<{ id: string }>).map((c) => c.id);
+    expect(changeIds).toEqual(['CHANGE-1']);
+    const actIds = (doc['activities'] as Array<{ id: string }>).map((a) => a.id).sort();
+    expect(actIds).toEqual(['ACTIVITY-1', 'ACTIVITY-2']);
+    const r = parseCanonicalFGCA(doc);
+    expect(r.valid).toBe(true);
+  });
+
+  it('returns empty arrays when none of the requested ids exist in canon', () => {
+    const viewDoc = {
+      ...VIEW_DOC,
+      view_config: { goals: { filter: 'ids', ids: ['GOAL-NONEXISTENT-1'] }, factors: { surface: 'derived' }, changes: { surface: 'derived' }, activities: { surface: 'derived' } },
+    };
+    const doc = resolveFGCA(viewDoc, SOURCES);
+    expect((doc['goals'] as unknown[]).length).toBe(0);
+    expect((doc['changes'] as unknown[]).length).toBe(0);
+    expect((doc['factors'] as unknown[]).length).toBe(0);
+  });
+});
+
+// ── resolveFGCA — surface=all ─────────────────────────────────────────────────
+
+describe('resolveFGCA — surface=all', () => {
+  it('factors.surface=all includes every factor even when only some are referenced', () => {
+    const viewDoc = {
+      ...VIEW_DOC,
+      view_config: { goals: { filter: 'ids', ids: ['GOAL-3'] }, factors: { surface: 'all' }, changes: { surface: 'derived' }, activities: { surface: 'derived' } },
+    };
+    const doc = resolveFGCA(viewDoc, SOURCES);
+    // GOAL-3 only references FACTOR-1, but surface=all → both factors
+    expect((doc['factors'] as unknown[]).length).toBe(2);
+  });
+
+  it('changes.surface=all includes every change', () => {
+    const viewDoc = {
+      ...VIEW_DOC,
+      view_config: { goals: { filter: 'ids', ids: ['GOAL-1'] }, factors: { surface: 'derived' }, changes: { surface: 'all' }, activities: { surface: 'derived' } },
+    };
+    const doc = resolveFGCA(viewDoc, SOURCES);
+    expect((doc['changes'] as unknown[]).length).toBe(3);
+  });
+});
+
+// ── resolveFGCA — empty / degenerate inputs ───────────────────────────────────
+
+describe('resolveFGCA — empty sources', () => {
+  it('returns empty arrays when canon has no elements', () => {
+    const doc = resolveFGCA(VIEW_DOC, { elements: [], relations: [] });
+    expect((doc['goals'] as unknown[]).length).toBe(0);
+    expect((doc['factors'] as unknown[]).length).toBe(0);
+    expect((doc['changes'] as unknown[]).length).toBe(0);
+    expect((doc['activities'] as unknown[]).length).toBe(0);
+  });
+
+  it('returns empty arrays for a non-object viewDoc', () => {
+    const doc = resolveFGCA(null, SOURCES);
+    expect((doc['goals'] as unknown[]).length).toBe(0);
+  });
+});
+
+// ── File-based regression — resolver + canon fixture + parseCanonicalFGCA ─────
+
+describe('resolveFGCA — file-based regression against canon fixture', () => {
+  const CANON_ROOT = path.resolve(
+    process.cwd(), '..', '..', 'tests', 'fixtures', 'notation-corpus', 'fgca', 'canon',
+  );
+  const VIEW_DIR = path.join(CANON_ROOT, 'views');
+  const ELEM_DIR = path.join(CANON_ROOT, 'elements');
+
+  function loadYamlsUnder(dir: string): unknown[] {
+    if (!fs.existsSync(dir)) return [];
+    const out: unknown[] = [];
+    function walk(d: string) {
+      for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
+        const full = path.join(d, entry.name);
+        if (entry.isDirectory()) { walk(full); }
+        else if (entry.name.endsWith('.yaml')) { out.push(yaml.load(fs.readFileSync(full, 'utf8'))); }
+      }
+    }
+    walk(dir);
+    return out;
+  }
+
+  const viewFiles = fs.existsSync(VIEW_DIR)
+    ? fs.readdirSync(VIEW_DIR).filter((f) => f.endsWith('.transitrix.yaml'))
+    : [];
+
+  for (const file of viewFiles) {
+    it(`resolves ${file} against canon fixtures and passes parseCanonicalFGCA`, () => {
+      const viewDoc = yaml.load(fs.readFileSync(path.join(VIEW_DIR, file), 'utf8'));
+      expect(isFGCAViewDoc(viewDoc)).toBe(true);
+      const elements = loadYamlsUnder(ELEM_DIR);
+      const doc = resolveFGCA(viewDoc, { elements, relations: [] });
+      const r = parseCanonicalFGCA(doc);
+      expect(r.valid).toBe(true);
+      expect(r.errors).toEqual([]);
+    });
+  }
+});

--- a/packages/diagrams/src/fgca/index.ts
+++ b/packages/diagrams/src/fgca/index.ts
@@ -36,6 +36,8 @@ export type {
   DiagramStyle,
   FGCAColumn,
 } from "./types";
+export { resolveFGCA, isFGCAViewDoc } from './resolver.js';
+export type { FGCAViewConfig, FGCACanonSources } from './resolver.js';
 export { default as FGCAFactorNode } from "./nodes/FGCAFactorNode";
 export { default as FGCAGoalNode } from "./nodes/FGCAGoalNode";
 export { default as FGCAChangeNode } from "./nodes/FGCAChangeNode";

--- a/packages/diagrams/src/fgca/resolver.ts
+++ b/packages/diagrams/src/fgca/resolver.ts
@@ -1,0 +1,157 @@
+/**
+ * FGCA canon resolver — assembles a flat canonical FGCA document from a
+ * view_config projection and a canon element/relation store (VP-3).
+ *
+ * Output shape matches the flat form that `parseCanonicalFGCA` expects:
+ * top-level `factors[]`, `goals[]`, `changes[]`, `activities[]` with typed
+ * string IDs.  Filesystem-free — callable from unit tests without vscode.
+ */
+
+export interface FGCAViewConfig {
+  goals?: {
+    filter?: 'all' | 'ids' | 'tags';
+    ids?: string[];
+    tags?: string[];
+  };
+  factors?: { surface?: 'derived' | 'all' };
+  changes?: { surface?: 'derived' | 'all' };
+  activities?: { surface?: 'derived' | 'all' };
+  display?: { depth?: number | null; collapsed?: string[] };
+}
+
+export interface FGCACanonSources {
+  elements: unknown[];
+  relations: unknown[];
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === 'object' && !Array.isArray(v);
+}
+
+function str(v: unknown): string | undefined {
+  return typeof v === 'string' && v.trim().length > 0 ? v : undefined;
+}
+
+function strArray(v: unknown): string[] {
+  if (!Array.isArray(v)) return [];
+  return v.filter((x): x is string => typeof x === 'string' && x.trim().length > 0);
+}
+
+function collectByNotation(
+  docs: unknown[],
+  notation: string,
+): Map<string, Record<string, unknown>> {
+  const out = new Map<string, Record<string, unknown>>();
+  for (const doc of docs) {
+    if (!isObject(doc)) continue;
+    if (str(doc['notation']) !== notation) continue;
+    const id = str(doc['id']);
+    if (!id) continue;
+    if (!out.has(id)) out.set(id, doc);
+  }
+  return out;
+}
+
+/**
+ * Returns true when the parsed view document uses the canon-projection form
+ * (`view_config` key present, no inline `factors[]` / `goals[]` arrays).
+ * Used by the preview to decide whether to run the resolver or fall back to
+ * direct `parseCanonicalFGCA` on the inline document.
+ */
+export function isFGCAViewDoc(parsed: unknown): boolean {
+  if (!isObject(parsed)) return false;
+  return 'view_config' in parsed && !('factors' in parsed) && !('goals' in parsed);
+}
+
+/**
+ * Assemble a flat canonical FGCA document from the canon element store,
+ * filtered by the view document's `view_config`.  The return value is ready
+ * to pass to `parseCanonicalFGCA`.
+ *
+ * Cross-reference fields (`goal.factors[]`, `change.goals[]`,
+ * `activity.changes[]`) are carried from the canon elements unchanged; the
+ * resolver decides which elements to include, not how they are shaped.
+ */
+export function resolveFGCA(
+  viewDoc: unknown,
+  sources: FGCACanonSources,
+): Record<string, unknown> {
+  if (!isObject(viewDoc)) {
+    return { notation: 'fgca', factors: [], goals: [], changes: [], activities: [] };
+  }
+
+  const vc = isObject(viewDoc['view_config']) ? viewDoc['view_config'] : {};
+  const goalsConf = isObject(vc['goals']) ? vc['goals'] : {};
+  const factorsConf = isObject(vc['factors']) ? vc['factors'] : {};
+  const changesConf = isObject(vc['changes']) ? vc['changes'] : {};
+  const activitiesConf = isObject(vc['activities']) ? vc['activities'] : {};
+
+  const factorElems = collectByNotation(sources.elements, 'factor');
+  const goalElems = collectByNotation(sources.elements, 'goal');
+  const changeElems = collectByNotation(sources.elements, 'change');
+  const activityElems = collectByNotation(sources.elements, 'activity');
+
+  // 1. Select goal set
+  const goalsFilter = str(goalsConf['filter']) ?? 'all';
+  let selectedGoals: Array<Record<string, unknown>>;
+  if (goalsFilter === 'ids') {
+    const ids = strArray(goalsConf['ids']);
+    selectedGoals = ids.flatMap((id) => { const g = goalElems.get(id); return g ? [g] : []; });
+  } else if (goalsFilter === 'tags') {
+    const tags = strArray(goalsConf['tags']);
+    selectedGoals = [...goalElems.values()].filter((g) =>
+      strArray(g['tags']).some((t) => tags.includes(t)),
+    );
+  } else {
+    // 'all' — include every goal element in the canon store
+    selectedGoals = [...goalElems.values()];
+  }
+  const selectedGoalIds = new Set(
+    selectedGoals.map((g) => str(g['id'])).filter((x): x is string => x !== undefined),
+  );
+
+  // 2. Select factors: derived follows goal.factors[]; all = every factor
+  let selectedFactors: Array<Record<string, unknown>>;
+  if (str(factorsConf['surface']) === 'all') {
+    selectedFactors = [...factorElems.values()];
+  } else {
+    const refIds = new Set<string>();
+    for (const g of selectedGoals) for (const fid of strArray(g['factors'])) refIds.add(fid);
+    selectedFactors = [...refIds].flatMap((id) => { const f = factorElems.get(id); return f ? [f] : []; });
+  }
+
+  // 3. Select changes: derived = changes referencing ≥1 selected goal
+  let selectedChanges: Array<Record<string, unknown>>;
+  if (str(changesConf['surface']) === 'all') {
+    selectedChanges = [...changeElems.values()];
+  } else {
+    selectedChanges = [...changeElems.values()].filter((c) =>
+      strArray(c['goals']).some((gid) => selectedGoalIds.has(gid)),
+    );
+  }
+  const selectedChangeIds = new Set(
+    selectedChanges.map((c) => str(c['id'])).filter((x): x is string => x !== undefined),
+  );
+
+  // 4. Select activities: derived = reference ≥1 selected change or goal (degenerate FGA link)
+  let selectedActivities: Array<Record<string, unknown>>;
+  if (str(activitiesConf['surface']) === 'all') {
+    selectedActivities = [...activityElems.values()];
+  } else {
+    selectedActivities = [...activityElems.values()].filter((a) =>
+      strArray(a['changes']).some((cid) => selectedChangeIds.has(cid)) ||
+      strArray(a['goals']).some((gid) => selectedGoalIds.has(gid)),
+    );
+  }
+
+  return {
+    notation: 'fgca',
+    id: viewDoc['id'],
+    name: viewDoc['name'],
+    spec_version: viewDoc['spec_version'],
+    factors: selectedFactors,
+    goals: selectedGoals,
+    changes: selectedChanges,
+    activities: selectedActivities,
+  };
+}

--- a/tests/fixtures/notation-corpus/fgca/canon/elements/activities/ACTIVITY-1.yaml
+++ b/tests/fixtures/notation-corpus/fgca/canon/elements/activities/ACTIVITY-1.yaml
@@ -1,0 +1,4 @@
+notation: activity
+id: ACTIVITY-1
+name: "Market research"
+changes: [CHANGE-1]

--- a/tests/fixtures/notation-corpus/fgca/canon/elements/activities/ACTIVITY-2.yaml
+++ b/tests/fixtures/notation-corpus/fgca/canon/elements/activities/ACTIVITY-2.yaml
@@ -1,0 +1,4 @@
+notation: activity
+id: ACTIVITY-2
+name: "MVP development"
+changes: [CHANGE-1]

--- a/tests/fixtures/notation-corpus/fgca/canon/elements/activities/ACTIVITY-3.yaml
+++ b/tests/fixtures/notation-corpus/fgca/canon/elements/activities/ACTIVITY-3.yaml
@@ -1,0 +1,4 @@
+notation: activity
+id: ACTIVITY-3
+name: "Process audit"
+changes: [CHANGE-2]

--- a/tests/fixtures/notation-corpus/fgca/canon/elements/activities/ACTIVITY-4.yaml
+++ b/tests/fixtures/notation-corpus/fgca/canon/elements/activities/ACTIVITY-4.yaml
@@ -1,0 +1,4 @@
+notation: activity
+id: ACTIVITY-4
+name: "RPA tooling rollout"
+changes: [CHANGE-2]

--- a/tests/fixtures/notation-corpus/fgca/canon/elements/activities/ACTIVITY-5.yaml
+++ b/tests/fixtures/notation-corpus/fgca/canon/elements/activities/ACTIVITY-5.yaml
@@ -1,0 +1,4 @@
+notation: activity
+id: ACTIVITY-5
+name: "CRM implementation"
+changes: [CHANGE-3]

--- a/tests/fixtures/notation-corpus/fgca/canon/elements/changes/CHANGE-1.yaml
+++ b/tests/fixtures/notation-corpus/fgca/canon/elements/changes/CHANGE-1.yaml
@@ -1,0 +1,4 @@
+notation: change
+id: CHANGE-1
+name: "Launch new product line"
+goals: [GOAL-1]

--- a/tests/fixtures/notation-corpus/fgca/canon/elements/changes/CHANGE-2.yaml
+++ b/tests/fixtures/notation-corpus/fgca/canon/elements/changes/CHANGE-2.yaml
@@ -1,0 +1,4 @@
+notation: change
+id: CHANGE-2
+name: "Automate manual processes"
+goals: [GOAL-2]

--- a/tests/fixtures/notation-corpus/fgca/canon/elements/changes/CHANGE-3.yaml
+++ b/tests/fixtures/notation-corpus/fgca/canon/elements/changes/CHANGE-3.yaml
@@ -1,0 +1,4 @@
+notation: change
+id: CHANGE-3
+name: "Enhance support platform"
+goals: [GOAL-3]

--- a/tests/fixtures/notation-corpus/fgca/canon/elements/factors/FACTOR-1.yaml
+++ b/tests/fixtures/notation-corpus/fgca/canon/elements/factors/FACTOR-1.yaml
@@ -1,0 +1,4 @@
+notation: factor
+id: FACTOR-1
+name: "Competitive market pressure"
+type: external

--- a/tests/fixtures/notation-corpus/fgca/canon/elements/factors/FACTOR-2.yaml
+++ b/tests/fixtures/notation-corpus/fgca/canon/elements/factors/FACTOR-2.yaml
@@ -1,0 +1,4 @@
+notation: factor
+id: FACTOR-2
+name: "Digital adoption acceleration"
+type: external

--- a/tests/fixtures/notation-corpus/fgca/canon/elements/goals/GOAL-1.yaml
+++ b/tests/fixtures/notation-corpus/fgca/canon/elements/goals/GOAL-1.yaml
@@ -1,0 +1,4 @@
+notation: goal
+id: GOAL-1
+name: "Grow revenue by 20%"
+factors: [FACTOR-1, FACTOR-2]

--- a/tests/fixtures/notation-corpus/fgca/canon/elements/goals/GOAL-2.yaml
+++ b/tests/fixtures/notation-corpus/fgca/canon/elements/goals/GOAL-2.yaml
@@ -1,0 +1,4 @@
+notation: goal
+id: GOAL-2
+name: "Reduce operational costs"
+factors: [FACTOR-2]

--- a/tests/fixtures/notation-corpus/fgca/canon/elements/goals/GOAL-3.yaml
+++ b/tests/fixtures/notation-corpus/fgca/canon/elements/goals/GOAL-3.yaml
@@ -1,0 +1,4 @@
+notation: goal
+id: GOAL-3
+name: "Improve customer retention"
+factors: [FACTOR-1]

--- a/tests/fixtures/notation-corpus/fgca/canon/views/FGCA-STRAT-1.fgca.transitrix.yaml
+++ b/tests/fixtures/notation-corpus/fgca/canon/views/FGCA-STRAT-1.fgca.transitrix.yaml
@@ -1,0 +1,20 @@
+notation: fgca
+spec_version: "0.1"
+
+id: FGCA-STRAT-1
+name: "Strategy 2026 — FGCA chain"
+description: "Factor → Goal → Change → Activity decomposition for the 2026 plan."
+period: "2026"
+version: "0.1"
+date: "2026-05-26"
+author: Transitrix
+
+view_config:
+  goals:
+    filter: all
+  factors:
+    surface: derived
+  changes:
+    surface: derived
+  activities:
+    surface: derived


### PR DESCRIPTION
## Summary

- Adds `resolveFGCA` / `isFGCAViewDoc` in `packages/diagrams/src/fgca/resolver.ts` — pure, FS-free resolver that takes a `view_config` projection + `CanonDocs` from the shared canon-loader and assembles the flat FGCA document `parseCanonicalFGCA` expects. Supports all `view_config` options: `goals.filter` (all/ids/tags) and per-layer `surface` (derived/all).
- `fgca-preview.ts`: `pushDocument` now loads canon via `loadCanon()`; `buildHtml` detects view_config-based docs and routes them through `resolveFGCA`. Legacy inline docs (`factors[]`/`goals[]` present) fall back to direct `parseCanonicalFGCA` for backward compatibility.
- `fgca-preview.ts`: adds `refreshIfSiblingSaved()` so the FGCA preview re-renders when any canon element/relation file under its `canon/` root is saved — mirrors the Activity Card pattern from VP-1.
- `extension.ts`: wires `fgcaPreview.refreshIfSiblingSaved()` into `onDidSaveTextDocument`.
- Canon fixture tree at `tests/fixtures/notation-corpus/fgca/canon/` (13 element files + view doc mirroring the existing `strategy-2026` inline fixture).

## Test plan

- [ ] 14 new unit tests in `resolver.test.ts` (all green, 900 total pass)
- [ ] TypeScript build clean (`tsc --noEmit`)
- [ ] Open a `*.fgca.transitrix.yaml` with `view_config` pointing at a `canon/` tree — diagram renders identical to the inline form
- [ ] Save a `canon/elements/` file while the FGCA preview is open — preview re-renders (multi-doc refresh)
- [ ] Open a legacy inline FGCA file — still renders correctly (backward compatibility path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)