### PR TITLE
fix: Process Blueprint restore + uniform title block across all previews

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -445,6 +445,11 @@
         "enablement": "config.transitrix.exportEnabled"
       },
       {
+        "command": "transitrixStudio.changeTheme",
+        "title": "Transitrix: Change diagram color scheme",
+        "category": "Transitrix"
+      },
+      {
         "command": "transitrixStudio.previewGoals",
         "title": "Transitrix: Preview goal tree",
         "category": "Transitrix",
@@ -728,7 +733,7 @@
     "menus": {
       "editor/title": [
         {
-          "when": "resourceFilename =~ /\\.(cervin|bpmn)\\.yaml$/",
+          "when": "resourceFilename =~ /\\.(cervin|bpmn\\.transitrix)\\.yaml$/",
           "command": "transitrix.openPreview",
           "group": "navigation@-10"
         },

--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -1,7 +1,7 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
-import { buildDiagramFrame, prepareSvgForExport, type ThemeId } from './diagram-frame.js';
+import { buildDiagramFrame, prepareSvgForExport, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
 import { TITLE_BLOCK_H, titleBlockSvg, todayIso } from './svg-title-block.js';
 import {
   validateActivities,
@@ -429,9 +429,7 @@ function buildActivityViews(doc: ActivityDoc, gaps: ActivitiesLayoutOptions, cur
   const networkSvgStr = networkSvg(doc, gaps, curvature, entryCurvature, networkHeading, filename, date, version);
   const gantt: GanttResult = computeGanttLayout(doc);
 
-  // Mirror titleBlockSvg's date line: `v{version} · {date}` when version is set.
-  const trimmedVersion = version?.trim();
-  const dateLine = trimmedVersion ? `v${trimmedVersion} · ${date}` : date;
+  const dateLine = date;
 
   if (isGanttUnavailable(gantt)) {
     // No SVG to embed the title into — fall back to an HTML title block plus
@@ -503,7 +501,8 @@ const ACTIVITIES_WEBVIEW_CSS = `
      keeps them keyboard-focusable while not taking layout space, and stops
      the webview default styles from showing a 13px input box. */
   .view-radio { position: absolute; left: -9999px; width: 1px; height: 1px; }
-  .view-tabs { display: flex; gap: 4px; padding: 12px 16px 0; border-bottom: 1px solid var(--ts-border, #cbd5e1); margin-bottom: 8px; }
+  #canvas { padding-top: 0; }
+  .view-tabs { display: flex; gap: 4px; padding: 8px 0 0; border-bottom: 1px solid var(--ts-border, #cbd5e1); margin-bottom: 8px; }
   .view-tab {
     padding: 6px 14px;
     font-size: 12px;
@@ -578,7 +577,7 @@ export class ActivitiesPreview {
           enableScripts: true,
           retainContextWhenHidden: true,
           localResourceRoots: [vscode.Uri.joinPath(this.extensionUri, 'media')],
-          enableCommandUris: ['transitrixStudio.saveActivitiesAsSvg', 'transitrixStudio.saveActivitiesAsPng', 'transitrixStudio.copyActivitiesAsPng', OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND],
+          enableCommandUris: ['transitrixStudio.saveActivitiesAsSvg', 'transitrixStudio.saveActivitiesAsPng', 'transitrixStudio.copyActivitiesAsPng', OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_THEME_COMMAND],
         },
       );
       this.panel.webview.onDidReceiveMessage((m) => { void applyControlMessage('activities', m); });
@@ -667,6 +666,7 @@ export class ActivitiesPreview {
       copyPngCommand: 'transitrixStudio.copyActivitiesAsPng',
       spacingCommand: OPEN_SPACING_SETTINGS_COMMAND,
       curvatureCommand: OPEN_CURVATURE_SETTINGS_COMMAND,
+      themeCommand: OPEN_THEME_COMMAND,
       interactive: { nonce, controlsPanel, controlsScript: buildControlsScript(nonce) },
     });
   }

--- a/extension/src/activity-card-preview.ts
+++ b/extension/src/activity-card-preview.ts
@@ -1,7 +1,7 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
-import { buildDiagramFrame, prepareSvgForExport, type ThemeId } from './diagram-frame.js';
+import { buildDiagramFrame, prepareSvgForExport, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
 import { TITLE_BLOCK_H, titleBlockSvg, todayIso } from './svg-title-block.js';
 import {
   validateActivityCard,
@@ -182,6 +182,7 @@ export class ActivityCardPreview {
             'transitrixStudio.saveActivityCardAsSvg',
             'transitrixStudio.saveActivityCardAsPng',
             'transitrixStudio.copyActivityCardAsPng',
+            'transitrixStudio.changeTheme',
           ],
         },
       );
@@ -192,6 +193,12 @@ export class ActivityCardPreview {
 
   async refreshSaved(doc: vscode.TextDocument): Promise<void> {
     if (!this.isShowingDocument(doc.uri)) return;
+    await this.pushDocument(doc);
+  }
+
+  async refreshConfig(): Promise<void> {
+    if (!this.panel || !this.trackedUri) return;
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.parse(this.trackedUri));
     await this.pushDocument(doc);
   }
 
@@ -258,6 +265,7 @@ export class ActivityCardPreview {
       saveSvgCommand: 'transitrixStudio.saveActivityCardAsSvg',
       savePngCommand: 'transitrixStudio.saveActivityCardAsPng',
       copyPngCommand: 'transitrixStudio.copyActivityCardAsPng',
+      themeCommand: OPEN_THEME_COMMAND,
     });
   }
 

--- a/extension/src/applications-preview.ts
+++ b/extension/src/applications-preview.ts
@@ -1,7 +1,7 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
-import { buildDiagramFrame, CATALOGUE_STYLES, type ThemeId } from './diagram-frame.js';
+import { buildDiagramFrame, CATALOGUE_STYLES, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 import { validateApplicationsCatalogue } from '../../packages/diagrams/src/applications/validate.js';
 
@@ -162,7 +162,7 @@ export class ApplicationsPreview {
         'applicationsPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true },
+        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.changeTheme'] },
       );
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
     }
@@ -171,6 +171,12 @@ export class ApplicationsPreview {
 
   async refreshSaved(doc: vscode.TextDocument): Promise<void> {
     if (!this.isShowingDocument(doc.uri)) return;
+    await this.pushDocument(doc);
+  }
+
+  async refreshConfig(): Promise<void> {
+    if (!this.panel || !this.trackedUri) return;
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.parse(this.trackedUri));
     await this.pushDocument(doc);
   }
 
@@ -226,6 +232,7 @@ export class ApplicationsPreview {
       version,
       date,
       extraStyles: `:root { --ts-col-w: ${colWPx}px; }\n` + CATALOGUE_STYLES + APPLICATIONS_STYLES,
+      themeCommand: OPEN_THEME_COMMAND,
     });
   }
 }

--- a/extension/src/blocks-preview.ts
+++ b/extension/src/blocks-preview.ts
@@ -1,7 +1,7 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
-import { buildDiagramFrame, prepareSvgForExport, type ThemeId } from './diagram-frame.js';
+import { buildDiagramFrame, prepareSvgForExport, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
 import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
 import { TITLE_BLOCK_H, titleBlockSvg, todayIso } from './svg-title-block.js';
 import {
@@ -102,7 +102,7 @@ export class BlocksPreview {
         {
           enableScripts: false,
           retainContextWhenHidden: true,
-          enableCommandUris: ['transitrixStudio.saveBlocksAsSvg', 'transitrixStudio.saveBlocksAsPng', 'transitrixStudio.copyBlocksAsPng'],
+          enableCommandUris: ['transitrixStudio.saveBlocksAsSvg', 'transitrixStudio.saveBlocksAsPng', 'transitrixStudio.copyBlocksAsPng', 'transitrixStudio.changeTheme'],
         },
       );
       this.panel.onDidDispose(() => {
@@ -115,6 +115,12 @@ export class BlocksPreview {
 
   async refreshSaved(doc: vscode.TextDocument): Promise<void> {
     if (!this.isShowingDocument(doc.uri)) return;
+    await this.pushDocument(doc);
+  }
+
+  async refreshConfig(): Promise<void> {
+    if (!this.panel || !this.trackedUri) return;
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.parse(this.trackedUri));
     await this.pushDocument(doc);
   }
 
@@ -167,6 +173,7 @@ export class BlocksPreview {
       saveSvgCommand: 'transitrixStudio.saveBlocksAsSvg',
       savePngCommand: 'transitrixStudio.saveBlocksAsPng',
       copyPngCommand: 'transitrixStudio.copyBlocksAsPng',
+      themeCommand: OPEN_THEME_COMMAND,
     });
   }
 

--- a/extension/src/capability-map-preview.ts
+++ b/extension/src/capability-map-preview.ts
@@ -1,7 +1,7 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
-import { buildDiagramFrame, CATALOGUE_STYLES, type ThemeId } from './diagram-frame.js';
+import { buildDiagramFrame, CATALOGUE_STYLES, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 import { validateCapabilityMap } from '../../packages/diagrams/src/capability-map/validate.js';
 
@@ -132,7 +132,7 @@ export class CapabilityMapPreview {
         'capabilityMapPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true },
+        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.changeTheme'] },
       );
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
     }
@@ -141,6 +141,12 @@ export class CapabilityMapPreview {
 
   async refreshSaved(doc: vscode.TextDocument): Promise<void> {
     if (!this.isShowingDocument(doc.uri)) return;
+    await this.pushDocument(doc);
+  }
+
+  async refreshConfig(): Promise<void> {
+    if (!this.panel || !this.trackedUri) return;
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.parse(this.trackedUri));
     await this.pushDocument(doc);
   }
 
@@ -197,6 +203,7 @@ export class CapabilityMapPreview {
       version,
       date,
       extraStyles: CATALOGUE_STYLES + CAPABILITY_MAP_STYLES,
+      themeCommand: OPEN_THEME_COMMAND,
     });
   }
 }

--- a/extension/src/compliance-impact-preview.ts
+++ b/extension/src/compliance-impact-preview.ts
@@ -291,7 +291,7 @@ export class ComplianceImpactPreview {
           enableScripts: true,
           retainContextWhenHidden: true,
           localResourceRoots: [vscode.Uri.joinPath(this.extensionUri, 'media')],
-          enableCommandUris: [OPEN_FILE_COMMAND, REFRESH_COMMAND],
+          enableCommandUris: [OPEN_FILE_COMMAND, REFRESH_COMMAND, 'transitrixStudio.changeTheme'],
         },
       );
       this.panel.webview.onDidReceiveMessage((m) => { void this.onMessage(m); });
@@ -392,9 +392,12 @@ export class ComplianceImpactPreview {
         '<style>\n' + generateWebviewCss(themeId) + '\n' + IMPACT_CSS + '\n' + ERROR_BLOCK_CSS + '\n</style>\n' +
         '</head>\n<body data-theme="' + escXml(themeId) + '">\n' +
         errInput + '\n' +
-        '<div id="ci-toolbar">' +
-        '<div class="ci-title">Compliance Impact Matrix</div>' +
-        '<a href="command:' + REFRESH_COMMAND + '" class="ci-btn" title="Re-scan the workspace and reload view config">Refresh</a>' +
+        '<div id="toolbar">' +
+        '<span class="toolbar-label">Compliance Impact Matrix</span>' +
+        '<div class="toolbar-actions">' +
+        '<a href="command:transitrixStudio.changeTheme" class="toolbar-btn" title="Change the color scheme for all diagram previews">Theme…</a>' +
+        '<a href="command:' + REFRESH_COMMAND + '" class="toolbar-btn" title="Re-scan the workspace and reload view config">Refresh</a>' +
+        '</div>' +
         '</div>\n' +
         errBlock + '\n' +
         '</body>\n</html>'
@@ -499,9 +502,19 @@ export class ComplianceImpactPreview {
       '">\n' +
       errInput +
       warnInput +
-      '  <div id="ci-toolbar">\n' +
-      '    <div class="ci-title">Compliance Impact Matrix</div>\n' +
-      '    <div class="ci-summary">' +
+      '  <div id="toolbar">\n' +
+      '    <span class="toolbar-label">Compliance Impact Matrix</span>\n' +
+      '    <div class="toolbar-actions">\n' +
+      '      <a href="command:transitrixStudio.changeTheme" class="toolbar-btn" title="Change the color scheme for all diagram previews">Theme…</a>\n' +
+      '      <a href="command:' +
+      REFRESH_COMMAND +
+      '" class="toolbar-btn" title="Re-scan the workspace and reload view config">Refresh</a>\n' +
+      '    </div>\n' +
+      '  </div>\n' +
+      errBlock +
+      warnBlock +
+      '  <div id="ci-filters">\n' +
+      '    <span class="ci-summary">' +
       rows.length +
       ' obligations &times; ' +
       columns.length +
@@ -509,17 +522,11 @@ export class ComplianceImpactPreview {
       totalGaps +
       '</strong> gaps' +
       pendingSummary +
-      '</div>\n' +
-      '    <div class="ci-config">' +
+      '</span>' +
+      '    <span class="ci-config">' +
       configLine +
-      '</div>\n' +
-      '    <a href="command:' +
-      REFRESH_COMMAND +
-      '" class="ci-btn" title="Re-scan the workspace and reload view config">Refresh</a>\n' +
-      '  </div>\n' +
-      errBlock +
-      warnBlock +
-      '  <div id="ci-filters">\n' +
+      '</span>' +
+      '    <span class="ci-filter-sep"></span>' +
       '    <span class="ci-filter-label">Status</span>' +
       statusBoxes +
       '\n' +
@@ -737,14 +744,16 @@ export class ComplianceImpactPreview {
 
 const IMPACT_CSS = `
 body { padding: 0; }
-#ci-toolbar { display: flex; align-items: center; gap: 12px; padding: 10px 16px; border-bottom: 1px solid var(--ts-border, #cbd5e1); flex-wrap: wrap; }
-.ci-title { font-size: 14px; font-weight: 700; color: var(--ts-text, #0f172a); }
-.ci-summary { font-size: 12px; color: var(--ts-text-muted, #64748b); }
+#toolbar { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 8px 16px; border-bottom: 1px solid var(--ts-border, #cbd5e1); flex-wrap: wrap; }
+.toolbar-label { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 12px; color: var(--ts-text-muted, #64748b); }
+.toolbar-actions { display: flex; gap: 4px; align-items: center; flex-wrap: wrap; justify-content: flex-end; }
+.toolbar-btn { cursor: pointer; user-select: none; font-size: 11px; padding: 1px 8px; border-radius: 4px; color: var(--ts-text-muted, #64748b); white-space: nowrap; text-decoration: none; }
+.toolbar-btn:hover { color: var(--ts-text, #0f172a); background: var(--ts-bg-elevated, #f1f5f9); }
+.ci-summary { font-size: 11px; color: var(--ts-text-muted, #64748b); }
 .ci-summary strong { color: var(--ts-text, #0f172a); }
-.ci-config { font-size: 11px; color: var(--ts-text-muted, #64748b); margin-left: auto; }
+.ci-config { font-size: 11px; color: var(--ts-text-muted, #64748b); padding-left: 4px; border-left: 1px solid var(--ts-border, #cbd5e1); margin-left: 4px; }
 .ci-config code { background: var(--ts-bg-subtle, #f1f5f9); padding: 1px 4px; border-radius: 3px; }
-.ci-btn { font-size: 11px; padding: 2px 10px; border-radius: 4px; color: var(--ts-text-muted, #64748b); text-decoration: none; border: 1px solid var(--ts-border, #cbd5e1); }
-.ci-btn:hover { color: var(--ts-text, #0f172a); background: var(--ts-bg-elevated, #f1f5f9); }
+.ci-filter-sep { flex-basis: 100%; height: 0; }
 #ci-filters { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; padding: 8px 16px; border-bottom: 1px solid var(--ts-border, #cbd5e1); font-size: 11px; }
 .ci-filter-label { font-weight: 600; color: var(--ts-text, #0f172a); margin-left: 8px; }
 .ci-filter-label:first-child { margin-left: 0; }

--- a/extension/src/compliance-matrix-preview.ts
+++ b/extension/src/compliance-matrix-preview.ts
@@ -92,7 +92,7 @@ export class ComplianceMatrixPreview {
           enableScripts: true,
           retainContextWhenHidden: true,
           localResourceRoots: [vscode.Uri.joinPath(this.extensionUri, 'media')],
-          enableCommandUris: [OPEN_FILE_COMMAND, REFRESH_COMMAND],
+          enableCommandUris: [OPEN_FILE_COMMAND, REFRESH_COMMAND, 'transitrixStudio.changeTheme'],
         },
       );
       this.panel.webview.onDidReceiveMessage((m) => { void this.onMessage(m); });
@@ -224,6 +224,7 @@ ${WARN_BLOCK_CSS}
   <div id="cm-toolbar">
     <div class="cm-title">Compliance Matrix</div>
     <div class="cm-summary">${summary.products} products × ${summary.requirements} requirements · <strong>${summary.gaps}</strong> gaps · ${summary.assertions} claims shown</div>
+    <a href="command:transitrixStudio.changeTheme" class="cm-btn" title="Change the color scheme for all diagram previews">Theme…</a>
     <a href="command:${REFRESH_COMMAND}" class="cm-btn" title="Re-scan the workspace">Refresh</a>
   </div>
   ${errBlock}${warnBlock}
@@ -346,7 +347,7 @@ body { padding: 0; }
 .cm-cell { width: var(--ts-col-w, 120px); height: 38px; text-align: center; vertical-align: middle; }
 .cm-badge { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 11px; font-weight: 600; }
 .cm-cell-link { text-decoration: none; }
-.cm-gap { background: repeating-linear-gradient(45deg, transparent, transparent 5px, var(--ts-bg-subtle, #f1f5f9) 5px, var(--ts-bg-subtle, #f1f5f9) 10px); }
+.cm-gap { background-color: var(--ts-bg, #fff); background-image: repeating-linear-gradient(135deg, rgba(100,116,139,0.18) 0, rgba(100,116,139,0.18) 2px, transparent 0, transparent 50%); background-size: 8px 8px; }
 .cm-pending { background: #fef9c3; border: 1px dashed #b45309 !important; }
 .cm-badge-pending { display: inline-block; padding: 2px 6px; border-radius: 8px; font-size: 10px; font-weight: 600; color: #b45309; background: #fef9c3; }
 .cm-compliant { background: var(--ts-status-success-bg, #d1fae5); }
@@ -357,7 +358,7 @@ body { padding: 0; }
 .cm-non_compliant .cm-badge { color: var(--ts-status-error-fg, #991b1b); }
 .cm-under_review { background: var(--ts-status-info-bg, #e0f2fe); }
 .cm-under_review .cm-badge { color: var(--ts-status-info-fg, #0c4a6e); }
-.cm-n_a { background: var(--ts-bg-subtle, #f1f5f9); }
+.cm-n_a { background-color: var(--ts-bg, #fff); background-image: repeating-linear-gradient(135deg, var(--ts-border, #cbd5e1) 0, var(--ts-border, #cbd5e1) 1.5px, transparent 0, transparent 50%); background-size: 8px 8px; }
 .cm-n_a .cm-badge { color: var(--ts-text-muted, #64748b); }
 .cm-pending_owner { background: #f3e8ff; }
 .cm-pending_owner .cm-badge { color: #6b21a8; }

--- a/extension/src/compliance-render.ts
+++ b/extension/src/compliance-render.ts
@@ -54,6 +54,7 @@ body { padding: 0; }
 #cmp-toolbar { display: flex; align-items: baseline; gap: 12px; padding: 12px 16px; border-bottom: 1px solid var(--ts-border, #cbd5e1); flex-wrap: wrap; }
 .cmp-title { font-size: 15px; font-weight: 700; color: var(--ts-text, #0f172a); }
 .cmp-subtitle { font-size: 12px; color: var(--ts-text-muted, #64748b); }
+.cmp-meta { width: 100%; font-size: 11px; color: var(--ts-text-muted, #64748b); letter-spacing: 0.04em; }
 .cmp-confidence { width: 100%; font-size: 11px; color: var(--ts-text-muted, #64748b); }
 .cmp-confidence-band { display: inline-block; padding: 0 6px; margin-right: 4px; border-radius: 3px; font-weight: 700; background: var(--ts-bg-subtle, #f1f5f9); color: var(--ts-text, #0f172a); }
 .cmp-confidence-band[data-band="A"] { background: var(--ts-status-success-bg, #d1fae5); color: var(--ts-status-success-fg, #065f46); }
@@ -112,9 +113,15 @@ body { padding: 0; }
 export interface ComplianceShellOptions {
   title: string;
   subtitle?: string;
+  /** Source filename shown as the second line of the header (e.g. "gdpr.law.transitrix.yaml"). Omit for workspace-wide views. */
+  filename?: string;
+  /** Generation date shown as "Generated: YYYY-MM-DD". Pass today's ISO date from the caller. */
+  date?: string;
   themeId: ThemeId;
   /** Command id for the Refresh button (re-scan). */
   refreshCommand: string;
+  /** Command id for the Theme… button. Pass 'transitrixStudio.changeTheme' from all callers. */
+  themeCommand?: string;
   /** Extra toolbar buttons (command URIs), rendered before Refresh. */
   extraButtons?: Array<{ command: string; label: string; title: string }>;
   /** Already-built body HTML (caller is responsible for escaping). */
@@ -169,7 +176,8 @@ ${WARN_BLOCK_CSS}
   <div id="cmp-toolbar">
     <span class="cmp-title">${escXml(opts.title)}</span>
     ${opts.subtitle ? `<span class="cmp-subtitle">${escXml(opts.subtitle)}</span>` : ''}
-    <span class="cmp-toolbar-actions">${(opts.extraButtons ?? []).map(b => `<a href="command:${b.command}" class="cmp-btn" title="${escXml(b.title)}">${escXml(b.label)}</a>`).join('')}<a href="command:${opts.refreshCommand}" class="cmp-btn" title="Re-scan the workspace">Refresh</a></span>
+    ${(opts.filename || opts.date) ? `<span class="cmp-meta">${[opts.filename ? escXml(opts.filename) : '', opts.date ? `Generated: ${escXml(opts.date)}` : ''].filter(Boolean).join(' · ')}</span>` : ''}
+    <span class="cmp-toolbar-actions">${(opts.extraButtons ?? []).map(b => `<a href="command:${b.command}" class="cmp-btn" title="${escXml(b.title)}">${escXml(b.label)}</a>`).join('')}${opts.themeCommand ? `<a href="command:${opts.themeCommand}" class="cmp-btn" title="Change the color scheme for all diagram previews">Theme…</a>` : ''}<a href="command:${opts.refreshCommand}" class="cmp-btn" title="Re-scan the workspace">Refresh</a></span>
     ${opts.confidence ? confidenceLineHtml(opts.confidence) : ''}
   </div>
   ${errBlock}${warnBlock}

--- a/extension/src/coverage-metric-preview.ts
+++ b/extension/src/coverage-metric-preview.ts
@@ -151,7 +151,7 @@ export class CoverageMetricPreview {
         {
           enableScripts: false,
           retainContextWhenHidden: true,
-          enableCommandUris: [OPEN_FILE_COMMAND, REFRESH_COMMAND],
+          enableCommandUris: [OPEN_FILE_COMMAND, REFRESH_COMMAND, 'transitrixStudio.changeTheme'],
         },
       );
       this.panel.onDidDispose(() => {
@@ -168,6 +168,12 @@ export class CoverageMetricPreview {
     if (this.panel && this.trackedUri === doc.uri.toString()) {
       await this.pushDocument(doc);
     }
+  }
+
+  async refreshConfig(): Promise<void> {
+    if (!this.panel || !this.trackedUri) return;
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.parse(this.trackedUri));
+    await this.pushDocument(doc);
   }
 
   private async pushDocument(doc: vscode.TextDocument): Promise<void> {
@@ -235,6 +241,7 @@ export class CoverageMetricPreview {
       '  <div id="cm-toolbar">\n' +
       `    <div class="cm-title">${titleLine}</div>\n` +
       (subtitleLine ? `    <div class="cm-subtitle">${subtitleLine}</div>\n` : '') +
+      `    <a href="command:transitrixStudio.changeTheme" class="cm-btn" title="Change the color scheme for all diagram previews">Theme…</a>\n` +
       `    <a href="command:${REFRESH_COMMAND}" class="cm-btn" title="Re-scan the workspace and reload">Refresh</a>\n` +
       '  </div>\n' +
       errBlock +

--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -4,6 +4,9 @@ import { CONTROLS_PANEL_CSS } from './preview-controls.js';
 
 export type { ThemeId };
 
+/** Command ID for the "Theme…" toolbar button — opens a QuickPick to change the global diagram theme. */
+export const OPEN_THEME_COMMAND = 'transitrixStudio.changeTheme';
+
 /**
  * Injects a <style> block with all --ts-* CSS variable definitions into an SVG string,
  * making it self-contained for file export (no external stylesheet required).
@@ -92,6 +95,18 @@ export interface DiagramFrameOpts {
    */
   scopeCommand?: string;
   /**
+   * Command ID for the "Theme…" toolbar button (opens a QuickPick to change the global
+   * `transitrix.theme` setting). Pass `OPEN_THEME_COMMAND` from all diagram previews.
+   * The preview's webview must include this command in `enableCommandUris`.
+   */
+  themeCommand?: string;
+  /**
+   * When true, adds a "Legend" toggle button to the toolbar (CSS-only, no scripts).
+   * The SVG must wrap its legend elements in `<g class="diagram-legend-col">`.
+   * Follows the same pattern as the title toggle (TX-R009).
+   */
+  legendToggle?: boolean;
+  /**
    * Opt-in to in-preview interactive controls (vkgeorgia/strategy#75/#76/#77 —
    * PR2). When present, the frame switches from the script-less static CSP to a
    * strict nonce-based CSP (`default-src 'none'; style-src 'unsafe-inline';
@@ -127,7 +142,7 @@ function escXml(s: string): string {
  */
 const FIX_PROMPT_CSS = `
 .fix-prompt-wrap {
-  margin: 8px 16px 12px;
+  margin: 8px 16px 0;
   border-left: 3px solid var(--vscode-editorWarning-foreground, #c07030);
   padding-left: 12px;
 }
@@ -171,7 +186,7 @@ const FIX_PROMPT_CSS = `
 // sibling combinator reaches the strip wherever it renders.
 export const ERROR_BLOCK_CSS = `
 .tx-err-toggle-cb{position:absolute;left:-9999px;width:1px;height:1px;opacity:0;}
-.tx-err{margin:8px 16px;border:1px solid var(--vscode-inputValidation-errorBorder,var(--vscode-errorForeground,#b91c1c));border-radius:6px;}
+.tx-err{margin:8px 16px 0;border:1px solid var(--vscode-inputValidation-errorBorder,var(--vscode-errorForeground,#b91c1c));border-radius:6px;}
 .tx-err-summary{display:block;cursor:pointer;user-select:none;padding:6px 10px;font-size:12px;font-weight:600;color:var(--vscode-errorForeground,#b91c1c);}
 .tx-err-summary::before{content:"\\25BE\\00a0";}
 .tx-err-toggle-cb:checked ~ .tx-err .tx-err-summary::before{content:"\\25B8\\00a0";}
@@ -188,7 +203,7 @@ export const ERROR_BLOCK_CSS = `
 // summary and the user expands to read.
 export const WARN_BLOCK_CSS = `
 .tx-warn-toggle-cb{position:absolute;left:-9999px;width:1px;height:1px;opacity:0;}
-.tx-warn{margin:8px 16px;border:1px solid var(--vscode-editorWarning-foreground,#c07030);border-radius:6px;}
+.tx-warn{margin:8px 16px 0;border:1px solid var(--vscode-editorWarning-foreground,#c07030);border-radius:6px;}
 .tx-warn-summary{display:block;cursor:pointer;user-select:none;padding:6px 10px;font-size:12px;font-weight:600;color:var(--vscode-editorWarning-foreground,#c07030);}
 .tx-warn-summary::before{content:"\\25BE\\00a0";}
 .tx-warn-toggle-cb:checked ~ .tx-warn .tx-warn-summary::before{content:"\\25B8\\00a0";}
@@ -282,6 +297,12 @@ const TITLE_TOGGLE_CSS = `
    .text-secondary from the shared theme so the typography matches. */
 .diagram-title-block-html { margin: 0 16px 12px; }
 .diagram-title-block-html div { line-height: 16px; }
+
+/* Legend column toggle (optional, opt-in via legendToggle). Checkbox drives
+   show/hide for <g class="diagram-legend-col"> inside the SVG canvas. Same
+   script-free checkbox+label+:checked~ pattern as the title toggle. */
+.legend-toggle-cb { position: absolute; left: -9999px; width: 1px; height: 1px; opacity: 0; }
+.legend-toggle-cb:not(:checked) ~ #canvas .diagram-legend-col { display: none; }
 `;
 
 /**
@@ -377,8 +398,8 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
     errorMsg = '', warnings = [],
     themeId = 'transitrix', extraStyles = '', fixPrompt = '',
     title, subtitle, version, date,
-    saveSvgCommand, savePngCommand, copyPngCommand, spacingCommand, curvatureCommand, scopeCommand,
-    interactive,
+    saveSvgCommand, savePngCommand, copyPngCommand, spacingCommand, curvatureCommand, scopeCommand, themeCommand,
+    interactive, legendToggle,
   } = opts;
 
   const canvasContent = bodyContent ?? svgContent;
@@ -410,7 +431,7 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
   // COLLAPSED (checkbox `checked`) — advisories shouldn't crowd the canvas.
   const { input: warnToggleInput, block: warnBlock } = buildWarnHtml(warnings);
 
-  const metaParts = [version ? `v${escXml(version)}` : null, date ? escXml(date) : null].filter(Boolean);
+  const metaParts = date ? [`Generated: ${escXml(date)}`] : [];
   const headerBlock = title
     ? `<div class="frame-header">
   <div class="frame-title">${escXml(title)}</div>
@@ -437,10 +458,15 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
   const showSpacing = Boolean(spacingCommand);
   const showCurvature = Boolean(curvatureCommand);
   const showScope = Boolean(scopeCommand);
+  const showTheme = Boolean(themeCommand);
   // Zoom control gates on the same signal as Save .svg — the six vector
   // previews opt in by passing a saveSvgCommand. HTML catalogues are out of
   // scope per the orchestrator's call on issue #30.
   const showZoom = Boolean(canvasContent) && Boolean(saveSvgCommand);
+  const showLegendToggle = Boolean(legendToggle);
+  const legendToggleInput = showLegendToggle
+    ? `<input type="checkbox" id="ts-legend-toggle" class="legend-toggle-cb" checked>`
+    : '';
   const toggleInput = showToggle
     ? `<input type="checkbox" id="ts-title-toggle" class="title-toggle-cb" checked>`
     : '';
@@ -457,6 +483,9 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
   }
   if (showToggle) {
     actionParts.push(`<label for="ts-title-toggle" class="title-toggle" title="Show or hide the diagram title">Title</label>`);
+  }
+  if (showLegendToggle) {
+    actionParts.push(`<label for="ts-legend-toggle" class="title-toggle" title="Show or hide the legend column">Legend</label>`);
   }
   if (showZoom) {
     actionParts.push(`<div class="zoom-control" title="Zoom level"><label for="z-50" class="zoom-label">50%</label><label for="z-75" class="zoom-label">75%</label><label for="z-100" class="zoom-label">100%</label><label for="z-150" class="zoom-label">150%</label><label for="z-200" class="zoom-label">200%</label></div>`);
@@ -478,6 +507,9 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
   }
   if (showScope) {
     actionParts.push(`<a href="command:${escXml(scopeCommand!)}" class="toolbar-btn" title="Scope this preview to a level cap or a single goal's subtree in Settings">Scope…</a>`);
+  }
+  if (showTheme) {
+    actionParts.push(`<a href="command:${escXml(themeCommand!)}" class="toolbar-btn" title="Change the color scheme for all diagram previews">Theme…</a>`);
   }
   const toolbarRight = actionParts.length > 0
     ? `<div class="toolbar-actions">${actionParts.join('')}</div>`
@@ -511,6 +543,7 @@ ${extraStyles}
   </style>
 </head>
 <body data-theme="${escXml(themeId)}">
+  ${legendToggleInput}
   ${toggleInput}
   ${zoomInputs}
   ${errToggleInput}

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -39,6 +39,7 @@ import {
   SCOPE_CONFIG_SECTION,
   VIEW_CONFIG_SECTION,
 } from './spacing-config.js';
+import { OPEN_THEME_COMMAND } from './diagram-frame.js';
 
 function isGoalsFile(doc: vscode.TextDocument): boolean {
   return doc.fileName.endsWith('.goals.transitrix.yaml');
@@ -396,13 +397,29 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     vscode.commands.registerCommand(OPEN_SCOPE_SETTINGS_COMMAND, () =>
       vscode.commands.executeCommand('workbench.action.openSettings', SCOPE_CONFIG_SECTION),
     ),
-    // Re-render the spacing/curvature/scope-aware previews when a gap, curvature
-    // or scope setting changes — the settings-driven persistence mechanism
-    // (vkgeorgia/strategy#75, #76, #77). Config is the single source of truth:
+    vscode.commands.registerCommand(OPEN_THEME_COMMAND, async () => {
+      const cfg = vscode.workspace.getConfiguration('transitrix');
+      const current = cfg.get<string>('theme', 'transitrix');
+      const items = [
+        { label: 'Transitrix Light', description: 'Default light theme', value: 'transitrix' },
+        { label: 'Transitrix Dark', description: 'Dark theme', value: 'transitrix-dark' },
+        { label: 'VS Code Adaptive', description: 'Follow the active VS Code color theme', value: 'vscode-adaptive' },
+      ].map(i => ({ ...i, label: (i.value === current ? '$(check) ' : '          ') + i.label }));
+      const picked = await vscode.window.showQuickPick(items, {
+        title: 'Transitrix Diagram Theme',
+        placeHolder: 'Select color scheme for all diagram previews',
+      });
+      if (!picked) return;
+      await cfg.update('theme', picked.value, vscode.ConfigurationTarget.Workspace);
+    }),
+    // Re-render the spacing/curvature/scope-aware previews when a gap, curvature,
+    // scope, or theme setting changes. Config is the single source of truth:
     // both the in-preview controls (PR2) and the "…" Settings links write here,
     // and this handler rebuilds the webview HTML from the tracked document.
     vscode.workspace.onDidChangeConfiguration((e) => {
+      const isThemeChange = e.affectsConfiguration('transitrix.theme');
       if (
+        !isThemeChange &&
         !e.affectsConfiguration(SPACING_CONFIG_SECTION) &&
         !e.affectsConfiguration(CURVATURE_CONFIG_SECTION) &&
         !e.affectsConfiguration(ENTRY_CURVATURE_CONFIG_SECTION) &&
@@ -413,6 +430,22 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       void fgcaPreview.refreshConfig();
       void fgaPreview.refreshConfig();
       void activitiesPreview.refreshConfig();
+      if (isThemeChange) {
+        void blocksPreview.refreshConfig();
+        void processBlueprintPreview.refreshConfig();
+        void activityCardPreview.refreshConfig();
+        void applicationsPreview.refreshConfig();
+        void productsPreview.refreshConfig();
+        void processMapPreview.refreshConfig();
+        void scenariosPreview.refreshConfig();
+        void capabilityMapPreview.refreshConfig();
+        void complianceMatrixPreview.refresh();
+        void complianceImpactPreview.refresh();
+        void singleLawPreview.refresh();
+        void singleProductPreview.refresh();
+        void gapDashboardPreview.refresh();
+        void coverageMetricPreview.refreshConfig();
+      }
     }),
     vscode.workspace.onDidSaveTextDocument((doc) => {
       // Multi-document: an open Activity Card re-resolves when any canon

--- a/extension/src/fgca-preview.ts
+++ b/extension/src/fgca-preview.ts
@@ -1,7 +1,7 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
-import { buildDiagramFrame, prepareSvgForExport, type ThemeId } from './diagram-frame.js';
+import { buildDiagramFrame, prepareSvgForExport, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
 import { TITLE_BLOCK_H, titleBlockSvg, todayIso } from './svg-title-block.js';
 import { loadCanon, findCanonRoot, isUnderCanon, type CanonDocs } from './canon-loader.js';
 import { parseCanonicalFGCA, parseCanonicalFGA } from '../../packages/diagrams/src/fgca/parse-canonical.js';
@@ -214,6 +214,7 @@ function renderChainPreview(
     spacingCommand: OPEN_SPACING_SETTINGS_COMMAND,
     curvatureCommand: OPEN_CURVATURE_SETTINGS_COMMAND,
     scopeCommand: OPEN_SCOPE_SETTINGS_COMMAND,
+    themeCommand: OPEN_THEME_COMMAND,
     interactive: { nonce, controlsPanel: buildControlsPanel(model), controlsScript: script, viewToggleHtml },
   });
   return { html, svg };
@@ -326,7 +327,7 @@ export class FGCAPreview {
           enableScripts: true,
           retainContextWhenHidden: true,
           localResourceRoots: [vscode.Uri.joinPath(this.extensionUri, 'media')],
-          enableCommandUris: ['transitrixStudio.saveFGCAAsSvg', 'transitrixStudio.saveFGCAAsPng', 'transitrixStudio.copyFGCAAsPng', OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND],
+          enableCommandUris: ['transitrixStudio.saveFGCAAsSvg', 'transitrixStudio.saveFGCAAsPng', 'transitrixStudio.copyFGCAAsPng', OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND, OPEN_THEME_COMMAND],
         },
       );
       this.panel.webview.onDidReceiveMessage((m) => { void applyControlMessage('fgca', m); });
@@ -478,7 +479,7 @@ export class FGAPreview {
           enableScripts: true,
           retainContextWhenHidden: true,
           localResourceRoots: [vscode.Uri.joinPath(this.extensionUri, 'media')],
-          enableCommandUris: ['transitrixStudio.saveFGAAsSvg', 'transitrixStudio.saveFGAAsPng', 'transitrixStudio.copyFGAAsPng', OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND],
+          enableCommandUris: ['transitrixStudio.saveFGAAsSvg', 'transitrixStudio.saveFGAAsPng', 'transitrixStudio.copyFGAAsPng', OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND, OPEN_THEME_COMMAND],
         },
       );
       this.panel.webview.onDidReceiveMessage((m) => { void applyControlMessage('fga', m); });

--- a/extension/src/gap-dashboard-preview.ts
+++ b/extension/src/gap-dashboard-preview.ts
@@ -36,7 +36,7 @@ export class GapDashboardPreview {
         'gapDashboardPreview',
         this.panelTitle,
         { viewColumn: vscode.ViewColumn.Active, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: [OPEN_FILE_COMMAND, REFRESH_COMMAND, EXPORT_CSV_COMMAND] },
+        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: [OPEN_FILE_COMMAND, REFRESH_COMMAND, EXPORT_CSV_COMMAND, 'transitrixStudio.changeTheme'] },
       );
       this.panel.onDidDispose(() => { this.panel = undefined; this.lastReport = undefined; });
     } else {
@@ -131,8 +131,10 @@ export class GapDashboardPreview {
     return complianceShell({
       title: 'Compliance Gap Dashboard',
       subtitle: total === 0 ? 'No gaps found' : `${total} gap(s) across 4 checks`,
+      date: todayIso(),
       themeId,
       refreshCommand: REFRESH_COMMAND,
+      themeCommand: 'transitrixStudio.changeTheme',
       extraButtons: [{ command: EXPORT_CSV_COMMAND, label: 'Export CSV', title: 'Save the gap report as a CSV file' }],
       bodyHtml: body,
       confidence: this.lastConfidence,

--- a/extension/src/goals-preview.ts
+++ b/extension/src/goals-preview.ts
@@ -1,7 +1,7 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
-import { buildDiagramFrame, prepareSvgForExport, type ThemeId } from './diagram-frame.js';
+import { buildDiagramFrame, prepareSvgForExport, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
 import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
 import { TITLE_BLOCK_H, titleBlockSvg, todayIso } from './svg-title-block.js';
 import {
@@ -121,7 +121,7 @@ export class GoalsPreview {
           enableScripts: true,
           retainContextWhenHidden: true,
           localResourceRoots: [vscode.Uri.joinPath(this.extensionUri, 'media')],
-          enableCommandUris: ['transitrixStudio.saveGoalsAsSvg', 'transitrixStudio.saveGoalsAsPng', 'transitrixStudio.copyGoalsAsPng', OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND],
+          enableCommandUris: ['transitrixStudio.saveGoalsAsSvg', 'transitrixStudio.saveGoalsAsPng', 'transitrixStudio.copyGoalsAsPng', OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND, OPEN_THEME_COMMAND],
         },
       );
       this.panel.webview.onDidReceiveMessage((m) => { void applyControlMessage('goals', m); });
@@ -216,6 +216,7 @@ export class GoalsPreview {
       spacingCommand: OPEN_SPACING_SETTINGS_COMMAND,
       curvatureCommand: OPEN_CURVATURE_SETTINGS_COMMAND,
       scopeCommand: OPEN_SCOPE_SETTINGS_COMMAND,
+      themeCommand: OPEN_THEME_COMMAND,
       interactive: { nonce, controlsPanel: buildControlsPanel(model), controlsScript: buildControlsScript(nonce) },
     });
   }

--- a/extension/src/preview-controls.ts
+++ b/extension/src/preview-controls.ts
@@ -110,7 +110,7 @@ function escXml(s: string): string {
 
 /** CSS for the control panel — injected into the frame's <style> only when interactive. */
 export const CONTROLS_PANEL_CSS = `
-.tx-ctl { margin: 0 16px 8px; font-size: 11px; color: var(--ts-text-muted, #64748b); border: 1px solid var(--ts-border, #cbd5e1); border-radius: 6px; }
+.tx-ctl { margin: 8px 16px 0; font-size: 11px; color: var(--ts-text-muted, #64748b); border: 1px solid var(--ts-border, #cbd5e1); border-radius: 6px; }
 .tx-ctl > summary { cursor: pointer; user-select: none; padding: 5px 10px; font-weight: 600; list-style: none; }
 .tx-ctl > summary::-webkit-details-marker { display: none; }
 .tx-ctl > summary::before { content: "\\25B8\\00a0"; }

--- a/extension/src/process-blueprint-preview.ts
+++ b/extension/src/process-blueprint-preview.ts
@@ -1,7 +1,7 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
-import { buildDiagramFrame, prepareSvgForExport, type ThemeId } from './diagram-frame.js';
+import { buildDiagramFrame, prepareSvgForExport, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
 import { TITLE_BLOCK_H, titleBlockSvg, todayIso } from './svg-title-block.js';
 import {
   validateProcessBlueprint,
@@ -12,6 +12,7 @@ import {
   type LaneConfig,
   type ProcessBlueprintFile,
   type ProcessBlueprintLayout,
+  type RowId,
 } from '../../packages/diagrams/src/process-blueprint/index.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
@@ -79,7 +80,6 @@ function complianceChipSvg(
       `<text class="compliance-badge-text" x="${bx}" y="${by}" text-anchor="middle" dominant-baseline="central">!</text>`,
     );
   }
-  // Wrap in a <g> so the chip is a single click target with drill-down data attributes.
   return `<g data-chip-law="${escXml(lawId)}" data-chip-stage="${escXml(stageId)}">\n${parts.join('\n')}\n</g>`;
 }
 
@@ -87,93 +87,133 @@ function layoutToSvg(layout: ProcessBlueprintLayout, filename?: string, date?: s
   const pad = 24;
   const showTitle = filename != null && date != null;
   const titleH = showTitle ? TITLE_BLOCK_H : 0;
-  const w = layout.bounds.width + pad * 2;
-  const h = layout.bounds.height + pad * 2 + titleH;
+  const tw = layout.bounds.width;
+  const th = layout.bounds.height;
+  const w = tw + pad * 2;
+  const h = th + pad * 2 + titleH;
   const ox = pad;
   const oy = pad + titleH;
+  const clipId = 'bp-clip';
 
   const parts: string[] = [];
+  // Pills and chips collected separately so they render after (on top of) grid lines.
+  const topParts: string[] = [];
 
+  // Outer background (fill only; border drawn last on top).
   parts.push(
-    `<rect class="diagram-node level-0" x="${ox}" y="${oy}" width="${layout.bounds.width}" height="${layout.bounds.height}" rx="6"/>`,
+    `<rect class="diagram-node level-0 bp-row-bg" x="${ox}" y="${oy}" width="${tw}" height="${th}" rx="6" stroke="none"/>`,
   );
 
+  // ClipPath — clips all inner content to the outer rounded rect so corner cells
+  // don't visually overflow the rx=6 boundary.
+  parts.push(`<defs><clipPath id="${clipId}"><rect x="${ox}" y="${oy}" width="${tw}" height="${th}" rx="6"/></clipPath></defs>`);
+
+  const inner: string[] = [];
+
+  // Stage headers (top row).
   for (const s of layout.stageHeaders) {
-    parts.push(
-      `<rect class="diagram-node level-1" x="${s.x + ox}" y="${s.y + oy}" width="${s.width}" height="${s.height}"/>`,
+    inner.push(
+      `<rect class="diagram-node level-1" x="${s.x + ox}" y="${s.y + oy}" width="${s.width}" height="${s.height}" stroke="none"/>`,
     );
-    parts.push(
+    inner.push(
       `<text class="text-header" x="${s.x + ox + s.width / 2}" y="${s.y + oy + s.height / 2}" text-anchor="middle" dominant-baseline="central">${escXml(truncate(s.name, 28))}</text>`,
     );
   }
 
+  // Legend column (row labels).
   for (const l of layout.legend) {
-    parts.push(
-      `<rect class="diagram-node level-2" x="${ox}" y="${l.y + oy}" width="${layout.legendColumnWidth}" height="${l.height}"/>`,
+    inner.push(
+      `<rect class="diagram-node level-2 bp-row-bg" x="${ox}" y="${l.y + oy}" width="${layout.legendColumnWidth}" height="${l.height}" stroke="none"/>`,
     );
-    parts.push(
+    inner.push(
       `<text class="text-primary" x="${ox + 12}" y="${l.y + oy + l.height / 2}" dominant-baseline="central">${escXml(l.label)}</text>`,
     );
   }
 
+  // Goal and result cells.
   const textX = layout.cellTextPadX;
   for (const c of layout.goalCells) {
-    parts.push(
-      `<rect class="diagram-node level-3" x="${c.x + ox}" y="${c.y + oy}" width="${c.width}" height="${c.height}"/>`,
+    inner.push(
+      `<rect class="diagram-node level-3 bp-row-bg" x="${c.x + ox}" y="${c.y + oy}" width="${c.width}" height="${c.height}" stroke="none"/>`,
     );
-    parts.push(
-      textCellSvg(c.lines, 'text-secondary', c.x + ox + textX, c.y + oy, c.height, layout.textLineHeight),
-    );
+    inner.push(textCellSvg(c.lines, 'text-secondary', c.x + ox + textX, c.y + oy, c.height, layout.textLineHeight));
   }
   for (const c of layout.resultCells) {
-    parts.push(
-      `<rect class="diagram-node level-4" x="${c.x + ox}" y="${c.y + oy}" width="${c.width}" height="${c.height}"/>`,
+    inner.push(
+      `<rect class="diagram-node level-4 bp-row-bg" x="${c.x + ox}" y="${c.y + oy}" width="${c.width}" height="${c.height}" stroke="none"/>`,
     );
-    parts.push(
-      textCellSvg(c.lines, 'text-secondary', c.x + ox + textX, c.y + oy, c.height, layout.textLineHeight),
-    );
+    inner.push(textCellSvg(c.lines, 'text-secondary', c.x + ox + textX, c.y + oy, c.height, layout.textLineHeight));
   }
 
+  // Aspect rows — transparent background; pills carry the colour.
   for (let r = 0; r < layout.aspectRows.length; r++) {
     const row = layout.aspectRows[r];
     const level = 5 + (r % 3);
-    parts.push(
-      `<rect class="diagram-node level-${level}" x="${layout.legendColumnWidth + ox}" y="${row.y + oy}" width="${layout.bounds.width - layout.legendColumnWidth}" height="${row.height}" opacity="0.15"/>`,
+    inner.push(
+      `<rect class="diagram-node level-${level} bp-row-bg" x="${layout.legendColumnWidth + ox}" y="${row.y + oy}" width="${tw - layout.legendColumnWidth}" height="${row.height}" stroke="none"/>`,
     );
-    for (let i = 1; i < layout.stageHeaders.length; i++) {
-      const x = layout.legendColumnWidth + i * layout.stageColumnWidth + ox;
-      parts.push(
-        `<line class="diagram-edge" x1="${x}" y1="${row.y + oy}" x2="${x}" y2="${row.y + row.height + oy}" opacity="0.3"/>`,
-      );
-    }
     for (const p of row.pills) {
-      parts.push(
+      const cx = p.x + ox + p.width / 2;
+      const pillLH = 15;
+      // p.lines: name lines (possibly wrapped), optionally with id as last line.
+      const hasIdLine = !!(p.id && p.lines.length > 0 && p.lines[p.lines.length - 1] === p.id);
+      const nameLines = hasIdLine ? p.lines.slice(0, -1) : p.lines;
+      const idLine = hasIdLine ? p.id : undefined;
+      const pillFirstY = p.y + oy + p.height / 2 - ((p.lines.length - 1) / 2) * pillLH;
+      topParts.push(
         `<rect class="diagram-node level-${level}" x="${p.x + ox}" y="${p.y + oy}" width="${p.width}" height="${p.height}" rx="6"/>`,
       );
-      const label = p.id ? `${p.name} · ${p.id}` : p.name;
-      parts.push(
-        `<text class="text-pill" x="${p.x + ox + p.width / 2}" y="${p.y + oy + p.height / 2}" text-anchor="middle" dominant-baseline="central">${escXml(truncate(label, Math.floor(p.width / 8)))}</text>`,
-      );
+      if (nameLines.length > 0) {
+        const tspans = nameLines
+          .map((ln, i) => `<tspan x="${cx}" y="${pillFirstY + i * pillLH}">${escXml(ln)}</tspan>`)
+          .join('');
+        topParts.push(`<text class="text-pill" text-anchor="middle" dominant-baseline="central">${tspans}</text>`);
+      }
+      if (idLine) {
+        topParts.push(
+          `<text class="text-secondary" x="${cx}" y="${pillFirstY + nameLines.length * pillLH}" text-anchor="middle" dominant-baseline="central">${escXml(idLine)}</text>`,
+        );
+      }
     }
   }
 
   // Compliance row (optional).
   if (layout.complianceRow) {
     const row = layout.complianceRow;
-    parts.push(
-      `<rect class="diagram-node level-5" x="${layout.legendColumnWidth + ox}" y="${row.y + oy}" width="${layout.bounds.width - layout.legendColumnWidth}" height="${row.height}" opacity="0.10"/>`,
+    inner.push(
+      `<rect class="diagram-node level-5 bp-row-bg" x="${layout.legendColumnWidth + ox}" y="${row.y + oy}" width="${tw - layout.legendColumnWidth}" height="${row.height}" stroke="none"/>`,
     );
-    for (let i = 1; i < layout.stageHeaders.length; i++) {
-      const x = layout.legendColumnWidth + i * layout.stageColumnWidth + ox;
-      parts.push(
-        `<line class="diagram-edge" x1="${x}" y1="${row.y + oy}" x2="${x}" y2="${row.y + row.height + oy}" opacity="0.3"/>`,
-      );
-    }
     for (const chip of row.chips) {
       const stageId = layout.stageHeaders[chip.stageIndex]?.id ?? '';
-      parts.push(complianceChipSvg(chip, ox, oy, stageId));
+      topParts.push(complianceChipSvg(chip, ox, oy, stageId));
     }
   }
+
+  // Grid lines — drawn before pills so they appear under pill content.
+  const gridX1 = ox;
+  const gridX2 = ox + tw;
+  const gridY1 = oy;
+  const gridY2 = oy + th;
+  if (layout.legend.length > 0) {
+    const headerBottomY = oy + layout.legend[0].y;
+    inner.push(`<line class="bp-grid-line" x1="${gridX1}" y1="${headerBottomY}" x2="${gridX2}" y2="${headerBottomY}"/>`);
+    for (let i = 0; i < layout.legend.length - 1; i++) {
+      const rowBottomY = oy + layout.legend[i].y + layout.legend[i].height;
+      inner.push(`<line class="bp-grid-line" x1="${gridX1}" y1="${rowBottomY}" x2="${gridX2}" y2="${rowBottomY}"/>`);
+    }
+  }
+  const legLineX = ox + layout.legendColumnWidth;
+  inner.push(`<line class="bp-grid-line" x1="${legLineX}" y1="${gridY1}" x2="${legLineX}" y2="${gridY2}"/>`);
+  for (let i = 1; i < layout.stageHeaders.length; i++) {
+    const stageLineX = ox + layout.legendColumnWidth + i * layout.stageColumnWidth;
+    inner.push(`<line class="bp-grid-line" x1="${stageLineX}" y1="${gridY1}" x2="${stageLineX}" y2="${gridY2}"/>`);
+  }
+
+  // Inner content (fills + grid lines) clipped to rounded outer rect.
+  parts.push(`<g clip-path="url(#${clipId})">${inner.join('\n')}${topParts.join('\n')}</g>`);
+
+  // Outer border on top (fill: none; stroke from theme).
+  parts.push(`<rect class="bp-border" x="${ox}" y="${oy}" width="${tw}" height="${th}" rx="6"/>`);
 
   const titleSvg = showTitle ? titleBlockSvg('Process Blueprint', filename!, date!, pad, pad, version) : '';
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">
@@ -257,6 +297,46 @@ const CHIP_DETAIL_PANEL_HTML = `
   <div id="tx-chip-content" class="tx-chip-content"></div>
 </div>`;
 
+const CHIP_LEGEND_HTML = `
+<div id="bp-chip-legend">
+  <span class="bp-chip-legend-heading">Legend</span>
+  <span class="bp-chip-legend-item">
+    <svg class="bp-chip-legend-svg" xmlns="http://www.w3.org/2000/svg" width="62" height="22">
+      <rect class="diagram-node level-5 compliance-chip" x="1" y="1" width="60" height="20" rx="5"/>
+      <text class="text-pill" x="31" y="11" text-anchor="middle" dominant-baseline="central">LAW-001</text>
+    </svg>
+    Compliant
+  </span>
+  <span class="bp-chip-legend-item">
+    <svg class="bp-chip-legend-svg" xmlns="http://www.w3.org/2000/svg" width="62" height="22">
+      <rect class="diagram-node level-5 compliance-chip" x="1" y="1" width="60" height="20" rx="5" stroke-dasharray="4 2"/>
+      <text class="text-pill" x="31" y="11" text-anchor="middle" dominant-baseline="central">LAW-002</text>
+    </svg>
+    New since last report
+  </span>
+  <span class="bp-chip-legend-item">
+    <svg class="bp-chip-legend-svg" xmlns="http://www.w3.org/2000/svg" width="62" height="22">
+      <rect class="diagram-node level-5 compliance-chip compliance-gap" x="1" y="1" width="60" height="20" rx="5"/>
+      <text class="text-pill" x="31" y="11" text-anchor="middle" dominant-baseline="central">LAW-003</text>
+    </svg>
+    Compliance gap
+  </span>
+  <span class="bp-chip-legend-item">
+    <svg class="bp-chip-legend-svg" xmlns="http://www.w3.org/2000/svg" width="62" height="22">
+      <rect class="diagram-node level-5 compliance-chip compliance-deadline" x="1" y="1" width="60" height="20" rx="5"/>
+      <text class="text-pill" x="31" y="11" text-anchor="middle" dominant-baseline="central">LAW-004</text>
+      <circle class="compliance-badge" cx="56" cy="6" r="5"/>
+      <text class="compliance-badge-text" x="56" y="6" text-anchor="middle" dominant-baseline="central">!</text>
+    </svg>
+    Deadline risk
+  </span>
+</div>`;
+
+// Outer border-only rect rendered on top of the clipped inner content.
+const BLUEPRINT_CSS = `
+.bp-border { fill: none; stroke: var(--ts-border, #cbd5e1); stroke-width: 1; }
+`;
+
 const CHIP_DETAIL_CSS = `
 [data-chip-law] { cursor: pointer; }
 .tx-chip-panel {
@@ -287,67 +367,119 @@ const CHIP_DETAIL_CSS = `
 .tx-chip-status-under-review, .tx-chip-status-pending-owner { background: var(--ts-status-info-bg, #e0f2fe); color: var(--ts-status-info-fg, #0c4a6e); }
 .tx-chip-status-n-a { background: var(--ts-bg-elevated, #f1f5f9); color: var(--ts-text-muted, #64748b); }
 .tx-chip-empty { color: var(--ts-text-muted, #64748b); font-size: 12px; padding: 4px 0; }
+.bp-row-bg { fill: none; }
+.bp-legend-btn::before { content: '\\2611\\00a0'; font-size: 12px; }
+.bp-legend-btn.bp-hidden::before { content: '\\2610\\00a0'; font-size: 12px; }
+.bp-legend-hidden #bp-chip-legend { display: none; }
+#bp-chip-legend {
+  display: flex; align-items: center; flex-wrap: wrap; gap: 8px 20px;
+  padding: 8px 24px;
+  font-size: 12px; color: var(--ts-text, #0f172a);
+  border-top: 1px solid var(--ts-border, #e2e8f0);
+  background: var(--ts-bg, #fff);
+}
+.bp-chip-legend-heading {
+  font-size: 10px; font-weight: 700; text-transform: uppercase;
+  letter-spacing: 0.06em; color: var(--ts-text-muted, #94a3b8); margin-right: 4px;
+}
+.bp-chip-legend-item { display: flex; align-items: center; gap: 6px; }
+.bp-chip-legend-svg { display: block; flex-shrink: 0; overflow: visible; }
 `;
 
-function buildChipDetailScript(nonce: string, chipData: Record<string, ChipDetail>): string {
+function buildDisplayControls(
+  rows: Array<{ id: string; label: string; hidden: boolean }>,
+  columns: Array<{ id: string; label: string; hidden: boolean }>,
+  stageColumnWidth: number,
+): string {
+  function chk(toggle: string, id: string, hidden: boolean, label: string): string {
+    return `<label><input type="checkbox" data-bp-toggle="${escXml(toggle)}" data-bp-id="${escXml(id)}"${hidden ? '' : ' checked'}> ${escXml(label)}</label>`;
+  }
+  const rowHtml = rows.map(r => chk('row', r.id, r.hidden, r.label)).join(' ');
+  const colHtml = columns.map(c => chk('column', c.id, c.hidden, c.label.length > 22 ? c.label.slice(0, 21) + '…' : c.label)).join(' ');
+  return `<details class="tx-ctl" id="tx-bp-ctl">
+  <summary>Display</summary>
+  <div class="tx-ctl-body">
+    <div class="tx-ctl-row"><span class="tx-ctl-label">Rows</span>${rowHtml}</div>
+    <div class="tx-ctl-row"><span class="tx-ctl-label">Columns</span>${colHtml}</div>
+    <div class="tx-ctl-row">
+      <span class="tx-ctl-label">Col width</span>
+      <input type="range" id="tx-bp-col-w-range" min="100" max="450" step="10" value="${stageColumnWidth}">
+      <output id="tx-bp-col-w-out">${stageColumnWidth}</output>px
+    </div>
+  </div>
+</details>`;
+}
+
+function buildBlueprintScript(nonce: string, chipData: Record<string, ChipDetail>): string {
   const safeJson = JSON.stringify(chipData).replace(/<\//g, '<\\/');
   return `<script nonce="${nonce}">
-(function () {
-  var data = ${safeJson};
-  var panel = document.getElementById('tx-chip-panel');
-  var content = document.getElementById('tx-chip-content');
-  var closeBtn = document.getElementById('tx-chip-close');
-  if (!panel || !content) return;
-  function esc(s) {
-    return String(s)
-      .replace(/&/g, '&amp;').replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-  }
-  var STATUS_LABEL = {
-    compliant: '\\u2713 Compliant', partial: '\\u007e Partial',
-    non_compliant: '\\u2717 Non-compliant', under_review: '\\u2299 Under review',
-    pending_owner: '\\u2299 Pending owner', n_a: '\\u2014 N/A'
-  };
-  function statusCls(s) { return 'tx-chip-status tx-chip-status-' + s.replace(/_/g, '-'); }
-  function renderDetail(d) {
-    var html = '<span class="tx-chip-law-heading">' + esc(d.lawId) + '<\\/span>'
-             + '<span class="tx-chip-stage-label">\\u00b7 Stage: ' + esc(d.stageName) + '<\\/span>';
-    if (!d.items || d.items.length === 0) {
-      html += '<div class="tx-chip-empty">No assertions for this stage.<\\/div>';
-    } else {
-      for (var i = 0; i < d.items.length; i++) {
-        var it = d.items[i];
-        html += '<div class="tx-chip-item">'
-              + '<div class="tx-chip-req-id">' + esc(it.reqId) + '<\\/div>'
-              + '<div class="tx-chip-req-name">' + esc(it.reqName) + '<\\/div>';
-        if (it.deadline) html += '<div class="tx-chip-deadline">Deadline: ' + esc(it.deadline) + '<\\/div>';
-        html += '<div class="tx-chip-assertion-row">'
-              + '<span class="tx-chip-subject">' + esc(it.subject) + '<\\/span> '
-              + '<span class="' + statusCls(it.status) + '">' + esc(STATUS_LABEL[it.status] || it.status) + '<\\/span>'
-              + '<\\/div><\\/div>';
-      }
-    }
-    return html;
-  }
-  var groups = document.querySelectorAll('[data-chip-law]');
-  for (var i = 0; i < groups.length; i++) {
-    (function (el) {
-      el.addEventListener('click', function (e) {
-        e.stopPropagation();
-        var lawId = el.getAttribute('data-chip-law');
-        var stageId = el.getAttribute('data-chip-stage');
-        var key = stageId + '|' + lawId;
-        var detail = data[key];
-        if (!detail) { panel.hidden = true; return; }
-        content.innerHTML = renderDetail(detail);
-        panel.hidden = false;
-      });
-    })(groups[i]);
-  }
-  if (closeBtn) closeBtn.addEventListener('click', function () { panel.hidden = true; });
-  document.addEventListener('click', function (e) {
-    if (!panel.hidden && !panel.contains(e.target)) panel.hidden = true;
+(function(){
+var vscode=acquireVsCodeApi();
+var toggles=document.querySelectorAll('[data-bp-toggle]');
+for(var i=0;i<toggles.length;i++){(function(el){
+  el.addEventListener('change',function(){
+    vscode.postMessage({type:'transitrix:bp-toggle',kind:el.getAttribute('data-bp-toggle'),id:el.getAttribute('data-bp-id'),visible:el.checked});
   });
+})(toggles[i]);}
+var colWRange=document.getElementById('tx-bp-col-w-range');
+var colWOut=document.getElementById('tx-bp-col-w-out');
+if(colWRange){colWRange.addEventListener('input',function(){
+  if(colWOut)colWOut.value=colWRange.value;
+  vscode.postMessage({type:'transitrix:bp-toggle',kind:'column-width',value:Number(colWRange.value)});
+});}
+var det=document.getElementById('tx-bp-ctl');
+if(det){var st=vscode.getState()||{};if(st.txBpCtlOpen)det.open=true;
+  det.addEventListener('toggle',function(){var s=vscode.getState()||{};s.txBpCtlOpen=det.open;vscode.setState(s);});}
+(function(){
+  if(!document.getElementById('bp-chip-legend'))return;
+  var legendBtn=document.createElement('label');
+  legendBtn.className='title-toggle bp-legend-btn';
+  legendBtn.title='Show or hide the compliance legend';
+  legendBtn.textContent='Legend';
+  var st2=vscode.getState()||{};
+  if(st2.txBpLegendHidden){legendBtn.classList.add('bp-hidden');document.body.classList.add('bp-legend-hidden');}
+  legendBtn.addEventListener('click',function(){
+    var hiding=!legendBtn.classList.contains('bp-hidden');
+    legendBtn.classList.toggle('bp-hidden',hiding);
+    document.body.classList.toggle('bp-legend-hidden',hiding);
+    var s=vscode.getState()||{};s.txBpLegendHidden=hiding;vscode.setState(s);
+  });
+  var actions=document.querySelector('#toolbar .toolbar-actions');
+  if(actions){
+    var titleLbl=actions.querySelector('label[for="ts-title-toggle"]');
+    if(titleLbl){actions.insertBefore(legendBtn,titleLbl.nextSibling);}
+    else{actions.insertBefore(legendBtn,actions.firstChild);}
+  }
+}());
+var data=${safeJson};
+var panel=document.getElementById('tx-chip-panel');
+var content=document.getElementById('tx-chip-content');
+var closeBtn=document.getElementById('tx-chip-close');
+if(panel&&content){
+  function esc(s){return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');}
+  var SL={compliant:'\\u2713 Compliant',partial:'\\u007e Partial',non_compliant:'\\u2717 Non-compliant',under_review:'\\u2299 Under review',pending_owner:'\\u2299 Pending owner',n_a:'\\u2014 N/A'};
+  function sc(s){return 'tx-chip-status tx-chip-status-'+s.replace(/_/g,'-');}
+  function rd(d){
+    var h='<span class="tx-chip-law-heading">'+esc(d.lawId)+'<\\/span><span class="tx-chip-stage-label">\\u00b7 Stage: '+esc(d.stageName)+'<\\/span>';
+    if(!d.items||!d.items.length){h+='<div class="tx-chip-empty">No assertions for this stage.<\\/div>';}
+    else{for(var i=0;i<d.items.length;i++){var it=d.items[i];
+      h+='<div class="tx-chip-item"><div class="tx-chip-req-id">'+esc(it.reqId)+'<\\/div><div class="tx-chip-req-name">'+esc(it.reqName)+'<\\/div>';
+      if(it.deadline)h+='<div class="tx-chip-deadline">Deadline: '+esc(it.deadline)+'<\\/div>';
+      h+='<div class="tx-chip-assertion-row"><span class="tx-chip-subject">'+esc(it.subject)+'<\\/span> <span class="'+sc(it.status)+'">'+esc(SL[it.status]||it.status)+'<\\/span><\\/div><\\/div>';
+    }}return h;
+  }
+  var chips=document.querySelectorAll('[data-chip-law]');
+  for(var i=0;i<chips.length;i++){(function(el){
+    el.addEventListener('click',function(e){
+      e.stopPropagation();
+      var key=el.getAttribute('data-chip-stage')+'|'+el.getAttribute('data-chip-law');
+      var d=data[key];if(!d){panel.hidden=true;return;}
+      content.innerHTML=rd(d);panel.hidden=false;
+    });
+  })(chips[i]);}
+  if(closeBtn)closeBtn.addEventListener('click',function(){panel.hidden=true;});
+  document.addEventListener('click',function(e){if(!panel.hidden&&!panel.contains(e.target))panel.hidden=true;});
+}
 }());
 <\/script>`;
 }
@@ -422,12 +554,22 @@ export class ProcessBlueprintPreview {
   private panel: vscode.WebviewPanel | undefined;
   private trackedUri: string | undefined;
   private lastSvg = '';
+  private hiddenRows = new Set<string>();
+  private hiddenStages = new Set<string>();
+  private lastYamlText = '';
+  private lastFilename = '';
+  // Column width persists across documents (user preference).
+  private stageColumnWidth = 220;
 
   isShowingDocument(uri: vscode.Uri): boolean {
     return this.panel != null && this.trackedUri === uri.toString();
   }
 
   async showOrReveal(doc: vscode.TextDocument): Promise<void> {
+    if (doc.uri.toString() !== this.trackedUri) {
+      this.hiddenRows.clear();
+      this.hiddenStages.clear();
+    }
     this.trackedUri = doc.uri.toString();
     if (this.panel) {
       this.panel.title = `${this.panelTitle} — ${path.basename(doc.fileName)}`;
@@ -437,9 +579,37 @@ export class ProcessBlueprintPreview {
         'processBlueprintPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: true, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.saveProcessBlueprintAsSvg', 'transitrixStudio.saveProcessBlueprintAsPng', 'transitrixStudio.copyProcessBlueprintAsPng'] },
+        {
+          enableScripts: true,
+          retainContextWhenHidden: true,
+          enableCommandUris: [
+            'transitrixStudio.saveProcessBlueprintAsSvg',
+            'transitrixStudio.saveProcessBlueprintAsPng',
+            'transitrixStudio.copyProcessBlueprintAsPng',
+            'transitrixStudio.changeTheme',
+          ],
+        },
       );
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
+      this.panel.webview.onDidReceiveMessage(async (msg: unknown) => {
+        if (!msg || typeof msg !== 'object') return;
+        const m = msg as Record<string, unknown>;
+        if (m['type'] !== 'transitrix:bp-toggle') return;
+        const kind = m['kind'] as string;
+        const id = m['id'] as string;
+        const visible = Boolean(m['visible']);
+        if (kind === 'row' || kind === 'column') {
+          if (!id) return;
+          if (kind === 'row') { if (visible) this.hiddenRows.delete(id); else this.hiddenRows.add(id); }
+          else { if (visible) this.hiddenStages.delete(id); else this.hiddenStages.add(id); }
+        } else if (kind === 'column-width') {
+          const wv = Number(m['value']);
+          if (Number.isFinite(wv)) this.stageColumnWidth = Math.max(100, Math.min(450, wv));
+        }
+        if (this.panel && this.lastYamlText) {
+          this.panel.webview.html = await this.buildHtml(this.lastYamlText, this.lastFilename);
+        }
+      });
     }
     await this.pushDocument(doc);
   }
@@ -449,17 +619,26 @@ export class ProcessBlueprintPreview {
     await this.pushDocument(doc);
   }
 
+  async refreshConfig(): Promise<void> {
+    if (!this.panel || !this.trackedUri) return;
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.parse(this.trackedUri));
+    await this.pushDocument(doc);
+  }
+
   private async pushDocument(doc: vscode.TextDocument): Promise<void> {
     if (!this.panel) return;
-    this.panel.webview.html = await this.buildHtml(doc.getText(), path.basename(doc.fileName));
+    this.lastYamlText = doc.getText();
+    this.lastFilename = path.basename(doc.fileName);
+    this.panel.webview.html = await this.buildHtml(this.lastYamlText, this.lastFilename);
   }
 
   private async buildHtml(yamlText: string, filename: string): Promise<string> {
     let svgContent = '';
     let errorMsg = '';
     let warnings: string[] = [];
-    let drillDownNonce = '';
-    let drillDownScript = '';
+    let controlsPanel = '';
+    let combinedScript = '';
+    let nonce = '';
 
     try {
       const parsed = coerceDatesToIsoStrings(yaml.load(yamlText) as unknown);
@@ -483,15 +662,48 @@ export class ProcessBlueprintPreview {
           userPrefs.visible_lanes ??
           (Array.isArray(laneConfigRaw?.visible_lanes) ? laneConfigRaw!.visible_lanes : undefined);
 
-        // Derive visible aspect categories and compliance lane visibility from merged lanes.
+        // Derive visible aspect categories from merged lanes (used when no visibleRows toggle active).
         const visibleAspects: AspectCategory[] | undefined = visibleLanes
           ? (ASPECT_CATEGORY_IDS.filter(c => visibleLanes.includes(c)) as AspectCategory[])
           : undefined;
-        const complianceVisible = visibleLanes ? visibleLanes.includes('compliance') : true;
+
+        // Compute available rows (only rows that have data or are enabled).
+        const availableRows: Array<{ id: string; label: string }> = [
+          { id: 'goal', label: 'Goal' },
+          { id: 'result', label: 'Result' },
+        ];
+        if (file.process_blueprint.systems?.length) availableRows.push({ id: 'systems', label: 'Systems' });
+        if (file.process_blueprint.actors?.length) availableRows.push({ id: 'actors', label: 'Actors' });
+        if (file.process_blueprint.equipment?.length) availableRows.push({ id: 'equipment', label: 'Equipment' });
+        if (file.process_blueprint.information_entities?.length) availableRows.push({ id: 'information_entities', label: 'Information' });
+        if (laneCfg.enabled) availableRows.push({ id: 'compliance', label: 'Compliance' });
+
+        const availableStages = file.process_blueprint.stages.map(s => ({ id: s.id, name: s.name }));
+
+        // Derive layout filter lists from session state.
+        const visibleRowsForLayout: RowId[] | undefined = this.hiddenRows.size === 0
+          ? undefined
+          : (availableRows.map(r => r.id as RowId).filter(id => !this.hiddenRows.has(id)));
+
+        const visibleStagesList: string[] | undefined = this.hiddenStages.size === 0
+          ? undefined
+          : availableStages.map(s => s.id).filter(id => !this.hiddenStages.has(id));
+
+        // When user has interacted with toggles, their choice controls compliance;
+        // otherwise fall back to the prefs-derived complianceVisible.
+        const complianceVisibleByPrefs = visibleLanes ? visibleLanes.includes('compliance') : true;
+        const complianceWillRender = laneCfg.enabled && (
+          visibleRowsForLayout
+            ? visibleRowsForLayout.includes('compliance')
+            : complianceVisibleByPrefs
+        );
+        const complianceLaneEnabled = visibleRowsForLayout
+          ? laneCfg.enabled  // let visibleRows handle filtering
+          : laneCfg.enabled && complianceVisibleByPrefs;
 
         let complianceInput: ComplianceLaneInput | undefined;
         let scannedCanon: ScannedCanon | undefined;
-        if (laneCfg.enabled && complianceVisible) {
+        if (complianceWillRender) {
           try {
             const canon = await scanComplianceCanon();
             scannedCanon = canon;
@@ -502,29 +714,38 @@ export class ProcessBlueprintPreview {
         }
 
         const layout = layoutProcessBlueprint(file, {
-          complianceLane: { ...laneCfg, enabled: laneCfg.enabled && complianceVisible },
+          stageColumnWidth: this.stageColumnWidth,
+          complianceLane: { ...laneCfg, enabled: complianceLaneEnabled },
           complianceInput,
-          visibleAspects,
+          visibleAspects: visibleRowsForLayout ? undefined : visibleAspects,
+          visibleRows: visibleRowsForLayout,
+          visibleStages: visibleStagesList,
         });
         svgContent = layoutToSvg(layout, filename, docDate, docVersion);
 
-        // Append the drill-down panel when compliance chips are present.
-        if (layout.complianceRow && scannedCanon) {
-          drillDownNonce = genNonce();
-          drillDownScript = buildChipDetailScript(
-            drillDownNonce,
-            buildChipDetailData(layout, scannedCanon),
-          );
+        // Build display controls panel and combined script.
+        nonce = genNonce();
+        const chipData = layout.complianceRow && scannedCanon
+          ? buildChipDetailData(layout, scannedCanon)
+          : {};
+        controlsPanel = buildDisplayControls(
+          availableRows.map(r => ({ ...r, hidden: this.hiddenRows.has(r.id) })),
+          availableStages.map(s => ({ id: s.id, label: s.name, hidden: this.hiddenStages.has(s.id) })),
+          this.stageColumnWidth,
+        );
+        combinedScript = buildBlueprintScript(nonce, chipData);
+
+        // Append the drill-down panel and visual legend when compliance chips are present.
+        if (layout.complianceRow) {
+          svgContent = svgContent + CHIP_DETAIL_PANEL_HTML + CHIP_LEGEND_HTML;
         }
       }
     } catch (e) {
       errorMsg = (e as Error).message ?? 'Parse error';
     }
 
-    // Store pure SVG only — the drill-down HTML panel must not be included
-    // here because lastSvg is passed directly to resvg for PNG rasterization.
-    this.lastSvg = svgContent;
-    const webviewSvgContent = drillDownNonce ? svgContent + CHIP_DETAIL_PANEL_HTML : svgContent;
+    // Store pure SVG only — HTML blocks must be stripped before passing to resvg for PNG.
+    this.lastSvg = svgContent.replace(CHIP_DETAIL_PANEL_HTML, '').replace(CHIP_LEGEND_HTML, '');
 
     const themeId = vscode.workspace
       .getConfiguration('transitrix')
@@ -533,16 +754,17 @@ export class ProcessBlueprintPreview {
     return buildDiagramFrame({
       filename,
       notation: 'Process Blueprint',
-      svgContent: webviewSvgContent,
+      svgContent,
       errorMsg,
       warnings,
       themeId,
-      extraStyles: CHIP_DETAIL_CSS,
+      extraStyles: BLUEPRINT_CSS + CHIP_DETAIL_CSS,
       saveSvgCommand: 'transitrixStudio.saveProcessBlueprintAsSvg',
       savePngCommand: 'transitrixStudio.saveProcessBlueprintAsPng',
       copyPngCommand: 'transitrixStudio.copyProcessBlueprintAsPng',
-      interactive: drillDownNonce
-        ? { nonce: drillDownNonce, controlsPanel: '', controlsScript: drillDownScript }
+      themeCommand: OPEN_THEME_COMMAND,
+      interactive: nonce
+        ? { nonce, controlsPanel, controlsScript: combinedScript }
         : undefined,
     });
   }

--- a/extension/src/process-map-preview.ts
+++ b/extension/src/process-map-preview.ts
@@ -1,7 +1,7 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
-import { buildDiagramFrame, CATALOGUE_STYLES, type ThemeId } from './diagram-frame.js';
+import { buildDiagramFrame, CATALOGUE_STYLES, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 import { validateProcessMap } from '../../packages/diagrams/src/process-map/validate.js';
 
@@ -137,7 +137,7 @@ export class ProcessMapPreview {
         'processMapPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true },
+        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.changeTheme'] },
       );
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
     }
@@ -146,6 +146,12 @@ export class ProcessMapPreview {
 
   async refreshSaved(doc: vscode.TextDocument): Promise<void> {
     if (!this.isShowingDocument(doc.uri)) return;
+    await this.pushDocument(doc);
+  }
+
+  async refreshConfig(): Promise<void> {
+    if (!this.panel || !this.trackedUri) return;
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.parse(this.trackedUri));
     await this.pushDocument(doc);
   }
 
@@ -205,6 +211,7 @@ export class ProcessMapPreview {
       version,
       date,
       extraStyles: `:root { --ts-col-w: ${colWPx}px; }\n` + CATALOGUE_STYLES + PROCESS_MAP_STYLES,
+      themeCommand: OPEN_THEME_COMMAND,
     });
   }
 }

--- a/extension/src/products-preview.ts
+++ b/extension/src/products-preview.ts
@@ -1,7 +1,7 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
-import { buildDiagramFrame, CATALOGUE_STYLES, type ThemeId } from './diagram-frame.js';
+import { buildDiagramFrame, CATALOGUE_STYLES, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 import { validateProductsCatalogue } from '../../packages/diagrams/src/products/validate.js';
 
@@ -129,7 +129,7 @@ export class ProductsPreview {
         'productsPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true },
+        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.changeTheme'] },
       );
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
     }
@@ -138,6 +138,12 @@ export class ProductsPreview {
 
   async refreshSaved(doc: vscode.TextDocument): Promise<void> {
     if (!this.isShowingDocument(doc.uri)) return;
+    await this.pushDocument(doc);
+  }
+
+  async refreshConfig(): Promise<void> {
+    if (!this.panel || !this.trackedUri) return;
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.parse(this.trackedUri));
     await this.pushDocument(doc);
   }
 
@@ -193,6 +199,7 @@ export class ProductsPreview {
       version,
       date,
       extraStyles: `:root { --ts-col-w: ${colWPx}px; }\n` + CATALOGUE_STYLES + PRODUCTS_STYLES,
+      themeCommand: OPEN_THEME_COMMAND,
     });
   }
 }

--- a/extension/src/scenarios-preview.ts
+++ b/extension/src/scenarios-preview.ts
@@ -1,7 +1,7 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
-import { buildDiagramFrame, CATALOGUE_STYLES, type ThemeId } from './diagram-frame.js';
+import { buildDiagramFrame, CATALOGUE_STYLES, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 import { validateScenario } from '../../packages/diagrams/src/scenarios/validate.js';
 
@@ -134,7 +134,7 @@ export class ScenariosPreview {
         'scenariosPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true },
+        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.changeTheme'] },
       );
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
     }
@@ -143,6 +143,12 @@ export class ScenariosPreview {
 
   async refreshSaved(doc: vscode.TextDocument): Promise<void> {
     if (!this.isShowingDocument(doc.uri)) return;
+    await this.pushDocument(doc);
+  }
+
+  async refreshConfig(): Promise<void> {
+    if (!this.panel || !this.trackedUri) return;
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.parse(this.trackedUri));
     await this.pushDocument(doc);
   }
 
@@ -200,6 +206,7 @@ export class ScenariosPreview {
       version,
       date,
       extraStyles: `:root { --ts-col-w: ${colWPx}px; }\n` + CATALOGUE_STYLES + SCENARIOS_STYLES,
+      themeCommand: OPEN_THEME_COMMAND,
     });
   }
 }

--- a/extension/src/single-law-preview.ts
+++ b/extension/src/single-law-preview.ts
@@ -41,7 +41,7 @@ export class SingleLawPreview {
         {
           enableScripts: false,
           retainContextWhenHidden: true,
-          enableCommandUris: [OPEN_FILE_COMMAND, REFRESH_COMMAND],
+          enableCommandUris: [OPEN_FILE_COMMAND, REFRESH_COMMAND, 'transitrixStudio.changeTheme'],
         },
       );
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
@@ -81,7 +81,7 @@ export class SingleLawPreview {
     if (!lawId) {
       this.panel.webview.html = complianceShell({
         title: 'Single-law tree',
-        themeId, refreshCommand: REFRESH_COMMAND,
+        themeId, refreshCommand: REFRESH_COMMAND, themeCommand: 'transitrixStudio.changeTheme',
         bodyHtml: `<div class="cmp-empty">This file has no <code>id</code> — open a codex artefact (LAW / REGULATION / POLICY / INTERNAL_STANDARD).</div>`,
       });
       return;
@@ -100,8 +100,11 @@ export class SingleLawPreview {
     this.panel.webview.html = complianceShell({
       title: lawName,
       subtitle: `${lawId} · ${tree.requirements.length} requirement(s)`,
+      filename: path.basename(doc.fileName),
+      date: todayIso(),
       themeId,
       refreshCommand: REFRESH_COMMAND,
+      themeCommand: 'transitrixStudio.changeTheme',
       bodyHtml: this.treeHtml(tree, scan.pathById),
       confidence,
     });

--- a/extension/src/single-product-preview.ts
+++ b/extension/src/single-product-preview.ts
@@ -40,7 +40,7 @@ export class SingleProductPreview {
         {
           enableScripts: false,
           retainContextWhenHidden: true,
-          enableCommandUris: [OPEN_FILE_COMMAND, REFRESH_COMMAND],
+          enableCommandUris: [OPEN_FILE_COMMAND, REFRESH_COMMAND, 'transitrixStudio.changeTheme'],
         },
       );
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
@@ -79,7 +79,7 @@ export class SingleProductPreview {
     if (!productId) {
       this.panel.webview.html = complianceShell({
         title: 'Single-product view',
-        themeId, refreshCommand: REFRESH_COMMAND,
+        themeId, refreshCommand: REFRESH_COMMAND, themeCommand: 'transitrixStudio.changeTheme',
         bodyHtml: `<div class="cmp-empty">This file has no <code>id</code> — open a <code>notation: product</code> file.</div>`,
       });
       return;
@@ -97,8 +97,11 @@ export class SingleProductPreview {
     this.panel.webview.html = complianceShell({
       title: productName,
       subtitle: `${productId} · ${view.requirements.length} requirement(s) asserted`,
+      filename: path.basename(doc.fileName),
+      date: todayIso(),
       themeId,
       refreshCommand: REFRESH_COMMAND,
+      themeCommand: 'transitrixStudio.changeTheme',
       bodyHtml: this.viewHtml(view, scan.pathById),
       confidence,
     });

--- a/extension/src/svg-title-block.ts
+++ b/extension/src/svg-title-block.ts
@@ -36,8 +36,7 @@ export function titleBlockSvg(
   top: number,
   version?: string,
 ): string {
-  const trimmedVersion = version?.trim();
-  const dateLine = trimmedVersion ? `v${trimmedVersion} · Generated: ${date}` : `Generated: ${date}`;
+  const dateLine = `Generated: ${date}`;
   return `<g class="diagram-title-block">
   <text class="text-header" x="${x}" y="${top + 14}">${escXml(heading)}</text>
   <text class="text-secondary" x="${x}" y="${top + 30}">${escXml(filename)}</text>

--- a/packages/diagrams/src/activities/cpm.ts
+++ b/packages/diagrams/src/activities/cpm.ts
@@ -5,6 +5,18 @@ export function computeCpm(activities: Activity[]): CpmResult {
 
   if (activities.length === 0) return result;
 
+  // When no activity carries any duration data, critical path is indeterminate —
+  // return all non-critical so the diagram renders in default grey.
+  const hasDuration = activities.some(
+    (a) => (a.duration !== undefined && a.duration !== null) || (a.duration_days !== undefined && a.duration_days !== null),
+  );
+  if (!hasDuration) {
+    for (const a of activities) {
+      result.set(a.id, { es: 0, ef: 0, ls: 0, lf: 0, slack: 0, isCritical: false });
+    }
+    return result;
+  }
+
   // Build successor map and in-degree for topological sort
   const successors = new Map<string, string[]>();
   const predecessors = new Map<string, string[]>();
@@ -45,7 +57,7 @@ export function computeCpm(activities: Activity[]): CpmResult {
   const ef = new Map<string, number>();
   for (const id of topoOrder) {
     const a = actById.get(id)!;
-    const dur = a.duration ?? 0;
+    const dur = a.duration ?? a.duration_days ?? 0;
     const maxPredEf = Math.max(0, ...(predecessors.get(id) ?? []).map(p => ef.get(p) ?? 0));
     es.set(id, maxPredEf);
     ef.set(id, maxPredEf + dur);
@@ -59,7 +71,7 @@ export function computeCpm(activities: Activity[]): CpmResult {
   const lf = new Map<string, number>();
   for (const id of [...topoOrder].reverse()) {
     const a = actById.get(id)!;
-    const dur = a.duration ?? 0;
+    const dur = a.duration ?? a.duration_days ?? 0;
     const succs = successors.get(id) ?? [];
     const minSuccLs = succs.length === 0 ? projectFinish : Math.min(...succs.map(s => ls.get(s) ?? projectFinish));
     lf.set(id, minSuccLs);

--- a/packages/diagrams/src/activities/gantt.ts
+++ b/packages/diagrams/src/activities/gantt.ts
@@ -113,9 +113,10 @@ function detectMode(doc: ActivityDoc, leaves: Activity[]): 'computed' | 'pinned'
   if (allPinned) return 'pinned';
   const hasProjectStart =
     typeof doc.project?.start_date === 'string' && doc.project.start_date.length > 0;
-  const allHaveDuration = leaves.every(
-    (a) => typeof a.duration === 'number' && Number.isFinite(a.duration) && a.duration >= 0,
-  );
+  const allHaveDuration = leaves.every((a) => {
+    const d = a.duration ?? a.duration_days;
+    return typeof d === 'number' && Number.isFinite(d) && d >= 0;
+  });
   if (hasProjectStart && allHaveDuration) return 'computed';
   return null;
 }
@@ -144,7 +145,7 @@ export function computeGanttLayout(doc: ActivityDoc): GanttResult {
     for (const a of leaves) {
       const startDate = a.start_date as string;
       const endDate = a.end_date as string;
-      const isMilestone = a.duration === 0 || startDate === endDate;
+      const isMilestone = (a.duration ?? a.duration_days) === 0 || startDate === endDate;
       const bar: GanttBar = {
         id: a.id,
         name: a.name,
@@ -166,7 +167,7 @@ export function computeGanttLayout(doc: ActivityDoc): GanttResult {
     for (const a of leaves) {
       const c = cpm.get(a.id);
       const es = c?.es ?? 0;
-      const dur = a.duration ?? 0;
+      const dur = a.duration ?? a.duration_days ?? 0;
       const startDate = nthWorkingDay(projectStart, es, calendar);
       const endDate = dur === 0
         ? startDate

--- a/packages/diagrams/src/activities/types.ts
+++ b/packages/diagrams/src/activities/types.ts
@@ -15,6 +15,7 @@ export interface Activity {
   id: string;
   name: string;
   duration?: number;
+  duration_days?: number;
   activity_type?: string;
   goals?: string[];
   scenario?: string;

--- a/packages/diagrams/src/activities/validate.ts
+++ b/packages/diagrams/src/activities/validate.ts
@@ -130,7 +130,7 @@ export function validateActivities(input: unknown): ActivityValidationResult {
     }
 
     // ACT-009: non-negative numeric fields
-    const numericFields = ['duration', 'labor_cost', 'resources_cost', 'effort', 'score', 'sort'] as const;
+    const numericFields = ['duration', 'duration_days', 'labor_cost', 'resources_cost', 'effort', 'score', 'sort'] as const;
     for (const field of numericFields) {
       const val = act[field];
       if (val !== undefined && val !== null) {
@@ -140,8 +140,8 @@ export function validateActivities(input: unknown): ActivityValidationResult {
       }
     }
 
-    // ACT-011: warn if no duration
-    if (act.duration === undefined || act.duration === null) {
+    // ACT-011: warn if no duration (duration_days is accepted as an alias)
+    if ((act.duration === undefined || act.duration === null) && (act.duration_days === undefined || act.duration_days === null)) {
       warnings.push({ code: 'ACT-011', message: `Activity "${id}" has no duration — cannot participate in CPM analysis`, path });
     }
   }

--- a/packages/diagrams/src/process-blueprint/index.ts
+++ b/packages/diagrams/src/process-blueprint/index.ts
@@ -1,5 +1,6 @@
 export type {
   AspectCategory,
+  RowId,
   Stage,
   AspectEntry,
   LaneConfig,

--- a/packages/diagrams/src/process-blueprint/layout.ts
+++ b/packages/diagrams/src/process-blueprint/layout.ts
@@ -13,6 +13,7 @@ import type {
   LegendCell,
   ProcessBlueprintFile,
   ProcessBlueprintLayout,
+  RowId,
   Stage,
   StageHeaderCell,
   StageTextCell,
@@ -31,7 +32,7 @@ const ASPECT_LABEL: Record<AspectCategory, string> = {
 // (absent = feature disabled) and must stay optional in the resolved type.
 type SizingOptionKeys = Exclude<
   keyof ProcessBlueprintLayoutOptions,
-  'complianceLane' | 'complianceInput' | 'visibleAspects'
+  'complianceLane' | 'complianceInput' | 'visibleAspects' | 'visibleRows' | 'visibleStages'
 >;
 
 /**
@@ -39,7 +40,7 @@ type SizingOptionKeys = Exclude<
  * the opt-in feature fields stay optional (undefined = feature disabled).
  */
 type ResolvedLayoutOptions = Required<Pick<ProcessBlueprintLayoutOptions, SizingOptionKeys>> &
-  Pick<ProcessBlueprintLayoutOptions, 'complianceLane' | 'complianceInput' | 'visibleAspects'>;
+  Pick<ProcessBlueprintLayoutOptions, 'complianceLane' | 'complianceInput' | 'visibleAspects' | 'visibleRows' | 'visibleStages'>;
 
 const DEFAULTS = {
   legendColumnWidth: 140,
@@ -48,14 +49,19 @@ const DEFAULTS = {
   goalRowHeight: 56,
   resultRowHeight: 56,
   aspectRowMinHeight: 60,
-  pillHeight: 28,
+  pillHeight: 40,
   pillGap: 4,
   cellPadding: 8,
-  textLineHeight: 15,
-  textCharWidth: 6.2,
+  // 17px gives comfortable breathing room between wrapped lines at typical
+  // webview font sizes (VS Code uses ~13–14px body, SVG text-secondary ≈ same).
+  textLineHeight: 17,
+  // 7.5px per char is a conservative estimate that causes wrap to trigger
+  // before text visually overflows the cell border.
+  textCharWidth: 7.5,
   cellTextPadX: 10,
   cellTextPadY: 10,
-  maxTextLines: 6,
+  // No hard truncation: rows grow to fit all wrapped lines.
+  maxTextLines: 100,
 } satisfies Required<Pick<ProcessBlueprintLayoutOptions, SizingOptionKeys>>;
 
 interface RawPill {
@@ -369,8 +375,24 @@ export function layoutProcessBlueprint(
   const opts = resolveOptions(options);
 
   const pb = file.process_blueprint;
-  const stages = Array.isArray(pb?.stages) ? pb.stages : [];
+
+  // Filter stages by visibleStages if set
+  const allStages = Array.isArray(pb?.stages) ? pb.stages : [];
+  const stages = opts.visibleStages
+    ? allStages.filter(s => s?.id != null && opts.visibleStages!.includes(s.id))
+    : allStages;
   const stageIndexById = buildStageIndex(stages);
+
+  // Row visibility from visibleRows
+  const visRows = opts.visibleRows;
+  const showGoal = !visRows || (visRows as string[]).includes('goal');
+  const showResult = !visRows || (visRows as string[]).includes('result');
+  const effectiveVisibleAspects: AspectCategory[] | undefined = visRows
+    ? (ASPECT_CATEGORIES.filter(c => (visRows as string[]).includes(c)) as AspectCategory[])
+    : opts.visibleAspects;
+  const effectiveComplianceEnabled =
+    opts.complianceLane?.enabled === true &&
+    (!visRows || (visRows as string[]).includes('compliance'));
 
   // Stage headers
   const stageHeaders: StageHeaderCell[] = stages.map((s, i) => ({
@@ -398,38 +420,39 @@ export function layoutProcessBlueprint(
   const goalLines = stages.map(s => wrap(s?.goal ?? ''));
   const resultLines = stages.map(s => wrap(s?.result ?? ''));
 
-  const goalRowY = opts.stageHeaderHeight;
-  const goalRowHeight = rowHeightFor(goalLines.map(l => l.length), opts.goalRowHeight);
-  const resultRowY = goalRowY + goalRowHeight;
-  const resultRowHeight = rowHeightFor(resultLines.map(l => l.length), opts.resultRowHeight);
+  let cursorY = opts.stageHeaderHeight;
+  let goalRowY = 0, goalRowHeight = 0;
+  let resultRowY = 0, resultRowHeight = 0;
+  const goalCells: StageTextCell[] = [];
+  const resultCells: StageTextCell[] = [];
 
-  const goalCells: StageTextCell[] = stages.map((s, i) => ({
-    stageIndex: i,
-    text: s?.goal ?? '',
-    lines: goalLines[i],
-    x: opts.legendColumnWidth + i * opts.stageColumnWidth,
-    y: goalRowY,
-    width: opts.stageColumnWidth,
-    height: goalRowHeight,
-  }));
-
-  const resultCells: StageTextCell[] = stages.map((s, i) => ({
-    stageIndex: i,
-    text: s?.result ?? '',
-    lines: resultLines[i],
-    x: opts.legendColumnWidth + i * opts.stageColumnWidth,
-    y: resultRowY,
-    width: opts.stageColumnWidth,
-    height: resultRowHeight,
-  }));
-
-  const aspectsStartY = resultRowY + resultRowHeight;
+  if (showGoal) {
+    goalRowY = cursorY;
+    goalRowHeight = rowHeightFor(goalLines.map(l => l.length), opts.goalRowHeight);
+    goalCells.push(...stages.map((s, i) => ({
+      stageIndex: i, text: s?.goal ?? '', lines: goalLines[i],
+      x: opts.legendColumnWidth + i * opts.stageColumnWidth, y: goalRowY,
+      width: opts.stageColumnWidth, height: goalRowHeight,
+    })));
+    cursorY += goalRowHeight;
+  }
+  if (showResult) {
+    resultRowY = cursorY;
+    resultRowHeight = rowHeightFor(resultLines.map(l => l.length), opts.resultRowHeight);
+    resultCells.push(...stages.map((s, i) => ({
+      stageIndex: i, text: s?.result ?? '', lines: resultLines[i],
+      x: opts.legendColumnWidth + i * opts.stageColumnWidth, y: resultRowY,
+      width: opts.stageColumnWidth, height: resultRowHeight,
+    })));
+    cursorY += resultRowHeight;
+  }
+  const aspectsStartY = cursorY;
 
   // Aspect rows: only categories with at least one entry, in fixed order.
-  // When visibleAspects is set, skip categories not in the list.
+  // When effectiveVisibleAspects is set, skip categories not in the list.
   const aspectCategoriesToRender =
-    opts.visibleAspects !== undefined
-      ? ASPECT_CATEGORIES.filter(c => opts.visibleAspects!.includes(c))
+    effectiveVisibleAspects !== undefined
+      ? ASPECT_CATEGORIES.filter(c => effectiveVisibleAspects.includes(c))
       : ASPECT_CATEGORIES;
 
   const aspectRows: AspectRow[] = [];
@@ -461,6 +484,13 @@ export function layoutProcessBlueprint(
       const width =
         (p.endStageIndex - p.startStageIndex + 1) * opts.stageColumnWidth - 2 * opts.cellPadding;
       const y = aspectCursorY + opts.cellPadding + slot[i] * (opts.pillHeight + opts.pillGap);
+      const pillMaxChars = Math.max(4, Math.floor((width - 2 * opts.cellPadding) / opts.textCharWidth));
+      const nameWrapped = wrapText(p.name, pillMaxChars, 2);
+      // Show id as second line only when the name fits on one line; otherwise
+      // use both lines for the name so it isn't truncated.
+      const lines: string[] = p.id && nameWrapped.length <= 1
+        ? [...nameWrapped, p.id].slice(0, 2)
+        : nameWrapped;
       return {
         category: p.category,
         entryIndex: p.entryIndex,
@@ -472,6 +502,7 @@ export function layoutProcessBlueprint(
         y,
         width,
         height: opts.pillHeight,
+        lines,
       };
     });
 
@@ -487,7 +518,7 @@ export function layoutProcessBlueprint(
 
   // Compliance lane — derived from assertions/requirements, rendered after aspect rows.
   let complianceRow: import('./types.js').ComplianceRow | undefined;
-  if (opts.complianceLane?.enabled && opts.complianceInput) {
+  if (effectiveComplianceEnabled && opts.complianceInput) {
     complianceRow = deriveComplianceRow(
       stages,
       stageIndexById,
@@ -502,8 +533,8 @@ export function layoutProcessBlueprint(
 
   // Legend (left column labels): one entry per row.
   const legend: LegendCell[] = [
-    { kind: 'goal', label: 'Goal', y: goalRowY, height: goalRowHeight },
-    { kind: 'result', label: 'Result', y: resultRowY, height: resultRowHeight },
+    ...(showGoal ? [{ kind: 'goal' as const, label: 'Goal', y: goalRowY, height: goalRowHeight }] : []),
+    ...(showResult ? [{ kind: 'result' as const, label: 'Result', y: resultRowY, height: resultRowHeight }] : []),
     ...aspectRows.map<LegendCell>(row => ({
       kind: 'aspect',
       category: row.category,
@@ -511,9 +542,7 @@ export function layoutProcessBlueprint(
       y: row.y,
       height: row.height,
     })),
-    ...(complianceRow
-      ? [{ kind: 'compliance' as const, label: 'Compliance', y: complianceRow.y, height: complianceRow.height }]
-      : []),
+    ...(complianceRow ? [{ kind: 'compliance' as const, label: 'Compliance', y: complianceRow.y, height: complianceRow.height }] : []),
   ];
 
   const totalWidth = opts.legendColumnWidth + stages.length * opts.stageColumnWidth;

--- a/packages/diagrams/src/process-blueprint/types.ts
+++ b/packages/diagrams/src/process-blueprint/types.ts
@@ -1,5 +1,7 @@
 export type AspectCategory = 'systems' | 'actors' | 'equipment' | 'information_entities';
 
+export type RowId = 'goal' | 'result' | 'systems' | 'actors' | 'equipment' | 'information_entities' | 'compliance';
+
 // ── Compliance lane types ────────────────────────────────────────────────────
 
 /**
@@ -191,6 +193,17 @@ export interface ProcessBlueprintLayoutOptions {
    * Pass an empty array to suppress all aspect rows.
    */
   visibleAspects?: AspectCategory[];
+  /**
+   * Restrict which rows are rendered. When absent, all rows with data are shown.
+   * When set, takes precedence over `visibleAspects` for aspect categories and
+   * overrides `complianceLane.enabled` for the compliance row.
+   */
+  visibleRows?: RowId[];
+  /**
+   * Restrict which stages (columns) are rendered by their stage ID.
+   * When absent, all stages are shown.
+   */
+  visibleStages?: string[];
 }
 
 import type { LayoutBounds } from '../geometry.js';
@@ -236,6 +249,8 @@ export interface AspectPill {
   y: number;
   width: number;
   height: number;
+  /** Word-wrapped lines of `name`, pre-fitted to the pill width by the layout. */
+  lines: string[];
 }
 
 export interface AspectRow {

--- a/scripts/package-extension.mjs
+++ b/scripts/package-extension.mjs
@@ -77,12 +77,13 @@ for (let i = 0; i < argv.length; i++) {
 }
 
 // Windows: spawning a .cmd (npm.cmd, npx.cmd) requires shell:true since
-// Node 18.20.2 (CVE-2024-27980). Quote the command so a path with spaces
-// survives; other executables (node via process.execPath) spawn directly.
+// Node 18.20.2 (CVE-2024-27980). Do NOT quote the command — Node 26 changed
+// %~dp0 resolution so a quoted command resolves relative to CWD instead of
+// the Node install dir, breaking npm.cmd's own path lookups.
 function run(command, args, options = {}) {
   const isBatch = process.platform === 'win32' && /\.(bat|cmd)$/i.test(command);
   return new Promise((resolve, reject) => {
-    const child = spawn(isBatch ? `"${command}"` : command, args, {
+    const child = spawn(command, args, {
       stdio: 'inherit',
       shell: isBatch,
       ...options,


### PR DESCRIPTION
## Summary

- **Process Blueprint**: restore three broken features — two-line pills (name + ID in gray), compliance legend toggle below the diagram, Display section with row/column/width controls; add clipPath rounded corners and transparent row backgrounds
- **Package (`process-blueprint`)**: add `RowId` type, `visibleRows`/`visibleStages` layout options, `lines[]` on `AspectPill` (layout engine pre-wraps pill text)
- **Title block**: uniform `Generated: YYYY-MM-DD` prefix across all diagram frame previews; compliance shell views (single-law, single-product, gap-dashboard) now show filename · Generated date

## Test plan

- [x] Process Blueprint: pills show name / ID two-line in VSIX 2.1.1
- [x] Process Blueprint: Legend checkbox shows/hides the compliance legend block below the diagram
- [x] Process Blueprint: Display section expands with Rows/Columns toggles and column-width slider
- [x] Process Blueprint: table corners all rounded, row backgrounds transparent
- [x] TypeScript: `npx tsc --noEmit` clean
- [x] VSIX: `output/transitrix-studio-2.1.1.vsix` builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)