### PR TITLE
docs: clarify .transitrixrc rule-override semantics (off/warn)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,11 @@ Project-level rule overrides (enabling/disabling validation rules) are read from
 [`schemas/transitrixrc.schema.json`](schemas/transitrixrc.schema.json); the rule-override
 format is documented in [`docs/validation.md`](docs/validation.md).
 
+The only override values are `"off"` (disable a rule; rejected for error-severity
+conformance gates) and `"warn"` (enable a rule, e.g. an off-by-default one). An
+override **only toggles whether a rule runs** — it does not change the rule's
+built-in severity, so `"<RULE>": "warn"` does not demote an error to a warning.
+
 The legacy **`.cervinrc`** filename is still read as a *fallback* when `.transitrixrc`
 is absent (see CLAUDE.md §Cervin naming, P4), but is **deprecated** — `loadTransitrixrc()`
 prints a one-time deprecation notice when it falls back, and `.cervinrc` support is slated

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -582,7 +582,7 @@ Semantic validation for process connectivity constraints per **method/methodolog
 
 ## Anti-Pattern Rules (RD-107 onwards)
 
-Anti-pattern rules detect suspicious modeling practices that may indicate errors, deadlock risks, or livelock scenarios. Unlike error rules, anti-patterns are warnings or info and can be configured (enabled/disabled) via `.cervinrc`.
+Anti-pattern rules detect suspicious modeling practices that may indicate errors, deadlock risks, or livelock scenarios. Unlike error rules, anti-patterns are warnings or info and can be enabled/disabled via `.transitrixrc` (see [Configuring rules](#configuring-rules-via-transitrixrc)).
 
 ### AP-FLOAT: Element has no incoming or outgoing flows (RD-107)
 - **Severity**: warning
@@ -644,7 +644,7 @@ Anti-pattern rules detect suspicious modeling practices that may indicate errors
 - **Description**: A gateway element (XOR, AND, OR, event-based) whose name starts with an imperative verb typical of task names (e.g., "Validate", "Approve", "Check", "Generate"). This is a heuristic hint that the element might be a task incorrectly modeled as a gateway. Gateways are routing constructs; tasks perform work.
 - **Note**: This is a heuristic hint, not a hard rule. Some gateways may legitimately have action-like names, especially in high-level process descriptions.
 - **Imperative verb list**: accept, approve, assign, authorize, calculate, cancel, check, classify, confirm, convert, create, decline, delete, derive, determine, distribute, document, evaluate, execute, extract, generate, identify, implement, invoice, judge, log, manage, notify, organize, pay, perform, prepare, process, produce, propose, publish, read, receive, reconcile, record, reduce, register, reject, release, remove, report, request, resolve, review, revise, schedule, send, sign, store, submit, summarize, test, track, transfer, transform, validate, verify, write.
-- **Default**: off by default (disabled). Enable via `.cervinrc`: `rules: { 'AP-GW-AS-TASK': 'on' }` or `rules: { 'AP-GW-AS-TASK': 'warn' }`.
+- **Default**: off by default (disabled). Enable via `.transitrixrc`: `"rules": { "AP-GW-AS-TASK": "warn" }`.
 - **Remediation**: Review the gateway's purpose. If it performs work, replace it with a task element. If it is genuinely a routing construct, rename it to a descriptive noun (e.g., "Approval Decision" instead of "Approve Order").
 - **Example Finding**:
   ```json
@@ -657,25 +657,38 @@ Anti-pattern rules detect suspicious modeling practices that may indicate errors
   }
   ```
 
-### Configuring Anti-Pattern Rules via `.transitrixrc`
+### Configuring rules via `.transitrixrc`
 
 > The canonical config file is **`.transitrixrc`**. The legacy **`.cervinrc`** is still
 > read as a fallback when `.transitrixrc` is absent (deprecated; removed in 2.0.0).
 
-Anti-pattern severity and enabled state can be overridden in `.transitrixrc`:
+`.transitrixrc` is a **JSON** file. The `rules` map enables or disables individual
+rules by ID:
 
-```yaml
-rules:
-  AP-FLOAT: 'off'           # Disable floating element check entirely
-  AP-NO-DEFAULT: 'warn'     # Keep as warning (default)
-  AP-IMPLICIT-JOIN: 'error' # Treat implicit join as blocking error
-  AP-GW-AS-TASK: 'on'       # Enable the gateway-as-task heuristic
+```json
+{
+  "rules": {
+    "AP-FLOAT": "off",
+    "AP-GW-AS-TASK": "warn"
+  }
+}
 ```
 
-Valid values: `'off'`, `'warn'`, `'error'`, `'on'` (synonymous with `'warn'`).
+The only valid override values are **`"off"`** and **`"warn"`**:
 
-Default severities (if not in `.cervinrc`):
-- `AP-FLOAT`: warning
-- `AP-NO-DEFAULT`: warning
-- `AP-IMPLICIT-JOIN`: warning
-- `AP-GW-AS-TASK`: warning (but **disabled by default**; must be explicitly enabled)
+- **`"off"`** — disable the rule. Error-severity rules are BPMN conformance gates
+  and **cannot** be disabled: `"off"` on such a rule is rejected at load time.
+- **`"warn"`** — enable the rule. Use it to turn on an off-by-default rule (such as
+  `AP-GW-AS-TASK`); for an already-enabled rule it is a no-op.
+
+> **`"warn"` does not change a rule's severity.** Every rule keeps its built-in
+> severity (error or warning); an override only toggles whether the rule runs.
+> Writing `"SE-001": "warn"` does **not** demote that error to a warning — to lower
+> a rule's reported severity, change the rule definition, not the config. (Values
+> such as `"error"` or `"on"` are **not** accepted and fail schema validation.)
+
+Default state:
+- `AP-FLOAT`: warning, enabled by default
+- `AP-NO-DEFAULT`: warning, enabled by default
+- `AP-IMPLICIT-JOIN`: warning, enabled by default
+- `AP-GW-AS-TASK`: warning, **disabled by default** — enable with `"warn"`

--- a/schemas/cervinrc.schema.json
+++ b/schemas/cervinrc.schema.json
@@ -7,12 +7,12 @@
     "rules": {
       "type": "object",
       "title": "Rule overrides",
-      "description": "Override validation rule severity levels. Errors cannot be downgraded.",
+      "description": "Enable or disable validation rules by ID. Overrides only toggle whether a rule runs; they do not change a rule's built-in severity. Error-severity rules are conformance gates and cannot be disabled.",
       "patternProperties": {
         "^[A-Z]+-[0-9-]+$": {
           "type": "string",
           "enum": ["off", "warn"],
-          "description": "Rule override value: 'off' to disable, 'warn' to report as warning"
+          "description": "'off' disables the rule (not allowed for error-severity rules); 'warn' enables the rule (e.g. an off-by-default one). This does not change the rule's severity — an error-severity rule stays an error."
         }
       },
       "additionalProperties": false

--- a/schemas/transitrixrc.schema.json
+++ b/schemas/transitrixrc.schema.json
@@ -7,12 +7,12 @@
     "rules": {
       "type": "object",
       "title": "Rule overrides",
-      "description": "Override validation rule severity levels. Errors cannot be downgraded.",
+      "description": "Enable or disable validation rules by ID. Overrides only toggle whether a rule runs; they do not change a rule's built-in severity. Error-severity rules are conformance gates and cannot be disabled.",
       "patternProperties": {
         "^[A-Z]+-[0-9-]+$": {
           "type": "string",
           "enum": ["off", "warn"],
-          "description": "Rule override value: 'off' to disable, 'warn' to report as warning"
+          "description": "'off' disables the rule (not allowed for error-severity rules); 'warn' enables the rule (e.g. an off-by-default one). This does not change the rule's severity — an error-severity rule stays an error."
         }
       },
       "additionalProperties": false

--- a/src/transitrixrc.ts
+++ b/src/transitrixrc.ts
@@ -121,8 +121,15 @@ export function assertNoCriticalRuleDowngrade(
 }
 
 /**
- * Merge config with rule registry to produce a set of enabled rule IDs.
- * Rules marked 'off' are excluded; off-by-default rules must be explicitly enabled.
+ * Merge config with rule registry to produce a set of *enabled* rule IDs.
+ *
+ * An override only toggles whether a rule runs — it never changes a rule's
+ * built-in severity:
+ *   - `"off"`  → exclude the rule (forbidden for error-severity rules; see
+ *                {@link assertNoCriticalRuleDowngrade}).
+ *   - `"warn"` → include the rule. This enables an off-by-default rule; for an
+ *                already-enabled rule it is a no-op. It does NOT demote an
+ *                error-severity rule to a warning.
  */
 export function mergeConfigWithDefaults(
   registeredRules: Map<string, ValidationRule>,
@@ -141,6 +148,7 @@ export function mergeConfigWithDefaults(
       if (override === 'off') {
         enabledRules.delete(ruleId)
       } else if (override === 'warn') {
+        // Enables the rule; severity is owned by the rule definition, not here.
         enabledRules.add(ruleId)
       }
     }


### PR DESCRIPTION
## Summary

Clarifies what a `.transitrixrc` rule override actually does. An override **only toggles whether a rule runs** — it never changes a rule's built-in severity. The schema accepts exactly `"off"` and `"warn"`, and `"off"` is rejected for error-severity conformance gates (`assertNoCriticalRuleDowngrade`).

The previous docs were misleading and partly wrong:
- listed `"error"` and `"on"` as valid values — both fail schema validation (`enum: ["off","warn"]`);
- described `"warn"` as "report as warning", implying a severity change that does not happen;
- used a YAML example, but `.transitrixrc` is parsed as JSON.

## Changes

- `docs/validation.md` — rewrote the config section: JSON example, the real `off`/`warn` value set, and an explicit note that `"warn"` does **not** demote an error to a warning. Fixed stray `.cervinrc`/`'on'` references.
- `schemas/transitrixrc.schema.json` + `schemas/cervinrc.schema.json` — accurate `rules` + per-value descriptions.
- `CONTRIBUTING.md` — one-line clarification under §Project config.
- `src/transitrixrc.ts` — clarified the `mergeConfigWithDefaults` doc/comment (no behaviour change).

## Test plan

- [x] `npm run compile` — green (schema constant compiles)
- [x] `npx vitest run` — 355 passed
- [x] No new lint errors
- [x] Both schema JSON files remain valid

## Notes

- Documentation-only intent (the `src/transitrixrc.ts` change is comments). No runtime behaviour change — actually lowering severity via config was intentionally **not** added, since error rules are conformance gates.
- Tracked under the internal task tracker.
- Do not merge — maintainer gates merges.
