### PR TITLE
fix(ci): add zipSigner() dependency for signPlugin task

### DIFF
--- a/intellij/build.gradle.kts
+++ b/intellij/build.gradle.kts
@@ -23,6 +23,8 @@ dependencies {
         // `instrumentCode` task (form/NotNull bytecode instrumentation);
         // without it the build fails with "No Java Compiler dependency found".
         instrumentationTools()
+        // Required for the `signPlugin` task — downloads the Marketplace ZIP Signer CLI.
+        zipSigner()
     }
 }
 


### PR DESCRIPTION
`:signPlugin` failed with:

```
No Marketplace ZIP Signer executable found.
Please ensure the `zipSigner()` entry is present in the project dependencies section
```

Adds `zipSigner()` to the `intellijPlatform` dependencies block in `build.gradle.kts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)