### PR TITLE
refactor(diagrams,extension): single blocks SVG emitter (review C, blocks slice)

### DIFF
--- a/extension/src/blocks-preview.ts
+++ b/extension/src/blocks-preview.ts
@@ -10,70 +10,31 @@ import {
   iterateBlocks,
   type BlocksFile,
   type BlocksLayout,
-  type LaidOutBlock,
 } from '../../packages/diagrams/src/blocks/index.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
-import { escXml } from '../../packages/diagrams/src/webview/render-util.js';
+import { renderBlocksLayoutSvg } from '../../packages/diagrams/src/webview/render-blocks.js';
 
-function truncate(text: string, maxChars: number): string {
-  if (text.length <= maxChars) return text;
-  return text.slice(0, Math.max(0, maxChars - 1)) + '…';
-}
+// Pad reserved around the diagram; mirrors `PAD` in the shared emitter
+// (`render-blocks.ts`) so the VS Code title block lines up with the body.
+const PAD = 24;
 
 /**
- * Pick the diagram-frame level class for a block at the given depth.
- *
- * `level-0` is the lightest fill in the brand colour ramp; deeper levels are
- * progressively darker. The methodology spec mandates "outermost lightest"
- * (08-blocks.md §7), so depth 1 (top-level) maps to `level-0`.
- *
- * The frame defines `level-0` … `level-6`; deeper blocks reuse `level-6` so
- * extreme nesting still renders without crashing (BL-008 already warns at
- * depth 6+).
+ * VS Code wrapper around the shared {@link renderBlocksLayoutSvg} emitter. Adds
+ * the rich title block (reserving `topInset` for it) and leaves the body — node
+ * rects, headers, level classes — to the single source of truth in
+ * `@transitrix/diagrams`. No embedded CSS: the webview supplies it live and the
+ * export path embeds it via `prepareSvgForExport`.
  */
-function levelClassForDepth(depth: number): string {
-  const idx = Math.min(Math.max(depth - 1, 0), 6);
-  return `level-${idx}`;
-}
-
-function emitBlockSvg(b: LaidOutBlock, ox: number, oy: number, parts: string[]): void {
-  const cls = levelClassForDepth(b.depth);
-  parts.push(
-    `<rect class="diagram-node ${cls}" x="${b.x + ox}" y="${b.y + oy}" width="${b.width}" height="${b.height}" rx="6"/>`,
-  );
-
-  // Header label, centred horizontally within the block's header strip.
-  const headerY = b.y + oy + b.headerHeight / 2;
-  const maxChars = Math.max(4, Math.floor(b.width / 8));
-  parts.push(
-    `<text class="text-header" x="${b.x + ox + b.width / 2}" y="${headerY}" text-anchor="middle" dominant-baseline="central">${escXml(truncate(b.name, maxChars))}</text>`,
-  );
-
-  for (const c of b.children) emitBlockSvg(c, ox, oy, parts);
-}
-
 function layoutToSvg(
   layout: BlocksLayout,
   filename?: string,
   date?: string,
   version?: string,
 ): string {
-  const pad = 24;
   const showTitle = filename != null && date != null;
   const titleH = showTitle ? TITLE_BLOCK_H : 0;
-  const w = layout.bounds.width + pad * 2;
-  const h = layout.bounds.height + pad * 2 + titleH;
-  const ox = pad;
-  const oy = pad + titleH;
-
-  const parts: string[] = [];
-  for (const top of layout.blocks) emitBlockSvg(top, ox, oy, parts);
-
-  const titleSvg = showTitle ? titleBlockSvg('Nested Blocks', filename!, date!, pad, pad, version) : '';
-  return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">
-${titleSvg}
-${parts.join('\n')}
-</svg>`;
+  const titleSvg = showTitle ? titleBlockSvg('Nested Blocks', filename!, date!, PAD, PAD, version) : '';
+  return renderBlocksLayoutSvg(layout, { topInset: titleH, title: titleSvg });
 }
 
 export class BlocksPreview {

--- a/packages/diagrams/src/webview/render-blocks.ts
+++ b/packages/diagrams/src/webview/render-blocks.ts
@@ -14,7 +14,7 @@
  */
 import { layoutNestedBlocks } from '../blocks/layout.js';
 import type { BlocksFile, BlocksLayout, LaidOutBlock } from '../blocks/types.js';
-import { generateSvgEmbedCss } from '../theme/index.js';
+import { generateSvgEmbedCss, type ThemeId } from '../theme/index.js';
 import { escXml } from './render-util.js';
 
 const PAD = 24;
@@ -57,6 +57,50 @@ function emitBlockSvg(b: LaidOutBlock, ox: number, oy: number, parts: string[]):
   for (const c of b.children) emitBlockSvg(c, ox, oy, parts);
 }
 
+export interface RenderBlocksLayoutOptions {
+  /** Extra vertical space reserved at the top of the canvas (e.g. for a title block). */
+  topInset?: number;
+  /** Raw SVG injected immediately after the opening tag — a header line or a full title block. */
+  title?: string;
+  /** When set, the theme CSS is embedded as `<style>` so the SVG is self-contained. */
+  embedCssTheme?: ThemeId;
+}
+
+/**
+ * The single Nested Blocks SVG emitter shared by every host. Takes an
+ * already-computed {@link BlocksLayout} (callers decide the layout options) and
+ * produces the `<svg>`. Hosts wrap it with their own chrome:
+ *   - IntelliJ/UI via {@link renderBlocksSvg} (embedded CSS + simple header);
+ *   - VS Code's blocks preview (rich title block, no embedded CSS — the webview
+ *     and the export path own styling).
+ */
+export function renderBlocksLayoutSvg(
+  layout: BlocksLayout,
+  options: RenderBlocksLayoutOptions = {},
+): string {
+  const { topInset = 0, title = '', embedCssTheme } = options;
+
+  const w = layout.bounds.width + PAD * 2;
+  const h = layout.bounds.height + PAD * 2 + topInset;
+  const ox = -layout.bounds.x + PAD;
+  const oy = -layout.bounds.y + PAD + topInset;
+
+  const parts: string[] = [];
+  for (const top of layout.blocks) emitBlockSvg(top, ox, oy, parts);
+
+  const styleLine = embedCssTheme ? `\n<style>${generateSvgEmbedCss(embedCssTheme)}</style>` : '';
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">${styleLine}
+${title}
+${parts.join('\n')}
+</svg>`;
+}
+
+/**
+ * Host-neutral blocks renderer (IntelliJ/UI). Lays the doc out with the default
+ * spacing, then delegates the actual SVG emission to {@link renderBlocksLayoutSvg}
+ * with the shared theme CSS embedded so the output is self-contained.
+ */
 export function renderBlocksSvg(doc: BlocksFile, options: RenderBlocksOptions = {}): string {
   const { title = '' } = options;
 
@@ -66,26 +110,9 @@ export function renderBlocksSvg(doc: BlocksFile, options: RenderBlocksOptions = 
     return `<svg xmlns="http://www.w3.org/2000/svg" width="0" height="0" viewBox="0 0 0 0"></svg>`;
   }
 
-  const w = layout.bounds.width + PAD * 2;
-  const h = layout.bounds.height + PAD * 2;
-  const ox = -layout.bounds.x + PAD;
-  const oy = -layout.bounds.y + PAD;
-
-  const parts: string[] = [];
-  for (const top of layout.blocks) emitBlockSvg(top, ox, oy, parts);
-
   const titleSvg = title
     ? `<text class="text-header" x="${PAD}" y="${PAD - 6}">${escXml(`Nested Blocks — ${title}`)}</text>`
     : '';
 
-  // Embed the shared theme CSS inside the SVG so the rendered output is
-  // self-contained — the JCEF host page only needs to drop the SVG into the
-  // DOM and styling resolves without any cooperation from the host stylesheet.
-  const embedCss = generateSvgEmbedCss('transitrix');
-
-  return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">
-<style>${embedCss}</style>
-${titleSvg}
-${parts.join('\n')}
-</svg>`;
+  return renderBlocksLayoutSvg(layout, { title: titleSvg, embedCssTheme: 'transitrix' });
 }


### PR DESCRIPTION
## Summary

Next slice of the **single SVG emitter per notation** epic (review C) — the Nested Blocks notation, following the same shape as the goals slice.

The blocks SVG body (node `<rect>`, header `<text>`, depth→level class, `viewBox` math, recursive child emit) was duplicated between the host-neutral package renderer (`packages/diagrams/src/webview/render-blocks.ts`, used by IntelliJ/UI) and the VS Code preview's local `layoutToSvg` (`extension/src/blocks-preview.ts`). Two emitters meant the design rules (no-italic, padding, level ramp) had to be kept in sync by hand.

## Changes

- **`packages/diagrams`** — extract the shared core `renderBlocksLayoutSvg(layout, options)`. Options carry the host-specific chrome: `topInset` (room for a title), `title` (raw SVG injected after the opening tag), `embedCssTheme` (embed `<style>` so the SVG is self-contained). The shared `emitBlockSvg` / `levelClassForDepth` / `truncate` helpers now live only here.
- `renderBlocksSvg(doc)` (IntelliJ/UI) is now a thin wrapper: lays the doc out, keeps the empty-doc `0×0` guard, builds the simple header, embeds the theme CSS. **Output unchanged.**
- **`extension/src/blocks-preview.ts`** — `layoutToSvg` is now a thin wrapper that builds the rich title block and reserves `topInset`, delegating the body to the shared emitter. No embedded CSS (the webview supplies it live; export embeds via `prepareSvgForExport`). The duplicated body, helpers, and the local `escXml`/`LaidOutBlock` imports are removed.

## Parity verification

The blocks layout always normalises to `bounds.x/y === 0`, so the shared offset (`-bounds.x + PAD`) is identical to the preview's old `pad`. Byte parity of the **VS Code** output was proven against the pre-refactor `layoutToSvg` via a temporary test before removal — identical strings for: single leaf, nested children, special characters, label truncation, multiple top-level blocks; each with/without the title block and with/without a version. The IntelliJ/UI path (`renderBlocksSvg`) is a byte-for-byte thin wrapper.

## Test plan

- [x] `npm run compile` (root) — green
- [x] `npm run compile:extension` — green
- [x] `npx vitest run` — 373 passed
- [x] `npm --workspace packages/diagrams test` — 921 passed
- [x] No new lint errors

## Notes

- Epic stays open; remaining notations (activity-card, process-blueprint, activities, fgca, …) follow one PR each.
- Do not merge — maintainer gates merges.
