### PR TITLE
feat(diagrams): show entity IDs inside FGCA/FGA and Activities nodes

### DIFF
--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -89,17 +89,30 @@ function networkSvg(doc: ActivityDoc, gaps: ActivitiesLayoutOptions = {}, curvat
     const x = n.x + ox;
     const y = n.y + oy;
     const isCritical = cpm.get(n.id)?.isCritical ?? false;
-    const isMilestone = (n.data.duration ?? -1) === 0;
+    const durVal = n.data.duration;
+    const isMilestone = (durVal ?? -1) === 0;
     const cls = `diagram-node act-node ${isCritical ? 'critical-node' : ''} ${isMilestone ? 'milestone-node' : ''}`.trim();
     const idLabel = escXml(n.id);
-    const nameLabel = escXml(truncate(n.data.name, 24));
-    const durLabel = n.data.duration !== undefined ? `${n.data.duration}d` : '—';
+    const words = n.data.name.split(' ');
+    let line1 = '';
+    let line2 = '';
+    for (const w of words) {
+      if ((line1 + ' ' + w).trim().length <= 24) line1 = (line1 + ' ' + w).trim();
+      else if ((line2 + ' ' + w).trim().length <= 24) line2 = (line2 + ' ' + w).trim();
+      else if (!line2) { line2 = w.slice(0, 22) + '…'; break; }
+    }
+    const twoLines = line2.length > 0;
+    const nameY1 = twoLines ? y + 18 : y + 28;
+    const nameY2 = y + 34;
+    const idY = twoLines ? y + 54 : y + 50;
+    const durLabel = (durVal !== undefined && durVal > 0) ? `${durVal}d` : '';
     return [
       `<rect class="${cls}" x="${x}" y="${y}" width="${N_NODE_W}" height="${N_NODE_H}" rx="6"/>`,
-      `<text class="text-id" x="${x + 8}" y="${y + 18}">${idLabel}</text>`,
-      `<text class="text-primary" x="${x + N_NODE_W / 2}" y="${y + N_NODE_H / 2}" text-anchor="middle" dominant-baseline="central">${nameLabel}</text>`,
-      `<text class="text-secondary" x="${x + N_NODE_W - 8}" y="${y + N_NODE_H - 10}" text-anchor="end">${durLabel}</text>`,
-    ].join('\n');
+      `<text class="text-primary" x="${x + N_NODE_W / 2}" y="${nameY1}" text-anchor="middle" dominant-baseline="central">${escXml(line1)}</text>`,
+      twoLines ? `<text class="text-primary" x="${x + N_NODE_W / 2}" y="${nameY2}" text-anchor="middle" dominant-baseline="central">${escXml(line2)}</text>` : '',
+      `<text class="text-id" x="${x + N_NODE_W / 2}" y="${idY}" text-anchor="middle" dominant-baseline="central">${idLabel}</text>`,
+      durLabel ? `<text class="text-secondary" x="${x + N_NODE_W - 8}" y="${y + N_NODE_H - 8}" text-anchor="end">${durLabel}</text>` : '',
+    ].filter(Boolean).join('\n');
   }).join('\n');
 
   const titleSvg = showTitle ? titleBlockSvg(heading!, filename!, date!, N_PAD, N_PAD, version) : '';

--- a/extension/src/fgca-preview.ts
+++ b/extension/src/fgca-preview.ts
@@ -269,12 +269,15 @@ function buildSvg(
       }
     }
     const twoLines = line2.length > 0;
-    const y1 = twoLines ? n.y + NODE_H / 2 - 8 : n.y + NODE_H / 2 + 5;
-    const y2 = y1 + 18;
+    const y1 = twoLines ? n.y + 16 : n.y + 26;
+    const y2 = n.y + 32;
+    const idY = twoLines ? n.y + 54 : n.y + 50;
+    const entityId = n.id.slice(n.id.indexOf('_') + 1);
     return [
       `<rect class="diagram-node layer-${n.col}" x="${n.x}" y="${n.y}" width="${NODE_W}" height="${NODE_H}" rx="8"/>`,
-      `<text class="text-primary" x="${n.x + NODE_W / 2}" y="${y1}" text-anchor="middle">${escXml(line1)}</text>`,
-      twoLines ? `<text class="text-secondary" x="${n.x + NODE_W / 2}" y="${y2}" text-anchor="middle">${escXml(line2)}</text>` : '',
+      `<text class="text-primary" x="${n.x + NODE_W / 2}" y="${y1}" text-anchor="middle" dominant-baseline="central">${escXml(line1)}</text>`,
+      twoLines ? `<text class="text-secondary" x="${n.x + NODE_W / 2}" y="${y2}" text-anchor="middle" dominant-baseline="central">${escXml(line2)}</text>` : '',
+      `<text class="text-id" x="${n.x + NODE_W / 2}" y="${idY}" text-anchor="middle" dominant-baseline="central">${escXml(entityId)}</text>`,
     ].filter(Boolean).join('\n');
   }).join('\n');
 

--- a/packages/diagrams/src/fgca/types.ts
+++ b/packages/diagrams/src/fgca/types.ts
@@ -1,32 +1,32 @@
 export interface FactorItem {
-  id: number;
+  id: number | string;
   name: string;
 }
 
 export interface GoalItem {
-  id: number;
+  id: number | string;
   name: string;
   level?: number;
   /** Goals may carry embedded factor links returned by the API. */
-  factor?: Array<{ id: number }>;
+  factor?: Array<{ id: number | string }>;
 }
 
 export interface BdnChangeWithActivities {
-  id: number;
+  id: number | string;
   name: string;
-  goal_id: number;
-  activity_ids: number[];
+  goal_id: number | string;
+  activity_ids: Array<number | string>;
 }
 
 export interface ActivityItem {
-  id: number;
+  id: number | string;
   name: string;
-  goal_id?: number | null;
+  goal_id?: number | string | null;
   activity_type_id?: number;
 }
 
 export interface ActivityTypeItem {
-  id: number;
+  id: number | string;
   name?: string;
 }
 

--- a/packages/diagrams/src/fgca/validate.ts
+++ b/packages/diagrams/src/fgca/validate.ts
@@ -47,12 +47,12 @@ export function validateFGCADoc(input: unknown): FGCAValidationResult {
   if (errors.length > 0) return { valid: false, errors, warnings };
 
   const doc = raw as unknown as FGCADoc;
-  const collectIds = (arr: unknown[]): Set<number> => {
-    const out = new Set<number>();
+  const collectIds = (arr: unknown[]): Set<number | string> => {
+    const out = new Set<number | string>();
     for (const el of arr) {
       if (el && typeof el === 'object') {
         const id = (el as { id?: unknown }).id;
-        if (typeof id === 'number') out.add(id);
+        if (typeof id === 'number' || typeof id === 'string') out.add(id);
       }
     }
     return out;
@@ -68,7 +68,7 @@ export function validateFGCADoc(input: unknown): FGCAValidationResult {
       continue;
     }
     const factor = f as { id?: unknown; name?: unknown };
-    if (typeof factor.id !== 'number') errors.push({ code: 'SCHEMA_INVALID', message: 'factor id must be a number', path: `factors[${i}]` });
+    if (typeof factor.id !== 'number' && typeof factor.id !== 'string') errors.push({ code: 'SCHEMA_INVALID', message: 'factor id must be a number or string', path: `factors[${i}]` });
     if (typeof factor.name !== 'string' || !factor.name.trim()) errors.push({ code: 'EMPTY_NAME', message: `Factor ${String(factor.id)} has empty name`, path: `factors[${i}]` });
   }
 
@@ -79,13 +79,13 @@ export function validateFGCADoc(input: unknown): FGCAValidationResult {
       continue;
     }
     const goal = g as { id?: unknown; name?: unknown; factor?: unknown };
-    if (typeof goal.id !== 'number') errors.push({ code: 'SCHEMA_INVALID', message: 'goal id must be a number', path: `goals[${i}]` });
+    if (typeof goal.id !== 'number' && typeof goal.id !== 'string') errors.push({ code: 'SCHEMA_INVALID', message: 'goal id must be a number or string', path: `goals[${i}]` });
     if (typeof goal.name !== 'string' || !goal.name.trim()) errors.push({ code: 'EMPTY_NAME', message: `Goal ${String(goal.id)} has empty name`, path: `goals[${i}]` });
     const factorRefs = Array.isArray(goal.factor) ? (goal.factor as unknown[]) : [];
     for (const fr of factorRefs) {
       if (!fr || typeof fr !== 'object') continue;
       const fid = (fr as { id?: unknown }).id;
-      if (typeof fid === 'number' && !factorIds.has(fid)) {
+      if ((typeof fid === 'number' || typeof fid === 'string') && !factorIds.has(fid)) {
         warnings.push({ code: 'BROKEN_REF', message: `Goal ${String(goal.id)} references missing factor ${fid}`, path: `goals[${i}].factor` });
       }
     }
@@ -98,14 +98,14 @@ export function validateFGCADoc(input: unknown): FGCAValidationResult {
       continue;
     }
     const change = c as { id?: unknown; name?: unknown; goal_id?: unknown; activity_ids?: unknown };
-    if (typeof change.id !== 'number') errors.push({ code: 'SCHEMA_INVALID', message: 'change id must be a number', path: `changes[${i}]` });
+    if (typeof change.id !== 'number' && typeof change.id !== 'string') errors.push({ code: 'SCHEMA_INVALID', message: 'change id must be a number or string', path: `changes[${i}]` });
     if (typeof change.name !== 'string' || !change.name.trim()) errors.push({ code: 'EMPTY_NAME', message: `Change ${String(change.id)} has empty name`, path: `changes[${i}]` });
-    if (typeof change.goal_id === 'number' && !goalIds.has(change.goal_id)) {
+    if ((typeof change.goal_id === 'number' || typeof change.goal_id === 'string') && !goalIds.has(change.goal_id)) {
       warnings.push({ code: 'BROKEN_REF', message: `Change ${String(change.id)} references missing goal ${change.goal_id}`, path: `changes[${i}].goal_id` });
     }
     const aids = Array.isArray(change.activity_ids) ? (change.activity_ids as unknown[]) : [];
     for (const aid of aids) {
-      if (typeof aid === 'number' && !activityIds.has(aid)) {
+      if ((typeof aid === 'number' || typeof aid === 'string') && !activityIds.has(aid)) {
         warnings.push({ code: 'BROKEN_REF', message: `Change ${String(change.id)} references missing activity ${aid}`, path: `changes[${i}].activity_ids` });
       }
     }
@@ -118,7 +118,7 @@ export function validateFGCADoc(input: unknown): FGCAValidationResult {
       continue;
     }
     const activity = a as { id?: unknown; name?: unknown };
-    if (typeof activity.id !== 'number') errors.push({ code: 'SCHEMA_INVALID', message: 'activity id must be a number', path: `activities[${i}]` });
+    if (typeof activity.id !== 'number' && typeof activity.id !== 'string') errors.push({ code: 'SCHEMA_INVALID', message: 'activity id must be a number or string', path: `activities[${i}]` });
     if (typeof activity.name !== 'string' || !activity.name.trim()) errors.push({ code: 'EMPTY_NAME', message: `Activity ${String(activity.id)} has empty name`, path: `activities[${i}]` });
   }
 

--- a/packages/diagrams/src/webview/render-activities.ts
+++ b/packages/diagrams/src/webview/render-activities.ts
@@ -116,17 +116,30 @@ export function renderActivitiesSvg(doc: ActivityDoc, options: RenderActivitiesO
       const x = n.x + ox;
       const y = n.y + oy;
       const isCritical = cpm.get(n.id)?.isCritical ?? false;
-      const isMilestone = (n.data.duration ?? -1) === 0;
+      const durVal = n.data.duration;
+      const isMilestone = (durVal ?? -1) === 0;
       const cls = `diagram-node act-node ${isCritical ? 'critical-node' : ''} ${isMilestone ? 'milestone-node' : ''}`.trim();
       const idLabel = escXml(n.id);
-      const nameLabel = escXml(truncate(n.data.name, 24));
-      const durLabel = n.data.duration !== undefined ? `${n.data.duration}d` : '—';
+      const words = n.data.name.split(' ');
+      let line1 = '';
+      let line2 = '';
+      for (const w of words) {
+        if ((line1 + ' ' + w).trim().length <= 24) line1 = (line1 + ' ' + w).trim();
+        else if ((line2 + ' ' + w).trim().length <= 24) line2 = (line2 + ' ' + w).trim();
+        else if (!line2) { line2 = w.slice(0, 22) + '…'; break; }
+      }
+      const twoLines = line2.length > 0;
+      const nameY1 = twoLines ? y + 18 : y + 28;
+      const nameY2 = y + 34;
+      const idY = twoLines ? y + 54 : y + 50;
+      const durLabel = (durVal !== undefined && durVal > 0) ? `${durVal}d` : '';
       return [
         `<rect class="${cls}" x="${x}" y="${y}" width="${N_NODE_W}" height="${N_NODE_H}" rx="6"/>`,
-        `<text class="text-id" x="${x + 8}" y="${y + 18}">${idLabel}</text>`,
-        `<text class="text-primary" x="${x + N_NODE_W / 2}" y="${y + N_NODE_H / 2}" text-anchor="middle" dominant-baseline="central">${nameLabel}</text>`,
-        `<text class="text-secondary" x="${x + N_NODE_W - 8}" y="${y + N_NODE_H - 10}" text-anchor="end">${escXml(durLabel)}</text>`,
-      ].join('\n');
+        `<text class="text-primary" x="${x + N_NODE_W / 2}" y="${nameY1}" text-anchor="middle" dominant-baseline="central">${escXml(line1)}</text>`,
+        twoLines ? `<text class="text-primary" x="${x + N_NODE_W / 2}" y="${nameY2}" text-anchor="middle" dominant-baseline="central">${escXml(line2)}</text>` : '',
+        `<text class="text-id" x="${x + N_NODE_W / 2}" y="${idY}" text-anchor="middle" dominant-baseline="central">${idLabel}</text>`,
+        durLabel ? `<text class="text-secondary" x="${x + N_NODE_W - 8}" y="${y + N_NODE_H - 8}" text-anchor="end">${durLabel}</text>` : '',
+      ].filter(Boolean).join('\n');
     })
     .join('\n');
 

--- a/packages/diagrams/src/webview/render-fgca.ts
+++ b/packages/diagrams/src/webview/render-fgca.ts
@@ -85,14 +85,17 @@ export function renderFgcaSvg(doc: FGCADoc, options: RenderFgcaOptions = {}): st
         }
       }
       const twoLines = line2.length > 0;
-      const y1 = twoLines ? n.y + NODE_H / 2 - 8 : n.y + NODE_H / 2 + 5;
-      const y2 = y1 + 18;
+      const y1 = twoLines ? n.y + 16 : n.y + 26;
+      const y2 = n.y + 32;
+      const idY = twoLines ? n.y + 54 : n.y + 50;
+      const entityId = n.id.slice(n.id.indexOf('_') + 1);
       return [
         `<rect class="diagram-node layer-${n.col}" x="${n.x}" y="${n.y}" width="${NODE_W}" height="${NODE_H}" rx="8"/>`,
-        `<text class="text-primary" x="${n.x + NODE_W / 2}" y="${y1}" text-anchor="middle">${escXml(line1)}</text>`,
+        `<text class="text-primary" x="${n.x + NODE_W / 2}" y="${y1}" text-anchor="middle" dominant-baseline="central">${escXml(line1)}</text>`,
         twoLines
-          ? `<text class="text-secondary" x="${n.x + NODE_W / 2}" y="${y2}" text-anchor="middle">${escXml(line2)}</text>`
+          ? `<text class="text-secondary" x="${n.x + NODE_W / 2}" y="${y2}" text-anchor="middle" dominant-baseline="central">${escXml(line2)}</text>`
           : '',
+        `<text class="text-id" x="${n.x + NODE_W / 2}" y="${idY}" text-anchor="middle" dominant-baseline="central">${escXml(entityId)}</text>`,
       ]
         .filter(Boolean)
         .join('\n');


### PR DESCRIPTION
## Summary

- **FGCA/FGA nodes**: entity ID (e.g. `FACTOR-EU-REG-1`) rendered as a grey `text-id` label centered at the bottom of each box; node name word-wraps to two lines before truncating
- **Activities nodes**: ID moved from top-left corner to bottom-center; name word-wraps to two lines; duration label only shown for non-milestone nodes with `duration > 0`
- **String ID support**: FGCA/FGA validator and types now accept `string` IDs throughout (previously only `number`) — `FactorItem`, `GoalItem`, `BdnChangeWithActivities`, `ActivityItem`, cross-ref checks, and `collectIds` all updated

Both the VS Code extension renderers (`extension/src/`) and the browser-safe renderers (`packages/diagrams/src/webview/`) are updated in sync.

## Test plan

- [ ] Open an FGCA/FGA diagram — verify entity IDs appear at the bottom of each node in grey
- [ ] Open an Activities diagram — verify IDs appear at bottom-center, names word-wrap for long labels
- [ ] Write an FGCA YAML with string IDs like `FACTOR-EU-REG-1` — verify no validation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)