### PR TITLE
fix(bpmn): restore horizontal entry for cross-lane gateway flows

### DIFF
--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -107,7 +107,7 @@ function networkSvg(doc: ActivityDoc, gaps: ActivitiesLayoutOptions = {}, curvat
     const idY = twoLines ? y + 54 : y + 50;
     const durLabel = (durVal !== undefined && durVal > 0) ? `${durVal}d` : '';
     return [
-      `<rect class="${cls}" x="${x}" y="${y}" width="${N_NODE_W}" height="${N_NODE_H}" rx="6"/>`,
+      `<rect class="${cls}" x="${x}" y="${y}" width="${N_NODE_W}" height="${N_NODE_H}" rx="8"/>`,
       `<text class="text-primary" x="${x + N_NODE_W / 2}" y="${nameY1}" text-anchor="middle" dominant-baseline="central">${escXml(line1)}</text>`,
       twoLines ? `<text class="text-primary" x="${x + N_NODE_W / 2}" y="${nameY2}" text-anchor="middle" dominant-baseline="central">${escXml(line2)}</text>` : '',
       `<text class="text-id" x="${x + N_NODE_W / 2}" y="${idY}" text-anchor="middle" dominant-baseline="central">${idLabel}</text>`,
@@ -491,7 +491,7 @@ function buildCanvasContent(views: ActivityViews): string {
 
 /** Diagram-class CSS used both in the webview and in saved .svg exports. */
 const ACTIVITIES_DIAGRAM_CSS = `
-  .act-node { fill: var(--ts-bg-surface, #f8fafc); stroke: var(--ts-border, #94a3b8); stroke-width: 1.5; }
+  .act-node { fill: var(--ts-layer-activity, #d4edda); stroke: var(--ts-node-stroke, #94a3b8); stroke-width: 1; }
   .critical-node { fill: #fff7ed; stroke: var(--ts-brand-orange, #ff4d00); stroke-width: 2.5; }
   .milestone-node { fill: #ecfeff; stroke: var(--ts-text-muted, #64748b); stroke-dasharray: 4 2; }
   .critical-edge { stroke: var(--ts-brand-orange, #ff4d00); stroke-width: 2; }

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -246,18 +246,22 @@ function routeCrossLane(
     const iy = toB.y + toB.height / 2;
 
     if (exitPort === 'bottom' || exitPort === 'top') {
-      // Cross the lane boundary without turning at the gap.
-      // Any bend happens at the source vertex level or at the target face — never mid-gap.
-      if (ep.x <= ix) {
-        // Gateway exit is left of the target left edge: drop straight at ep.x to
-        // target centre Y, then enter the left face with a rightward segment.
-        return dedupePoints([ep, { x: ep.x, y: iy }, { x: ix, y: iy }]);
-      }
-      // Gateway is above / to the right of the target (same column or shifted right):
-      // drop straight to the target face Y, then slide horizontally to the target centre.
-      // The single bend is at the target face, not in the lane gap.
+      if (!fromLaneBound) return diagonalFallbackRects(fromB, toB);
+      const chanY = targetBelow
+        ? fromLaneBound.y + fromLaneBound.height + laneVerticalGap / 2
+        : fromLaneBound.y - laneVerticalGap / 2;
       const targetFaceX = toB.x + toB.width / 2;
       const targetFaceY = targetBelow ? toB.y : toB.y + toB.height;
+
+      if (ep.x < ix) {
+        // Gateway exit is LEFT of the target left edge: travel horizontally at chanY
+        // (the inter-lane gap, where no elements sit) then drop to the target face.
+        // This avoids clipping through intermediate elements in the target lane.
+        return dedupePoints([ep, { x: ep.x, y: chanY }, { x: targetFaceX, y: chanY }, { x: targetFaceX, y: targetFaceY }]);
+      }
+
+      // Gateway is directly above / to the right of the target (same column):
+      // drop straight to the target face — no lateral movement at chanY, no kink.
       return dedupePoints([ep, { x: ep.x, y: targetFaceY }, { x: targetFaceX, y: targetFaceY }]);
     }
 

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -246,20 +246,23 @@ function routeCrossLane(
     const iy = toB.y + toB.height / 2;
 
     if (exitPort === 'bottom' || exitPort === 'top') {
-      // Gateway vertical exit: travel through inter-lane gap, then approach the
-      // target left face horizontally so the arrow enters left-to-right.
       if (!fromLaneBound) return diagonalFallbackRects(fromB, toB);
       const chanY = targetBelow
         ? fromLaneBound.y + fromLaneBound.height + laneVerticalGap / 2
         : fromLaneBound.y - laneVerticalGap / 2;
-      const approachX = ix - GATEWAY_BRANCH_CLEARANCE_PX;
-      return dedupePoints([
-        ep,
-        { x: ep.x,      y: chanY },   // vertical to inter-lane gap
-        { x: approachX, y: chanY },   // horizontal along gap to approach column
-        { x: approachX, y: iy },      // vertical to target centre Y
-        { x: ix,        y: iy },      // horizontal into target left vertex
-      ]);
+
+      if (ep.x <= ix) {
+        // Gateway exit is left of the target left edge: drop to target centre Y
+        // at the exit column, then enter the left face with a rightward segment.
+        return dedupePoints([ep, { x: ep.x, y: chanY }, { x: ep.x, y: iy }, { x: ix, y: iy }]);
+      }
+
+      // Gateway is directly above / to the right of the target (same column or
+      // shifted right): enter through the perpendicular face so the path drops
+      // straight down (or up) without a lateral kink at the inter-lane channel.
+      const targetFaceX = toB.x + toB.width / 2;
+      const targetFaceY = targetBelow ? toB.y : toB.y + toB.height;
+      return dedupePoints([ep, { x: ep.x, y: chanY }, { x: targetFaceX, y: chanY }, { x: targetFaceX, y: targetFaceY }]);
     }
 
     // Right exit: symmetric S-curve with bend at midpoint, enter target from left.

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -246,13 +246,20 @@ function routeCrossLane(
     const iy = toB.y + toB.height / 2;
 
     if (exitPort === 'bottom' || exitPort === 'top') {
-      // Gateway vertical exit: through inter-lane gap to target left-edge column,
-      // then down/up to target centre Y. No approach offset — eliminates the kink.
+      // Gateway vertical exit: travel through inter-lane gap, then approach the
+      // target left face horizontally so the arrow enters left-to-right.
       if (!fromLaneBound) return diagonalFallbackRects(fromB, toB);
       const chanY = targetBelow
         ? fromLaneBound.y + fromLaneBound.height + laneVerticalGap / 2
         : fromLaneBound.y - laneVerticalGap / 2;
-      return dedupePoints([ep, { x: ep.x, y: chanY }, { x: ix, y: chanY }, { x: ix, y: iy }]);
+      const approachX = ix - GATEWAY_BRANCH_CLEARANCE_PX;
+      return dedupePoints([
+        ep,
+        { x: ep.x,      y: chanY },   // vertical to inter-lane gap
+        { x: approachX, y: chanY },   // horizontal along gap to approach column
+        { x: approachX, y: iy },      // vertical to target centre Y
+        { x: ix,        y: iy },      // horizontal into target left vertex
+      ]);
     }
 
     // Right exit: symmetric S-curve with bend at midpoint, enter target from left.

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -246,23 +246,19 @@ function routeCrossLane(
     const iy = toB.y + toB.height / 2;
 
     if (exitPort === 'bottom' || exitPort === 'top') {
-      if (!fromLaneBound) return diagonalFallbackRects(fromB, toB);
-      const chanY = targetBelow
-        ? fromLaneBound.y + fromLaneBound.height + laneVerticalGap / 2
-        : fromLaneBound.y - laneVerticalGap / 2;
-
+      // Cross the lane boundary without turning at the gap.
+      // Any bend happens at the source vertex level or at the target face — never mid-gap.
       if (ep.x <= ix) {
-        // Gateway exit is left of the target left edge: drop to target centre Y
-        // at the exit column, then enter the left face with a rightward segment.
-        return dedupePoints([ep, { x: ep.x, y: chanY }, { x: ep.x, y: iy }, { x: ix, y: iy }]);
+        // Gateway exit is left of the target left edge: drop straight at ep.x to
+        // target centre Y, then enter the left face with a rightward segment.
+        return dedupePoints([ep, { x: ep.x, y: iy }, { x: ix, y: iy }]);
       }
-
-      // Gateway is directly above / to the right of the target (same column or
-      // shifted right): enter through the perpendicular face so the path drops
-      // straight down (or up) without a lateral kink at the inter-lane channel.
+      // Gateway is above / to the right of the target (same column or shifted right):
+      // drop straight to the target face Y, then slide horizontally to the target centre.
+      // The single bend is at the target face, not in the lane gap.
       const targetFaceX = toB.x + toB.width / 2;
       const targetFaceY = targetBelow ? toB.y : toB.y + toB.height;
-      return dedupePoints([ep, { x: ep.x, y: chanY }, { x: targetFaceX, y: chanY }, { x: targetFaceX, y: targetFaceY }]);
+      return dedupePoints([ep, { x: ep.x, y: targetFaceY }, { x: targetFaceX, y: targetFaceY }]);
     }
 
     // Right exit: symmetric S-curve with bend at midpoint, enter target from left.


### PR DESCRIPTION
## Root cause

PR #239 replaced a 5-waypoint path with a 3-point shortcut. The shortened path ended with a vertical segment `(ix, chanY)→(ix, iy)`, causing bpmn-js to render the arrowhead entering the target block **from the top** instead of from the left.

A first attempt restored the original `approachX = toB.x − 20` stub, which fixed the entry direction but introduced visible **kinks**: when the gateway and target are in the same horizontal column (directly connected, so ELK assigns them the same X layer), the path travelled ~(width/2 + 20)px **leftward** at the inter-lane gap before coming back right — a Z-shape.

## Fix

**Lane boundaries are not waypoints.** The arrow should cross the gap straight; any bend belongs at the source vertex or at the target face — never mid-gap.

Two cases, no `chanY` in either path:

```
ep.x ≤ toB.x  (gateway exit is left of the target left edge)
  → drop straight at ep.x to target centre Y
  → enter left face with a rightward segment
  → bend is at target Y level

ep.x > toB.x  (gateway is directly above / same column)
  → drop straight to the target face Y at ep.x
  → slide horizontally to target centre X
  → bend is at the target face, not in the gap
```

## Test plan

- [ ] GW-VERIFIED → TASK-LOG-REQUEST (same column, target below): arrow drops straight into TASK-LOG-REQUEST top face — no kink at the lane boundary
- [ ] GW-ARCHIVE → TASK-CONFIRM (same column, target above): arrow rises straight into TASK-CONFIRM bottom face — no kink
- [ ] Flow where gateway is to the left of the target: arrow enters target left face pointing right
- [ ] Same-lane flows, backward loops, right-exit S-curves — unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)