### PR TITLE
feat(preview): curvature slider fires live on drag

### DIFF
--- a/extension/src/preview-controls.ts
+++ b/extension/src/preview-controls.ts
@@ -179,7 +179,7 @@ function spacingRow(s: SpacingControlModel): string {
 function curvatureRow(c: CurvatureControlModel): string {
   return `<div class="tx-ctl-row">
     <span class="tx-ctl-label">Curvature</span>
-    <input type="range" data-tx-control="curvature" data-tx-output="tx-curv-out"
+    <input type="range" data-tx-control="curvature" data-tx-event="input" data-tx-output="tx-curv-out"
       min="${CURVATURE_MIN}" max="${CURVATURE_MAX}" step="${CURVATURE_STEP}" value="${c.value}">
     <output id="tx-curv-out">${c.value}</output>
   </div>`;

--- a/tests/preview-controls.test.ts
+++ b/tests/preview-controls.test.ts
@@ -50,6 +50,12 @@ describe('buildControlsPanel', () => {
     expect(html).toContain('<output id="tx-vgap-out">');
   });
 
+  it('curvature slider fires live on drag', () => {
+    const html = buildControlsPanel(baseModel());
+    expect(html).toContain('type="range" data-tx-control="curvature" data-tx-event="input"');
+    expect(html).toContain('<output id="tx-curv-out">');
+  });
+
   it('omits the scope row when no scope model is given (Activities)', () => {
     const html = buildControlsPanel(baseModel());
     expect(html).not.toContain('data-tx-control="scope"');


### PR DESCRIPTION
## Summary

- Adds `data-tx-event="input"` to the curvature `<input type="range">` in `buildControlsPanel`
- Curvature now re-renders on every drag tick, matching the spacing slider behaviour
- The wiring script already reads `data-tx-event` to pick the trigger event — no script changes needed
- Adds a dedicated test asserting `data-tx-event="input"` on the curvature input

## Test plan

- [ ] 901 tests pass
- [ ] Open a Goals / FGA / FGCA preview, drag the Curvature slider — diagram redraws continuously while dragging (no waiting for mouse-up)