### PR TITLE
fix(extension): make the BPMN findings 'open-docs' click work

### DIFF
--- a/extension/src/preview.ts
+++ b/extension/src/preview.ts
@@ -8,6 +8,11 @@ import type { LayoutMetrics, ValidationReport } from './types.js';
 
 export type CompileFn = (yaml: string) => Promise<{ xml: string; metrics: LayoutMetrics; validation: ValidationReport }>;
 
+/** Where rule `docUrl` references resolve — the project docs on GitHub. */
+const DOCS_BASE_URL = 'https://github.com/transitrix/transitrix-studio/blob/main';
+/** Accepts only repo-relative `docs/….md` paths with an optional `#anchor`. */
+const VALIDATION_DOC_PATH = /^docs\/[A-Za-z0-9._/-]+\.md(#[A-Za-z0-9._-]+)?$/;
+
 /** Webview: bpmn-js viewer + compile loop. */
 export class CervinPreview {
   readonly panelTitle = 'BPMN Preview';
@@ -51,13 +56,16 @@ export class CervinPreview {
 
       this.panel.webview.html = this.buildHtml(this.panel.webview);
 
-      this.panel.webview.onDidReceiveMessage((msg: { type?: string; svg?: string }) => {
+      this.panel.webview.onDidReceiveMessage((msg: { type?: string; svg?: string; url?: string }) => {
         if (msg?.type === 'diagram-ready' && this.panel && this.trackedUri) {
           const fp = path.basename(vscode.Uri.parse(this.trackedUri).fsPath);
           this.panel.title = `${this.panelTitle} — ${fp}`;
         }
         if (msg?.type === 'export-svg' && typeof msg.svg === 'string' && this.pendingExport) {
           this.pendingExport.resolve(msg.svg);
+        }
+        if (msg?.type === 'open-docs') {
+          this.openDocs(msg.url);
         }
       });
 
@@ -68,6 +76,18 @@ export class CervinPreview {
     }
 
     await this.pushDocument(doc);
+  }
+
+  /**
+   * Opens a validation-doc reference (the findings list forwards the rule's
+   * `docUrl`). The value is a trusted, repo-relative `docs/….md#anchor`, but
+   * it is validated strictly here — rejecting traversal and any non-`docs`
+   * target — before being handed to the browser.
+   */
+  private openDocs(rawUrl: unknown): void {
+    if (typeof rawUrl !== 'string') return;
+    if (rawUrl.includes('..') || !VALIDATION_DOC_PATH.test(rawUrl)) return;
+    void vscode.env.openExternal(vscode.Uri.parse(`${DOCS_BASE_URL}/${rawUrl}`));
   }
 
   async refreshSaved(doc: vscode.TextDocument): Promise<void> {


### PR DESCRIPTION
## Summary

- The BPMN preview's findings list rendered every finding with a `docUrl` as clickable (`cursor: pointer`) and posted an `open-docs` message, but the panel's `onDidReceiveMessage` only handled `diagram-ready` and `export-svg` — so clicking a finding did nothing.
- Add an `open-docs` handler in `extension/src/preview.ts` that opens the rule's documentation.

## Behaviour

- Rule `docUrl`s are repo-relative `docs/validation.md#<anchor>` (see `src/validator.ts`, `src/compiler.ts`). The handler resolves them against the project docs on GitHub (`.../blob/main/docs/validation.md#se-001`) and opens via `vscode.env.openExternal`.
- The value is validated strictly before use: must match `docs/….md` with an optional `#anchor` and contain no `..` (defense-in-depth, even though `docUrl` is produced by our own validator).

## Test plan

- [x] `npm run compile:extension` — green
- [x] `npx vitest run` — 355 passed
- [x] `npm --workspace packages/diagrams test` — 921 passed
- [x] No new lint errors

## Notes

- No automated test added: the extension has no unit-test harness (`extension/**/*.test.ts` is empty) and `openDocs` depends on the `vscode` API. The validation regex + URL build are pure and small.
- Tracked under the internal task tracker.
- Do not merge — maintainer gates merges.
