### PR TITLE
docs(intellij): add 0.2.0 change-notes to plugin.xml

### DIFF
--- a/intellij/src/main/resources/META-INF/plugin.xml
+++ b/intellij/src/main/resources/META-INF/plugin.xml
@@ -25,6 +25,13 @@
     ]]></description>
 
     <change-notes><![CDATA[
+        <h3>0.2.0</h3>
+        <ul>
+            <li>Publishing pipeline fixed: Gradle wrapper, zipSigner dependency, and
+            CI secrets aligned so automated Marketplace uploads now work reliably.</li>
+            <li>No functional changes to the plugin itself.</li>
+        </ul>
+
         <h3>0.1.0 — Initial release</h3>
         <ul>
             <li>Live notation preview for all Transitrix YAML formats: Goals trees,


### PR DESCRIPTION
## Summary

- Adds `<change-notes>` entry for 0.2.0 to `intellij/src/main/resources/META-INF/plugin.xml`
- The JetBrains Marketplace requires change-notes for each uploaded version; without them the upload is rejected or the version page is incomplete
- 0.2.0 had no user-facing changes — only CI pipeline fixes (Gradle wrapper, zipSigner dependency, secret alignment)

## Next step

After merging, trigger **Actions → JetBrains Marketplace — publish → Run workflow** (or cut a GitHub Release) to upload 0.2.0 to the Marketplace.

## Test plan

- [ ] `plugin.xml` parses correctly (Gradle `patchPluginXml` task passes during build)
- [ ] Marketplace shows the 0.2.0 entry after the workflow runs