### PR TITLE
feat(activity-card): generated date label, 2-col roles, chain section subtitles

### DIFF
--- a/extension/src/activity-card-preview.ts
+++ b/extension/src/activity-card-preview.ts
@@ -82,11 +82,11 @@ function layoutToSvg(layout: ActivityCardLayout, filename?: string, date?: strin
     parts.push(`<text class="text-primary" x="${d.x + ox + 12}" y="${d.y + oy + 40}" dominant-baseline="central">${escXml(d.value)}</text>`);
   }
 
-  // Stakeholder role slots.
+  // Stakeholder role slots (2-column grid).
   for (const s of layout.stakeholderRoleSlots) {
     parts.push(`<rect class="diagram-node level-2" x="${s.x + ox}" y="${s.y + oy}" width="${s.width}" height="${s.height}" rx="6"/>`);
     parts.push(`<text class="text-secondary" x="${s.x + ox + 10}" y="${s.y + oy + 16}" dominant-baseline="central">${escXml(s.role)}</text>`);
-    parts.push(`<text class="text-primary" x="${s.x + ox + 10}" y="${s.y + oy + 36}" dominant-baseline="central">${escXml(truncate(s.name, 20))}</text>`);
+    parts.push(`<text class="text-primary" x="${s.x + ox + 10}" y="${s.y + oy + 36}" dominant-baseline="central">${escXml(truncate(s.name, 40))}</text>`);
   }
 
   // Description row.
@@ -105,7 +105,7 @@ function layoutToSvg(layout: ActivityCardLayout, filename?: string, date?: strin
     const section = layout.chainSections[si];
     const level = SECTION_LEVEL[section.type] ?? 5;
     parts.push(`<rect class="diagram-node level-1" x="${section.x + ox}" y="${section.y + oy}" width="${section.width}" height="${section.height}" rx="6"/>`);
-    parts.push(`<text class="text-header" x="${section.x + ox + 12}" y="${section.y + oy + section.height / 2 - (section.height - 24) / 2 + 2}" dominant-baseline="central">${escXml(section.label)}</text>`);
+    parts.push(`<text class="text-header" x="${section.x + ox + 12}" y="${section.y + oy + 14}" dominant-baseline="central">${escXml(section.label)}<tspan class="text-secondary" font-size="11" font-style="italic"> (${escXml(section.subtitle)})</tspan></text>`);
     if (section.isEmpty) {
       parts.push(`<text class="text-secondary" x="${section.x + ox + 12}" y="${section.y + oy + 24 + 8 + 16}" dominant-baseline="central" font-style="italic">— not on file</text>`);
     } else {

--- a/extension/src/svg-title-block.ts
+++ b/extension/src/svg-title-block.ts
@@ -37,7 +37,7 @@ export function titleBlockSvg(
   version?: string,
 ): string {
   const trimmedVersion = version?.trim();
-  const dateLine = trimmedVersion ? `v${trimmedVersion} · ${date}` : date;
+  const dateLine = trimmedVersion ? `v${trimmedVersion} · Generated: ${date}` : `Generated: ${date}`;
   return `<g class="diagram-title-block">
   <text class="text-header" x="${x}" y="${top + 14}">${escXml(heading)}</text>
   <text class="text-secondary" x="${x}" y="${top + 30}">${escXml(filename)}</text>

--- a/packages/diagrams/src/activity-card/layout.ts
+++ b/packages/diagrams/src/activity-card/layout.ts
@@ -148,24 +148,29 @@ export function layoutActivityCard(
   }));
   cursorY += DATES_H + CELL_GAP;
 
-  // ── 3. Stakeholder role slots row ────────────────────────────────────────
+  // ── 3. Stakeholder role slots — 2-column grid ────────────────────────────
   const ROLE_DEFS: Array<{ role: string; label: string }> = [
     { role: 'initiator', label: 'Initiator' },
     { role: 'owner', label: 'Owner' },
     { role: 'sponsor', label: 'Sponsor' },
     { role: 'project_manager', label: 'PM' },
   ];
-  const roleSlotW = (contentW - CELL_GAP * (ROLE_DEFS.length - 1)) / ROLE_DEFS.length;
+  const ROLE_COLS = 2;
+  const roleSlotW = (contentW - CELL_GAP * (ROLE_COLS - 1)) / ROLE_COLS;
   const stakeholderRoleSlots: StakeholderRoleSlot[] = ROLE_DEFS.map(({ role, label }, i) => {
+    const col = i % ROLE_COLS;
+    const row = Math.floor(i / ROLE_COLS);
     const match = (card.stakeholders ?? []).find((s) => s.role === role);
     return {
       role: label,
       name: match?.name ?? '—',
-      x: contentX + i * (roleSlotW + CELL_GAP), y: cursorY,
+      x: contentX + col * (roleSlotW + CELL_GAP),
+      y: cursorY + row * (ROLES_H + CELL_GAP),
       width: roleSlotW, height: ROLES_H,
     };
   });
-  cursorY += ROLES_H + SECTION_GAP;
+  const roleRows = Math.ceil(ROLE_DEFS.length / ROLE_COLS);
+  cursorY += roleRows * (ROLES_H + CELL_GAP) - CELL_GAP + SECTION_GAP;
 
   // ── 4. Description row (optional) ────────────────────────────────────────
   let descriptionRow: InfoRow | undefined;
@@ -189,6 +194,7 @@ export function layoutActivityCard(
   function pushChainSection(
     type: ChainSectionLayout['type'],
     label: string,
+    subtitle: string,
     rawNodes: Array<{ id: string; name: string; meta?: string }>,
   ): void {
     const isEmpty = rawNodes.length === 0;
@@ -211,23 +217,23 @@ export function layoutActivityCard(
       : rawNodes.length * (CHAIN_NODE_H + opts.rowGap) - opts.rowGap;
     const sectionH = CHAIN_HEADER_H + 8 + bodyH + 8;
 
-    chainSections.push({ type, label, nodes, isEmpty, x: contentX, y: sectionY, width: contentW, height: sectionH });
+    chainSections.push({ type, label, subtitle, nodes, isEmpty, x: contentX, y: sectionY, width: contentW, height: sectionH });
     cursorY += sectionH + CONNECTOR_H;
   }
 
   const { drivers, goals, changes } = card.motivation;
   const assessments = card.assessments ?? [];
 
-  pushChainSection('drivers', 'Drivers',
+  pushChainSection('drivers', 'Drivers', 'What prompted this initiative?',
     drivers.map((d) => ({ id: d.id, name: d.name })));
 
-  pushChainSection('assessments', 'Assessments',
+  pushChainSection('assessments', 'Assessments', 'What is the current gap?',
     assessments.map((a) => ({ id: a.id, name: a.name, meta: a.observed_at })));
 
-  pushChainSection('goals', 'Goals',
+  pushChainSection('goals', 'Goals', 'What outcome do we target?',
     goals.map((g) => ({ id: g.id, name: g.name })));
 
-  pushChainSection('changes', 'Changes',
+  pushChainSection('changes', 'Changes', 'What will change?',
     changes.map((c) => ({ id: c.id, name: c.name })));
 
   // Remove trailing CONNECTOR_H — last section connects to milestones with SECTION_GAP.

--- a/packages/diagrams/src/activity-card/types.ts
+++ b/packages/diagrams/src/activity-card/types.ts
@@ -288,6 +288,8 @@ export interface ChainSectionLayout {
   type: 'drivers' | 'assessments' | 'goals' | 'changes';
   /** Section header label. */
   label: string;
+  /** Short question answered by this section, shown in grey after the label. */
+  subtitle: string;
   nodes: ChainNode[];
   isEmpty: boolean;
   x: number;

--- a/packages/diagrams/src/webview/render-activity-card.ts
+++ b/packages/diagrams/src/webview/render-activity-card.ts
@@ -109,11 +109,11 @@ function buildBody(layout: ActivityCardLayout, ox: number, oy: number): string {
     parts.push(`<text class="text-primary" x="${d.x + ox + 12}" y="${d.y + oy + 40}" dominant-baseline="central">${escXml(d.value)}</text>`);
   }
 
-  // Stakeholder role slots.
+  // Stakeholder role slots (2-column grid).
   for (const s of layout.stakeholderRoleSlots) {
     parts.push(`<rect class="diagram-node level-2" x="${s.x + ox}" y="${s.y + oy}" width="${s.width}" height="${s.height}" rx="6"/>`);
     parts.push(`<text class="text-secondary" x="${s.x + ox + 10}" y="${s.y + oy + 16}" dominant-baseline="central">${escXml(s.role)}</text>`);
-    parts.push(`<text class="text-primary" x="${s.x + ox + 10}" y="${s.y + oy + 36}" dominant-baseline="central">${escXml(truncate(s.name, 20))}</text>`);
+    parts.push(`<text class="text-primary" x="${s.x + ox + 10}" y="${s.y + oy + 36}" dominant-baseline="central">${escXml(truncate(s.name, 40))}</text>`);
   }
 
   // Description row.
@@ -141,9 +141,9 @@ function buildBody(layout: ActivityCardLayout, ox: number, oy: number): string {
     parts.push(
       `<rect class="diagram-node level-1" x="${section.x + ox}" y="${section.y + oy}" width="${section.width}" height="${section.height}" rx="6"/>`,
     );
-    // Section header label.
+    // Section header label + subtitle.
     parts.push(
-      `<text class="text-header" x="${section.x + ox + 12}" y="${section.y + oy + section.height / 2 - (section.height - 24) / 2 + 2}" dominant-baseline="central">${escXml(section.label)}</text>`,
+      `<text class="text-header" x="${section.x + ox + 12}" y="${section.y + oy + 14}" dominant-baseline="central">${escXml(section.label)}<tspan class="text-secondary" font-size="11" font-style="italic"> (${escXml(section.subtitle)})</tspan></text>`,
     );
 
     if (section.isEmpty) {


### PR DESCRIPTION
## Summary

Three layout improvements to the Activity Card preview:

- **Generated date label**: title block line 3 now reads `Generated: YYYY-MM-DD` (or `v{ver} · Generated: …`) so it is not confused with any project date field.
- **2-column stakeholder grid**: Initiator / Owner / Sponsor / PM are now in a 2×2 layout (~364 px per slot) instead of 4 across — department names and person names no longer truncate at 20 chars (raised to 40).
- **Chain section subtitles**: each section header now carries a concise grey italic question in parentheses to guide readers:
  - *Drivers* — "What prompted this initiative?"
  - *Assessments* — "What is the current gap?"
  - *Goals* — "What outcome do we target?"
  - *Changes* — "What will change?"

## Changed files

| File | What changed |
|------|-------------|
| `extension/src/svg-title-block.ts` | "Generated: " prefix on date line |
| `packages/diagrams/src/activity-card/types.ts` | `subtitle: string` on `ChainSectionLayout` |
| `packages/diagrams/src/activity-card/layout.ts` | 2-col role grid; subtitle args on `pushChainSection` |
| `packages/diagrams/src/webview/render-activity-card.ts` | render subtitle tspan; name truncate 20→40 |
| `extension/src/activity-card-preview.ts` | same two renderer fixes |

## Test plan

- [ ] 921 tests pass (`npm test`)
- [ ] Open GDPR remediation card in VS Code — title block shows "Generated: 2026-06-20"
- [ ] Initiator / Owner in row 1; Sponsor / PM in row 2; names not clipped
- [ ] "Drivers (What prompted this initiative?)" etc. visible in grey italic on each chain section

🤖 Generated with [Claude Code](https://claude.com/claude-code)