### PR TITLE
fix(extension): show header in applications and products previews

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Transitrix Studio — changelog
 
+## 2.2.0 — 2026-06-21
+
+BPMN diagram polish: PNG export, unified diagram styles, left-face entry for cross-lane flows, entity IDs in nodes.
+
+### Added
+
+- **BPMN preview — Save as PNG.** Export the rendered BPMN diagram to a `.png` file directly from the preview toolbar.
+- **Entity IDs in diagram nodes.** FGCA, FGA, and Activities nodes now show the entity ID below the name in grey, matching the Goal tree convention.
+
+### Fixed
+
+- **BPMN cross-lane gateway flows — left-face entry.** Arrows from gateway bottom/top exit ports now always enter the target block from the left face. Previously they could enter from the top or bottom depending on the gateway's position relative to the target.
+- **BPMN edge routing polish.** Corrected kinks in same-lane top/bottom exit routes, fixed `defaultFlow` attribute handling, and tightened preview layout.
+- **Activities diagram — unified node style.** Fill colour, stroke colour, stroke width, and corner radius now match Goal tree / FGA / FGCA out of the box.
+- **Preview panel titles** — standardised to `[Type] Preview — filename` pattern across all notations.
+- **Process Blueprint** — restored correct PNG export layout; uniform title block across all previews.
+
 ## 2.1.1 — 2026-06-20
 
 Activity Card layout polish, no-italic rule fully applied.

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Architecture-as-code for the modern enterprise. Author 17 notations — goals, processes, capabilities, BPMN, applications, more — as plain YAML, get live diagrams in VS Code. Diffable in git. AI-friendly. Open source. Built on ArchiMate 3.2 and BPMN 2.0.",
   "license": "MIT",
   "icon": "icon.png",

--- a/extension/src/applications-preview.ts
+++ b/extension/src/applications-preview.ts
@@ -211,6 +211,10 @@ export class ApplicationsPreview {
         const raw = parsed as Record<string, unknown>;
         const catalogue = raw['applications_catalogue'] as ApplicationsCatalogueHeader;
         bodyContent = buildApplicationsTable(catalogue);
+        if (!title) title = catalogue.name;
+        if (!subtitle && catalogue.description) subtitle = catalogue.description;
+        if (!version && catalogue.version) version = catalogue.version;
+        if (!date) date = catalogue.updated_at;
       }
     } catch (e) {
       errorMsg = (e as Error).message ?? 'Parse error';

--- a/extension/src/compliance-impact-preview.ts
+++ b/extension/src/compliance-impact-preview.ts
@@ -745,7 +745,7 @@ export class ComplianceImpactPreview {
 const IMPACT_CSS = `
 body { padding: 0; }
 #toolbar { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 8px 16px; border-bottom: 1px solid var(--ts-border, #cbd5e1); flex-wrap: wrap; }
-.toolbar-label { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 12px; color: var(--ts-text-muted, #64748b); }
+.toolbar-label { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 13px; font-weight: 700; color: var(--ts-header-text, #0f172a); }
 .toolbar-actions { display: flex; gap: 4px; align-items: center; flex-wrap: wrap; justify-content: flex-end; }
 .toolbar-btn { cursor: pointer; user-select: none; font-size: 11px; padding: 1px 8px; border-radius: 4px; color: var(--ts-text-muted, #64748b); white-space: nowrap; text-decoration: none; }
 .toolbar-btn:hover { color: var(--ts-text, #0f172a); background: var(--ts-bg-elevated, #f1f5f9); }

--- a/extension/src/compliance-matrix-preview.ts
+++ b/extension/src/compliance-matrix-preview.ts
@@ -320,7 +320,7 @@ ${WARN_BLOCK_CSS}
 const MATRIX_CSS = `
 body { padding: 0; }
 #cm-toolbar { display: flex; align-items: center; gap: 14px; padding: 10px 16px; border-bottom: 1px solid var(--ts-border, #cbd5e1); flex-wrap: wrap; }
-.cm-title { font-size: 14px; font-weight: 700; color: var(--ts-text, #0f172a); }
+.cm-title { font-size: 13px; font-weight: 700; color: var(--ts-header-text, #0f172a); }
 .cm-summary { font-size: 12px; color: var(--ts-text-muted, #64748b); }
 .cm-summary strong { color: var(--ts-text, #0f172a); }
 .cm-btn { font-size: 11px; padding: 2px 10px; border-radius: 4px; color: var(--ts-text-muted, #64748b); text-decoration: none; border: 1px solid var(--ts-border, #cbd5e1); }

--- a/extension/src/compliance-render.ts
+++ b/extension/src/compliance-render.ts
@@ -52,10 +52,10 @@ export function openLink(command: string, fsPath: string | undefined, inner: str
 const COMPLIANCE_CSS = `
 body { padding: 0; }
 #cmp-toolbar { display: flex; align-items: baseline; gap: 12px; padding: 12px 16px; border-bottom: 1px solid var(--ts-border, #cbd5e1); flex-wrap: wrap; }
-.cmp-title { font-size: 15px; font-weight: 700; color: var(--ts-text, #0f172a); }
-.cmp-subtitle { font-size: 12px; color: var(--ts-text-muted, #64748b); }
-.cmp-meta { width: 100%; font-size: 11px; color: var(--ts-text-muted, #64748b); letter-spacing: 0.04em; }
-.cmp-confidence { width: 100%; font-size: 11px; color: var(--ts-text-muted, #64748b); }
+.cmp-title { font-size: 13px; font-weight: 700; color: var(--ts-header-text, #0f172a); }
+.cmp-subtitle { font-size: 11px; color: var(--ts-text-secondary, #475569); }
+.cmp-meta { width: 100%; font-size: 11px; color: var(--ts-text-secondary, #475569); letter-spacing: 0.04em; }
+.cmp-confidence { width: 100%; font-size: 11px; color: var(--ts-text-secondary, #475569); }
 .cmp-confidence-band { display: inline-block; padding: 0 6px; margin-right: 4px; border-radius: 3px; font-weight: 700; background: var(--ts-bg-subtle, #f1f5f9); color: var(--ts-text, #0f172a); }
 .cmp-confidence-band[data-band="A"] { background: var(--ts-status-success-bg, #d1fae5); color: var(--ts-status-success-fg, #065f46); }
 .cmp-confidence-band[data-band="B"] { background: var(--ts-status-info-bg, #e0f2fe); color: var(--ts-status-info-fg, #0c4a6e); }

--- a/extension/src/coverage-metric-preview.ts
+++ b/extension/src/coverage-metric-preview.ts
@@ -99,8 +99,9 @@ function buildTableHtml(matrix: CoverageMatrix): string {
 const COVERAGE_CSS = `
 body { padding: 0; margin: 0; font-family: var(--vscode-font-family, sans-serif); font-size: 13px; color: var(--ts-text, #0f172a); }
 #cm-toolbar { display: flex; align-items: center; gap: 12px; padding: 10px 16px; border-bottom: 1px solid var(--ts-border, #cbd5e1); flex-wrap: wrap; }
-.cm-title { font-size: 14px; font-weight: 700; color: var(--ts-text, #0f172a); }
-.cm-subtitle { font-size: 12px; color: var(--ts-text-muted, #64748b); }
+.cm-title { font-size: 13px; font-weight: 700; color: var(--ts-header-text, #0f172a); }
+.cm-subtitle { font-size: 11px; color: var(--ts-text-secondary, #475569); }
+.cm-meta { font-size: 11px; color: var(--ts-text-secondary, #475569); letter-spacing: 0.04em; flex-basis: 100%; }
 .cm-btn { font-size: 11px; padding: 2px 10px; border-radius: 4px; color: var(--ts-text-muted, #64748b); text-decoration: none; border: 1px solid var(--ts-border, #cbd5e1); margin-left: auto; }
 .cm-btn:hover { color: var(--ts-text, #0f172a); background: var(--ts-bg-elevated, #f1f5f9); }
 .cm-wrap { padding: 16px 20px 24px; overflow-x: auto; }
@@ -178,10 +179,11 @@ export class CoverageMetricPreview {
 
   private async pushDocument(doc: vscode.TextDocument): Promise<void> {
     if (!this.panel) return;
-    this.panel.webview.html = await this.buildHtml(doc.getText());
+    const filename = doc.uri.path.split('/').pop() ?? '';
+    this.panel.webview.html = await this.buildHtml(doc.getText(), filename);
   }
 
-  private async buildHtml(yamlText: string): Promise<string> {
+  private async buildHtml(yamlText: string, filename = ''): Promise<string> {
     const cfg = vscode.workspace.getConfiguration('transitrix');
     const themeId = cfg.get<ThemeId>('theme', 'transitrix');
     const colW = cfg.get<string>('report.columnWidth', 'normal');
@@ -241,6 +243,7 @@ export class CoverageMetricPreview {
       '  <div id="cm-toolbar">\n' +
       `    <div class="cm-title">${titleLine}</div>\n` +
       (subtitleLine ? `    <div class="cm-subtitle">${subtitleLine}</div>\n` : '') +
+      (filename ? `    <div class="cm-meta">${escXml(filename)} · Generated: ${new Date().toISOString().slice(0, 10)}</div>\n` : '') +
       `    <a href="command:transitrixStudio.changeTheme" class="cm-btn" title="Change the color scheme for all diagram previews">Theme…</a>\n` +
       `    <a href="command:${REFRESH_COMMAND}" class="cm-btn" title="Re-scan the workspace and reload">Refresh</a>\n` +
       '  </div>\n' +

--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -242,10 +242,10 @@ export function buildErrorHtml(errorMsg: string): { input: string; block: string
 }
 
 const FRAME_HEADER_CSS = `
-.frame-header{padding:16px 20px 20px;}
-.frame-title{font-size:18px;font-weight:700;color:var(--ts-text,#0f172a);margin-bottom:4px;}
-.frame-subtitle{font-size:13px;color:var(--ts-text-muted,#64748b);margin-bottom:4px;}
-.frame-meta{font-size:11px;color:var(--ts-text-muted,#64748b);letter-spacing:0.04em;}
+.frame-header{padding:14px 24px 10px;}
+.frame-title{font-size:13px;font-weight:700;color:var(--ts-header-text,#0f172a);font-family:var(--vscode-font-family,system-ui,-apple-system,sans-serif);line-height:16px;margin-bottom:0;}
+.frame-subtitle{font-size:11px;font-weight:400;color:var(--ts-text-secondary,#475569);font-family:var(--vscode-font-family,system-ui,-apple-system,sans-serif);line-height:16px;margin-bottom:0;}
+.frame-meta{font-size:11px;font-weight:400;color:var(--ts-text-secondary,#475569);font-family:var(--vscode-font-family,system-ui,-apple-system,sans-serif);letter-spacing:0.04em;line-height:16px;}
 `;
 
 /**

--- a/extension/src/products-preview.ts
+++ b/extension/src/products-preview.ts
@@ -178,6 +178,10 @@ export class ProductsPreview {
         const raw = parsed as Record<string, unknown>;
         const catalogue = raw['products_catalogue'] as ProductsCatalogueHeader;
         bodyContent = buildProductsTable(catalogue);
+        if (!title) title = catalogue.name;
+        if (!subtitle && catalogue.description) subtitle = catalogue.description;
+        if (!version && catalogue.version) version = catalogue.version;
+        if (!date) date = catalogue.updated_at;
       }
     } catch (e) {
       errorMsg = (e as Error).message ?? 'Parse error';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
## Summary

- `applications-preview.ts` and `products-preview.ts` read `raw['title']` / `raw['description']` / `raw['version']` / `raw['date']` from the top-level YAML, but catalogue files store metadata inside the nested `applications_catalogue` / `products_catalogue` object. Top-level keys are absent → `title` stays `undefined` → `buildDiagramFrame` skips the `frame-header` entirely.
- Fix: after successful validation, fall back to `catalogue.name` / `.description` / `.version` / `.updated_at` when no top-level overrides are present. Mirrors the existing pattern in `process-map-preview.ts` (lines 189–192) and `scenarios-preview.ts` (lines 185–187).

## Test plan

- [ ] Open `eu-portfolio.applications.transitrix.yaml` in the extension — frame-header now shows "Acme Corp — EU Applications Portfolio" with subtitle and date
- [ ] Open a products catalogue file — frame-header appears with name/description from `products_catalogue`
- [ ] Files that do have top-level `title:` are unaffected (top-level takes precedence)
- [ ] 921 tests pass (`npm test`)
