### PR TITLE
fix(extension): standardize preview panel titles to [Type] Preview

### DIFF
--- a/extension/src/compliance-impact-preview.ts
+++ b/extension/src/compliance-impact-preview.ts
@@ -268,7 +268,7 @@ function applyFilter(
 }
 
 export class ComplianceImpactPreview {
-  readonly panelTitle = 'Compliance Impact Matrix';
+  readonly panelTitle = 'Compliance Impact Matrix Preview';
   private panel: vscode.WebviewPanel | undefined;
   private matrix: ImpactMatrix | undefined;
   private config: ImpactViewConfig | undefined;

--- a/extension/src/compliance-matrix-preview.ts
+++ b/extension/src/compliance-matrix-preview.ts
@@ -70,7 +70,7 @@ function collectJurisdictions(matrix: ComplianceMatrix): string[] {
 }
 
 export class ComplianceMatrixPreview {
-  readonly panelTitle = 'Compliance Matrix';
+  readonly panelTitle = 'Compliance Matrix Preview';
   private panel: vscode.WebviewPanel | undefined;
   private fullMatrix: ComplianceMatrix | undefined;
   private assertionPaths = new Map<string, string>();

--- a/extension/src/coverage-metric-preview.ts
+++ b/extension/src/coverage-metric-preview.ts
@@ -135,7 +135,7 @@ body { padding: 0; margin: 0; font-family: var(--vscode-font-family, sans-serif)
 `;
 
 export class CoverageMetricPreview {
-  readonly panelTitle = 'Coverage Metric';
+  readonly panelTitle = 'Coverage Metric Preview';
   private panel: vscode.WebviewPanel | undefined;
   private trackedUri: string | undefined;
 

--- a/extension/src/gap-dashboard-preview.ts
+++ b/extension/src/gap-dashboard-preview.ts
@@ -22,7 +22,7 @@ function todayIso(): string {
 }
 
 export class GapDashboardPreview {
-  readonly panelTitle = 'Compliance Gap Dashboard';
+  readonly panelTitle = 'Compliance Gap Dashboard Preview';
   private panel: vscode.WebviewPanel | undefined;
   private lastReport: GapReport | undefined;
   private lastConfidence: ViewScore | undefined;

--- a/extension/src/single-law-preview.ts
+++ b/extension/src/single-law-preview.ts
@@ -21,7 +21,7 @@ const OPEN_FILE_COMMAND = 'transitrixStudio.openComplianceFile';
 const REFRESH_COMMAND = 'transitrixStudio.refreshSingleLaw';
 
 export class SingleLawPreview {
-  readonly panelTitle = 'Compliance — Law';
+  readonly panelTitle = 'Compliance Law Preview';
   private panel: vscode.WebviewPanel | undefined;
   private trackedUri: string | undefined;
 

--- a/extension/src/single-product-preview.ts
+++ b/extension/src/single-product-preview.ts
@@ -20,7 +20,7 @@ const OPEN_FILE_COMMAND = 'transitrixStudio.openComplianceFile';
 const REFRESH_COMMAND = 'transitrixStudio.refreshSingleProduct';
 
 export class SingleProductPreview {
-  readonly panelTitle = 'Compliance — Product';
+  readonly panelTitle = 'Compliance Product Preview';
   private panel: vscode.WebviewPanel | undefined;
   private trackedUri: string | undefined;
 


### PR DESCRIPTION
## Summary

All six compliance preview panels were missing the "Preview" suffix in their `panelTitle`. Standardized to match the existing FGCA/FGA/Activities/BPMN pattern: `[Diagram Type] Preview`.

| File | Before | After |
|------|--------|-------|
| `compliance-matrix-preview.ts` | `Compliance Matrix` | `Compliance Matrix Preview` |
| `compliance-impact-preview.ts` | `Compliance Impact Matrix` | `Compliance Impact Matrix Preview` |
| `coverage-metric-preview.ts` | `Coverage Metric` | `Coverage Metric Preview` |
| `gap-dashboard-preview.ts` | `Compliance Gap Dashboard` | `Compliance Gap Dashboard Preview` |
| `single-law-preview.ts` | `Compliance — Law` | `Compliance Law Preview` |
| `single-product-preview.ts` | `Compliance — Product` | `Compliance Product Preview` |

## Test plan

- [ ] Open each compliance diagram type and verify the VS Code tab title reads `[Type] Preview — <filename>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)