### PR TITLE
fix(activity-card): vertically centre badge text; bump to 2.1.0

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Architecture-as-code for the modern enterprise. Author 17 notations — goals, processes, capabilities, BPMN, applications, more — as plain YAML, get live diagrams in VS Code. Diffable in git. AI-friendly. Open source. Built on ArchiMate 3.2 and BPMN 2.0.",
   "license": "MIT",
   "icon": "icon.png",
@@ -105,7 +105,11 @@
         },
         "transitrix.report.columnWidth": {
           "type": "string",
-          "enum": ["narrow", "normal", "wide"],
+          "enum": [
+            "narrow",
+            "normal",
+            "wide"
+          ],
           "enumDescriptions": [
             "Narrow columns (80 px)",
             "Normal columns (120 px)",

--- a/extension/src/activity-card-preview.ts
+++ b/extension/src/activity-card-preview.ts
@@ -65,14 +65,14 @@ function layoutToSvg(layout: ActivityCardLayout, filename?: string, date?: strin
   if (layout.activityTypeBadge) {
     const b = layout.activityTypeBadge;
     parts.push(`<rect class="diagram-node level-2" x="${b.x + ox}" y="${b.y + oy}" width="${b.width}" height="${b.height}" rx="4"/>`);
-    parts.push(`<text class="text-secondary" x="${b.x + ox + b.width / 2}" y="${b.y + oy + b.height / 2}" text-anchor="middle" dominant-baseline="central">${escXml(b.label)}</text>`);
+    parts.push(`<text class="text-secondary" style="dominant-baseline:central;text-anchor:middle" x="${b.x + ox + b.width / 2}" y="${b.y + oy + b.height / 2}">${escXml(b.label)}</text>`);
   }
 
   // Status badge.
   if (layout.statusBadge) {
     const b = layout.statusBadge;
     parts.push(`<rect class="diagram-node level-3" x="${b.x + ox}" y="${b.y + oy}" width="${b.width}" height="${b.height}" rx="4"/>`);
-    parts.push(`<text class="text-secondary" x="${b.x + ox + b.width / 2}" y="${b.y + oy + b.height / 2}" text-anchor="middle" dominant-baseline="central">${escXml(b.label)}</text>`);
+    parts.push(`<text class="text-secondary" style="dominant-baseline:central;text-anchor:middle" x="${b.x + ox + b.width / 2}" y="${b.y + oy + b.height / 2}">${escXml(b.label)}</text>`);
   }
 
   // Dates band.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/diagrams/src/webview/render-activity-card.ts
+++ b/packages/diagrams/src/webview/render-activity-card.ts
@@ -92,14 +92,14 @@ function buildBody(layout: ActivityCardLayout, ox: number, oy: number): string {
   if (layout.activityTypeBadge) {
     const b = layout.activityTypeBadge;
     parts.push(`<rect class="diagram-node level-2" x="${b.x + ox}" y="${b.y + oy}" width="${b.width}" height="${b.height}" rx="4"/>`);
-    parts.push(`<text class="text-secondary" x="${b.x + ox + b.width / 2}" y="${b.y + oy + b.height / 2}" text-anchor="middle" dominant-baseline="central">${escXml(b.label)}</text>`);
+    parts.push(`<text class="text-secondary" style="dominant-baseline:central;text-anchor:middle" x="${b.x + ox + b.width / 2}" y="${b.y + oy + b.height / 2}">${escXml(b.label)}</text>`);
   }
 
   // Status badge.
   if (layout.statusBadge) {
     const b = layout.statusBadge;
     parts.push(`<rect class="diagram-node level-3" x="${b.x + ox}" y="${b.y + oy}" width="${b.width}" height="${b.height}" rx="4"/>`);
-    parts.push(`<text class="text-secondary" x="${b.x + ox + b.width / 2}" y="${b.y + oy + b.height / 2}" text-anchor="middle" dominant-baseline="central">${escXml(b.label)}</text>`);
+    parts.push(`<text class="text-secondary" style="dominant-baseline:central;text-anchor:middle" x="${b.x + ox + b.width / 2}" y="${b.y + oy + b.height / 2}">${escXml(b.label)}</text>`);
   }
 
   // Date fields.


### PR DESCRIPTION
## Summary

- Fix `dominant-baseline` specificity on activity type and status badge text: presentation attribute (specificity 0-0-0) was losing to CSS class rules, causing "programme" / "in progress" text to float above vertical centre. Changed to inline `style="dominant-baseline:central;text-anchor:middle"` (specificity 1-0-0) in both `render-activity-card.ts` and `extension/src/activity-card-preview.ts`.
- Bump `extension/package.json` and `package.json` from 2.0.0 → 2.1.0.

## Test plan

- [ ] Open GDPR remediation activity card in VS Code preview — "programme" and "in progress" badges have text visually centred in the box
- [ ] Verify no regression on other card sections (dates, stakeholders, chain nodes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)