### PR TITLE
feat(activity-card): resolve Assessment elements for the motivation chain

### DIFF
--- a/organizations/acme_corp/canon/elements/01_motivation/assessments/ASSESSMENT-GDPR-GAPS-2026-1.yaml
+++ b/organizations/acme_corp/canon/elements/01_motivation/assessments/ASSESSMENT-GDPR-GAPS-2026-1.yaml
@@ -1,0 +1,31 @@
+# ASSESSMENT element — dated finding about the EU regulatory driver.
+# Schema: notations/ELEMENT_PRIMITIVES.md §7.16 + envelope §3.
+# Answers "what specific problem are we solving?" for the GDPR remediation card.
+# Assesses FACTOR-EU-REG-1 (the standing EU regulatory pressure driver).
+
+notation: assessment
+id: ASSESSMENT-GDPR-GAPS-2026-1
+name: "2026 gap assessment: 3 open GDPR compliance gaps in the CRM platform"
+assesses: FACTOR-EU-REG-1
+description: >
+  The 2026 data-protection gap assessment identified three open gaps:
+  (1) erasure pipeline does not reach the 7-year cold-storage archive,
+  (2) no data-subject-request handling workflow,
+  (3) onboarding consent flow does not meet Art. 7 GDPR standards.
+  All three must be closed before the supervisory-authority pre-audit.
+observed_at: "2026-04-10"
+method: audit
+source: "Internal data-protection gap assessment, April 2026"
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-06-20"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-04-10"
+valid_to: null

--- a/packages/diagrams/src/activity-card/__tests__/resolver.test.ts
+++ b/packages/diagrams/src/activity-card/__tests__/resolver.test.ts
@@ -50,6 +50,15 @@ const CHANGE = {
   goals: ['GOAL-EU-MARKET-1'],
 };
 
+const ASSESSMENT = {
+  notation: 'assessment',
+  id: 'ASSESSMENT-EU-MDR-WINDOW-1',
+  name: 'Notified-body capacity constrained through 2026',
+  assesses: 'FACTOR-EU-MDR-1',
+  description: 'Bottleneck in notified-body capacity narrows the available certification window.',
+  observed_at: '2026-03-01',
+};
+
 const STAKEHOLDER = {
   notation: 'stakeholder',
   id: 'STAKEHOLDER-OPS-1',
@@ -82,7 +91,7 @@ const REL_STAKEHOLDER = {
   valid_to: null,
 };
 
-const elements = [PROJECT, CHILD, UNRELATED, FACTOR, GOAL, CHANGE, STAKEHOLDER];
+const elements = [PROJECT, CHILD, UNRELATED, FACTOR, GOAL, CHANGE, STAKEHOLDER, ASSESSMENT];
 const relations = [REL_GOAL, REL_STAKEHOLDER];
 const sources = { elements, relations };
 
@@ -102,10 +111,55 @@ describe('resolveActivityCard', () => {
     expect(c.childActivities.map((a) => a.id)).toEqual(['ACTIVITY-EU-CHILD-1']);
     // project goal text field = the directly-served goal name
     expect(c.goalNames).toEqual(['Access EU market']);
+    // assessments resolved for in-scope drivers
+    expect(c.assessments).toEqual([
+      {
+        id: 'ASSESSMENT-EU-MDR-WINDOW-1',
+        name: 'Notified-body capacity constrained through 2026',
+        driverId: 'FACTOR-EU-MDR-1',
+        description: 'Bottleneck in notified-body capacity narrows the available certification window.',
+        observed_at: '2026-03-01',
+      },
+    ]);
     // stakeholders resolved from the activity_stakeholder relation (with role)
     expect(c.stakeholders).toEqual([
       { id: 'STAKEHOLDER-OPS-1', name: 'Operations', type: 'internal', interest: 'high', influence: 'medium', role: 'sponsor' },
     ]);
+  });
+
+  it('returns empty assessments when no assessment elements are in canon', () => {
+    const r = resolveActivityCard(CARD, {
+      elements: [PROJECT, CHILD, FACTOR, GOAL, CHANGE],
+      relations,
+    });
+    expect(r.valid).toBe(true);
+    expect(r.resolved!.assessments).toEqual([]);
+  });
+
+  it('omits assessments whose assesses driver is not in the motivation chain', () => {
+    const unrelatedAssessment = {
+      notation: 'assessment',
+      id: 'ASSESSMENT-UNRELATED-1',
+      name: 'Something unrelated',
+      assesses: 'FACTOR-UNRELATED-99',
+      observed_at: '2026-01-01',
+    };
+    const r = resolveActivityCard(CARD, {
+      elements: [PROJECT, CHILD, FACTOR, GOAL, CHANGE, unrelatedAssessment],
+      relations,
+    });
+    expect(r.valid).toBe(true);
+    expect(r.resolved!.assessments).toEqual([]);
+  });
+
+  it('sorts assessments by observed_at ascending', () => {
+    const a1 = { notation: 'assessment', id: 'ASSESSMENT-A-1', name: 'Later', assesses: 'FACTOR-EU-MDR-1', observed_at: '2026-06-01' };
+    const a2 = { notation: 'assessment', id: 'ASSESSMENT-A-2', name: 'Earlier', assesses: 'FACTOR-EU-MDR-1', observed_at: '2026-01-01' };
+    const r = resolveActivityCard(CARD, {
+      elements: [PROJECT, CHILD, FACTOR, GOAL, CHANGE, a1, a2],
+      relations,
+    });
+    expect(r.resolved!.assessments.map((a) => a.id)).toEqual(['ASSESSMENT-A-2', 'ASSESSMENT-A-1']);
   });
 
   it('resolves stakeholder role from the activity_stakeholder relation', () => {

--- a/packages/diagrams/src/activity-card/resolver.ts
+++ b/packages/diagrams/src/activity-card/resolver.ts
@@ -43,6 +43,7 @@ import type {
   ActivityCardDoc,
   ActivityCardSources,
   ResolvedActivityCard,
+  ResolvedAssessment,
   ResolvedChange,
   ResolvedChildActivity,
   ResolvedFactor,
@@ -312,6 +313,32 @@ export function resolveActivityCard(
     factors.push({ id: fid, name: rec ? str(rec['name']) ?? fid : fid });
   }
 
+  // ── Assessments — findings that assesses an in-scope Driver ─────────────────
+  // Assessments answer "what specific problem are we solving?" They are resolved
+  // from ASSESSMENT elements whose `assesses` field matches a Driver id that
+  // appeared in the motivation chain above. Empty when none exist — the gap is
+  // intentionally visible on the card so the author knows it needs filling.
+  const driverIdSet = new Set(factors.map((f) => f.id));
+  const assessmentElems = collectByNotation(sources.elements, 'assessment');
+  const assessments: ResolvedAssessment[] = [];
+  for (const [aid, rec] of assessmentElems) {
+    const driverId = str(rec['assesses']);
+    if (!driverId || !driverIdSet.has(driverId)) continue;
+    assessments.push({
+      id: aid,
+      name: str(rec['name']) ?? aid,
+      driverId,
+      description: str(rec['description']),
+      observed_at: str(rec['observed_at']),
+    });
+  }
+  assessments.sort((a, b) => {
+    if (!a.observed_at && !b.observed_at) return 0;
+    if (!a.observed_at) return 1;
+    if (!b.observed_at) return -1;
+    return a.observed_at < b.observed_at ? -1 : a.observed_at > b.observed_at ? 1 : 0;
+  });
+
   // ── Child activities — parent = project id ──────────────────────────────────
   const childActivities: ResolvedChildActivity[] = [];
   for (const [id, rec] of activities) {
@@ -375,6 +402,7 @@ export function resolveActivityCard(
     project,
     milestones,
     motivation: { factors, goals, changes },
+    assessments,
     childActivities,
     goalNames,
     stakeholders,

--- a/packages/diagrams/src/activity-card/types.ts
+++ b/packages/diagrams/src/activity-card/types.ts
@@ -120,6 +120,22 @@ export interface ResolvedFactor {
   name: string;
 }
 
+/**
+ * A dated finding about the current state of a Driver, answering the
+ * question "what specific problem are we solving?" (pain point).
+ * Resolved from ASSESSMENT elements whose `assesses` field points to a
+ * Driver that is in scope for this activity's motivation chain.
+ */
+export interface ResolvedAssessment {
+  id: string;
+  name: string;
+  /** ID of the Driver this assessment observes. */
+  driverId: string;
+  description?: string;
+  /** ISO 8601 date when the finding was observed. */
+  observed_at?: string;
+}
+
 export interface ResolvedGoal {
   id: string;
   name: string;
@@ -174,6 +190,12 @@ export interface ResolvedActivityCard {
   /** Sorted ascending by `date`. */
   milestones: ResolvedMilestone[];
   motivation: ResolvedMotivation;
+  /**
+   * Assessments (pain points) for the in-scope Drivers, sorted by
+   * `observed_at` ascending. Empty when no Assessment elements are found —
+   * the gap is intentionally visible on the card.
+   */
+  assessments: ResolvedAssessment[];
   /** Activities whose `parent` = the project Activity id. */
   childActivities: ResolvedChildActivity[];
   /**

--- a/packages/diagrams/src/webview/render-activity-card.ts
+++ b/packages/diagrams/src/webview/render-activity-card.ts
@@ -78,6 +78,7 @@ function resolveSingleDoc(doc: ActivityCardDoc): ResolvedActivityCard {
     project: { id: card?.project ?? '', name: card?.project ?? '' },
     milestones,
     motivation: { factors: [], goals: [], changes: [] },
+    assessments: [],
     childActivities: [],
   };
 }


### PR DESCRIPTION
## Summary

- Adds `ResolvedAssessment` type (`id`, `name`, `driverId`, `description`, `observed_at`)
- Resolver collects ASSESSMENT elements whose `assesses` field matches a Driver in the activity's motivation chain; results sorted by `observed_at` ascending
- Exposed as `assessments: ResolvedAssessment[]` on `ResolvedActivityCard`
- When no assessments exist the field is empty — the gap is intentionally visible on the card so the author knows it needs filling
- `resolveSingleDoc` (host-neutral JCEF path) updated with `assessments: []`
- Added example element `ASSESSMENT-GDPR-GAPS-2026-1` for the acme_corp GDPR remediation

The layout PR (follow-up) will render assessments between Drivers and Goals in the body chain.

## Test plan

- [x] 906 tests pass locally
- [x] New tests: assessments resolved for in-scope drivers, empty when none in canon, omits unrelated assessments, sorts by `observed_at`