### PR TITLE
feat(skills): add /canon-status and /codex-status Claude Code skills

### DIFF
--- a/.claude/commands/canon-status.md
+++ b/.claude/commands/canon-status.md
@@ -1,0 +1,79 @@
+Report entity counts in the project's `canon/` directory, grouped by entity type and lifecycle stage.
+
+---
+
+## Step 1 - locate canon
+
+Find the canon root by checking these paths in order from the current directory:
+1. `canon/` relative to the current working directory
+2. Walk up parent directories until a `canon/` directory is found, or the root of the git repo is reached
+
+If no `canon/` directory is found at all, print:
+
+```
+/canon-status: no canon directory found in this repo
+```
+
+and stop.
+
+---
+
+## Step 2 - collect files
+
+Scan recursively for YAML files under:
+- `<canon-root>/elements/`
+- `<canon-root>/relations/`
+
+Glob: `**/*.yaml` (and `**/*.yml` as a fallback). Skip README.md and any non-YAML files.
+
+For each YAML file parse the top-level frontmatter keys. YAML comment lines (`# ...`) are skipped automatically.
+
+---
+
+## Step 3 - extract type and stage
+
+For each file, extract two values:
+
+**Entity type** - read in priority order:
+1. `notation:` field (the canonical key in Transitrix notation files)
+2. `type:` field (fallback for older or alternate layouts)
+3. If neither is present, use `(unknown)`
+
+**Lifecycle stage** - read in priority order:
+1. `admission_state:` field. Values: `proposed` / `active` / `rejected`. Absent means `active` (back-compat rule: human-authored canon is admitted by construction).
+2. If `admission_state:` is absent and a `status:` field is present, use its value directly.
+3. If neither field is present, treat as `active`.
+
+Skip files where the entity type is `(unknown)` - they are not typed entities.
+
+---
+
+## Step 4 - build counts
+
+Group the collected (type, stage) pairs.
+
+Rows = all distinct entity types found, sorted alphabetically.
+Columns = all distinct stage values found, sorted as: `proposed` first, then `active`, then `rejected`, then any other values alphabetically.
+
+---
+
+## Step 5 - output the table
+
+Print:
+
+```
+/canon-status - <repo-name or current directory>
+
+| Type | proposed | active | rejected | ... |
+|------|----------|--------|----------|-----|
+| capability | 0 | 4 | 0 | ... |
+| goal | 0 | 3 | 0 | ... |
+| ... | ... | ... | ... | ... |
+| **Total** | **N** | **N** | **N** | ... |
+```
+
+Rules:
+- Omit a stage column entirely if its total is 0.
+- Print a `**Total**` row at the bottom summing each column.
+- If every entity across all types has stage `active` (or absent), print a note after the table: `All entities are active (admitted).`
+- Count only: no file paths, no IDs, no descriptions.

--- a/.claude/commands/codex-status.md
+++ b/.claude/commands/codex-status.md
@@ -1,0 +1,80 @@
+Report counts of compliance-relevant codex entries grouped by entity category and admission stage.
+
+---
+
+## Step 1 - locate entry points
+
+From the current working directory (or repo root), identify three entry locations:
+
+1. **REQUIREMENT files** - YAML files anywhere under `canon/` whose `notation:` field is `requirement`. Typically at `canon/elements/01_motivation/requirements/*.yaml`.
+2. **ASSERTION files** - YAML files anywhere under `canon/` whose `notation:` field is `assertion`. Typically at `canon/assertions/*.yaml` or `canon/elements/**/*.yaml`.
+3. **CODEX_SOURCE entries** - all YAML files under a `codex/` directory at the repo root (any depth). These carry `zone: codex`; they do not use the `notation:` key.
+
+If none of the three groups yields any files, print:
+
+```
+/codex-status: no codex entries found in this repo
+```
+
+and stop.
+
+---
+
+## Step 2 - collect and categorise
+
+Scan all YAML files in the three locations above. Assign each file to exactly one category:
+
+| Category label | Criteria |
+|---|---|
+| `REQUIREMENT` | `notation: requirement` anywhere under `canon/` |
+| `ASSERTION` | `notation: assertion` anywhere under `canon/` |
+| `CODEX_SOURCE` | Any `.yaml` file directly under a `codex/` directory tree |
+
+Skip README.md and any file that does not parse as valid YAML.
+
+---
+
+## Step 3 - extract admission stage
+
+For each file, determine its admission stage:
+
+**For REQUIREMENT and ASSERTION files** - read in priority order:
+1. `admission_state:` field. Values: `proposed` / `active` / `rejected`. Absent means `active`.
+2. If `admission_state:` is absent and a `status:` field is present, use it.
+3. If neither is present, treat as `active`.
+
+**For CODEX_SOURCE files** - read in priority order:
+1. `admission_state:` field if present.
+2. If `zone: codex` is set and `admission_state:` is absent, treat as `admitted`.
+3. If neither `zone:` nor `admission_state:` is set, treat as `proposed`.
+
+---
+
+## Step 4 - build counts
+
+Group by (category, stage).
+
+Rows = `REQUIREMENT`, `ASSERTION`, `CODEX_SOURCE` (always in this order; show a row even if count is 0).
+Columns = all distinct stage values found, sorted as: `proposed` first, then `active` / `admitted`, then `rejected`, then any other values alphabetically.
+
+---
+
+## Step 5 - output the table
+
+Print:
+
+```
+/codex-status - <repo-name or current directory>
+
+| Category | proposed | active | rejected | ... |
+|----------|----------|--------|----------|-----|
+| REQUIREMENT | 0 | 6 | 0 | ... |
+| ASSERTION | 1 | 7 | 0 | ... |
+| CODEX_SOURCE | 0 | 2 | 0 | ... |
+| **Total** | **N** | **N** | **N** | ... |
+```
+
+Rules:
+- Omit a stage column entirely if its total across all rows is 0.
+- Print a `**Total**` row at the bottom summing each column.
+- Count only: no file paths, no IDs, no descriptions.


### PR DESCRIPTION
## Summary

- **`/canon-status`** — scans `canon/elements/**/*.yaml` and `canon/relations/**/*.yaml`; outputs a markdown table of entity counts by `notation:` type × `admission_state` lifecycle stage. Handles repos with no `canon/` directory gracefully.
- **`/codex-status`** — scans for REQUIREMENT, ASSERTION, and CODEX_SOURCE entries; outputs a three-row count table by admission stage. Handles repos with no codex entries gracefully.

Both skills are read-only. File convention: `.claude/commands/<skill>.md`, matching the mermaid-views precedent.

Field mapping follows the Transitrix methodology canon:
- Entity type: `notation:` field (fallback: `type:`)
- Lifecycle stage: `admission_state:` field (absent = `active`; fallback: `status:`)
- CODEX_SOURCE entries: `zone: codex` present → `admitted`

## Test plan

- [ ] `npm run compile` — passes (no TS changes)
- [ ] `npm test` — 900 tests green
- [ ] Manual: run `/canon-status` in `acme-corp` — table shows goal/capability/requirement/assertion/relation rows with correct counts
- [ ] Manual: run `/codex-status` in `acme-corp` — table shows REQUIREMENT/ASSERTION/CODEX_SOURCE rows
- [ ] Manual: run both skills in a repo without `canon/` — prints the "not found" message, no error

🤖 Generated with [Claude Code](https://claude.com/claude-code)