### PR TITLE
chore(intellij): bump plugin version to 0.2.0

### DIFF
--- a/intellij/gradle.properties
+++ b/intellij/gradle.properties
@@ -1,7 +1,7 @@
 pluginGroup = com.transitrix.intellij
 pluginName = transitrix-intellij
 # Versioned independently from the VS Code extension's package.json.
-pluginVersion = 0.1.0
+pluginVersion = 0.2.0
 
 # IntelliJ IDEA Community 2024.2 — JCEF-bearing baseline (JCEF requires 2020.2+).
 platformVersion = 2024.2


### PR DESCRIPTION
`publishPlugin` failed because version `0.1.0` was already uploaded manually to the Marketplace.

Bumps `pluginVersion` in `intellij/gradle.properties` to `0.2.0` so CI can publish the new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)