### PR TITLE
feat(activity-card): add status and activity_type to Activity element and resolver

### DIFF
--- a/organizations/acme_corp/canon/elements/05_implementation/activities/ACTIVITY-CRM-EU-1.yaml
+++ b/organizations/acme_corp/canon/elements/05_implementation/activities/ACTIVITY-CRM-EU-1.yaml
@@ -6,6 +6,8 @@
 notation: activity
 id: ACTIVITY-CRM-EU-1
 name: "Implement EU-localised CRM rollout"
+activity_type: project
+status: in_progress
 delivers_changes:
   - CHANGE-EU-CRM-1
 description: >

--- a/packages/diagrams/src/activity-card/__tests__/resolver.test.ts
+++ b/packages/diagrams/src/activity-card/__tests__/resolver.test.ts
@@ -146,12 +146,24 @@ describe('resolveActivityCard', () => {
     expect(r.errors.some((e) => e.code === 'PC-001')).toBe(true);
   });
 
-  it('PC-002 when the activity carries an explicit non-project type', () => {
+  it('resolves activity_type and status from the Activity element', () => {
     const r = resolveActivityCard(CARD, {
-      elements: [{ ...PROJECT, activity_type: 'Task' }, CHILD, FACTOR, GOAL, CHANGE],
+      elements: [{ ...PROJECT, activity_type: 'programme', status: 'on_track' }, CHILD, FACTOR, GOAL, CHANGE],
       relations,
     });
-    expect(r.errors.some((e) => e.code === 'PC-002')).toBe(true);
+    expect(r.valid).toBe(true);
+    expect(r.resolved!.project.activity_type).toBe('programme');
+    expect(r.resolved!.project.status).toBe('on_track');
+  });
+
+  it('accepts any activity_type value without error (card works at all levels)', () => {
+    for (const t of ['programme', 'project', 'workstream', 'task', 'initiative']) {
+      const r = resolveActivityCard(CARD, {
+        elements: [{ ...PROJECT, activity_type: t }, CHILD, FACTOR, GOAL, CHANGE],
+        relations,
+      });
+      expect(r.errors.some((e) => e.code === 'PC-002'), `should not error for type "${t}"`).toBe(false);
+    }
   });
 
   it('PC-003 when a milestone change is not in the project changes', () => {

--- a/packages/diagrams/src/activity-card/resolver.ts
+++ b/packages/diagrams/src/activity-card/resolver.ts
@@ -172,20 +172,6 @@ export function resolveActivityCard(
     return { valid: false, errors, warnings };
   }
 
-  // PC-002 — the resolved Activity should be the project scale. In the element
-  // model all activity scales (initiative / programme / project / task) share
-  // one ACTIVITY TYPE and `activity_type` references an ActivityType element,
-  // so a missing/non-literal value is acceptable; only an explicit, clearly
-  // non-project marker is flagged. (Canonical project-identification semantics
-  // are tracked as a follow-up internally.)
-  const activityType = str(projectRec['activity_type']);
-  if (activityType !== undefined && activityType !== 'Project' && activityType !== 'project') {
-    errors.push({
-      code: 'PC-002',
-      message: `Activity "${projectId}" has activity_type "${activityType}", expected the project scale`,
-    });
-  }
-
   // LIFECYCLE-001..003 on the project Activity.
   const validFrom = projectRec['valid_from'];
   const validToRaw = projectRec['valid_to'];
@@ -374,6 +360,8 @@ export function resolveActivityCard(
     valid_to: validToOk ? (validToRaw as string) : undefined,
     start_date: str(projectRec['start_date']),
     end_date: str(projectRec['end_date']),
+    activity_type: str(projectRec['activity_type']),
+    status: str(projectRec['status']),
   };
 
   const resolved: ResolvedActivityCard = {

--- a/packages/diagrams/src/activity-card/types.ts
+++ b/packages/diagrams/src/activity-card/types.ts
@@ -93,6 +93,17 @@ export interface ResolvedProject {
   /** Planned work range. */
   start_date?: string;
   end_date?: string;
+  /**
+   * Activity scale: programme | project | workstream | task (or any custom
+   * value). Shown in the card header so the reader knows what level this card
+   * represents. Optional — card shows "—" when absent.
+   */
+  activity_type?: string;
+  /**
+   * Current execution state: planned | in_progress | on_track | at_risk |
+   * blocked | completed | cancelled. Optional — card shows "—" when absent.
+   */
+  status?: string;
 }
 
 export interface ResolvedMilestone {

--- a/tests/fixtures/notation-corpus/activity-card/canon/elements/05_implementation/activities/ACTIVITY-EU-PROGRAMME-1.yaml
+++ b/tests/fixtures/notation-corpus/activity-card/canon/elements/05_implementation/activities/ACTIVITY-EU-PROGRAMME-1.yaml
@@ -6,6 +6,8 @@
 notation: activity
 id: ACTIVITY-EU-PROGRAMME-1
 name: "EU MDR conformity programme"
+activity_type: programme
+status: in_progress
 delivers_changes: [CHANGE-EU-COMPLIANCE-1]
 start_date: "2026-04-15"
 end_date: "2027-03-15"


### PR DESCRIPTION
## Summary

- Adds `activity_type` field to the Activity element (programme | project | workstream | task) — identifies the level of the activity shown on the card
- Adds `status` field to the Activity element (planned | in_progress | on_track | at_risk | blocked | completed | cancelled) — current execution state
- Both fields are resolved by the card resolver and exposed on `ResolvedProject`; the layout will consume them in a follow-up PR (card header redesign)
- Removes PC-002 validation: the Activity Card is designed to work at any activity level, not only "project" scale
- Updated example elements (`ACTIVITY-CRM-EU-1`, `ACTIVITY-EU-PROGRAMME-1`) with sample values

## Test plan

- [x] 901 tests pass locally
- [x] New resolver tests: `resolves activity_type and status from the Activity element`, `accepts any activity_type value without error`
- [x] PC-002 test replaced with positive coverage of multi-level support