### PR TITLE
refactor(activity-card): rename Factor → Driver in TypeScript API

### DIFF
--- a/packages/diagrams/src/activity-card/__tests__/example.test.ts
+++ b/packages/diagrams/src/activity-card/__tests__/example.test.ts
@@ -53,7 +53,7 @@ describe('activity-card worked example (eu-programme)', () => {
       'MILESTONE-EU-CONFORMITY-CERT-1',
       'MILESTONE-EU-MARKET-LAUNCH-1',
     ]);
-    expect(c.motivation.factors.map((f) => f.id)).toEqual(['FACTOR-EU-MDR-1']);
+    expect(c.motivation.drivers.map((d) => d.id)).toEqual(['FACTOR-EU-MDR-1']);
     expect(c.motivation.goals.map((g) => g.id)).toEqual(['GOAL-EU-MARKET-1']);
     expect(c.motivation.changes.map((x) => x.id)).toEqual(['CHANGE-EU-COMPLIANCE-1']);
     expect(c.childActivities).toHaveLength(4);

--- a/packages/diagrams/src/activity-card/__tests__/layout.test.ts
+++ b/packages/diagrams/src/activity-card/__tests__/layout.test.ts
@@ -18,8 +18,8 @@ const RESOLVED: ResolvedActivityCard = {
     { id: 'MILESTONE-CERT-1', name: 'Cert', date: '2027-01-31', deliversChanges: ['CHANGE-EU-COMPLIANCE-1'] },
   ],
   motivation: {
-    factors: [{ id: 'FACTOR-EU-MDR-1', name: 'EU MDR regulation' }],
-    goals: [{ id: 'GOAL-EU-MARKET-1', name: 'Access EU market', factorIds: ['FACTOR-EU-MDR-1'] }],
+    drivers: [{ id: 'FACTOR-EU-MDR-1', name: 'EU MDR regulation' }],
+    goals: [{ id: 'GOAL-EU-MARKET-1', name: 'Access EU market', driverIds: ['FACTOR-EU-MDR-1'] }],
     changes: [{ id: 'CHANGE-EU-COMPLIANCE-1', name: 'Achieve MDR compliance', goalIds: ['GOAL-EU-MARKET-1'] }],
   },
   assessments: [
@@ -115,7 +115,7 @@ describe('layoutActivityCard', () => {
   it('empty chain sections have isEmpty=true', () => {
     const l = layoutActivityCard({
       ...RESOLVED,
-      motivation: { factors: [], goals: [], changes: [] },
+      motivation: { drivers: [], goals: [], changes: [] },
       assessments: [],
     });
     expect(l.chainSections.every((s) => s.isEmpty)).toBe(true);
@@ -159,7 +159,7 @@ describe('layoutActivityCard', () => {
       cardId: 'ACTIVITY_CARD-X-1',
       project: { id: 'ACTIVITY-X-1', name: 'Empty' },
       milestones: [],
-      motivation: { factors: [], goals: [], changes: [] },
+      motivation: { drivers: [], goals: [], changes: [] },
       assessments: [],
       childActivities: [],
     });

--- a/packages/diagrams/src/activity-card/__tests__/resolver.test.ts
+++ b/packages/diagrams/src/activity-card/__tests__/resolver.test.ts
@@ -104,7 +104,7 @@ describe('resolveActivityCard', () => {
     expect(c.project.valid_from).toBe('2026-04-01');
     expect(c.project.start_date).toBe('2026-04-15');
     expect(c.milestones).toHaveLength(1);
-    expect(c.motivation.factors.map((f) => f.id)).toEqual(['FACTOR-EU-MDR-1']);
+    expect(c.motivation.drivers.map((d) => d.id)).toEqual(['FACTOR-EU-MDR-1']);
     expect(c.motivation.goals.map((g) => g.id)).toEqual(['GOAL-EU-MARKET-1']);
     expect(c.motivation.changes.map((ch) => ch.id)).toEqual(['CHANGE-EU-COMPLIANCE-1']);
     // only the activity whose parent = the project

--- a/packages/diagrams/src/activity-card/index.ts
+++ b/packages/diagrams/src/activity-card/index.ts
@@ -5,6 +5,7 @@ export type {
   ActivityCardSources,
   ResolvedProject,
   ResolvedMilestone,
+  ResolvedDriver,
   ResolvedFactor,
   ResolvedAssessment,
   ResolvedGoal,

--- a/packages/diagrams/src/activity-card/layout.ts
+++ b/packages/diagrams/src/activity-card/layout.ts
@@ -215,11 +215,11 @@ export function layoutActivityCard(
     cursorY += sectionH + CONNECTOR_H;
   }
 
-  const { factors, goals, changes } = card.motivation;
+  const { drivers, goals, changes } = card.motivation;
   const assessments = card.assessments ?? [];
 
   pushChainSection('drivers', 'Drivers',
-    factors.map((f) => ({ id: f.id, name: f.name })));
+    drivers.map((d) => ({ id: d.id, name: d.name })));
 
   pushChainSection('assessments', 'Assessments',
     assessments.map((a) => ({ id: a.id, name: a.name, meta: a.observed_at })));
@@ -234,14 +234,14 @@ export function layoutActivityCard(
   cursorY = cursorY - CONNECTOR_H + SECTION_GAP;
 
   // Node-level chain edges.
-  const driverIdSet = new Set(factors.map((f) => f.id));
+  const driverIdSet = new Set(drivers.map((d) => d.id));
   const goalIdSet = new Set(goals.map((g) => g.id));
   for (const a of assessments) {
     if (driverIdSet.has(a.driverId)) chainEdges.push({ sourceId: a.driverId, targetId: a.id });
   }
   for (const g of goals) {
-    for (const fid of g.factorIds) {
-      if (driverIdSet.has(fid)) chainEdges.push({ sourceId: fid, targetId: g.id });
+    for (const did of g.driverIds) {
+      if (driverIdSet.has(did)) chainEdges.push({ sourceId: did, targetId: g.id });
     }
   }
   for (const c of changes) {

--- a/packages/diagrams/src/activity-card/resolver.ts
+++ b/packages/diagrams/src/activity-card/resolver.ts
@@ -46,7 +46,7 @@ import type {
   ResolvedAssessment,
   ResolvedChange,
   ResolvedChildActivity,
-  ResolvedFactor,
+  ResolvedDriver,
   ResolvedGoal,
   ResolvedMilestone,
   ResolvedProject,
@@ -267,8 +267,10 @@ export function resolveActivityCard(
     return { valid: false, errors, warnings };
   }
 
-  // ── Motivation chain — expand against canon FACTOR / GOAL / CHANGE elements ──
-  const factorElems = collectByNotation(sources.elements, 'factor');
+  // ── Motivation chain — expand against canon DRIVER / GOAL / CHANGE elements ──
+  // Note: YAML corpus still uses `notation: factor` and `goal.factors` field names;
+  // the YAML keys are stable. The resolved TypeScript API uses "driver/driverIds".
+  const driverElems = collectByNotation(sources.elements, 'factor');
   const goalElems = collectByNotation(sources.elements, 'goal');
   const changeElems = collectByNotation(sources.elements, 'change');
 
@@ -286,7 +288,7 @@ export function resolveActivityCard(
   }
 
   // Goals shown = the project's declared goals ∪ goals referenced by in-scope
-  // changes (so the F→G→C chain stays connected).
+  // changes (so the D→G→C chain stays connected).
   const goalIdSet = new Set<string>(projectGoalIds);
   for (const ch of changes) for (const g of ch.goalIds) goalIdSet.add(g);
 
@@ -300,30 +302,30 @@ export function resolveActivityCard(
       });
       continue;
     }
-    goals.push({ id: gid, name: str(rec['name']) ?? gid, factorIds: strArray(rec['factors']) });
+    goals.push({ id: gid, name: str(rec['name']) ?? gid, driverIds: strArray(rec['factors']) });
   }
 
-  // Factors shown = those referenced by the in-scope goals.
-  const factorIdSet = new Set<string>();
-  for (const g of goals) for (const f of g.factorIds) factorIdSet.add(f);
+  // Drivers shown = those referenced by the in-scope goals.
+  const driverIdSet = new Set<string>();
+  for (const g of goals) for (const d of g.driverIds) driverIdSet.add(d);
 
-  const factors: ResolvedFactor[] = [];
-  for (const fid of factorIdSet) {
-    const rec = factorElems.get(fid);
-    factors.push({ id: fid, name: rec ? str(rec['name']) ?? fid : fid });
+  const drivers: ResolvedDriver[] = [];
+  for (const did of driverIdSet) {
+    const rec = driverElems.get(did);
+    drivers.push({ id: did, name: rec ? str(rec['name']) ?? did : did });
   }
 
-  // ── Assessments — findings that assesses an in-scope Driver ─────────────────
+  // ── Assessments — findings that assess an in-scope Driver ────────────────────
   // Assessments answer "what specific problem are we solving?" They are resolved
   // from ASSESSMENT elements whose `assesses` field matches a Driver id that
   // appeared in the motivation chain above. Empty when none exist — the gap is
   // intentionally visible on the card so the author knows it needs filling.
-  const driverIdSet = new Set(factors.map((f) => f.id));
+  const driverIdLookup = new Set(drivers.map((d) => d.id));
   const assessmentElems = collectByNotation(sources.elements, 'assessment');
   const assessments: ResolvedAssessment[] = [];
   for (const [aid, rec] of assessmentElems) {
     const driverId = str(rec['assesses']);
-    if (!driverId || !driverIdSet.has(driverId)) continue;
+    if (!driverId || !driverIdLookup.has(driverId)) continue;
     assessments.push({
       id: aid,
       name: str(rec['name']) ?? aid,
@@ -401,7 +403,7 @@ export function resolveActivityCard(
     cardDescription: str(card.description),
     project,
     milestones,
-    motivation: { factors, goals, changes },
+    motivation: { drivers, goals, changes },
     assessments,
     childActivities,
     goalNames,

--- a/packages/diagrams/src/activity-card/types.ts
+++ b/packages/diagrams/src/activity-card/types.ts
@@ -120,10 +120,13 @@ export interface ResolvedMilestone {
   deliversChanges: string[];
 }
 
-export interface ResolvedFactor {
+export interface ResolvedDriver {
   id: string;
   name: string;
 }
+
+/** @deprecated Use {@link ResolvedDriver}. */
+export type ResolvedFactor = ResolvedDriver;
 
 /**
  * A dated finding about the current state of a Driver, answering the
@@ -144,8 +147,8 @@ export interface ResolvedAssessment {
 export interface ResolvedGoal {
   id: string;
   name: string;
-  /** FACTOR-… IDs that motivate this goal (canonical `goal.factors`). */
-  factorIds: string[];
+  /** DRIVER-… IDs that motivate this goal (canonical `goal.factors` YAML field). */
+  driverIds: string[];
 }
 
 export interface ResolvedChange {
@@ -155,9 +158,9 @@ export interface ResolvedChange {
   goalIds: string[];
 }
 
-/** Motivation chain: Factors → Goals → Changes, scoped to the project. */
+/** Motivation chain: Drivers → Goals → Changes, scoped to the project. */
 export interface ResolvedMotivation {
-  factors: ResolvedFactor[];
+  drivers: ResolvedDriver[];
   goals: ResolvedGoal[];
   changes: ResolvedChange[];
 }

--- a/packages/diagrams/src/webview/render-activity-card.ts
+++ b/packages/diagrams/src/webview/render-activity-card.ts
@@ -68,7 +68,7 @@ function resolveSingleDoc(doc: ActivityCardDoc): ResolvedActivityCard {
     // only. The layout falls back to '—' for the unknown date fields.
     project: { id: card?.project ?? '', name: card?.project ?? '' },
     milestones,
-    motivation: { factors: [], goals: [], changes: [] },
+    motivation: { drivers: [], goals: [], changes: [] },
     assessments: [],
     childActivities: [],
     notes: card?.notes,


### PR DESCRIPTION
## Summary

- Renames `ResolvedFactor` → `ResolvedDriver`; keeps `ResolvedFactor` as a `@deprecated` type alias for one minor
- Renames `factorIds` → `driverIds` on `ResolvedGoal`
- Renames `motivation.factors` → `motivation.drivers` on `ResolvedMotivation`
- Adds `ResolvedDriver` to the `index.ts` public exports
- YAML corpus (`notation: factor`, `goal.factors` field) is **not changed** — the rename is TypeScript-API-only
- Updates all tests and internal callers (`layout.ts`, `resolver.ts`, `render-activity-card.ts`)

352 tests pass, no new TypeScript errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)