### PR TITLE
feat(activity-card): add role to activity_stakeholder relation

### DIFF
--- a/organizations/acme_corp/canon/relations/REL-CRM-EU-STAKE-OPS-1.yaml
+++ b/organizations/acme_corp/canon/relations/REL-CRM-EU-STAKE-OPS-1.yaml
@@ -1,0 +1,20 @@
+# activity_stakeholder relation — Operations team as owner of the EU CRM rollout.
+# The `role` field identifies the stakeholder's project-role:
+# initiator | owner | sponsor | project_manager.
+notation: relation
+id: REL-CRM-EU-STAKE-OPS-1
+type: activity_stakeholder
+from: ACTIVITY-CRM-EU-1
+to: STAKEHOLDER-OPS-1
+role: owner
+
+zone: canon
+admitted_at: "2026-06-20"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2026-05-26"
+valid_to: null

--- a/packages/diagrams/src/activity-card/__tests__/resolver.test.ts
+++ b/packages/diagrams/src/activity-card/__tests__/resolver.test.ts
@@ -77,6 +77,7 @@ const REL_STAKEHOLDER = {
   type: 'activity_stakeholder',
   from: 'ACTIVITY-EU-PROGRAMME-1',
   to: 'STAKEHOLDER-OPS-1',
+  role: 'sponsor',
   valid_from: '2026-04-01',
   valid_to: null,
 };
@@ -101,10 +102,24 @@ describe('resolveActivityCard', () => {
     expect(c.childActivities.map((a) => a.id)).toEqual(['ACTIVITY-EU-CHILD-1']);
     // project goal text field = the directly-served goal name
     expect(c.goalNames).toEqual(['Access EU market']);
-    // stakeholders resolved from the activity_stakeholder relation
+    // stakeholders resolved from the activity_stakeholder relation (with role)
     expect(c.stakeholders).toEqual([
-      { id: 'STAKEHOLDER-OPS-1', name: 'Operations', type: 'internal', interest: 'high', influence: 'medium' },
+      { id: 'STAKEHOLDER-OPS-1', name: 'Operations', type: 'internal', interest: 'high', influence: 'medium', role: 'sponsor' },
     ]);
+  });
+
+  it('resolves stakeholder role from the activity_stakeholder relation', () => {
+    const relWithRole = { ...REL_STAKEHOLDER, role: 'project_manager' };
+    const r = resolveActivityCard(CARD, { elements, relations: [REL_GOAL, relWithRole] });
+    expect(r.valid).toBe(true);
+    expect(r.resolved!.stakeholders[0].role).toBe('project_manager');
+  });
+
+  it('resolves stakeholder without role when relation has no role field', () => {
+    const relNoRole = { ...REL_STAKEHOLDER, role: undefined };
+    const r = resolveActivityCard(CARD, { elements, relations: [REL_GOAL, relNoRole] });
+    expect(r.valid).toBe(true);
+    expect(r.resolved!.stakeholders[0].role).toBeUndefined();
   });
 
   it('resolves no stakeholders (empty list) when none are linked', () => {
@@ -126,7 +141,7 @@ describe('resolveActivityCard', () => {
       relations: [REL_GOAL, REL_STAKEHOLDER],
     });
     expect(r.valid).toBe(true);
-    expect(r.resolved!.stakeholders).toEqual([{ id: 'STAKEHOLDER-OPS-1', name: 'STAKEHOLDER-OPS-1' }]);
+    expect(r.resolved!.stakeholders).toEqual([{ id: 'STAKEHOLDER-OPS-1', name: 'STAKEHOLDER-OPS-1', role: 'sponsor' }]);
     expect(r.warnings.some((w) => w.code === 'PC-001')).toBe(true);
   });
 

--- a/packages/diagrams/src/activity-card/resolver.ts
+++ b/packages/diagrams/src/activity-card/resolver.ts
@@ -124,13 +124,17 @@ function activeActivityGoals(relations: unknown[], fromId: string): string[] {
 }
 
 /**
- * STAKEHOLDER ids reached by an *active* `activity_stakeholder` relation
- * originating at `fromId`. Mirrors `activeActivityGoals`: a relation with a
- * non-null `valid_to` has ended and is excluded, so the card shows the
- * project's currently-engaged stakeholders.
+ * STAKEHOLDER ids + roles reached by an *active* `activity_stakeholder`
+ * relation originating at `fromId`. A relation with a non-null `valid_to` has
+ * ended and is excluded, so the card shows the project's currently-engaged
+ * stakeholders. The optional `role` field on the relation carries the
+ * project-role (initiator | owner | sponsor | project_manager).
  */
-function activeActivityStakeholders(relations: unknown[], fromId: string): string[] {
-  const out: string[] = [];
+function activeActivityStakeholders(
+  relations: unknown[],
+  fromId: string,
+): Array<{ id: string; role?: string }> {
+  const out: Array<{ id: string; role?: string }> = [];
   for (const doc of relations) {
     if (!isObject(doc)) continue;
     if (str(doc['notation']) !== 'relation') continue;
@@ -140,7 +144,7 @@ function activeActivityStakeholders(relations: unknown[], fromId: string): strin
     if (!to) continue;
     const validTo = doc['valid_to'];
     if (validTo !== undefined && validTo !== null) continue; // ended relation
-    if (!out.includes(to)) out.push(to);
+    if (!out.some((s) => s.id === to)) out.push({ id: to, role: str(doc['role']) });
   }
   return out;
 }
@@ -333,14 +337,14 @@ export function resolveActivityCard(
   // ── Stakeholders — active `activity_stakeholder` relations from the project ──
   const stakeholderElems = collectByNotation(sources.elements, 'stakeholder');
   const stakeholders: ResolvedStakeholder[] = [];
-  for (const sid of activeActivityStakeholders(sources.relations, projectId)) {
+  for (const { id: sid, role } of activeActivityStakeholders(sources.relations, projectId)) {
     const rec = stakeholderElems.get(sid);
     if (!rec) {
       warnings.push({
         code: 'PC-001',
         message: `Stakeholder "${sid}" not found as a STAKEHOLDER element in canon; shown by id`,
       });
-      stakeholders.push({ id: sid, name: sid });
+      stakeholders.push({ id: sid, name: sid, role });
       continue;
     }
     stakeholders.push({
@@ -349,6 +353,7 @@ export function resolveActivityCard(
       type: str(rec['type']),
       interest: str(rec['interest']),
       influence: str(rec['influence']),
+      role,
     });
   }
 

--- a/packages/diagrams/src/activity-card/types.ts
+++ b/packages/diagrams/src/activity-card/types.ts
@@ -158,6 +158,12 @@ export interface ResolvedStakeholder {
   type?: string;
   interest?: string;
   influence?: string;
+  /**
+   * Project role from the `activity_stakeholder` relation:
+   * initiator | owner | sponsor | project_manager.
+   * Optional — card shows the name without a role badge when absent.
+   */
+  role?: string;
 }
 
 export interface ResolvedActivityCard {


### PR DESCRIPTION
## Summary

- Adds optional `role` field to the `activity_stakeholder` relation (initiator | owner | sponsor | project_manager)
- Threads the role through to `ResolvedStakeholder.role` in the resolver
- The card header redesign (follow-up PR) will use this to group stakeholders by project role (who needs it / who does it)
- When `role` is absent the stakeholder is still resolved and displayed without a role badge
- Added example relation `REL-CRM-EU-STAKE-OPS-1.yaml` in acme_corp canon

## Test plan

- [x] 903 tests pass locally
- [x] New tests: `resolves stakeholder role from the activity_stakeholder relation`, `resolves stakeholder without role when relation has no role field`
- [x] Existing "warns but still lists a stakeholder whose element is missing" test updated to include role in expected output