### PR TITLE
feat(preview): live spacing sliders — range inputs with immediate drag re-render

### DIFF
--- a/extension/src/preview-controls.ts
+++ b/extension/src/preview-controls.ts
@@ -166,11 +166,13 @@ function spacingRow(s: SpacingControlModel): string {
   return `<div class="tx-ctl-row">
     <span class="tx-ctl-label">Spacing</span>
     <label title="Horizontal gap between columns (px)">H
-      <input type="number" data-tx-control="spacing" data-tx-field="horizontalGap"
-        min="${SPACING_MIN}" max="${SPACING_MAX}" step="1" value="${s.horizontalGap}"></label>
+      <input type="range" data-tx-control="spacing" data-tx-field="horizontalGap" data-tx-event="input" data-tx-output="tx-hgap-out"
+        min="${SPACING_MIN}" max="${SPACING_MAX}" step="1" value="${s.horizontalGap}">
+      <output id="tx-hgap-out">${s.horizontalGap}</output></label>
     <label title="Vertical gap between stacked nodes (px)">V
-      <input type="number" data-tx-control="spacing" data-tx-field="verticalGap"
-        min="${SPACING_MIN}" max="${SPACING_MAX}" step="1" value="${s.verticalGap}"></label>
+      <input type="range" data-tx-control="spacing" data-tx-field="verticalGap" data-tx-event="input" data-tx-output="tx-vgap-out"
+        min="${SPACING_MIN}" max="${SPACING_MAX}" step="1" value="${s.verticalGap}">
+      <output id="tx-vgap-out">${s.verticalGap}</output></label>
   </div>`;
 }
 
@@ -258,7 +260,8 @@ export function buildControlsScript(nonce: string): string {
         var out = document.getElementById(outId);
         if (out) el.addEventListener('input', function () { out.value = el.value; });
       }
-      el.addEventListener('change', function () {
+      var triggerEvt = el.getAttribute('data-tx-event') || 'change';
+      el.addEventListener(triggerEvt, function () {
         if (control === 'scope' && field === 'rootId') {
           var v = el.value;
           if (v) { var lvl = sel('scope', 'maxLevel'); if (lvl) lvl.value = ''; }

--- a/tests/preview-controls.test.ts
+++ b/tests/preview-controls.test.ts
@@ -36,8 +36,18 @@ describe('buildControlsPanel', () => {
       spacing: { horizontalGap: 180, verticalGap: 40, defaults: spacingDefaults },
       curvature: { value: 2.5, default: 1 },
     }));
-    expect(html).toContain('data-tx-field="horizontalGap"\n        min="20" max="300" step="1" value="180"');
+    expect(html).toContain('data-tx-field="horizontalGap" data-tx-event="input" data-tx-output="tx-hgap-out"\n        min="20" max="300" step="1" value="180"');
     expect(html).toContain('value="2.5"');
+  });
+
+  it('spacing inputs are range sliders that fire live on drag', () => {
+    const html = buildControlsPanel(baseModel());
+    expect(html).toContain('type="range" data-tx-control="spacing" data-tx-field="horizontalGap"');
+    expect(html).toContain('type="range" data-tx-control="spacing" data-tx-field="verticalGap"');
+    expect(html).toContain('data-tx-event="input"');
+    // Output elements show the current value alongside each slider.
+    expect(html).toContain('<output id="tx-hgap-out">');
+    expect(html).toContain('<output id="tx-vgap-out">');
   });
 
   it('omits the scope row when no scope model is given (Activities)', () => {


### PR DESCRIPTION
## Summary

- Replaces the H/V spacing number inputs in the in-preview Controls panel with `type="range"` sliders
- Adds `data-tx-event="input"` to spacing sliders so each drag tick fires a `postMessage` — the diagram re-renders immediately while the user drags
- Adds `<output>` elements next to each spacing slider to display the current value in px
- Extends `buildControlsScript` with a `data-tx-event` attribute contract: elements that carry `data-tx-event="input"` trigger on `input`; all others (scope select, scope level number input, curvature slider) keep their existing `change` behaviour unchanged

All other controls are unaffected. 900 tests pass; TypeScript compiles clean.

## Test plan

- [ ] Open a Goals / FGA / FGCA / Activities diagram preview
- [ ] Expand the Controls panel
- [ ] Drag the H or V spacing slider — diagram re-renders on every drag tick (immediate feedback)
- [ ] Confirm the px value shown in the `<output>` next to each slider updates live while dragging
- [ ] Confirm Curvature and Scope controls still behave as before (re-render on release / commit)
- [ ] Confirm VS Code `transitrix.spacing.*` settings update to match the dragged value after release

🤖 Generated with [Claude Code](https://claude.com/claude-code)