### PR TITLE
refactor(diagrams,extension): single goals SVG emitter (review C, goals slice)

### DIFF
--- a/extension/src/goals-preview.ts
+++ b/extension/src/goals-preview.ts
@@ -7,11 +7,11 @@ import { TITLE_BLOCK_H, titleBlockSvg, todayIso } from './svg-title-block.js';
 import {
   layoutGoalTree,
   type GoalTreeLayout,
-  type LaidOutEdge,
 } from '../../packages/diagrams/src/goals/index.js';
+import { renderGoalsLayoutSvg } from '../../packages/diagrams/src/webview/render-goals.js';
 import { parseCanonicalGoals } from '../../packages/diagrams/src/goals/parse-canonical.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
-import { horizontalCubicEdgePath, DEFAULT_EDGE_CURVATURE } from '../../packages/diagrams/src/edge-path.js';
+import { DEFAULT_EDGE_CURVATURE } from '../../packages/diagrams/src/edge-path.js';
 import { checkScopeRoot } from '../../packages/diagrams/src/scope.js';
 import { readSpacing, readCurvature, readEntryCurvature, readScope, applyControlMessage, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND } from './spacing-config.js';
 import { genNonce, buildControlsPanel, buildControlsScript, type ControlsModel, type ScopeGoalOption } from './preview-controls.js';
@@ -29,63 +29,22 @@ const NODE_H = 60;
 const RANK_SEP = 100;
 const NODE_SEP = 24;
 
-function escXml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-}
-
 function layoutToSvg(layout: GoalTreeLayout, treeName: string, filename?: string, date?: string, version?: string, curvature: number = DEFAULT_EDGE_CURVATURE, entryCurvature?: number): string {
+  // The SVG body (nodes, edges, arrow marker, edge geometry) comes from the
+  // shared @transitrix/diagrams goals renderer — the single emitter for every
+  // host. This preview only reserves room for and stacks its rich title block
+  // on top. No theme CSS is embedded here: the webview supplies it live, and
+  // export embeds it via prepareSvgForExport.
   const pad = 24;
   const showTitle = filename != null && date != null;
-  const titleH = showTitle ? TITLE_BLOCK_H : 0;
-  const w = layout.bounds.width + pad * 2;
-  const h = layout.bounds.height + pad * 2 + titleH;
-  const ox = -layout.bounds.x + pad;
-  const oy = -layout.bounds.y + pad + titleH;
-
-  const nodeMap = new Map(layout.nodes.map(n => [n.id, n]));
-
-  // Cubic bezier with horizontal control handles (shared geometry in
-  // @transitrix/diagrams). `curvature` scales the handle length: 1 = default,
-  // 0 = straight, higher = stronger arc (vkgeorgia/strategy#76).
-  function edgePath(e: LaidOutEdge): string {
-    const s = nodeMap.get(e.source);
-    const t = nodeMap.get(e.target);
-    if (!s || !t) return '';
-    const sx = s.x + ox + s.width;
-    const sy = s.y + oy + s.height / 2;
-    const tx = t.x + ox;
-    const ty = t.y + oy + t.height / 2;
-    return horizontalCubicEdgePath(sx, sy, tx, ty, curvature, entryCurvature);
-  }
-
-  const edgeSvg = layout.edges.map(e =>
-    `<path d="${edgePath(e)}" class="diagram-edge" marker-end="url(#arrow)"/>`
-  ).join('\n');
-
-  const nodeSvg = layout.nodes.map(n => {
-    const x = n.x + ox;
-    const y = n.y + oy;
-    const level = n.data.level % 8;
-    const labelText = n.data.name ?? String(n.id);
-    const label = labelText.length > 36 ? labelText.slice(0, 34) + '…' : labelText;
-    return `<g>
-  <rect class="diagram-node level-${level}" x="${x}" y="${y}" width="${n.width}" height="${n.height}" rx="8"/>
-  <text class="text-primary" x="${x + n.width / 2}" y="${y + n.height / 2}" text-anchor="middle" dominant-baseline="central">${escXml(label)}</text>
-</g>`;
-  }).join('\n');
-
   const heading = treeName ? `Goal tree — ${treeName}` : 'Goal tree';
-  const titleSvg = showTitle ? titleBlockSvg(heading, filename!, date!, pad, pad, version) : '';
-  return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">
-<defs>
-  <marker id="arrow" markerWidth="8" markerHeight="8" refX="8" refY="3" orient="auto">
-    <path d="M0,0 L0,6 L8,3 z" class="arrow-fill"/>
-  </marker>
-</defs>
-${titleSvg}
-${nodeSvg}
-${edgeSvg}
-</svg>`;
+  const title = showTitle ? titleBlockSvg(heading, filename!, date!, pad, pad, version) : '';
+  return renderGoalsLayoutSvg(layout, {
+    curvature,
+    entryCurvature,
+    topInset: showTitle ? TITLE_BLOCK_H : 0,
+    title,
+  });
 }
 
 // ── GoalsPreview webview class ───────────────────────────────────────────────

--- a/packages/diagrams/src/webview/render-goals.ts
+++ b/packages/diagrams/src/webview/render-goals.ts
@@ -13,7 +13,7 @@
 import { layoutGoalTree } from '../goals/layout.js';
 import type { GoalTree, GoalTreeLayout, LaidOutEdge } from '../goals/types.js';
 import { horizontalCubicEdgePath, DEFAULT_EDGE_CURVATURE } from '../edge-path.js';
-import { generateSvgEmbedCss } from '../theme/index.js';
+import { generateSvgEmbedCss, type ThemeId } from '../theme/index.js';
 
 const NODE_W = 250;
 const NODE_H = 60;
@@ -37,6 +37,11 @@ export interface RenderGoalsOptions {
   entryCurvature?: number;
 }
 
+/**
+ * Host-neutral goals renderer (IntelliJ/UI). Lays the tree out with the default
+ * spacing, then delegates the actual SVG emission to {@link renderGoalsLayoutSvg}
+ * with the shared theme CSS embedded so the output is self-contained.
+ */
 export function renderGoalsSvg(tree: GoalTree, options: RenderGoalsOptions = {}): string {
   const { treeName = '', curvature = DEFAULT_EDGE_CURVATURE, entryCurvature } = options;
 
@@ -51,10 +56,43 @@ export function renderGoalsSvg(tree: GoalTree, options: RenderGoalsOptions = {})
     return `<svg xmlns="http://www.w3.org/2000/svg" width="0" height="0" viewBox="0 0 0 0"></svg>`;
   }
 
+  const title = treeName
+    ? `<text class="text-header" x="${PAD}" y="${PAD - 6}">${escXml(`Goal tree — ${treeName}`)}</text>`
+    : '';
+
+  // Embed the shared theme CSS so the JCEF host page only needs to drop the SVG
+  // into the DOM — styling resolves without help from the host stylesheet. The
+  // VS Code preview omits this (its webview supplies the CSS) and embeds it only
+  // on export via `prepareSvgForExport`.
+  return renderGoalsLayoutSvg(layout, { curvature, entryCurvature, title, embedCssTheme: 'transitrix' });
+}
+
+export interface RenderGoalsLayoutOptions {
+  curvature?: number;
+  entryCurvature?: number;
+  /** Extra vertical space reserved at the top of the canvas (e.g. for a title block). */
+  topInset?: number;
+  /** Raw SVG injected immediately after `<defs>` — a header line or a full title block. */
+  title?: string;
+  /** When set, the theme CSS is embedded as `<style>` so the SVG is self-contained. */
+  embedCssTheme?: ThemeId;
+}
+
+/**
+ * The single goals SVG emitter shared by every host. Takes an already-computed
+ * {@link GoalTreeLayout} (callers decide spacing/scope) and produces the `<svg>`.
+ * Hosts wrap it with their own chrome:
+ *   - IntelliJ/UI via {@link renderGoalsSvg} (embedded CSS + simple header);
+ *   - VS Code's goals preview (rich title block, no embedded CSS — the webview
+ *     and the export path own styling).
+ */
+export function renderGoalsLayoutSvg(layout: GoalTreeLayout, options: RenderGoalsLayoutOptions = {}): string {
+  const { curvature = DEFAULT_EDGE_CURVATURE, entryCurvature, topInset = 0, title = '', embedCssTheme } = options;
+
   const w = layout.bounds.width + PAD * 2;
-  const h = layout.bounds.height + PAD * 2;
+  const h = layout.bounds.height + PAD * 2 + topInset;
   const ox = -layout.bounds.x + PAD;
-  const oy = -layout.bounds.y + PAD;
+  const oy = -layout.bounds.y + PAD + topInset;
 
   const nodeMap = new Map(layout.nodes.map((n) => [n.id, n]));
 
@@ -87,24 +125,15 @@ export function renderGoalsSvg(tree: GoalTree, options: RenderGoalsOptions = {})
     })
     .join('\n');
 
-  const titleSvg = treeName
-    ? `<text class="text-header" x="${PAD}" y="${PAD - 6}">${escXml(`Goal tree — ${treeName}`)}</text>`
-    : '';
+  const styleLine = embedCssTheme ? `\n<style>${generateSvgEmbedCss(embedCssTheme)}</style>` : '';
 
-  // Embed the shared theme CSS inside the SVG so the rendered output is
-  // self-contained — the JCEF host page only needs to drop the SVG into the
-  // DOM and styling resolves without any cooperation from the host stylesheet.
-  // Matches what the VS Code path produces via `prepareSvgForExport`.
-  const embedCss = generateSvgEmbedCss('transitrix');
-
-  return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">
-<style>${embedCss}</style>
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">${styleLine}
 <defs>
   <marker id="arrow" markerWidth="8" markerHeight="8" refX="8" refY="3" orient="auto">
     <path d="M0,0 L0,6 L8,3 z" class="arrow-fill"/>
   </marker>
 </defs>
-${titleSvg}
+${title}
 ${nodeSvg}
 ${edgeSvg}
 </svg>`;


### PR DESCRIPTION
## Summary

First slice of the **single SVG emitter per notation** epic — the goals notation.

The goals SVG body (defs/arrow marker, node `<rect>`+`<text>`, edge `<path>`, edge geometry, `viewBox` math) was duplicated **byte-for-byte** between the host-neutral package renderer (`packages/diagrams/src/webview/render-goals.ts`, used by IntelliJ/UI) and the VS Code preview's local `layoutToSvg` (`extension/src/goals-preview.ts`). That duplication is the core "two emitters per notation" drift from the v2.2.0 review.

## Changes

- **`packages/diagrams`** — extract the shared core `renderGoalsLayoutSvg(layout, options)`. Options carry the host-specific chrome: `curvature`, `entryCurvature`, `topInset` (room for a title), `title` (raw SVG injected after `<defs>`), `embedCssTheme` (embed `<style>` so the SVG is self-contained).
- `renderGoalsSvg(tree)` (IntelliJ/UI) is now a thin wrapper: lays the tree out, builds the simple header, embeds the theme CSS. **Output unchanged** — the existing `render-goals` unit tests pass as-is.
- **`extension/src/goals-preview.ts`** — `layoutToSvg` is now a thin wrapper that stacks the rich title block + reserves `topInset`, delegating the body to the shared emitter. No embedded CSS (the webview supplies it live; export embeds via `prepareSvgForExport`). The duplicated body and the dead local `escXml` are removed.

## Parity verification

Byte parity of the **VS Code** output (the risky path) was proven against the pre-refactor `layoutToSvg` via a temporary test before removal — identical strings for: with/without title block, special characters, label truncation, and custom curvature/entry-curvature/spacing. The IntelliJ/UI path is locked by the existing `render-goals.test.ts`.

A visual sanity check in the running extension is still worthwhile before merge.

## Test plan

- [x] `npm run compile` (root) — green
- [x] `npm run compile:extension` — green
- [x] `npx vitest run` — 355 passed
- [x] `npm --workspace packages/diagrams test` — 921 passed (incl. `render-goals`)
- [x] No new lint errors

## Notes

- Epic stays open; remaining notations follow one PR each.
- Overlaps `escXml`-consolidation PR #252 and touches the same files as it (`goals-preview.ts`, `render-goals.ts`) — independent concerns from `main`, not stacked; a trivial rebase/merge-order resolution may be needed.
- Tracked under the internal task tracker.
- Do not merge — maintainer gates merges.
