### PR TITLE
chore(release): 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
-## [Unreleased]
-
 ## [2.0.0] — 2026-06-18
+
+### Changed
+
+- **Toolbar "Copy PNG" button renamed to "Copy image"** — cleaner label, avoids the all-caps acronym.
 
 ### Breaking changes
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "1.6.0",
+  "version": "2.0.0",
   "description": "Architecture-as-code for the modern enterprise. Author 17 notations — goals, processes, capabilities, BPMN, applications, more — as plain YAML, get live diagrams in VS Code. Diffable in git. AI-friendly. Open source. Built on ArchiMate 3.2 and BPMN 2.0.",
   "license": "MIT",
   "icon": "icon.png",

--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -468,7 +468,7 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
     actionParts.push(`<a href="command:${escXml(savePngCommand!)}" class="toolbar-btn" title="Save the current diagram as a .png file">Save .png</a>`);
   }
   if (showCopyPng) {
-    actionParts.push(`<a href="command:${escXml(copyPngCommand!)}" class="toolbar-btn" title="Copy the current diagram to the clipboard as a PNG image">Copy PNG</a>`);
+    actionParts.push(`<a href="command:${escXml(copyPngCommand!)}" class="toolbar-btn" title="Copy the current diagram to the clipboard as a PNG image">Copy image</a>`);
   }
   if (showSpacing) {
     actionParts.push(`<a href="command:${escXml(spacingCommand!)}" class="toolbar-btn" title="Adjust the horizontal/vertical spacing for this notation in Settings">Spacing…</a>`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "1.6.0",
+  "version": "2.0.0",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
## Release 2.0.0

Version bump `1.6.0 → 2.0.0` + финальные штрихи перед тегом.

### Что входит в этот PR

- `package.json` + `extension/package.json`: `1.6.0` → `2.0.0`
- CHANGELOG: убран пустой `[Unreleased]`; добавлено переименование кнопки «Copy PNG» → «Copy image» в раздел Changed
- `extension/src/diagram-frame.ts`: лейбл кнопки `Copy PNG` → `Copy image`

### Что уже на main (в релиз входит)

- `feat!` Cervin deprecation P7 (#211) — все breaking changes 2.0.0
- PNG export fix (raster + SVG contamination)
- Compliance lane + drill-down (CV-series)
- FGCA canon-loader migration (VP-3)
- Coverage-metric, blocks hint, и прочие фиксы 1.5.x–1.6.x

После мержа: поставить тег `v2.0.0` и опубликовать GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)