### PR TITLE
chore: bump @transitrix/diagrams 1.0.0 → 1.0.1

### DIFF
--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",


### PR DESCRIPTION
## Summary

`packages/diagrams/package.json` version was not bumped in PR #234. npm CI fails with:

> 403 Forbidden — You cannot publish over the previously published versions: 1.0.0.

One-line fix: `1.0.0` → `1.0.1`.

Covers the 2.1.1 rendering changes already on `main`: `dominant-baseline:central` in CSS text classes, process-blueprint inline style conversion, layout height increases, `styles.css` italic removal.

## Test plan

- [ ] npm publish workflow passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)