### PR TITLE
fix(bpmn): skip chanY segment when target lane is clear

### DIFF
--- a/src/layout.ts
+++ b/src/layout.ts
@@ -204,14 +204,34 @@ function routeSameLane(
   return dedupePoints([{ x: ex, y: ey }, { x: midX, y: ey }, { x: midX, y: iy }, { x: ix, y: iy }]);
 }
 
+/** Returns true if no element in `els` intersects the vertical segment at x=segX
+ *  between y1 and y2 (inclusive, with epsilon tolerance on the x-axis). */
+function verticalSegmentClear(
+  segX: number,
+  y1: number,
+  y2: number,
+  els: Bounds[],
+): boolean {
+  const minY = Math.min(y1, y2);
+  const maxY = Math.max(y1, y2);
+  const eps = CROSS_LANE_EDGE_OVERLAP_EPSILON_PX;
+  return els.every(
+    (el) =>
+      segX < el.x - eps ||
+      segX > el.x + el.width + eps ||
+      el.y + el.height <= minY ||
+      el.y >= maxY,
+  );
+}
+
 /** Orthogonal route for two elements in different lanes.
  *
  *  Preferred port: exit right-center of source, enter left-center of target.
  *
- *  For gateway flows with 'top'/'bottom' exit port: exit vertically through
- *  inter-lane gap (chanY), move horizontally to 20 px left of target, drop to
- *  target centre Y, then enter from the left face (5-point elbow). This avoids
- *  passing through intermediate elements that may sit in the target lane.
+ *  For gateway flows with 'top'/'bottom' exit port: when the target lane is
+ *  empty between the exit x and the target's left face, a simple 3-point
+ *  L-path is used (down + right into left face).  When intermediate elements
+ *  exist, the path travels via chanY (inter-lane gap) to stay clear.
  *
  *  For right-exit flows: horizontal from source right face to the approach
  *  column (20 px left of target), then vertical to target centre Y, then
@@ -223,7 +243,9 @@ function routeSameLane(
  *  `exitPort` lets gateway port-distribution override the exit vertex: 'bottom'
  *  routes downward out of the bottom vertex, 'top' upward.
  *  `laneVerticalGap` is the vertical spacing between lanes; used to compute the
- *  inter-lane channel coordinate for vertical gateway exits. */
+ *  inter-lane channel coordinate for vertical gateway exits.
+ *  `targetLaneElements` is the list of target-lane element bounds (excluding the
+ *  target itself); when provided, enables the 3-point path optimisation. */
 function routeCrossLane(
   fromB: Bounds,
   toB: Bounds,
@@ -231,6 +253,7 @@ function routeCrossLane(
   toLaneBound?: Bounds,
   exitPort: Port = 'right',
   laneVerticalGap = 40,
+  targetLaneElements?: Bounds[],
 ): { x: number; y: number }[] {
   const targetBelow = toB.y >= fromB.y + fromB.height - CROSS_LANE_EDGE_OVERLAP_EPSILON_PX;
   const targetAbove = toB.y + toB.height <= fromB.y + CROSS_LANE_EDGE_OVERLAP_EPSILON_PX;
@@ -250,10 +273,21 @@ function routeCrossLane(
       const chanY = targetBelow
         ? fromLaneBound.y + fromLaneBound.height + laneVerticalGap / 2
         : fromLaneBound.y - laneVerticalGap / 2;
-      // Always enter the target from the left face (→).
+      const approachX = toB.x - GATEWAY_BRANCH_CLEARANCE_PX;
+
+      // Optimisation: when the exit x is at or left of the target's left face
+      // and the straight vertical segment at ep.x through the target lane is
+      // clear of all intermediate elements, use a simple 3-point L-path.
+      if (
+        ep.x <= toB.x &&
+        targetLaneElements !== undefined &&
+        verticalSegmentClear(ep.x, chanY, iy, targetLaneElements)
+      ) {
+        return dedupePoints([ep, { x: ep.x, y: iy }, { x: toB.x, y: iy }]);
+      }
+
       // Travel via chanY (inter-lane gap) to avoid elements in the target lane,
       // then drop to target centre Y and approach from the left.
-      const approachX = toB.x - GATEWAY_BRANCH_CLEARANCE_PX;
       return dedupePoints([ep, { x: ep.x, y: chanY }, { x: approachX, y: chanY }, { x: approachX, y: iy }, { x: toB.x, y: iy }]);
     }
 
@@ -655,9 +689,15 @@ export async function layoutProcess(
       const fromLaneBound = fromL ? laneBounds.get(fromL) : undefined;
       const toLaneBound = toL ? laneBounds.get(toL) : undefined;
       const isSourceGateway = GATEWAY_TYPES.has(elementTypeMap.get(f.from) ?? '');
+      const targetLaneEls: Bounds[] | undefined = toL
+        ? ir.lanes
+            .find((l) => l.id === toL)
+            ?.elements.filter((el) => el.id !== f.to)
+            .flatMap((el) => { const b = elements.get(el.id); return b ? [b] : []; })
+        : undefined;
       wps = fromL === toL
         ? routeSameLane(fb, tb, exitOffset, exitPort, isSourceGateway)
-        : routeCrossLane(fb, tb, fromLaneBound, toLaneBound, exitPort, o.laneVerticalGap);
+        : routeCrossLane(fb, tb, fromLaneBound, toLaneBound, exitPort, o.laneVerticalGap, targetLaneEls);
       if (wps.length < 2) wps = diagonalFallbackRects(fb, tb);
     }
     return { ...f, waypoints: wps };

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -590,6 +590,75 @@ describe('layout', () => {
       expect(seg2, `segment (${wps[i].x.toFixed(0)},${wps[i].y.toFixed(0)})→(${wps[i + 1].x.toFixed(0)},${wps[i + 1].y.toFixed(0)}) intersects bot-task-2`).toBe(false);
     }
   });
+  // RD-127 optimisation: when the target lane is clear of intermediate elements,
+  // the cross-lane gateway flow uses a 3-point L-path (down + horizontal) instead
+  // of the 5-point chanY elbow.
+  it('cross-lane gateway flow uses 3-point L-path when target lane is clear', async () => {
+    // Fixture: 2 lanes stacked vertically.
+    //   Top lane: start → gw  (gw is in a later ELK column than start)
+    //   Bot lane: target only  (no intermediate elements)
+    // Flow gw → target: gw exits BOTTOM; target lane is empty → 3-point L-path expected.
+    const ir = parseYamlToIr(`process:
+  id: rd127-opt-repro
+  name: RD-127-opt repro
+  pools:
+    - id: pool
+      name: Pool
+      lanes:
+        - id: lane-top
+          name: Top
+          elements:
+            - id: start
+              type: startEvent
+            - id: gw
+              type: parallelGateway
+              name: Decide
+        - id: lane-bot
+          name: Bot
+          elements:
+            - id: target
+              type: task
+              name: Target
+  flows:
+    - from: start
+      to: gw
+    - from: gw
+      to: target
+`);
+    const layout = await layoutProcess(ir);
+
+    const flow = layout.flows.find((f) => f.from === 'gw' && f.to === 'target');
+    expect(flow, 'gw→target flow not found').toBeDefined();
+
+    const gwB = layout.elements.get('gw')!;
+    const targetB = layout.elements.get('target')!;
+    const topBound = layout.laneBounds.get('lane-top')!;
+    const laneVerticalGap = 40; // default
+    const chanY = topBound.y + topBound.height + laneVerticalGap / 2;
+
+    const wps = flow!.waypoints;
+
+    // 3-point L-path: [gw-bottom, (ep.x, target-center-y), (target.x, target-center-y)]
+    expect(wps.length, 'expected 3-point path, got more').toBeLessThanOrEqual(3);
+    expect(wps.length).toBeGreaterThanOrEqual(2);
+
+    // No waypoint should lie at chanY — that would indicate the unnecessary kink.
+    for (const wp of wps) {
+      expect(Math.abs(wp.y - chanY), `waypoint y=${wp.y.toFixed(1)} is at chanY=${chanY.toFixed(1)}`).toBeGreaterThan(2);
+    }
+
+    // First waypoint: gateway bottom center.
+    const gwCX = gwB.x + gwB.width / 2;
+    const gwBottom = gwB.y + gwB.height;
+    expect(wps[0].x).toBeCloseTo(gwCX, 0);
+    expect(wps[0].y).toBeCloseTo(gwBottom, 0);
+
+    // Last waypoint: target left-center entry.
+    const last = wps[wps.length - 1];
+    expect(last.x).toBeCloseTo(targetB.x, 0);
+    expect(last.y).toBeCloseTo(targetB.y + targetB.height / 2, 0);
+  });
+
   // TX-023: direction-aware gateway port assignment (same-lane TOP/BOTTOM for vertical branches)
   it('TX-023 — same-lane gateway branches above/below exit TOP/BOTTOM vertices', async () => {
     // feature-release: gw-deploy-split (parallelGateway) in lane-infra


### PR DESCRIPTION
## Summary

- When a cross-lane gateway exits via bottom/top port and the target lane has no intermediate elements blocking the straight vertical path, route a simple 3-point L-shape (down → right into target left face) instead of the 5-point chanY elbow
- The chanY horizontal exists to avoid clipping intermediate elements; when none are present it produces a visible kink with no geometric benefit
- Adds `verticalSegmentClear()` helper and optional `targetLaneElements` parameter to `routeCrossLane()`; callers without the parameter fall back to the existing 5-point path

## Changes

- `src/layout.ts` — `verticalSegmentClear()` helper; updated `routeCrossLane()` signature with optional `targetLaneElements?: Bounds[]`; updated `layoutProcess` to collect and pass target-lane elements
- `tests/integration.test.ts` — new test verifying 3-point path when target lane is empty; RD-127 test (intermediate elements present → 5-point path) is unchanged

## Test plan

- [x] All 921 tests pass (`npm test`)
- [x] TypeScript compiles clean (`npm run compile`)
- [x] RD-127 regression (intermediate elements → 5-point path) still green
- [x] New test: empty target lane → 3-point path, no chanY waypoint