### PR TITLE
feat(extension): unify diagram metadata standard (CONTRACT §1.1)

### DIFF
--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -634,7 +634,9 @@ export class ActivitiesPreview {
       // incoherent, so the doc's own date wins when present.
       const raw = (parsed && typeof parsed === 'object' ? parsed : {}) as Record<string, unknown>;
       const docVersion = typeof raw['version'] === 'string' ? raw['version'] : undefined;
-      const docDate = typeof raw['date'] === 'string' ? raw['date'] : todayIso();
+      const docDate = (typeof raw['generated_at'] === 'string' ? raw['generated_at'] : undefined)
+        ?? (typeof raw['date'] === 'string' ? raw['date'] : undefined)
+        ?? todayIso();
       const v = validateActivities(parsed);
       warnings = v.warnings.map(w => `${w.code}: ${w.message}`);
       if (!v.valid) {

--- a/extension/src/activity-card-preview.ts
+++ b/extension/src/activity-card-preview.ts
@@ -248,7 +248,9 @@ export class ActivityCardPreview {
         } else {
           const meta = (parsed && typeof parsed === 'object' ? parsed : {}) as Record<string, unknown>;
           const docVersion = typeof meta['version'] === 'string' ? (meta['version'] as string) : undefined;
-          const docDate = typeof meta['date'] === 'string' ? (meta['date'] as string) : todayIso();
+          const docDate = (typeof meta['generated_at'] === 'string' ? (meta['generated_at'] as string) : undefined)
+            ?? (typeof meta['date'] === 'string' ? (meta['date'] as string) : undefined)
+            ?? todayIso();
           const layout = layoutActivityCard(r.resolved);
           svgContent = layoutToSvg(layout, filename, docDate, docVersion);
         }

--- a/extension/src/applications-preview.ts
+++ b/extension/src/applications-preview.ts
@@ -1,7 +1,7 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
-import { buildDiagramFrame, CATALOGUE_STYLES, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
+import { buildDiagramFrame, extractDiagramMeta, CATALOGUE_STYLES, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 import { validateApplicationsCatalogue } from '../../packages/diagrams/src/applications/validate.js';
 
@@ -198,10 +198,7 @@ export class ApplicationsPreview {
 
       if (parsed && typeof parsed === 'object') {
         const raw = parsed as Record<string, unknown>;
-        if (typeof raw['title'] === 'string') title = raw['title'];
-        if (typeof raw['description'] === 'string') subtitle = raw['description'];
-        if (raw['version'] !== undefined) version = String(raw['version']);
-        if (typeof raw['date'] === 'string') date = raw['date'];
+        ({ title, subtitle, date, version } = extractDiagramMeta(raw));
       }
 
       const v = validateApplicationsCatalogue(parsed);
@@ -211,6 +208,10 @@ export class ApplicationsPreview {
         const raw = parsed as Record<string, unknown>;
         const catalogue = raw['applications_catalogue'] as ApplicationsCatalogueHeader;
         bodyContent = buildApplicationsTable(catalogue);
+        if (!title) title = catalogue.name;
+        if (!subtitle && catalogue.description) subtitle = catalogue.description;
+        if (!version && catalogue.version) version = catalogue.version;
+        if (!date) date = catalogue.updated_at;
       }
     } catch (e) {
       errorMsg = (e as Error).message ?? 'Parse error';

--- a/extension/src/blocks-preview.ts
+++ b/extension/src/blocks-preview.ts
@@ -142,11 +142,14 @@ export class BlocksPreview {
         errorMsg = v.errors.map((e) => `${e.code}: ${e.message}`).join('\n');
       } else {
         const file = parsed as BlocksFile;
+        const raw = (parsed && typeof parsed === 'object' ? parsed : {}) as Record<string, unknown>;
         const nb =
           (file as unknown as { nested_blocks?: { version?: unknown; date?: unknown } })
             .nested_blocks ?? {};
         const docVersion = typeof nb.version === 'string' ? nb.version : undefined;
-        const docDate = typeof nb.date === 'string' ? nb.date : todayIso();
+        const docDate = (typeof raw['generated_at'] === 'string' ? raw['generated_at'] : undefined)
+          ?? (typeof nb.date === 'string' ? nb.date : undefined)
+          ?? todayIso();
         const layout = layoutNestedBlocks(file);
         svgContent = layoutToSvg(layout, filename, docDate, docVersion);
 

--- a/extension/src/capability-map-preview.ts
+++ b/extension/src/capability-map-preview.ts
@@ -1,7 +1,7 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
-import { buildDiagramFrame, CATALOGUE_STYLES, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
+import { buildDiagramFrame, extractDiagramMeta, CATALOGUE_STYLES, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 import { validateCapabilityMap } from '../../packages/diagrams/src/capability-map/validate.js';
 
@@ -167,10 +167,7 @@ export class CapabilityMapPreview {
       const parsed = coerceDatesToIsoStrings(yaml.load(yamlText) as unknown);
       if (parsed && typeof parsed === 'object') {
         const raw = parsed as Record<string, unknown>;
-        if (typeof raw['title'] === 'string') title = raw['title'];
-        if (typeof raw['description'] === 'string') subtitle = raw['description'];
-        if (typeof raw['version'] === 'string') version = String(raw['version']);
-        if (typeof raw['date'] === 'string') date = raw['date'];
+        ({ title, subtitle, date, version } = extractDiagramMeta(raw));
       }
 
       const v = validateCapabilityMap(parsed);

--- a/extension/src/compliance-impact-preview.ts
+++ b/extension/src/compliance-impact-preview.ts
@@ -393,7 +393,7 @@ export class ComplianceImpactPreview {
         '</head>\n<body data-theme="' + escXml(themeId) + '">\n' +
         errInput + '\n' +
         '<div id="toolbar">' +
-        '<span class="toolbar-label">Compliance Impact Matrix</span>' +
+        '<span class="toolbar-label">' + escXml(this.config?.name ?? 'Compliance Impact Matrix') + '</span>' +
         '<div class="toolbar-actions">' +
         '<a href="command:transitrixStudio.changeTheme" class="toolbar-btn" title="Change the color scheme for all diagram previews">Theme…</a>' +
         '<a href="command:' + REFRESH_COMMAND + '" class="toolbar-btn" title="Re-scan the workspace and reload view config">Refresh</a>' +
@@ -503,7 +503,7 @@ export class ComplianceImpactPreview {
       errInput +
       warnInput +
       '  <div id="toolbar">\n' +
-      '    <span class="toolbar-label">Compliance Impact Matrix</span>\n' +
+      '    <span class="toolbar-label">' + escXml(config.name) + '</span>\n' +
       '    <div class="toolbar-actions">\n' +
       '      <a href="command:transitrixStudio.changeTheme" class="toolbar-btn" title="Change the color scheme for all diagram previews">Theme…</a>\n' +
       '      <a href="command:' +

--- a/extension/src/coverage-metric-preview.ts
+++ b/extension/src/coverage-metric-preview.ts
@@ -188,22 +188,31 @@ export class CoverageMetricPreview {
     const colWPx = colW === 'narrow' ? 80 : colW === 'wide' ? 200 : 120;
 
     let bodyHtml: string;
-    let titleLine: string;
+    let titleLine = '';
     let subtitleLine = '';
+    let metaDate = '';
     let warnings: string[] = [];
     let errorMsg = '';
 
     try {
       const parsed = yaml.load(yamlText) as unknown;
+      // root.name / root.generated_at take priority per CONTRACT §1.1.
+      if (parsed && typeof parsed === 'object') {
+        const raw = parsed as Record<string, unknown>;
+        if (typeof raw['name'] === 'string') titleLine = escXml(raw['name']);
+        if (typeof raw['description'] === 'string') subtitleLine = escXml(raw['description'].trim());
+        const genAt = typeof raw['generated_at'] === 'string' ? raw['generated_at'] : undefined;
+        metaDate = genAt ?? (typeof raw['date'] === 'string' ? raw['date'] : '');
+      }
       const r = parseCoverageMetricConfig(parsed);
       if (!r.ok) {
         errorMsg = 'Parse errors:\n' + r.errors.join('\n');
         bodyHtml = '';
-        titleLine = 'Coverage Metric — parse error';
+        if (!titleLine) titleLine = 'Coverage Metric — parse error';
       } else {
         const config = r.config;
-        titleLine = escXml(config.name);
-        if (config.description) subtitleLine = escXml(config.description.trim());
+        if (!titleLine) titleLine = escXml(config.name);
+        if (!subtitleLine && config.description) subtitleLine = escXml(config.description.trim());
         if (config.warnings) warnings = config.warnings;
         const canon: ScannedCanon = await scanComplianceCanon();
         const matrix = buildCoverageMatrix(canon, config);

--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -8,6 +8,32 @@ export type { ThemeId };
 export const OPEN_THEME_COMMAND = 'transitrixStudio.changeTheme';
 
 /**
+ * Extracts standard diagram-level metadata from a raw parsed YAML object.
+ *
+ * Per CONTRACT §1.1, every notation stores its canonical metadata at the root level:
+ *   name:         "Human-readable diagram title"  # required
+ *   generated_at: "YYYY-MM-DD"                    # optional
+ *
+ * Backward-compat reads: `title` (legacy alias for `name`), `date` (legacy alias
+ * for `generated_at`), and `description`/`version` which are not in the standard
+ * but widely present in existing files.
+ */
+export function extractDiagramMeta(raw: Record<string, unknown>): {
+  title: string | undefined;
+  subtitle: string | undefined;
+  date: string | undefined;
+  version: string | undefined;
+} {
+  const name = typeof raw['name'] === 'string' ? raw['name'] : undefined;
+  const title = name ?? (typeof raw['title'] === 'string' ? raw['title'] : undefined);
+  const subtitle = typeof raw['description'] === 'string' ? raw['description'] : undefined;
+  const genAt = typeof raw['generated_at'] === 'string' ? raw['generated_at'] : undefined;
+  const date = genAt ?? (typeof raw['date'] === 'string' ? raw['date'] : undefined);
+  const version = raw['version'] !== undefined ? String(raw['version']) : undefined;
+  return { title, subtitle, date, version };
+}
+
+/**
  * Injects a <style> block with all --ts-* CSS variable definitions into an SVG string,
  * making it self-contained for file export (no external stylesheet required).
  *

--- a/extension/src/fgca-preview.ts
+++ b/extension/src/fgca-preview.ts
@@ -378,9 +378,11 @@ export class FGCAPreview {
 
     try {
       const parsed = coerceDatesToIsoStrings(yaml.load(yamlText) as unknown);
-      const meta = (parsed && typeof parsed === 'object' ? parsed : {}) as { version?: unknown; date?: unknown };
+      const meta = (parsed && typeof parsed === 'object' ? parsed : {}) as { version?: unknown; date?: unknown; generated_at?: unknown };
       docVersion = typeof meta.version === 'string' ? meta.version : undefined;
-      docDate = typeof meta.date === 'string' ? meta.date : todayIso();
+      docDate = (typeof meta.generated_at === 'string' ? meta.generated_at : undefined)
+        ?? (typeof meta.date === 'string' ? meta.date : undefined)
+        ?? todayIso();
       // Canon-projection form (VP-3): view_config present, no inline elements.
       // Fall back to inline parsing for legacy documents that carry factors[]/goals[].
       const input = isFGCAViewDoc(parsed) ? resolveFGCA(parsed, sources) : parsed;
@@ -517,9 +519,11 @@ export class FGAPreview {
 
     try {
       const parsed = coerceDatesToIsoStrings(yaml.load(yamlText) as unknown);
-      const meta = (parsed && typeof parsed === 'object' ? parsed : {}) as { version?: unknown; date?: unknown };
+      const meta = (parsed && typeof parsed === 'object' ? parsed : {}) as { version?: unknown; date?: unknown; generated_at?: unknown };
       docVersion = typeof meta.version === 'string' ? meta.version : undefined;
-      docDate = typeof meta.date === 'string' ? meta.date : todayIso();
+      docDate = (typeof meta.generated_at === 'string' ? meta.generated_at : undefined)
+        ?? (typeof meta.date === 'string' ? meta.date : undefined)
+        ?? todayIso();
       const v = parseCanonicalFGA(parsed);
       warnings = v.warnings.map(w => `${w.code}: ${w.message}`);
       if (!v.valid || !v.parsed) {

--- a/extension/src/goals-preview.ts
+++ b/extension/src/goals-preview.ts
@@ -169,10 +169,12 @@ export class GoalsPreview {
       if (!v.valid || !v.parsed) {
         errorMsg = v.errors.map(e => `${e.code}: ${e.message}`).join('\n');
       } else {
-        const meta = parsedYaml as { name?: unknown; version?: unknown; date?: unknown };
+        const meta = parsedYaml as { name?: unknown; version?: unknown; date?: unknown; generated_at?: unknown };
         const treeName = typeof meta.name === 'string' ? meta.name : '';
         const docVersion = typeof meta.version === 'string' ? meta.version : undefined;
-        const docDate = typeof meta.date === 'string' ? meta.date : todayIso();
+        const docDate = (typeof meta.generated_at === 'string' ? meta.generated_at : undefined)
+          ?? (typeof meta.date === 'string' ? meta.date : undefined)
+          ?? todayIso();
         goalOptions = v.parsed.goals.map(g => ({ id: String(g.id), name: g.name ?? '' }));
         maxLevelPresent = v.parsed.goals.reduce((m, g) => Math.max(m, typeof g.level === 'number' ? g.level : 0), 0);
         const scopeWarning = checkScopeRoot(scope, v.parsed.goals.map(g => g.id));

--- a/extension/src/process-blueprint-preview.ts
+++ b/extension/src/process-blueprint-preview.ts
@@ -648,9 +648,12 @@ export class ProcessBlueprintPreview {
         errorMsg = v.errors.map(e => `${e.code}: ${e.message}`).join('\n');
       } else {
         const file = parsed as ProcessBlueprintFile;
+        const raw = (parsed && typeof parsed === 'object' ? parsed : {}) as Record<string, unknown>;
         const pb = (file as unknown as { process_blueprint?: { version?: unknown; date?: unknown } }).process_blueprint ?? {};
         const docVersion = typeof pb.version === 'string' ? pb.version : undefined;
-        const docDate = typeof pb.date === 'string' ? pb.date : todayIso();
+        const docDate = (typeof raw['generated_at'] === 'string' ? raw['generated_at'] : undefined)
+          ?? (typeof pb.date === 'string' ? pb.date : undefined)
+          ?? todayIso();
 
         // Compliance lane — scan workspace when opt-in via lane_config.compliance: true.
         const laneConfigRaw = file.process_blueprint?.lane_config;

--- a/extension/src/process-map-preview.ts
+++ b/extension/src/process-map-preview.ts
@@ -1,7 +1,7 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
-import { buildDiagramFrame, CATALOGUE_STYLES, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
+import { buildDiagramFrame, extractDiagramMeta, CATALOGUE_STYLES, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 import { validateProcessMap } from '../../packages/diagrams/src/process-map/validate.js';
 
@@ -173,10 +173,7 @@ export class ProcessMapPreview {
 
       if (parsed && typeof parsed === 'object') {
         const raw = parsed as Record<string, unknown>;
-        if (typeof raw['title'] === 'string') title = raw['title'];
-        if (typeof raw['description'] === 'string') subtitle = raw['description'];
-        if (typeof raw['version'] === 'string') version = String(raw['version']);
-        if (typeof raw['date'] === 'string') date = raw['date'];
+        ({ title, subtitle, date, version } = extractDiagramMeta(raw));
       }
 
       const v = validateProcessMap(parsed);

--- a/extension/src/products-preview.ts
+++ b/extension/src/products-preview.ts
@@ -1,7 +1,7 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
-import { buildDiagramFrame, CATALOGUE_STYLES, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
+import { buildDiagramFrame, extractDiagramMeta, CATALOGUE_STYLES, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 import { validateProductsCatalogue } from '../../packages/diagrams/src/products/validate.js';
 
@@ -165,10 +165,7 @@ export class ProductsPreview {
 
       if (parsed && typeof parsed === 'object') {
         const raw = parsed as Record<string, unknown>;
-        if (typeof raw['title'] === 'string') title = raw['title'];
-        if (typeof raw['description'] === 'string') subtitle = raw['description'];
-        if (typeof raw['version'] === 'string') version = String(raw['version']);
-        if (typeof raw['date'] === 'string') date = raw['date'];
+        ({ title, subtitle, date, version } = extractDiagramMeta(raw));
       }
 
       const v = validateProductsCatalogue(parsed);
@@ -178,6 +175,10 @@ export class ProductsPreview {
         const raw = parsed as Record<string, unknown>;
         const catalogue = raw['products_catalogue'] as ProductsCatalogueHeader;
         bodyContent = buildProductsTable(catalogue);
+        if (!title) title = catalogue.name;
+        if (!subtitle && catalogue.description) subtitle = catalogue.description;
+        if (!version && catalogue.version) version = catalogue.version;
+        if (!date) date = catalogue.updated_at;
       }
     } catch (e) {
       errorMsg = (e as Error).message ?? 'Parse error';

--- a/extension/src/scenarios-preview.ts
+++ b/extension/src/scenarios-preview.ts
@@ -1,7 +1,7 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
-import { buildDiagramFrame, CATALOGUE_STYLES, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
+import { buildDiagramFrame, extractDiagramMeta, CATALOGUE_STYLES, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 import { validateScenario } from '../../packages/diagrams/src/scenarios/validate.js';
 
@@ -169,10 +169,7 @@ export class ScenariosPreview {
       const parsed = coerceDatesToIsoStrings(yaml.load(yamlText) as unknown);
       if (parsed && typeof parsed === 'object') {
         const raw = parsed as Record<string, unknown>;
-        if (typeof raw['title'] === 'string') title = raw['title'];
-        if (typeof raw['description'] === 'string') subtitle = raw['description'];
-        if (typeof raw['version'] === 'string') version = String(raw['version']);
-        if (typeof raw['date'] === 'string') date = raw['date'];
+        ({ title, subtitle, date, version } = extractDiagramMeta(raw));
       }
 
       const v = validateScenario(parsed);

--- a/organizations/acme_corp/canon/views/activities/gdpr-remediation.activities.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/activities/gdpr-remediation.activities.transitrix.yaml
@@ -5,13 +5,13 @@
 notation: activities
 spec_version: "0.1"
 
-title: "GDPR Remediation Programme 2026"
+name: "GDPR Remediation Programme 2026"
 description: |
   Critical path for closing the EU data-protection gaps surfaced by the 2026
   gap assessment — including the cold-storage archive erasure gap that holds
   ASSERTION-ECOMM-GDPR-ERASURE-1 in a non_compliant state.
 version: "0.1"
-date: "2026-06-10"
+generated_at: "2026-06-10"
 author: "Acme Compliance Office"
 
 activities:

--- a/organizations/acme_corp/canon/views/activity-card/eu-gdpr-remediation.activity-card.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/activity-card/eu-gdpr-remediation.activity-card.transitrix.yaml
@@ -14,6 +14,8 @@
 
 notation: activity-card
 spec_version: "0.1"
+name: "GDPR Remediation — Activity Card"
+generated_at: "2026-06-10"
 
 activity_card:
   id: ACTIVITY_CARD-GDPR-REMEDIATION-1

--- a/organizations/acme_corp/canon/views/applications/eu-portfolio.applications.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/applications/eu-portfolio.applications.transitrix.yaml
@@ -4,6 +4,8 @@
 
 notation: applications
 spec_version: "0.1"
+name: "Acme Corp — EU Applications Portfolio"
+generated_at: "2026-06-10"
 
 applications_catalogue:
   id: APPLICATIONS_CAT-EU-1

--- a/organizations/acme_corp/canon/views/blocks/personal-data-landscape.blocks.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/blocks/personal-data-landscape.blocks.transitrix.yaml
@@ -6,6 +6,8 @@
 
 notation: blocks
 spec_version: "0.1"
+name: "Personal-data landscape"
+generated_at: "2026-06-10"
 
 nested_blocks:
   id: BLOCKS-PERSONAL-DATA-1

--- a/organizations/acme_corp/canon/views/bpmn/data-subject-erasure.bpmn.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/bpmn/data-subject-erasure.bpmn.transitrix.yaml
@@ -5,6 +5,8 @@
 
 notation: bpmn
 spec_version: "0.1"
+name: "Data Subject Erasure Request (GDPR Art. 17)"
+generated_at: "2026-06-10"
 
 process:
   id: PROCESS-DSR-HANDLE-1

--- a/organizations/acme_corp/canon/views/capabilities/compliance-domain.capability-map.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/capabilities/compliance-domain.capability-map.transitrix.yaml
@@ -5,10 +5,10 @@
 
 notation: capability-map
 spec_version: "0.1"
-title: "Acme Corp — Capability Map with Compliance Overlay"
+name: "Acme Corp — Capability Map with Compliance Overlay"
 description: "Core business capabilities and the cross-cutting compliance capability, with current and target CMMI maturity."
 version: "1.0"
-date: "2026-06-10"
+generated_at: "2026-06-10"
 
 capability_map:
   id: CAPABILITY_MAP-COMPLIANCE-1

--- a/organizations/acme_corp/canon/views/compliance-impact/eu-compliance.compliance-impact.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/compliance-impact/eu-compliance.compliance-impact.transitrix.yaml
@@ -3,6 +3,8 @@
 
 notation: compliance-impact
 spec_version: "0.1"
+name: "acme_corp — EU Compliance Impact (GDPR + NIS2)"
+generated_at: "2026-06-10"
 
 view:
   id: COMPLIANCE_IMPACT-ACME-EU-1

--- a/organizations/acme_corp/canon/views/coverage-metric/eu-coverage.coverage-metric.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/coverage-metric/eu-coverage.coverage-metric.transitrix.yaml
@@ -3,6 +3,8 @@
 
 notation: coverage-metric
 spec_version: "0.2"
+name: "acme_corp — EU Coverage Metric (GDPR + NIS2)"
+generated_at: "2026-06-10"
 
 view:
   id: COVERAGE_METRIC-ACME-EU-1

--- a/organizations/acme_corp/canon/views/fga/eu-compliance.fga.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/fga/eu-compliance.fga.transitrix.yaml
@@ -10,7 +10,7 @@ description: >
   Factor → Goal → Activity chain for the GDPR/NIS2 compliance workstream.
   Changes layer omitted — activities map directly to the compliance goal.
 period: "2026"
-date: "2026-06-10"
+generated_at: "2026-06-10"
 author: "Acme Compliance Office"
 
 factors:

--- a/organizations/acme_corp/canon/views/fgca/eu-expansion.fgca.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/fgca/eu-expansion.fgca.transitrix.yaml
@@ -12,7 +12,7 @@ description: >
   regulatory window drives a market-presence goal; the required transformation is
   an EU-localised, GDPR-conformant platform; activities deliver it.
 period: "2026"
-date: "2026-06-10"
+generated_at: "2026-06-10"
 author: "Acme Strategy Office"
 
 factors:

--- a/organizations/acme_corp/canon/views/goals/eu-strategy.goals.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/goals/eu-strategy.goals.transitrix.yaml
@@ -9,7 +9,7 @@ id: GOALS-STRATEGY-2026
 name: "Acme Corp — Strategy 2026 Goals Tree"
 description: "Goal hierarchy for the 2026 EU-expansion plan, including the regulatory-compliance branch."
 period: "2026"
-date: "2026-06-10"
+generated_at: "2026-06-10"
 author: "Acme Strategy Office"
 
 goal_types:

--- a/organizations/acme_corp/canon/views/process-blueprint/order-fulfilment.process-blueprint.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/process-blueprint/order-fulfilment.process-blueprint.transitrix.yaml
@@ -5,6 +5,8 @@
 
 notation: process-blueprint
 spec_version: "0.1"
+name: "Order fulfilment — operational blueprint"
+generated_at: "2026-06-10"
 
 process_blueprint:
   id: PROCESS_BLUEPRINT-FULFIL-1

--- a/organizations/acme_corp/canon/views/processmap/enterprise.process-map.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/processmap/enterprise.process-map.transitrix.yaml
@@ -4,6 +4,8 @@
 
 notation: process-map
 spec_version: "0.1"
+name: "Acme Corp — Process Landscape"
+generated_at: "2026-06-10"
 
 process_map:
   id: PM-ACME-1

--- a/organizations/acme_corp/canon/views/products/eu-portfolio.products.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/products/eu-portfolio.products.transitrix.yaml
@@ -4,6 +4,8 @@
 
 notation: products
 spec_version: "0.1"
+name: "Acme Corp — EU Products Portfolio"
+generated_at: "2026-06-10"
 
 products_catalogue:
   id: PRODUCTS_CAT-EU-1

--- a/organizations/acme_corp/canon/views/scenarios/eu-go-live.scenarios.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/scenarios/eu-go-live.scenarios.transitrix.yaml
@@ -5,10 +5,10 @@
 
 notation: scenarios
 spec_version: "0.1"
-title: "EU Go-Live 2026"
+name: "EU Go-Live 2026"
 description: "Target scenario: live in three EU markets with all compliance gaps closed."
 version: "1.0"
-date: "2026-06-10"
+generated_at: "2026-06-10"
 
 scenario:
   id: SCENARIO-EU-GOLIVE-1


### PR DESCRIPTION
## Summary

Implements the diagram-level metadata standard agreed with the methodology project (CONTRACT §1.1). Every notation file now declares its human-readable title and publication date at the **root level** of the YAML:

```yaml
name: "Human-readable diagram title"   # required — replaces legacy title/nested.name
generated_at: "YYYY-MM-DD"             # optional — replaces legacy date/updated_at
```

- **`extractDiagramMeta(raw)`** — new shared helper exported from `diagram-frame.ts`. Reads `root.name` (with `title` backward-compat fallback) and `root.generated_at` (with `date` fallback). Eliminates duplicated notation-specific extraction code across 10 preview files.
- **HTML-table previews** (capability-map, scenarios, process-map, applications, products) — simplified to use the helper first; notation-specific nested fallbacks kept for any file not yet migrated.
- **SVG-based previews** (activities, activity-card, blocks, fgca, goals, process-blueprint) — date read updated to prefer `root.generated_at` over `root.date` / `nested.date`.
- **compliance-impact** — toolbar label now uses `config.name` instead of hardcoded `"Compliance Impact Matrix"`.
- **coverage-metric** — `root.name`/`root.generated_at` read before parsing the view config, with `view.name` as fallback.
- **Corpus migration** — all 14 `organizations/acme_corp/canon/views/` files updated: 3 had `title` → `name`; 6 had `date` → `generated_at`; 5 had nested-only name/date and got root fields added. BPMN and activity-card (previously had no root metadata) now have `name` + `generated_at`.

## Test plan

- [ ] 921 tests pass (`npm test`)
- [ ] Open each notation in the extension — frame-header shows the diagram name and date
- [ ] Old files without `name:` (only `title:`) still show their title (backward-compat path)
- [ ] compliance-impact toolbar shows the view name from `view.name` / `root.name`
