### PR TITLE
chore: bump JetBrains plugin version 0.2.0 → 0.2.1 for 2.1.1 release

### DIFF
--- a/intellij/gradle.properties
+++ b/intellij/gradle.properties
@@ -1,7 +1,7 @@
 pluginGroup = com.transitrix.intellij
 pluginName = transitrix-intellij
 # Versioned independently from the VS Code extension's package.json.
-pluginVersion = 0.2.0
+pluginVersion = 0.2.1
 
 # IntelliJ IDEA Community 2024.2 — JCEF-bearing baseline (JCEF requires 2020.2+).
 platformVersion = 2024.2


### PR DESCRIPTION
## Summary

`intellij/gradle.properties` — `pluginVersion` was not bumped in PR #234 (2.1.1 release). The JetBrains Marketplace CI job failed with:

> Upload failed: The com.transitrix.studio plugin already contains version 0.2.0 in channel

One-line fix: `0.2.0` → `0.2.1`.

## Test plan

- [ ] JetBrains Marketplace publish workflow passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)