### PR TITLE
chore(release): cut 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [2.1.0] — 2026-06-20
+
+### Added
+
+- **Activity Card — full motivation chain.** The card now resolves and displays the complete **Driver → Assessment → Goal → Change** chain from the canon element store. Empty sections render a "— not on file" gap indicator so authors see missing data. Each section header carries a concise subtitle question (e.g. *"What prompted this initiative?"*).
+- **Activity Card — status and activity type badges.** `status` and `activity_type` fields on the Activity element are now shown as styled badges in the card header (`planned`, `in_progress`, `programme`, `project`, …).
+- **Activity Card — stakeholder role slots.** `Initiator`, `Owner`, `Sponsor`, and `PM` slots are resolved from `activity_stakeholder` relations and rendered in a 2-column grid. Names are no longer truncated at 20 characters.
+- **GDPR remediation example.** `organizations/acme_corp/` ships a complete `ACTIVITY-GDPR-REMEDIATION-1` programme with a full motivation chain, three workstream children, and an Activity Card view.
+- **Preview live sliders.** Spacing and curvature sliders update the diagram immediately on drag.
+- **`@transitrix/diagrams` npm publish CI workflow.**
+
+### Changed
+
+- **All previews — "Generated:" date label.** The date line in every diagram title block now reads `Generated: YYYY-MM-DD` to distinguish it from project date fields.
+- **Activity Card — badge text vertically centred.** Uses `style="dominant-baseline:central"` (inline; specificity 1-0-0) so CSS class rules cannot override the alignment.
+- **`ResolvedDriver` replaces `ResolvedFactor`** in `@transitrix/diagrams`. `ResolvedFactor` is kept as a deprecated alias and will be removed in 2.2.0. YAML corpus is unchanged (`notation: factor`, `goal.factors`).
+
+### Internal
+
+- **Cervin deprecation P5.** `src/transitrixrc.ts` is now the canonical module; `src/cervinrc.ts` is a thin re-export shim. `loadCervinrc()` and `CERVINRC_SCHEMA` deprecated aliases kept through 2.x.
+
 ## [2.0.0] — 2026-06-18
 
 ### Changed

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Transitrix Studio — changelog
 
+## 2.1.0 — 2026-06-20
+
+Activity Card motivation chain, stakeholder grid, live sliders, "Generated:" date label.
+
+### Added
+
+- **Activity Card — full motivation chain.** Resolves and displays the complete Driver → Assessment → Goal → Change chain from the canon element store. Empty sections show "— not on file". Section headers carry concise subtitles (e.g. *"What prompted this initiative?"*).
+- **Activity Card — status and activity type badges** in the header (`planned`, `in_progress`, `programme`, `project`, …).
+- **Activity Card — stakeholder role grid.** Initiator / Owner / Sponsor / PM slots resolved from `activity_stakeholder` relations; rendered in a 2-column grid so names are not truncated.
+- **Preview live sliders.** Spacing and curvature sliders re-render the diagram immediately on drag, not only on release.
+- **GDPR remediation example** in `organizations/acme_corp/` with full motivation chain and three workstream children.
+
+### Changed
+
+- **"Generated:" date label** on every diagram title block — distinguishes the render date from project date fields.
+- **Activity Card badge text vertically centred** — fixes text floating above centre in "programme" / "in progress" badges.
+
 ## 1.6.0 — 2026-06-17
 
 Column-width controls, product names in impact headers, coverage-metric spec fix.


### PR DESCRIPTION
Updates `CHANGELOG.md` and `extension/CHANGELOG.md` for the 2.1.0 release.

### What is in 2.1.0

**Activity Card**
- Full motivation chain: Driver → Assessment → Goal → Change, resolved from the canon element store; empty sections show "— not on file"; section headers carry concise subtitle questions
- Status and activity type badges in the header
- Stakeholder role grid (Initiator / Owner / Sponsor / PM) — 2-column layout, no truncation
- Badge text vertically centred (CSS specificity fix)

**Previews**
- "Generated: YYYY-MM-DD" label on every diagram title block
- Spacing and curvature sliders update on drag (not only on release)

**Example**
- GDPR remediation programme in `organizations/acme_corp/` with full motivation chain and three workstream children

**Internal**
- Cervin P5: `src/transitrixrc.ts` canonical; `cervinrc.ts` re-export shim
- `ResolvedFactor` → `ResolvedDriver` in `@transitrix/diagrams` (deprecated alias kept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)