### PR TITLE
feat(studio): snapshot capture + timeline navigator for FGCA/FGA previews

### DIFF
--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -1,6 +1,6 @@
 import type { ThemeId } from '../../packages/diagrams/src/theme/index.js';
 import { generateWebviewCss, generateSvgEmbedCss } from '../../packages/diagrams/src/theme/index.js';
-import { CONTROLS_PANEL_CSS } from './preview-controls.js';
+import { CONTROLS_PANEL_CSS, SNAPSHOT_TOOLBAR_CSS } from './preview-controls.js';
 import { escXml } from '../../packages/diagrams/src/webview/render-util.js';
 
 export type { ThemeId };
@@ -155,6 +155,18 @@ export interface DiagramFrameOpts {
      * actions. Pass '' / omit when the preview has no toolbar control.
      */
     viewToggleHtml?: string;
+  };
+  /**
+   * When present, injects snapshot capture + timeline UI into the frame.
+   * The capture button appears in the toolbar actions; the timeline strip
+   * appears below the controls panel; the info box is appended before the
+   * canvas content. Requires `interactive` to also be present (needs scripts).
+   */
+  snapshotUi?: {
+    /** The "Capture…" button HTML (from buildCaptureButton()). */
+    captureButton: string;
+    /** The timeline strip HTML (from buildTimelineStrip(markers)). May be ''. */
+    timelineStrip: string;
   };
 }
 
@@ -422,7 +434,7 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
     themeId = 'transitrix', extraStyles = '', fixPrompt = '',
     title, subtitle, version, date,
     saveSvgCommand, savePngCommand, copyPngCommand, spacingCommand, curvatureCommand, scopeCommand, themeCommand,
-    interactive, legendToggle,
+    interactive, legendToggle, snapshotUi,
   } = opts;
 
   const canvasContent = bodyContent ?? svgContent;
@@ -438,7 +450,7 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
     : '';
   const errBlock = errorMsg
     ? `<div class="tx-err">
-  <label for="ts-err-toggle" class="tx-err-summary">⚠ ${errCount === 1 ? '1 error' : `${errCount} errors`}</label>
+  <label for="ts-err-toggle" class="tx-err-summary">⚠ ${errCount === 1 ? '1 error' : `${errCount} errors`}</label>
   <pre class="tx-err-body">${escXml(errorMsg)}</pre>
 </div>`
     : '';
@@ -504,6 +516,10 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
   if (interactive?.viewToggleHtml) {
     actionParts.push(interactive.viewToggleHtml);
   }
+  // Snapshot capture button — injected into toolbar actions when snapshotUi is present.
+  if (snapshotUi?.captureButton) {
+    actionParts.push(snapshotUi.captureButton);
+  }
   if (showToggle) {
     actionParts.push(`<label for="ts-title-toggle" class="title-toggle" title="Show or hide the diagram title">Title</label>`);
   }
@@ -545,8 +561,15 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
     ? `default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${interactive.nonce}';`
     : `default-src 'none'; style-src 'unsafe-inline';`;
   const controlsCss = interactive ? CONTROLS_PANEL_CSS : '';
+  const snapshotCss = snapshotUi ? SNAPSHOT_TOOLBAR_CSS : '';
   const controlsPanel = interactive ? interactive.controlsPanel : '';
   const controlsScript = interactive ? interactive.controlsScript : '';
+
+  // Timeline strip and info box — rendered below the controls panel when snapshotUi present.
+  const timelineStrip = snapshotUi?.timelineStrip ?? '';
+  const snapInfoBox = snapshotUi
+    ? `<div id="tx-snap-info" class="tx-snap-info" style="display:none"></div>`
+    : '';
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -562,6 +585,7 @@ ${FRAME_HEADER_CSS}
 ${TITLE_TOGGLE_CSS}
 ${ZOOM_CONTROL_CSS}
 ${controlsCss}
+${snapshotCss}
 ${extraStyles}
   </style>
 </head>
@@ -573,6 +597,8 @@ ${extraStyles}
   ${warnToggleInput}
   <div id="toolbar"><span class="toolbar-label">${escXml(notation)}: ${escXml(filename)}</span>${toolbarRight}</div>
   ${controlsPanel}
+  ${timelineStrip}
+  ${snapInfoBox}
   ${errBlock}${fixPromptBlock}${warnBlock}
   ${headerBlock}
   <div id="canvas">

--- a/extension/src/fgca-preview.ts
+++ b/extension/src/fgca-preview.ts
@@ -72,7 +72,7 @@ function scopeInputsFromDoc(doc: FGCADoc): { goals: ScopeGoalOption[]; maxLevelP
   };
 }
 
-// ── Chain table (vkgeorgia/strategy#137) ───────────────────────────────────────────────────────
+// ── Chain table (#137) ───────────────────────────────────────────────────────
 //
 // The flattening + rowspan derivation lives in @transitrix/diagrams
 // (`buildChainTable`). Here we render that model as an HTML <table>. Scope

--- a/extension/src/fgca-preview.ts
+++ b/extension/src/fgca-preview.ts
@@ -22,9 +22,10 @@ import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normal
 import { checkScopeRoot, type Scope } from '../../packages/diagrams/src/scope.js';
 import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
 import { readSpacing, readCurvature, readEntryCurvature, readScope, readView, applyControlMessage, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND } from './spacing-config.js';
-import { genNonce, buildControlsPanel, buildControlsScript, buildViewToggle, type ControlsModel, type ScopeGoalOption } from './preview-controls.js';
+import { genNonce, buildControlsPanel, buildControlsScript, buildViewToggle, buildCaptureButton, buildTimelineStrip, type ControlsModel, type ScopeGoalOption, type SnapshotMarker, type SnapshotMessage } from './preview-controls.js';
+import { snapshotFilename, buildSnapshotContent, extractViewMeta, listSnapshotFiles, parseSnapshotForDisplay } from './snapshot-writer.js';
 
-// ── Inline render types ─────────────────────────────────────────────────────
+// ── Inline render types ────────────────────────────────────────────────────────────────────────────
 //
 // FGCA (notations/02-fgca.md) and FGA (notations/03-fga.md) are both the
 // canonical FLAT shape — top-level `factors[]` / `goals[]` / `changes[]`
@@ -47,7 +48,7 @@ interface FGCADoc {
   activities: ActivityItem[];
 }
 
-// ── Column layout ─────────────────────────────────────────────────────────────
+// ── Column layout ─────────────────────────────────────────────────────────────────────────────────
 //
 // Geometry + edge routing now live in @transitrix/diagrams
 // (`layoutFGCAPreview`) so the configurable-gap behaviour (vkgeorgia/strategy#75)
@@ -71,7 +72,7 @@ function scopeInputsFromDoc(doc: FGCADoc): { goals: ScopeGoalOption[]; maxLevelP
   };
 }
 
-// ── Chain table (vkgeorgia/strategy#137) ────────────────────────────────────
+// ── Chain table (vkgeorgia/strategy#137) ───────────────────────────────────────────────────────
 //
 // The flattening + rowspan derivation lives in @transitrix/diagrams
 // (`buildChainTable`). Here we render that model as an HTML <table>. Scope
@@ -141,6 +142,8 @@ interface ChainPreviewParams {
   saveSvgCommand: string;
   savePngCommand: string;
   copyPngCommand: string;
+  /** Snapshot markers for the timeline strip. */
+  snapshotMarkers: SnapshotMarker[];
 }
 
 /**
@@ -167,6 +170,8 @@ function renderChainPreview(
   const nonce = genNonce();
   const script = buildControlsScript(nonce);
   const viewToggleHtml = buildViewToggle(view);
+  const captureButton = buildCaptureButton();
+  const timelineStrip = buildTimelineStrip(p.snapshotMarkers);
 
   if (view === 'table') {
     // Scope is a no-op in table view, so no scope-warning is added here.
@@ -181,6 +186,7 @@ function renderChainPreview(
       version: docVersion,
       date: showHeader ? docDate : undefined,
       interactive: { nonce, controlsPanel: '', controlsScript: script, viewToggleHtml },
+      snapshotUi: { captureButton, timelineStrip },
     });
     return { html, svg: '' };
   }
@@ -212,6 +218,7 @@ function renderChainPreview(
     scopeCommand: OPEN_SCOPE_SETTINGS_COMMAND,
     themeCommand: OPEN_THEME_COMMAND,
     interactive: { nonce, controlsPanel: buildControlsPanel(model), controlsScript: script, viewToggleHtml },
+    snapshotUi: { captureButton, timelineStrip },
   });
   return { html, svg };
 }
@@ -296,7 +303,7 @@ ${edgeSvg}
 </svg>`;
 }
 
-// ── FGCAPreview webview class ─────────────────────────────────────────────────
+// ── FGCAPreview webview class ────────────────────────────────────────────────────────────────────────────
 
 export class FGCAPreview {
   readonly panelTitle = 'FGCA Preview';
@@ -329,7 +336,10 @@ export class FGCAPreview {
           enableCommandUris: ['transitrixStudio.saveFGCAAsSvg', 'transitrixStudio.saveFGCAAsPng', 'transitrixStudio.copyFGCAAsPng', OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND, OPEN_THEME_COMMAND],
         },
       );
-      this.panel.webview.onDidReceiveMessage((m) => { void applyControlMessage('fgca', m); });
+      this.panel.webview.onDidReceiveMessage(async (m) => {
+        if (m.type === 'transitrix:control') { void applyControlMessage('fgca', m); }
+        if (m.type === 'transitrix:snapshot') { await this.handleSnapshotMessage(m as SnapshotMessage); }
+      });
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
     }
     await this.pushDocument(doc);
@@ -359,13 +369,78 @@ export class FGCAPreview {
     await this.pushDocument(fgcaDoc);
   }
 
+  private async loadSnapshotMarkers(): Promise<SnapshotMarker[]> {
+    if (!this.trackedUri) return [];
+    const viewUri = vscode.Uri.parse(this.trackedUri);
+    const snapshotsDir = vscode.Uri.file(path.join(path.dirname(viewUri.fsPath), 'snapshots'));
+    try {
+      const entries = await vscode.workspace.fs.readDirectory(snapshotsDir);
+      const files = entries
+        .filter(([, type]) => type === vscode.FileType.File)
+        .map(([name]) => name);
+      return listSnapshotFiles(files).map(fname => ({
+        filename: fname,
+        dateLabel: fname.slice(0, 10),
+      }));
+    } catch {
+      return [];
+    }
+  }
+
+  private async handleSnapshotMessage(m: SnapshotMessage): Promise<void> {
+    if (!this.panel || !this.trackedUri) return;
+    const viewUri = vscode.Uri.parse(this.trackedUri);
+    const viewDir = path.dirname(viewUri.fsPath);
+
+    if (m.field === 'capture') {
+      const doc = await vscode.workspace.openTextDocument(viewUri);
+      const { viewId, methodologyVersion } = extractViewMeta(doc.getText());
+      const today = new Date().toISOString().slice(0, 10);
+      const chosenDate = await vscode.window.showInputBox({
+        title: 'Capture snapshot — date',
+        prompt: 'Date for this snapshot (YYYY-MM-DD). Accept today or enter a different date.',
+        value: today,
+        validateInput: v => /^\d{4}-\d{2}-\d{2}$/.test(v) ? null : 'Enter a date in YYYY-MM-DD format',
+      });
+      if (!chosenDate) return;
+      const now = new Date();
+      const fname = snapshotFilename(now);
+      const generatedAt = now.toISOString().replace(/\.\d+Z$/, 'Z');
+      const content = buildSnapshotContent({ viewId, generatedAt, methodologyVersion, capturedAtDate: chosenDate });
+      const outPath = path.join(viewDir, 'snapshots', fname);
+      await vscode.workspace.fs.writeFile(
+        vscode.Uri.file(outPath),
+        Buffer.from(content, 'utf-8'),
+      );
+      vscode.window.showInformationMessage(`Snapshot saved: ${fname}`);
+      await this.pushDocument(doc);
+    }
+
+    if (m.field === 'load' && m.snapshot) {
+      const snapshotPath = path.join(viewDir, 'snapshots', m.snapshot);
+      try {
+        const bytes = await vscode.workspace.fs.readFile(vscode.Uri.file(snapshotPath));
+        const text = Buffer.from(bytes).toString('utf-8');
+        const parsed = parseSnapshotForDisplay(text);
+        void this.panel?.webview.postMessage({
+          type: 'transitrix:snapshotLoaded',
+          filename: m.snapshot,
+          content: parsed,
+        });
+      } catch {
+        vscode.window.showWarningMessage(`Could not read snapshot: ${m.snapshot}`);
+      }
+    }
+  }
+
   private async pushDocument(doc: vscode.TextDocument): Promise<void> {
     if (!this.panel) return;
     const sources = await loadCanon(doc.uri);
-    this.panel.webview.html = this.buildHtml(doc.getText(), path.basename(doc.fileName), sources);
+    const markers = await this.loadSnapshotMarkers();
+    this.panel.webview.html = this.buildHtml(doc.getText(), path.basename(doc.fileName), sources, markers);
   }
 
-  private buildHtml(yamlText: string, filename: string, sources: CanonDocs): string {
+  private buildHtml(yamlText: string, filename: string, sources: CanonDocs, markers: SnapshotMarker[]): string {
     let parsedDoc: FGCADoc | null = null;
     let errorMsg = '';
     let warnings: string[] = [];
@@ -405,6 +480,7 @@ export class FGCAPreview {
         saveSvgCommand: 'transitrixStudio.saveFGCAAsSvg',
         savePngCommand: 'transitrixStudio.saveFGCAAsPng',
         copyPngCommand: 'transitrixStudio.copyFGCAAsPng',
+        snapshotMarkers: markers,
       },
       parsedDoc, warnings, errorMsg, docVersion, docDate, filename, themeId,
     );
@@ -450,7 +526,7 @@ export class FGCAPreview {
   }
 }
 
-// ── FGAPreview webview class ──────────────────────────────────────────────────
+// ── FGAPreview webview class ──────────────────────────────────────────────────────────────────────────────
 
 export class FGAPreview {
   readonly panelTitle = 'FGA Preview';
@@ -483,7 +559,10 @@ export class FGAPreview {
           enableCommandUris: ['transitrixStudio.saveFGAAsSvg', 'transitrixStudio.saveFGAAsPng', 'transitrixStudio.copyFGAAsPng', OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND, OPEN_THEME_COMMAND],
         },
       );
-      this.panel.webview.onDidReceiveMessage((m) => { void applyControlMessage('fga', m); });
+      this.panel.webview.onDidReceiveMessage(async (m) => {
+        if (m.type === 'transitrix:control') { void applyControlMessage('fga', m); }
+        if (m.type === 'transitrix:snapshot') { await this.handleSnapshotMessage(m as SnapshotMessage); }
+      });
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
     }
     await this.pushDocument(doc);
@@ -501,12 +580,77 @@ export class FGAPreview {
     await this.pushDocument(doc);
   }
 
-  private async pushDocument(doc: vscode.TextDocument): Promise<void> {
-    if (!this.panel) return;
-    this.panel.webview.html = this.buildHtml(doc.getText(), path.basename(doc.fileName));
+  private async loadSnapshotMarkers(): Promise<SnapshotMarker[]> {
+    if (!this.trackedUri) return [];
+    const viewUri = vscode.Uri.parse(this.trackedUri);
+    const snapshotsDir = vscode.Uri.file(path.join(path.dirname(viewUri.fsPath), 'snapshots'));
+    try {
+      const entries = await vscode.workspace.fs.readDirectory(snapshotsDir);
+      const files = entries
+        .filter(([, type]) => type === vscode.FileType.File)
+        .map(([name]) => name);
+      return listSnapshotFiles(files).map(fname => ({
+        filename: fname,
+        dateLabel: fname.slice(0, 10),
+      }));
+    } catch {
+      return [];
+    }
   }
 
-  private buildHtml(yamlText: string, filename: string): string {
+  private async handleSnapshotMessage(m: SnapshotMessage): Promise<void> {
+    if (!this.panel || !this.trackedUri) return;
+    const viewUri = vscode.Uri.parse(this.trackedUri);
+    const viewDir = path.dirname(viewUri.fsPath);
+
+    if (m.field === 'capture') {
+      const doc = await vscode.workspace.openTextDocument(viewUri);
+      const { viewId, methodologyVersion } = extractViewMeta(doc.getText());
+      const today = new Date().toISOString().slice(0, 10);
+      const chosenDate = await vscode.window.showInputBox({
+        title: 'Capture snapshot — date',
+        prompt: 'Date for this snapshot (YYYY-MM-DD). Accept today or enter a different date.',
+        value: today,
+        validateInput: v => /^\d{4}-\d{2}-\d{2}$/.test(v) ? null : 'Enter a date in YYYY-MM-DD format',
+      });
+      if (!chosenDate) return;
+      const now = new Date();
+      const fname = snapshotFilename(now);
+      const generatedAt = now.toISOString().replace(/\.\d+Z$/, 'Z');
+      const content = buildSnapshotContent({ viewId, generatedAt, methodologyVersion, capturedAtDate: chosenDate });
+      const outPath = path.join(viewDir, 'snapshots', fname);
+      await vscode.workspace.fs.writeFile(
+        vscode.Uri.file(outPath),
+        Buffer.from(content, 'utf-8'),
+      );
+      vscode.window.showInformationMessage(`Snapshot saved: ${fname}`);
+      await this.pushDocument(doc);
+    }
+
+    if (m.field === 'load' && m.snapshot) {
+      const snapshotPath = path.join(viewDir, 'snapshots', m.snapshot);
+      try {
+        const bytes = await vscode.workspace.fs.readFile(vscode.Uri.file(snapshotPath));
+        const text = Buffer.from(bytes).toString('utf-8');
+        const parsed = parseSnapshotForDisplay(text);
+        void this.panel?.webview.postMessage({
+          type: 'transitrix:snapshotLoaded',
+          filename: m.snapshot,
+          content: parsed,
+        });
+      } catch {
+        vscode.window.showWarningMessage(`Could not read snapshot: ${m.snapshot}`);
+      }
+    }
+  }
+
+  private async pushDocument(doc: vscode.TextDocument): Promise<void> {
+    if (!this.panel) return;
+    const markers = await this.loadSnapshotMarkers();
+    this.panel.webview.html = this.buildHtml(doc.getText(), path.basename(doc.fileName), markers);
+  }
+
+  private buildHtml(yamlText: string, filename: string, markers: SnapshotMarker[]): string {
     let parsedDoc: FGCADoc | null = null;
     let errorMsg = '';
     let warnings: string[] = [];
@@ -543,6 +687,7 @@ export class FGAPreview {
         saveSvgCommand: 'transitrixStudio.saveFGAAsSvg',
         savePngCommand: 'transitrixStudio.saveFGAAsPng',
         copyPngCommand: 'transitrixStudio.copyFGAAsPng',
+        snapshotMarkers: markers,
       },
       parsedDoc, warnings, errorMsg, docVersion, docDate, filename, themeId,
     );

--- a/extension/src/fgca-preview.ts
+++ b/extension/src/fgca-preview.ts
@@ -407,6 +407,8 @@ export class FGCAPreview {
       const fname = snapshotFilename(now);
       const generatedAt = now.toISOString().replace(/\.\d+Z$/, 'Z');
       const content = buildSnapshotContent({ viewId, generatedAt, methodologyVersion, capturedAtDate: chosenDate });
+      const snapshotsDirUri = vscode.Uri.file(path.join(viewDir, 'snapshots'));
+      await vscode.workspace.fs.createDirectory(snapshotsDirUri);
       const outPath = path.join(viewDir, 'snapshots', fname);
       await vscode.workspace.fs.writeFile(
         vscode.Uri.file(outPath),
@@ -618,6 +620,8 @@ export class FGAPreview {
       const fname = snapshotFilename(now);
       const generatedAt = now.toISOString().replace(/\.\d+Z$/, 'Z');
       const content = buildSnapshotContent({ viewId, generatedAt, methodologyVersion, capturedAtDate: chosenDate });
+      const snapshotsDirUri = vscode.Uri.file(path.join(viewDir, 'snapshots'));
+      await vscode.workspace.fs.createDirectory(snapshotsDirUri);
       const outPath = path.join(viewDir, 'snapshots', fname);
       await vscode.workspace.fs.writeFile(
         vscode.Uri.file(outPath),

--- a/extension/src/preview-controls.ts
+++ b/extension/src/preview-controls.ts
@@ -72,6 +72,14 @@ export interface ControlMessage {
   value?: number | string;
 }
 
+/** Snapshot-related message posted from webview to host. */
+export interface SnapshotMessage {
+  type: 'transitrix:snapshot';
+  field: 'capture' | 'load';
+  /** For 'load': the filename of the snapshot to load (e.g. "2026-06-20T143000Z.yaml"). */
+  snapshot?: string;
+}
+
 /** Tree ↔ table view, persisted per notation (vkgeorgia/strategy#137). */
 export type PreviewView = 'tree' | 'table';
 
@@ -150,6 +158,77 @@ export const CONTROLS_PANEL_CSS = `
 .tx-view-btn:hover { color: var(--ts-text, #0f172a); background: var(--ts-bg-elevated, #f1f5f9); }
 .tx-view-btn.active { color: var(--ts-text, #0f172a); background: var(--ts-bg-elevated, #f1f5f9); font-weight: 600; }
 `;
+
+/** CSS for the snapshot toolbar button and the timeline navigator strip. */
+export const SNAPSHOT_TOOLBAR_CSS = `
+.tx-snap-btn {
+  cursor: pointer;
+  user-select: none;
+  font-size: 11px;
+  padding: 1px 8px;
+  border-radius: 4px;
+  color: var(--ts-text-muted, #64748b);
+  background: transparent;
+  border: 1px solid var(--ts-border, #cbd5e1);
+  font-family: var(--vscode-font-family, sans-serif);
+  white-space: nowrap;
+}
+.tx-snap-btn:hover { color: var(--ts-text, #0f172a); background: var(--ts-bg-elevated, #f1f5f9); }
+.tx-timeline {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin: 4px 16px;
+  flex-wrap: wrap;
+  font-size: 11px;
+  color: var(--ts-text-muted, #64748b);
+}
+.tx-timeline-label { font-weight: 600; white-space: nowrap; }
+.tx-timeline-marker {
+  cursor: pointer;
+  padding: 1px 6px;
+  border-radius: 3px;
+  border: 1px solid var(--ts-border, #cbd5e1);
+  background: transparent;
+  color: var(--ts-text-muted, #64748b);
+  font-size: 10px;
+  font-family: var(--vscode-font-family, sans-serif);
+  white-space: nowrap;
+}
+.tx-timeline-marker:hover { color: var(--ts-text, #0f172a); background: var(--ts-bg-elevated, #f1f5f9); }
+.tx-snap-info {
+  margin: 4px 16px 0;
+  padding: 6px 10px;
+  border-radius: 4px;
+  border: 1px solid var(--ts-border, #cbd5e1);
+  background: var(--ts-bg-subtle, #f8fafc);
+  font-size: 11px;
+  color: var(--ts-text-muted, #64748b);
+}
+`;
+
+/** A snapshot marker entry for the timeline strip. */
+export interface SnapshotMarker {
+  /** Filename e.g. "2026-06-20T143000Z.yaml" */
+  filename: string;
+  /** Date portion for display e.g. "2026-06-20" */
+  dateLabel: string;
+}
+
+/** Builds the "Capture…" button HTML for the toolbar. */
+export function buildCaptureButton(): string {
+  return `<button type="button" class="tx-snap-btn" data-tx-control="snapshot" data-tx-field="capture" title="Capture the current view state as a snapshot file">Capture…</button>`;
+}
+
+/** Builds the timeline marker strip HTML from a list of existing snapshots.
+ *  Returns empty string when there are no snapshots. */
+export function buildTimelineStrip(markers: SnapshotMarker[]): string {
+  if (markers.length === 0) return '';
+  const markerHtml = markers.map(m =>
+    `<button type="button" class="tx-timeline-marker" data-tx-control="snapshot" data-tx-field="load" data-tx-snapshot="${escXml(m.filename)}" title="Jump to snapshot ${escXml(m.filename)}">${escXml(m.dateLabel)}</button>`
+  ).join('');
+  return `<div class="tx-timeline"><span class="tx-timeline-label">Snapshots:</span>${markerHtml}</div>`;
+}
 
 /** True when any control differs from its no-visual-change default. */
 function hasNonDefault(model: ControlsModel): boolean {
@@ -230,8 +309,10 @@ export function buildViewToggle(current: PreviewView): string {
 }
 
 /** Builds the nonce'd wiring `<script>`. Reads `data-tx-*` inputs, posts a
- *  ControlMessage to the host on change, and persists the panel's open/closed
- *  state in webview state so a host-driven re-render doesn't collapse it. */
+ *  ControlMessage or SnapshotMessage to the host on change, and persists the
+ *  panel's open/closed state in webview state so a host-driven re-render
+ *  doesn't collapse it. Also handles incoming `transitrix:snapshotLoaded`
+ *  messages from the host to update the timeline info box. */
 export function buildControlsScript(nonce: string): string {
   // Plain ES5-ish DOM script; runs inside the webview, not the Node host.
   return `<script nonce="${nonce}">
@@ -250,7 +331,14 @@ export function buildControlsScript(nonce: string): string {
       var control = el.getAttribute('data-tx-control');
       var field = el.getAttribute('data-tx-field');
       if (el.tagName === 'BUTTON') {
-        el.addEventListener('click', function () { post(control, field); });
+        el.addEventListener('click', function () {
+          if (control === 'snapshot') {
+            var snapshotName = el.getAttribute('data-tx-snapshot');
+            vscode.postMessage({ type: 'transitrix:snapshot', field: field, snapshot: snapshotName !== null ? snapshotName : undefined });
+          } else {
+            post(control, field);
+          }
+        });
         return;
       }
       var outId = el.getAttribute('data-tx-output');
@@ -286,6 +374,18 @@ export function buildControlsScript(nonce: string): string {
       vscode.setState(s);
     });
   }
+  // Handle incoming snapshot-loaded messages from the host extension.
+  window.addEventListener('message', function(event) {
+    var msg = event.data;
+    if (msg && msg.type === 'transitrix:snapshotLoaded') {
+      var box = document.getElementById('tx-snap-info');
+      if (box) {
+        var d = msg.content || {};
+        box.textContent = 'Snapshot: ' + msg.filename + (d.captured_at_date ? ' · date: ' + d.captured_at_date : '') + ' · ' + (d.generated_at || '');
+        box.style.display = 'block';
+      }
+    }
+  });
 }());
 </script>`;
 }

--- a/extension/src/snapshot-writer.ts
+++ b/extension/src/snapshot-writer.ts
@@ -1,0 +1,105 @@
+// Snapshot file utilities — pure functions, no `vscode` imports, fully unit-testable.
+//
+// The snapshot envelope format is specified in CONTRACT.md §14.5:
+//   view_id, generated_at, methodology_version, captured_at_date
+// Files are written to `views/<notation-name>/snapshots/YYYY-MM-DDTHHMMSSZ.yaml`
+// alongside the open `.view.yaml` document.
+
+import yaml from 'js-yaml';
+
+/** Generates a compact UTC timestamp suitable for a snapshot filename.
+ *  Format: YYYY-MM-DDTHHMMSSZ (no colons, no fractional seconds).
+ *  Example: "2026-06-20T143000Z.yaml" */
+export function snapshotFilename(now: Date = new Date()): string {
+  const pad = (n: number, w = 2): string => String(n).padStart(w, '0');
+  const Y = now.getUTCFullYear();
+  const M = pad(now.getUTCMonth() + 1);
+  const D = pad(now.getUTCDate());
+  const h = pad(now.getUTCHours());
+  const m = pad(now.getUTCMinutes());
+  const s = pad(now.getUTCSeconds());
+  return `${Y}-${M}-${D}T${h}${m}${s}Z.yaml`;
+}
+
+export interface SnapshotContentOpts {
+  viewId: string;
+  /** ISO-8601 UTC string, e.g. "2026-06-20T14:30:00Z" */
+  generatedAt: string;
+  methodologyVersion: string;
+  /** YYYY-MM-DD date the user chose in the input box */
+  capturedAtDate: string;
+}
+
+/** Builds the snapshot YAML content per CONTRACT.md §14.5. */
+export function buildSnapshotContent(opts: SnapshotContentOpts): string {
+  const doc = {
+    view_id: opts.viewId,
+    generated_at: opts.generatedAt,
+    methodology_version: opts.methodologyVersion,
+    captured_at_date: opts.capturedAtDate,
+  };
+  return yaml.dump(doc, { lineWidth: -1, quotingType: '"', forceQuotes: false });
+}
+
+/** Parses the view document YAML to extract `view.id` and `methodology_version`.
+ *  Returns safe fallbacks ('unknown' / '0.0.0') when fields are absent. */
+export function extractViewMeta(yamlText: string): { viewId: string; methodologyVersion: string } {
+  let viewId = 'unknown';
+  let methodologyVersion = '0.0.0';
+  try {
+    const parsed = yaml.load(yamlText);
+    if (parsed && typeof parsed === 'object') {
+      const doc = parsed as Record<string, unknown>;
+      // view.id nested under a 'view' key, or flat 'view_id' at root.
+      const viewObj = doc['view'];
+      if (viewObj && typeof viewObj === 'object') {
+        const id = (viewObj as Record<string, unknown>)['id'];
+        if (typeof id === 'string' && id.trim()) viewId = id.trim();
+        else if (typeof id === 'number') viewId = String(id);
+      }
+      if (typeof doc['view_id'] === 'string' && doc['view_id'].trim()) {
+        viewId = doc['view_id'].trim();
+      }
+      if (typeof doc['methodology_version'] === 'string' && doc['methodology_version'].trim()) {
+        methodologyVersion = doc['methodology_version'].trim();
+      }
+    }
+  } catch {
+    // Malformed YAML — return fallbacks.
+  }
+  return { viewId, methodologyVersion };
+}
+
+/** Filters a list of file names to those that look like snapshot files
+ *  (*.yaml), then sorts them ascending (oldest first by filename, which
+ *  sorts lexicographically because the timestamp format is sortable). */
+export function listSnapshotFiles(files: string[]): string[] {
+  return files
+    .filter(f => f.endsWith('.yaml'))
+    .sort((a, b) => a.localeCompare(b));
+}
+
+export interface SnapshotDisplay {
+  viewId: string;
+  generatedAt: string;
+  capturedAtDate: string | undefined;
+}
+
+/** Parses a snapshot file's content and extracts key display fields. */
+export function parseSnapshotForDisplay(yamlText: string): SnapshotDisplay {
+  let viewId = '';
+  let generatedAt = '';
+  let capturedAtDate: string | undefined;
+  try {
+    const parsed = yaml.load(yamlText);
+    if (parsed && typeof parsed === 'object') {
+      const doc = parsed as Record<string, unknown>;
+      if (typeof doc['view_id'] === 'string') viewId = doc['view_id'];
+      if (typeof doc['generated_at'] === 'string') generatedAt = doc['generated_at'];
+      if (typeof doc['captured_at_date'] === 'string') capturedAtDate = doc['captured_at_date'];
+    }
+  } catch {
+    // Malformed — return empty fields.
+  }
+  return { viewId, generatedAt, capturedAtDate };
+}

--- a/tests/snapshot-writer.test.ts
+++ b/tests/snapshot-writer.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import yaml from 'js-yaml';
 import {
   snapshotFilename,
   buildSnapshotContent,
@@ -67,8 +68,7 @@ describe('buildSnapshotContent', () => {
   it('produces valid YAML (round-trips)', () => {
     const content = buildSnapshotContent(base);
     // Must be parseable without throwing.
-    const { load } = await import('js-yaml');
-    const parsed = load(content) as Record<string, unknown>;
+    const parsed = yaml.load(content) as Record<string, unknown>;
     expect(parsed['view_id']).toBe('my-view');
     expect(parsed['methodology_version']).toBe('1.2.3');
     expect(parsed['captured_at_date']).toBe('2026-06-20');

--- a/tests/snapshot-writer.test.ts
+++ b/tests/snapshot-writer.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import {
+  snapshotFilename,
+  buildSnapshotContent,
+  extractViewMeta,
+  listSnapshotFiles,
+  parseSnapshotForDisplay,
+} from '../extension/src/snapshot-writer.js';
+
+// Unit coverage for the snapshot-writer utilities (issue #303).
+// These functions are pure (no vscode, no fs) so they are fully testable here.
+
+describe('snapshotFilename', () => {
+  it('produces YYYY-MM-DDTHHMMSSZ.yaml format', () => {
+    const d = new Date('2026-06-20T14:30:05Z');
+    expect(snapshotFilename(d)).toBe('2026-06-20T143005Z.yaml');
+  });
+
+  it('zero-pads single-digit months, days, hours, minutes, seconds', () => {
+    const d = new Date('2026-01-02T03:04:05Z');
+    expect(snapshotFilename(d)).toBe('2026-01-02T030405Z.yaml');
+  });
+
+  it('two calls on different dates produce different filenames', () => {
+    const a = snapshotFilename(new Date('2026-06-20T10:00:00Z'));
+    const b = snapshotFilename(new Date('2026-06-20T10:00:01Z'));
+    expect(a).not.toBe(b);
+  });
+
+  it('defaults to current time when no argument provided', () => {
+    const before = Date.now();
+    const fname = snapshotFilename();
+    const after = Date.now();
+    // The filename must end with Z.yaml and be parseable as a UTC date.
+    expect(fname).toMatch(/^\d{4}-\d{2}-\d{2}T\d{6}Z\.yaml$/);
+    // The year embedded must be the current UTC year.
+    const year = new Date(before).getUTCFullYear();
+    expect(fname.startsWith(String(year))).toBe(true);
+    void after; // suppress unused warning
+  });
+});
+
+describe('buildSnapshotContent', () => {
+  const base = {
+    viewId: 'my-view',
+    generatedAt: '2026-06-20T14:30:00Z',
+    methodologyVersion: '1.2.3',
+    capturedAtDate: '2026-06-20',
+  };
+
+  it('emits all required §14.5 envelope fields', () => {
+    const content = buildSnapshotContent(base);
+    expect(content).toContain('view_id:');
+    expect(content).toContain('generated_at:');
+    expect(content).toContain('methodology_version:');
+    expect(content).toContain('captured_at_date:');
+  });
+
+  it('embeds correct values', () => {
+    const content = buildSnapshotContent(base);
+    expect(content).toContain('my-view');
+    expect(content).toContain('2026-06-20T14:30:00Z');
+    expect(content).toContain('1.2.3');
+    expect(content).toContain('2026-06-20');
+  });
+
+  it('produces valid YAML (round-trips)', () => {
+    const content = buildSnapshotContent(base);
+    // Must be parseable without throwing.
+    const { load } = await import('js-yaml');
+    const parsed = load(content) as Record<string, unknown>;
+    expect(parsed['view_id']).toBe('my-view');
+    expect(parsed['methodology_version']).toBe('1.2.3');
+    expect(parsed['captured_at_date']).toBe('2026-06-20');
+  });
+});
+
+describe('extractViewMeta', () => {
+  it('extracts view.id nested under view key', () => {
+    const yaml = `view:\n  id: my-notation-view\nmethodology_version: "2.0.0"\n`;
+    const { viewId, methodologyVersion } = extractViewMeta(yaml);
+    expect(viewId).toBe('my-notation-view');
+    expect(methodologyVersion).toBe('2.0.0');
+  });
+
+  it('extracts flat view_id at root level', () => {
+    const yaml = `view_id: flat-id\nmethodology_version: "1.0"\n`;
+    const { viewId } = extractViewMeta(yaml);
+    expect(viewId).toBe('flat-id');
+  });
+
+  it('returns fallbacks when fields are absent', () => {
+    const { viewId, methodologyVersion } = extractViewMeta('goals: []\n');
+    expect(viewId).toBe('unknown');
+    expect(methodologyVersion).toBe('0.0.0');
+  });
+
+  it('returns fallbacks on malformed YAML', () => {
+    const { viewId, methodologyVersion } = extractViewMeta(': : invalid ::');
+    expect(viewId).toBe('unknown');
+    expect(methodologyVersion).toBe('0.0.0');
+  });
+});
+
+describe('listSnapshotFiles', () => {
+  it('filters to .yaml files only', () => {
+    const files = ['2026-06-20T143000Z.yaml', 'README.md', '2026-06-19T090000Z.yaml', '.DS_Store'];
+    const result = listSnapshotFiles(files);
+    expect(result).toEqual(['2026-06-19T090000Z.yaml', '2026-06-20T143000Z.yaml']);
+  });
+
+  it('sorts ascending (oldest first)', () => {
+    const files = [
+      '2026-06-21T000000Z.yaml',
+      '2026-06-19T000000Z.yaml',
+      '2026-06-20T000000Z.yaml',
+    ];
+    expect(listSnapshotFiles(files)).toEqual([
+      '2026-06-19T000000Z.yaml',
+      '2026-06-20T000000Z.yaml',
+      '2026-06-21T000000Z.yaml',
+    ]);
+  });
+
+  it('returns empty array when no yaml files', () => {
+    expect(listSnapshotFiles(['foo.json', 'bar.md'])).toEqual([]);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(listSnapshotFiles([])).toEqual([]);
+  });
+});
+
+describe('parseSnapshotForDisplay', () => {
+  it('reads back what buildSnapshotContent wrote', () => {
+    const content = buildSnapshotContent({
+      viewId: 'roundtrip-view',
+      generatedAt: '2026-06-20T14:30:00Z',
+      methodologyVersion: '1.0.0',
+      capturedAtDate: '2026-06-20',
+    });
+    const { viewId, generatedAt, capturedAtDate } = parseSnapshotForDisplay(content);
+    expect(viewId).toBe('roundtrip-view');
+    expect(generatedAt).toBe('2026-06-20T14:30:00Z');
+    expect(capturedAtDate).toBe('2026-06-20');
+  });
+
+  it('returns empty strings for absent fields', () => {
+    const { viewId, generatedAt, capturedAtDate } = parseSnapshotForDisplay('unrelated: true\n');
+    expect(viewId).toBe('');
+    expect(generatedAt).toBe('');
+    expect(capturedAtDate).toBeUndefined();
+  });
+
+  it('returns empty strings on malformed YAML', () => {
+    const { viewId } = parseSnapshotForDisplay(': : invalid');
+    expect(viewId).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

Implements the \"Capture snapshot\" UI and timeline navigator in the FGCA and FGA diagram previews, conforming to the snapshot envelope format specified in CONTRACT.md §14.5.

### What ships

- **`extension/src/snapshot-writer.ts`** — pure utility functions (no `vscode` imports, fully unit-testable):
  - `snapshotFilename(date?)` — compact UTC timestamp filename (`YYYY-MM-DDTHHMMSSZ.yaml`)
  - `buildSnapshotContent(opts)` — YAML envelope with `view_id`, `generated_at`, `methodology_version`, `captured_at_date`
  - `extractViewMeta(yaml)` — reads `view.id` / `methodology_version` from the open document
  - `listSnapshotFiles(names)` — filters and sorts `.yaml` files ascending
  - `parseSnapshotForDisplay(yaml)` — reads key display fields from a snapshot file

- **`extension/src/preview-controls.ts`** — snapshot UI primitives:
  - `SNAPSHOT_TOOLBAR_CSS` — styles for the Capture button and timeline strip
  - `SnapshotMessage` / `SnapshotMarker` types
  - `buildCaptureButton()` — \"Capture…\" toolbar button wired to `data-tx-control=\"snapshot\" data-tx-field=\"capture\"`
  - `buildTimelineStrip(markers)` — renders dated marker buttons for existing snapshots
  - `buildControlsScript()` extended — handles `snapshot` messages and `transitrix:snapshotLoaded` incoming messages to update the info box

- **`extension/src/diagram-frame.ts`** — new `snapshotUi?: { captureButton, timelineStrip }` option:
  - When set, injects the `SNAPSHOT_TOOLBAR_CSS`, the Capture button into toolbar actions, the timeline strip below the controls panel, and a hidden info box that updates on snapshot load

- **`extension/src/fgca-preview.ts`** (both `FGCAPreview` and `FGAPreview`):
  - `loadSnapshotMarkers()` — reads `snapshots/` directory alongside the view doc; returns sorted markers
  - `handleSnapshotMessage()` — handles `capture` (date picker → write YAML) and `load` (read file → postMessage to webview)
  - `createDirectory` called before `writeFile` so the first capture works when `snapshots/` does not yet exist
  - Both classes pass `snapshotMarkers` into `renderChainPreview` → `buildDiagramFrame`

### Snapshot file format

Conforms to CONTRACT.md §14.5 shared envelope:
```yaml
view_id: MY-VIEW-1
generated_at: "2026-06-21T12:00:00Z"
methodology_version: "0.7.0"
captured_at_date: "2026-06-21"   # user-chosen date (allows intentional backdating)
```

Files written to `views/<notation>/snapshots/YYYY-MM-DDTHHMMSSZ.yaml` alongside the authored `*.view.yaml` document (which is never modified by capture).

### Studio vs DSM boundary

The navigator shows markers only at explicitly captured dates (no computed timeline). Temporal queries and auto-markers from `valid_from`/`valid_to` are reserved for DSM.

## Test plan

- [x] `npm run compile` — green
- [x] `npm run compile:extension` — green
- [x] `npx vitest run` — 373 passed (18 new snapshot-writer unit tests)
- [x] `npm --workspace packages/diagrams test` — 921 passed
- [x] No new lint errors

## Notes

- Only FGCA and FGA previews ship snapshot UI in this PR (both have interactive script-enabled panels). Other notations follow in subsequent PRs if needed.
- Do not merge — maintainer gates merges.