### PR TITLE
chore: bump 2.1.1 → 2.2.0

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Transitrix Studio — changelog
 
+## 2.2.0 — 2026-06-21
+
+BPMN diagram polish: PNG export, unified diagram styles, left-face entry for cross-lane flows, entity IDs in nodes.
+
+### Added
+
+- **BPMN preview — Save as PNG.** Export the rendered BPMN diagram to a `.png` file directly from the preview toolbar.
+- **Entity IDs in diagram nodes.** FGCA, FGA, and Activities nodes now show the entity ID below the name in grey, matching the Goal tree convention.
+
+### Fixed
+
+- **BPMN cross-lane gateway flows — left-face entry.** Arrows from gateway bottom/top exit ports now always enter the target block from the left face. Previously they could enter from the top or bottom depending on the gateway's position relative to the target.
+- **BPMN edge routing polish.** Corrected kinks in same-lane top/bottom exit routes, fixed `defaultFlow` attribute handling, and tightened preview layout.
+- **Activities diagram — unified node style.** Fill colour, stroke colour, stroke width, and corner radius now match Goal tree / FGA / FGCA out of the box.
+- **Preview panel titles** — standardised to `[Type] Preview — filename` pattern across all notations.
+- **Process Blueprint** — restored correct PNG export layout; uniform title block across all previews.
+
 ## 2.1.1 — 2026-06-20
 
 Activity Card layout polish, no-italic rule fully applied.

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Architecture-as-code for the modern enterprise. Author 17 notations — goals, processes, capabilities, BPMN, applications, more — as plain YAML, get live diagrams in VS Code. Diffable in git. AI-friendly. Open source. Built on ArchiMate 3.2 and BPMN 2.0.",
   "license": "MIT",
   "icon": "icon.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
## Summary

Version bump **2.1.1 → 2.2.0** with changelog for all changes since the last release.

### What's in 2.2.0

**Added**
- BPMN preview — Save as PNG export
- Entity IDs in FGCA / FGA / Activities diagram nodes

**Fixed**
- BPMN cross-lane gateway flows — arrows now always enter from the left face
- BPMN edge routing kinks and `defaultFlow` attribute
- Activities diagram node style unified with Goal tree / FGA / FGCA
- Preview panel titles standardised to `[Type] Preview — filename`
- Process Blueprint PNG export and title block

## Test plan

- [x] All 352 tests pass (`npx vitest run`)
- [x] `extension/package.json` version = `2.2.0`
- [x] `package.json` version = `2.2.0`
- [x] Changelog entry dated 2026-06-21

🤖 Generated with [Claude Code](https://claude.com/claude-code)