### PR TITLE
fix(extension): align frame-header typography with SVG title block

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Transitrix Studio — changelog
 
+## 2.2.0 — 2026-06-21
+
+BPMN diagram polish: PNG export, unified diagram styles, left-face entry for cross-lane flows, entity IDs in nodes.
+
+### Added
+
+- **BPMN preview — Save as PNG.** Export the rendered BPMN diagram to a `.png` file directly from the preview toolbar.
+- **Entity IDs in diagram nodes.** FGCA, FGA, and Activities nodes now show the entity ID below the name in grey, matching the Goal tree convention.
+
+### Fixed
+
+- **BPMN cross-lane gateway flows — left-face entry.** Arrows from gateway bottom/top exit ports now always enter the target block from the left face. Previously they could enter from the top or bottom depending on the gateway's position relative to the target.
+- **BPMN edge routing polish.** Corrected kinks in same-lane top/bottom exit routes, fixed `defaultFlow` attribute handling, and tightened preview layout.
+- **Activities diagram — unified node style.** Fill colour, stroke colour, stroke width, and corner radius now match Goal tree / FGA / FGCA out of the box.
+- **Preview panel titles** — standardised to `[Type] Preview — filename` pattern across all notations.
+- **Process Blueprint** — restored correct PNG export layout; uniform title block across all previews.
+
 ## 2.1.1 — 2026-06-20
 
 Activity Card layout polish, no-italic rule fully applied.

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Architecture-as-code for the modern enterprise. Author 17 notations — goals, processes, capabilities, BPMN, applications, more — as plain YAML, get live diagrams in VS Code. Diffable in git. AI-friendly. Open source. Built on ArchiMate 3.2 and BPMN 2.0.",
   "license": "MIT",
   "icon": "icon.png",

--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -242,10 +242,10 @@ export function buildErrorHtml(errorMsg: string): { input: string; block: string
 }
 
 const FRAME_HEADER_CSS = `
-.frame-header{padding:16px 20px 20px;}
-.frame-title{font-size:18px;font-weight:700;color:var(--ts-text,#0f172a);margin-bottom:4px;}
-.frame-subtitle{font-size:13px;color:var(--ts-text-muted,#64748b);margin-bottom:4px;}
-.frame-meta{font-size:11px;color:var(--ts-text-muted,#64748b);letter-spacing:0.04em;}
+.frame-header{padding:14px 24px 10px;}
+.frame-title{font-size:13px;font-weight:700;color:var(--ts-header-text,#0f172a);font-family:var(--vscode-font-family,system-ui,-apple-system,sans-serif);line-height:16px;margin-bottom:0;}
+.frame-subtitle{font-size:11px;font-weight:400;color:var(--ts-text-secondary,#475569);font-family:var(--vscode-font-family,system-ui,-apple-system,sans-serif);line-height:16px;margin-bottom:0;}
+.frame-meta{font-size:11px;font-weight:400;color:var(--ts-text-secondary,#475569);font-family:var(--vscode-font-family,system-ui,-apple-system,sans-serif);letter-spacing:0.04em;line-height:16px;}
 `;
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
## Summary

HTML catalogue previews (Capability Map, Compliance views, etc.) use a `frame-header` div whose `.frame-title` / `.frame-subtitle` / `.frame-meta` CSS classes previously used different sizes and colour tokens from the SVG title block in Goal tree / FGA / Process Blueprint.

Changes to `FRAME_HEADER_CSS` in `diagram-frame.ts`:

| Class | Before | After |
|-------|--------|-------|
| `.frame-title` | 18 px / `--ts-text` | 13 px 700 / `--ts-header-text` — matches `text-header` |
| `.frame-subtitle` | 13 px / `--ts-text-muted` | 11 px 400 / `--ts-text-secondary` — matches `text-secondary` |
| `.frame-meta` | 11 px / `--ts-text-muted` | 11 px 400 / `--ts-text-secondary` — matches `text-secondary` |
| padding | `16px 20px 20px` | `14px 24px 10px` — aligns with SVG left-pad and compact height |
| line-height | unset | `16px` — matches 16 px spacing between SVG text baselines |
| font-family | unset | `var(--vscode-font-family, …)` — explicit, matches SVG |

No behavioural changes; no new tests needed (pure CSS).

## Test plan

- [x] 352 tests pass
- [ ] Visual: Capability Map and Compliance previews — header visually matches Goal tree / Process Blueprint header

🤖 Generated with [Claude Code](https://claude.com/claude-code)