### PR TITLE
refactor(extension,diagrams): consolidate escXml/escHtml into one shared escaper

### DIFF
--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -1,4 +1,5 @@
 import * as path from 'node:path';
+import { escXml } from '../../packages/diagrams/src/webview/render-util.js';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, prepareSvgForExport, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
@@ -27,10 +28,6 @@ const ACTIVITIES_DEFAULT_H_GAP = 80;
 const ACTIVITIES_DEFAULT_V_GAP = 24;
 
 // ── Shared helpers ───────────────────────────────────────────────────────────
-
-function escXml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-}
 
 function truncate(s: string, maxLen: number): string {
   return s.length > maxLen ? s.slice(0, maxLen - 1) + '…' : s;

--- a/extension/src/applications-preview.ts
+++ b/extension/src/applications-preview.ts
@@ -1,4 +1,5 @@
 import * as path from 'node:path';
+import { escHtml } from '../../packages/diagrams/src/webview/render-util.js';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, extractDiagramMeta, CATALOGUE_STYLES, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
@@ -46,10 +47,6 @@ interface ApplicationsCatalogueHeader {
 }
 
 // ── HTML table render helpers ─────────────────────────────────────────────────
-
-function escHtml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-}
 
 const BADGE_CLASS: Record<string, string> = {
   Active:          'badge-active',

--- a/extension/src/blocks-preview.ts
+++ b/extension/src/blocks-preview.ts
@@ -13,10 +13,7 @@ import {
   type LaidOutBlock,
 } from '../../packages/diagrams/src/blocks/index.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
-
-function escXml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-}
+import { escXml } from '../../packages/diagrams/src/webview/render-util.js';
 
 function truncate(text: string, maxChars: number): string {
   if (text.length <= maxChars) return text;

--- a/extension/src/capability-map-preview.ts
+++ b/extension/src/capability-map-preview.ts
@@ -1,4 +1,5 @@
 import * as path from 'node:path';
+import { escHtml } from '../../packages/diagrams/src/webview/render-util.js';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, extractDiagramMeta, CATALOGUE_STYLES, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
@@ -32,10 +33,6 @@ interface CapabilityMapHeader {
 }
 
 // ── HTML render helpers ───────────────────────────────────────────────────────
-
-function escHtml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-}
 
 const MATURITY_LABEL: Record<number, string> = {
   1: 'Initial',

--- a/extension/src/compliance-impact-preview.ts
+++ b/extension/src/compliance-impact-preview.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { escXml } from '../../packages/diagrams/src/webview/render-util.js';
 import yaml from 'js-yaml';
 import { generateWebviewCss, type ThemeId } from '../../packages/diagrams/src/theme/index.js';
 import {
@@ -57,10 +58,6 @@ const STATUS_LABELS: Record<AssertionStatus, string> = {
 
 const OPEN_FILE_COMMAND = 'transitrixStudio.openComplianceFile';
 const REFRESH_COMMAND = 'transitrixStudio.refreshComplianceImpact';
-
-function escXml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-}
 
 function todayIso(): string {
   return new Date().toISOString().slice(0, 10);

--- a/extension/src/compliance-matrix-preview.ts
+++ b/extension/src/compliance-matrix-preview.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { escXml } from '../../packages/diagrams/src/webview/render-util.js';
 import { generateWebviewCss, type ThemeId } from '../../packages/diagrams/src/theme/index.js';
 import {
   buildComplianceMatrix,
@@ -55,10 +56,6 @@ const ALL_SEVERITIES = ['high', 'medium', 'low'];
 
 const OPEN_FILE_COMMAND = 'transitrixStudio.openComplianceFile';
 const REFRESH_COMMAND = 'transitrixStudio.refreshComplianceMatrix';
-
-function escXml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-}
 
 /** Union of jurisdictions resolved across the matrix's columns, sorted. */
 function collectJurisdictions(matrix: ComplianceMatrix): string[] {

--- a/extension/src/compliance-render.ts
+++ b/extension/src/compliance-render.ts
@@ -1,4 +1,6 @@
 import { generateWebviewCss, type ThemeId } from '../../packages/diagrams/src/theme/index.js';
+import { escXml } from '../../packages/diagrams/src/webview/render-util.js';
+export { escXml };
 import type { AssertionStatus } from '../../packages/diagrams/src/assertion/types.js';
 import type { ViewScore } from '../../packages/diagrams/src/confidence/index.js';
 import { computeDeadlineStatus } from '../../packages/diagrams/src/compliance/impact.js';
@@ -18,11 +20,6 @@ export const STATUS_LABELS: Record<AssertionStatus, string> = {
   pending_owner: 'Pending owner',
   n_a: 'N/A',
 };
-
-export function escXml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-}
-
 /** A coloured status pill. */
 export function statusBadge(status: AssertionStatus): string {
   return `<span class="cmp-badge cmp-${status}">${escXml(STATUS_LABELS[status])}</span>`;

--- a/extension/src/coverage-metric-preview.ts
+++ b/extension/src/coverage-metric-preview.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { escXml } from '../../packages/diagrams/src/webview/render-util.js';
 import yaml from 'js-yaml';
 import { generateWebviewCss, type ThemeId } from '../../packages/diagrams/src/theme/index.js';
 import {
@@ -21,10 +22,6 @@ import { WARN_BLOCK_CSS, buildWarnHtml, ERROR_BLOCK_CSS, buildErrorHtml } from '
 
 const OPEN_FILE_COMMAND = 'transitrixStudio.openComplianceFile';
 const REFRESH_COMMAND = 'transitrixStudio.refreshCoverageMetric';
-
-function escXml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-}
 
 function pct(n: number): string {
   return (n * 100).toFixed(1) + '%';

--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -1,6 +1,7 @@
 import type { ThemeId } from '../../packages/diagrams/src/theme/index.js';
 import { generateWebviewCss, generateSvgEmbedCss } from '../../packages/diagrams/src/theme/index.js';
 import { CONTROLS_PANEL_CSS } from './preview-controls.js';
+import { escXml } from '../../packages/diagrams/src/webview/render-util.js';
 
 export type { ThemeId };
 
@@ -155,10 +156,6 @@ export interface DiagramFrameOpts {
      */
     viewToggleHtml?: string;
   };
-}
-
-function escXml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
 
 /**

--- a/extension/src/fgca-preview.ts
+++ b/extension/src/fgca-preview.ts
@@ -1,4 +1,5 @@
 import * as path from 'node:path';
+import { escXml } from '../../packages/diagrams/src/webview/render-util.js';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, prepareSvgForExport, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
@@ -61,11 +62,6 @@ const COL_LABELS: Record<string, string> = {
 };
 
 // ── SVG renderer ──────────────────────────────────────────────────────────────
-
-function escXml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-}
-
 /** Goal options + deepest level for the scope control, from a parsed doc. FGCA
  *  and FGA goals are flat, so a `root` scope is the single matching goal. */
 function scopeInputsFromDoc(doc: FGCADoc): { goals: ScopeGoalOption[]; maxLevelPresent: number } {

--- a/extension/src/goals-preview.ts
+++ b/extension/src/goals-preview.ts
@@ -1,4 +1,5 @@
 import * as path from 'node:path';
+import { escXml } from '../../packages/diagrams/src/webview/render-util.js';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, prepareSvgForExport, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
@@ -28,10 +29,6 @@ const NODE_W = 250;
 const NODE_H = 60;
 const RANK_SEP = 100;
 const NODE_SEP = 24;
-
-function escXml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-}
 
 function layoutToSvg(layout: GoalTreeLayout, treeName: string, filename?: string, date?: string, version?: string, curvature: number = DEFAULT_EDGE_CURVATURE, entryCurvature?: number): string {
   const pad = 24;

--- a/extension/src/preview-controls.ts
+++ b/extension/src/preview-controls.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from 'node:crypto';
+import { escXml } from '../../packages/diagrams/src/webview/render-util.js';
 
 // In-preview interactive control panel for the spacing / curvature / scope
 // previews (vkgeorgia/strategy#75 / #76 / #77 — PR2).
@@ -104,9 +105,6 @@ export function colWidthRootCss(px: number): string {
   return `:root { --ts-col-w: ${px}px; }`;
 }
 
-function escXml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-}
 
 /** CSS for the control panel — injected into the frame's <style> only when interactive. */
 export const CONTROLS_PANEL_CSS = `

--- a/extension/src/process-blueprint-preview.ts
+++ b/extension/src/process-blueprint-preview.ts
@@ -18,10 +18,7 @@ import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normal
 import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
 import { scanComplianceCanon, type ScannedCanon } from './compliance-scan.js';
 import { genNonce } from './preview-controls.js';
-
-function escXml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-}
+import { escXml } from '../../packages/diagrams/src/webview/render-util.js';
 
 function truncate(text: string, maxChars: number): string {
   if (text.length <= maxChars) return text;

--- a/extension/src/process-map-preview.ts
+++ b/extension/src/process-map-preview.ts
@@ -1,4 +1,5 @@
 import * as path from 'node:path';
+import { escHtml } from '../../packages/diagrams/src/webview/render-util.js';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, extractDiagramMeta, CATALOGUE_STYLES, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
@@ -39,10 +40,6 @@ interface ProcessMapHeader {
 }
 
 // ── HTML render helpers ───────────────────────────────────────────────────────
-
-function escHtml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-}
 
 const STATUS_BADGE: Record<string, string> = {
   Active:     'badge-active',

--- a/extension/src/products-preview.ts
+++ b/extension/src/products-preview.ts
@@ -1,4 +1,5 @@
 import * as path from 'node:path';
+import { escHtml } from '../../packages/diagrams/src/webview/render-util.js';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, extractDiagramMeta, CATALOGUE_STYLES, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
@@ -34,10 +35,6 @@ interface ProductsCatalogueHeader {
 }
 
 // ── HTML table render helpers ─────────────────────────────────────────────────
-
-function escHtml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-}
 
 const BADGE_CLASS: Record<string, string> = {
   Active:     'badge-active',

--- a/extension/src/scenarios-preview.ts
+++ b/extension/src/scenarios-preview.ts
@@ -1,4 +1,5 @@
 import * as path from 'node:path';
+import { escHtml } from '../../packages/diagrams/src/webview/render-util.js';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, extractDiagramMeta, CATALOGUE_STYLES, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
@@ -29,10 +30,6 @@ interface ScenarioHeader {
 }
 
 // ── HTML render helpers ───────────────────────────────────────────────────────
-
-function escHtml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-}
 
 const STATUS_BADGE: Record<string, string> = {
   Active:   'badge-active',

--- a/extension/src/svg-title-block.ts
+++ b/extension/src/svg-title-block.ts
@@ -14,11 +14,9 @@
 // interactive preview, and the right behaviour for exported SVG files
 // (the title travels with the diagram outside VS Code).
 
-export const TITLE_BLOCK_H = 60;
+import { escXml } from '../../packages/diagrams/src/webview/render-util.js';
 
-function escXml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-}
+export const TITLE_BLOCK_H = 60;
 
 /**
  * Build the title <g> for embedding at (x, top) inside an SVG.

--- a/packages/diagrams/src/compliance/html.ts
+++ b/packages/diagrams/src/compliance/html.ts
@@ -16,6 +16,7 @@ import type { ComplianceCanon } from './classify.js';
 import type { ReportScope } from './markdown.js';
 import type { AssertionStatus } from '../assertion/types.js';
 import type { ImpactMatrix } from './impact.js';
+import { escHtml } from '../webview/render-util.js';
 
 const STATUS_LABELS: Record<AssertionStatus, string> = {
   compliant: 'Compliant',
@@ -31,14 +32,6 @@ export interface HtmlOptions {
   today?: string;
   /** Title override; defaults to the per-scope title. */
   title?: string;
-}
-
-function escHtml(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
 }
 
 function badge(status: AssertionStatus): string {

--- a/packages/diagrams/src/webview/render-goals.ts
+++ b/packages/diagrams/src/webview/render-goals.ts
@@ -14,6 +14,7 @@ import { layoutGoalTree } from '../goals/layout.js';
 import type { GoalTree, GoalTreeLayout, LaidOutEdge } from '../goals/types.js';
 import { horizontalCubicEdgePath, DEFAULT_EDGE_CURVATURE } from '../edge-path.js';
 import { generateSvgEmbedCss } from '../theme/index.js';
+import { escXml } from './render-util.js';
 
 const NODE_W = 250;
 const NODE_H = 60;
@@ -22,14 +23,6 @@ const NODE_SEP = 24;
 const PAD = 24;
 const LABEL_MAX = 36;
 const LABEL_TRIM = 34;
-
-function escXml(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
-}
 
 export interface RenderGoalsOptions {
   treeName?: string;

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -11,6 +11,7 @@ import blocksTablesMarkdown from '../../tests/fixtures/notation-corpus/nested-bl
 import initialGoalsYaml from '../../tests/fixtures/notation-corpus/goals/strategy-2026.goals.transitrix.yaml?raw';
 
 import { validateGoalTree, layoutGoalTree } from '../../packages/diagrams/src/goals/index.js';
+import { escXml } from '../../packages/diagrams/src/webview/render-util.js';
 import type { GoalTree, GoalTreeLayout, LaidOutNode, LaidOutEdge } from '../../packages/diagrams/src/goals/types.js';
 
 /** Single Markdown table sample for the nested-blocks “Markdown table” input mode. */
@@ -452,10 +453,6 @@ function getViewer(): InstanceType<typeof NavigatedViewer> {
 // ── Goals tree SVG renderer ──────────────────────────────────────────────────
 
 const LEVEL_COLORS = ['#dbeafe', '#e0e7ff', '#d4edda', '#fef3c7', '#fce7f3', '#e0f2fe', '#f3e8ff', '#fef9c3'];
-
-function escXml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-}
 
 function goalsLayoutToSvg(layout: GoalTreeLayout, tree: GoalTree): string {
   const pad = 24;


### PR DESCRIPTION
## Summary

- Consolidate ~18 duplicated `escXml`/`escHtml`/`escapeHtml` copies into a single shared escaper (`packages/diagrams/src/webview/render-util.ts`).
- Extension previews, the diagrams `webview/render-*` + `compliance/html.ts` renderers, and the local `ui/` editor now import the shared `escXml`/`escHtml`.
- `extension/src/compliance-render.ts` re-exports the shared `escXml`, so its three consumers (`single-law`, `single-product`, `gap-dashboard`) are unchanged.
- The browser-side DOM-based `escapeHtml` in `extension/webview/viewer.ts` is intentionally left as-is (separate webview bundle / runtime).

## Why

Removes a DRY violation and the risk of divergent escaping behaviour (a copy that, e.g., skips a character) becoming an XSS surface in the webview previews. Found in the v2.2.0 architecture review (finding A).

## Test plan

- [x] `npm run compile` (root) — green
- [x] `npm run compile:extension` — green
- [x] `npx vitest run` — 355 passed
- [x] `npm --workspace packages/diagrams test` — 921 passed
- [x] No new lint errors on changed files

## Notes

- Pre-existing, unrelated: `npm run ui:build` fails at `ui/vite.config.ts:8` importing `handleBlocksCompile` (not exported by `src/serve-ui.ts`) — reproduced on clean `main`, out of scope here.
- Tracked under the internal task tracker.
- Do not merge — maintainer gates merges.
