### PR TITLE
refactor(extension): shared StaticPreview / StaticSvgPreview base class (review B)

### DIFF
--- a/extension/src/activity-card-preview.ts
+++ b/extension/src/activity-card-preview.ts
@@ -1,8 +1,9 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
-import { buildDiagramFrame, prepareSvgForExport, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
+import { buildDiagramFrame, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
 import { TITLE_BLOCK_H, titleBlockSvg, todayIso } from './svg-title-block.js';
+import { StaticSvgPreview } from './static-preview.js';
 import {
   validateActivityCard,
   resolveActivityCard,
@@ -18,7 +19,6 @@ import {
   isUnderCanon,
   loadCanon,
 } from './canon-loader.js';
-import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
 
 // The Activity Card is the first MULTI-DOCUMENT Studio preview. The card YAML
 // names a project Activity; the project's name/dates, the motivation chain,
@@ -60,52 +60,20 @@ ${body}
 </svg>`;
 }
 
-export class ActivityCardPreview {
+export class ActivityCardPreview extends StaticSvgPreview {
   readonly panelTitle = 'Activity Card Preview';
-  private panel: vscode.WebviewPanel | undefined;
-  private trackedUri: string | undefined;
-  private lastSvg = '';
+  protected readonly viewType = 'activityCardPreview';
+  protected readonly enableCommandUris = [
+    'transitrixStudio.saveActivityCardAsSvg',
+    'transitrixStudio.saveActivityCardAsPng',
+    'transitrixStudio.copyActivityCardAsPng',
+    'transitrixStudio.changeTheme',
+  ];
+  protected readonly stripExt = /\.activity-card\.transitrix\.yaml$/;
+  protected readonly emptyMessage = 'No card rendered yet. Open a *.activity-card.transitrix.yaml file first.';
 
-  isShowingDocument(uri: vscode.Uri): boolean {
-    return this.panel != null && this.trackedUri === uri.toString();
-  }
-
-  async showOrReveal(doc: vscode.TextDocument): Promise<void> {
-    this.trackedUri = doc.uri.toString();
-    if (this.panel) {
-      this.panel.title = `${this.panelTitle} — ${path.basename(doc.fileName)}`;
-      this.panel.reveal(vscode.ViewColumn.Beside, true);
-    } else {
-      this.panel = vscode.window.createWebviewPanel(
-        'activityCardPreview',
-        `${this.panelTitle} — ${path.basename(doc.fileName)}`,
-        { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        {
-          enableScripts: false,
-          retainContextWhenHidden: true,
-          enableCommandUris: [
-            'transitrixStudio.saveActivityCardAsSvg',
-            'transitrixStudio.saveActivityCardAsPng',
-            'transitrixStudio.copyActivityCardAsPng',
-            'transitrixStudio.changeTheme',
-          ],
-        },
-      );
-      this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
-    }
-    await this.pushDocument(doc);
-  }
-
-  async refreshSaved(doc: vscode.TextDocument): Promise<void> {
-    if (!this.isShowingDocument(doc.uri)) return;
-    await this.pushDocument(doc);
-  }
-
-  async refreshConfig(): Promise<void> {
-    if (!this.panel || !this.trackedUri) return;
-    const doc = await vscode.workspace.openTextDocument(vscode.Uri.parse(this.trackedUri));
-    await this.pushDocument(doc);
-  }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  protected renderHtml(_yamlText: string, _filename: string): string { return ''; }
 
   /**
    * Multi-document refresh: when a canon element/relation document under the
@@ -124,7 +92,7 @@ export class ActivityCardPreview {
     await this.pushDocument(cardDoc);
   }
 
-  private async pushDocument(doc: vscode.TextDocument): Promise<void> {
+  protected override async pushDocument(doc: vscode.TextDocument): Promise<void> {
     if (!this.panel) return;
     const sources = await loadCanon(doc.uri);
     this.panel.webview.html = this.buildHtml(doc.getText(), path.basename(doc.fileName), sources);
@@ -176,42 +144,6 @@ export class ActivityCardPreview {
     });
   }
 
-  private pngTarget() {
-    return {
-      rawSvg: this.lastSvg || undefined,
-      themeId: vscode.workspace.getConfiguration('transitrix').get<ThemeId>('theme', 'transitrix'),
-      emptyMessage: 'No card rendered yet. Open a *.activity-card.transitrix.yaml file first.',
-    };
-  }
-
-  saveAsPng(): Promise<void> {
-    const sourceUri = this.trackedUri ? vscode.Uri.parse(this.trackedUri) : undefined;
-    return savePngFromSvg({ ...this.pngTarget(), sourceUri, stripExt: /\.activity-card\.transitrix\.yaml$/ });
-  }
-
-  copyAsPng(): Promise<void> {
-    return copyPngFromSvg(this.pngTarget());
-  }
-
-  async saveAsSvg(): Promise<void> {
-    if (!this.lastSvg) {
-      vscode.window.showWarningMessage('No card rendered yet. Open a *.activity-card.transitrix.yaml file first.');
-      return;
-    }
-    const sourceUri = this.trackedUri ? vscode.Uri.parse(this.trackedUri) : undefined;
-    const stem = sourceUri
-      ? path.basename(sourceUri.fsPath).replace(/\.activity-card\.transitrix\.yaml$/, '')
-      : 'diagram';
-    const defaultUri = sourceUri
-      ? vscode.Uri.file(path.join(path.dirname(sourceUri.fsPath), `${stem}.svg`))
-      : vscode.Uri.file(`${stem}.svg`);
-    const target = await vscode.window.showSaveDialog({ defaultUri, filters: { 'SVG Image': ['svg'] } });
-    if (!target) return;
-    const themeId = vscode.workspace.getConfiguration('transitrix').get<ThemeId>('theme', 'transitrix');
-    const svg = prepareSvgForExport(this.lastSvg, themeId);
-    await vscode.workspace.fs.writeFile(target, Buffer.from(svg, 'utf-8'));
-    vscode.window.showInformationMessage(`Saved: ${path.basename(target.fsPath)}`);
-  }
 }
 
 /** Suffix guard used by the extension router. */

--- a/extension/src/applications-preview.ts
+++ b/extension/src/applications-preview.ts
@@ -1,10 +1,10 @@
-import * as path from 'node:path';
 import { escHtml } from '../../packages/diagrams/src/webview/render-util.js';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, extractDiagramMeta, CATALOGUE_STYLES, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 import { validateApplicationsCatalogue } from '../../packages/diagrams/src/applications/validate.js';
+import { StaticPreview } from './static-preview.js';
 
 // ── Types (used by render helpers) ───────────────────────────────────────────
 
@@ -140,49 +140,12 @@ function buildApplicationsTable(catalogue: ApplicationsCatalogueHeader): string 
 
 // ── ApplicationsPreview webview class ────────────────────────────────────────
 
-export class ApplicationsPreview {
+export class ApplicationsPreview extends StaticPreview {
   readonly panelTitle = 'Applications Preview';
-  private panel: vscode.WebviewPanel | undefined;
-  private trackedUri: string | undefined;
+  protected readonly viewType = 'applicationsPreview';
+  protected readonly enableCommandUris = ['transitrixStudio.changeTheme'];
 
-  isShowingDocument(uri: vscode.Uri): boolean {
-    return this.panel != null && this.trackedUri === uri.toString();
-  }
-
-  async showOrReveal(doc: vscode.TextDocument): Promise<void> {
-    this.trackedUri = doc.uri.toString();
-    if (this.panel) {
-      this.panel.title = `${this.panelTitle} — ${path.basename(doc.fileName)}`;
-      this.panel.reveal(vscode.ViewColumn.Beside, true);
-    } else {
-      this.panel = vscode.window.createWebviewPanel(
-        'applicationsPreview',
-        `${this.panelTitle} — ${path.basename(doc.fileName)}`,
-        { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.changeTheme'] },
-      );
-      this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
-    }
-    await this.pushDocument(doc);
-  }
-
-  async refreshSaved(doc: vscode.TextDocument): Promise<void> {
-    if (!this.isShowingDocument(doc.uri)) return;
-    await this.pushDocument(doc);
-  }
-
-  async refreshConfig(): Promise<void> {
-    if (!this.panel || !this.trackedUri) return;
-    const doc = await vscode.workspace.openTextDocument(vscode.Uri.parse(this.trackedUri));
-    await this.pushDocument(doc);
-  }
-
-  private async pushDocument(doc: vscode.TextDocument): Promise<void> {
-    if (!this.panel) return;
-    this.panel.webview.html = this.buildHtml(doc.getText(), path.basename(doc.fileName));
-  }
-
-  private buildHtml(yamlText: string, filename: string): string {
+  protected renderHtml(yamlText: string, filename: string): string {
     let bodyContent = '';
     let errorMsg = '';
     let title: string | undefined;

--- a/extension/src/blocks-preview.ts
+++ b/extension/src/blocks-preview.ts
@@ -1,9 +1,9 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
-import { buildDiagramFrame, prepareSvgForExport, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
-import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
+import { buildDiagramFrame, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
 import { TITLE_BLOCK_H, titleBlockSvg, todayIso } from './svg-title-block.js';
+import { StaticSvgPreview } from './static-preview.js';
 import {
   validateNestedBlocks,
   layoutNestedBlocks,
@@ -13,6 +13,7 @@ import {
 } from '../../packages/diagrams/src/blocks/index.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 import { renderBlocksLayoutSvg } from '../../packages/diagrams/src/webview/render-blocks.js';
+
 
 // Pad reserved around the diagram; mirrors `PAD` in the shared emitter
 // (`render-blocks.ts`) so the VS Code title block lines up with the body.
@@ -37,57 +38,19 @@ function layoutToSvg(
   return renderBlocksLayoutSvg(layout, { topInset: titleH, title: titleSvg });
 }
 
-export class BlocksPreview {
+export class BlocksPreview extends StaticSvgPreview {
   readonly panelTitle = 'Blocks Preview';
-  private panel: vscode.WebviewPanel | undefined;
-  private trackedUri: string | undefined;
-  private lastSvg = '';
+  protected readonly viewType = 'blocksPreview';
+  protected readonly enableCommandUris = [
+    'transitrixStudio.saveBlocksAsSvg',
+    'transitrixStudio.saveBlocksAsPng',
+    'transitrixStudio.copyBlocksAsPng',
+    'transitrixStudio.changeTheme',
+  ];
+  protected readonly stripExt = /\.blocks\.transitrix\.yaml$/;
+  protected readonly emptyMessage = 'No diagram rendered yet. Open a *.blocks.transitrix.yaml file first.';
 
-  isShowingDocument(uri: vscode.Uri): boolean {
-    return this.panel != null && this.trackedUri === uri.toString();
-  }
-
-  async showOrReveal(doc: vscode.TextDocument): Promise<void> {
-    this.trackedUri = doc.uri.toString();
-    if (this.panel) {
-      this.panel.title = `${this.panelTitle} — ${path.basename(doc.fileName)}`;
-      this.panel.reveal(vscode.ViewColumn.Beside, true);
-    } else {
-      this.panel = vscode.window.createWebviewPanel(
-        'blocksPreview',
-        `${this.panelTitle} — ${path.basename(doc.fileName)}`,
-        { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        {
-          enableScripts: false,
-          retainContextWhenHidden: true,
-          enableCommandUris: ['transitrixStudio.saveBlocksAsSvg', 'transitrixStudio.saveBlocksAsPng', 'transitrixStudio.copyBlocksAsPng', 'transitrixStudio.changeTheme'],
-        },
-      );
-      this.panel.onDidDispose(() => {
-        this.panel = undefined;
-        this.trackedUri = undefined;
-      });
-    }
-    await this.pushDocument(doc);
-  }
-
-  async refreshSaved(doc: vscode.TextDocument): Promise<void> {
-    if (!this.isShowingDocument(doc.uri)) return;
-    await this.pushDocument(doc);
-  }
-
-  async refreshConfig(): Promise<void> {
-    if (!this.panel || !this.trackedUri) return;
-    const doc = await vscode.workspace.openTextDocument(vscode.Uri.parse(this.trackedUri));
-    await this.pushDocument(doc);
-  }
-
-  private async pushDocument(doc: vscode.TextDocument): Promise<void> {
-    if (!this.panel) return;
-    this.panel.webview.html = this.buildHtml(doc.getText(), path.basename(doc.fileName));
-  }
-
-  private buildHtml(yamlText: string, filename: string): string {
+  protected renderHtml(yamlText: string, filename: string): string {
     let svgContent = '';
     let errorMsg = '';
     let warnings: string[] = [];
@@ -138,49 +101,6 @@ export class BlocksPreview {
     });
   }
 
-  private pngTarget() {
-    return {
-      rawSvg: this.lastSvg || undefined,
-      themeId: vscode.workspace.getConfiguration('transitrix').get<ThemeId>('theme', 'transitrix'),
-      emptyMessage: 'No diagram rendered yet. Open a *.blocks.transitrix.yaml file first.',
-    };
-  }
-
-  saveAsPng(): Promise<void> {
-    const sourceUri = this.trackedUri ? vscode.Uri.parse(this.trackedUri) : undefined;
-    return savePngFromSvg({ ...this.pngTarget(), sourceUri, stripExt: /\.blocks\.transitrix\.yaml$/ });
-  }
-
-  copyAsPng(): Promise<void> {
-    return copyPngFromSvg(this.pngTarget());
-  }
-
-  async saveAsSvg(): Promise<void> {
-    if (!this.lastSvg) {
-      vscode.window.showWarningMessage(
-        'No diagram rendered yet. Open a *.blocks.transitrix.yaml file first.',
-      );
-      return;
-    }
-    const sourceUri = this.trackedUri ? vscode.Uri.parse(this.trackedUri) : undefined;
-    const stem = sourceUri
-      ? path.basename(sourceUri.fsPath).replace(/\.blocks\.transitrix\.yaml$/, '')
-      : 'diagram';
-    const defaultUri = sourceUri
-      ? vscode.Uri.file(path.join(path.dirname(sourceUri.fsPath), `${stem}.svg`))
-      : vscode.Uri.file(`${stem}.svg`);
-    const target = await vscode.window.showSaveDialog({
-      defaultUri,
-      filters: { 'SVG Image': ['svg'] },
-    });
-    if (!target) return;
-    const themeId = vscode.workspace
-      .getConfiguration('transitrix')
-      .get<ThemeId>('theme', 'transitrix');
-    const svg = prepareSvgForExport(this.lastSvg, themeId);
-    await vscode.workspace.fs.writeFile(target, Buffer.from(svg, 'utf-8'));
-    vscode.window.showInformationMessage(`Saved: ${path.basename(target.fsPath)}`);
-  }
 }
 
 // `iterateBlocks` is re-exported by the diagrams package and used internally

--- a/extension/src/capability-map-preview.ts
+++ b/extension/src/capability-map-preview.ts
@@ -1,10 +1,10 @@
-import * as path from 'node:path';
 import { escHtml } from '../../packages/diagrams/src/webview/render-util.js';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, extractDiagramMeta, CATALOGUE_STYLES, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 import { validateCapabilityMap } from '../../packages/diagrams/src/capability-map/validate.js';
+import { StaticPreview } from './static-preview.js';
 
 // ── Types (used by render helpers) ───────────────────────────────────────────
 
@@ -110,49 +110,12 @@ function buildCapabilityMapBody(map: CapabilityMapHeader): string {
 
 // ── CapabilityMapPreview webview class ────────────────────────────────────────
 
-export class CapabilityMapPreview {
+export class CapabilityMapPreview extends StaticPreview {
   readonly panelTitle = 'Capability Map Preview';
-  private panel: vscode.WebviewPanel | undefined;
-  private trackedUri: string | undefined;
+  protected readonly viewType = 'capabilityMapPreview';
+  protected readonly enableCommandUris = ['transitrixStudio.changeTheme'];
 
-  isShowingDocument(uri: vscode.Uri): boolean {
-    return this.panel != null && this.trackedUri === uri.toString();
-  }
-
-  async showOrReveal(doc: vscode.TextDocument): Promise<void> {
-    this.trackedUri = doc.uri.toString();
-    if (this.panel) {
-      this.panel.title = `${this.panelTitle} — ${path.basename(doc.fileName)}`;
-      this.panel.reveal(vscode.ViewColumn.Beside, true);
-    } else {
-      this.panel = vscode.window.createWebviewPanel(
-        'capabilityMapPreview',
-        `${this.panelTitle} — ${path.basename(doc.fileName)}`,
-        { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.changeTheme'] },
-      );
-      this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
-    }
-    await this.pushDocument(doc);
-  }
-
-  async refreshSaved(doc: vscode.TextDocument): Promise<void> {
-    if (!this.isShowingDocument(doc.uri)) return;
-    await this.pushDocument(doc);
-  }
-
-  async refreshConfig(): Promise<void> {
-    if (!this.panel || !this.trackedUri) return;
-    const doc = await vscode.workspace.openTextDocument(vscode.Uri.parse(this.trackedUri));
-    await this.pushDocument(doc);
-  }
-
-  private async pushDocument(doc: vscode.TextDocument): Promise<void> {
-    if (!this.panel) return;
-    this.panel.webview.html = this.buildHtml(doc.getText(), path.basename(doc.fileName));
-  }
-
-  private buildHtml(yamlText: string, filename: string): string {
+  protected renderHtml(yamlText: string, filename: string): string {
     let bodyContent = '';
     let errorMsg = '';
     let title: string | undefined;

--- a/extension/src/process-map-preview.ts
+++ b/extension/src/process-map-preview.ts
@@ -1,10 +1,10 @@
-import * as path from 'node:path';
 import { escHtml } from '../../packages/diagrams/src/webview/render-util.js';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, extractDiagramMeta, CATALOGUE_STYLES, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 import { validateProcessMap } from '../../packages/diagrams/src/process-map/validate.js';
+import { StaticPreview } from './static-preview.js';
 
 // ── Types (used by render helpers) ───────────────────────────────────────────
 
@@ -115,49 +115,12 @@ function buildProcessMapBody(map: ProcessMapHeader): string {
 
 // ── ProcessMapPreview webview class ───────────────────────────────────────────
 
-export class ProcessMapPreview {
+export class ProcessMapPreview extends StaticPreview {
   readonly panelTitle = 'Process Map Preview';
-  private panel: vscode.WebviewPanel | undefined;
-  private trackedUri: string | undefined;
+  protected readonly viewType = 'processMapPreview';
+  protected readonly enableCommandUris = ['transitrixStudio.changeTheme'];
 
-  isShowingDocument(uri: vscode.Uri): boolean {
-    return this.panel != null && this.trackedUri === uri.toString();
-  }
-
-  async showOrReveal(doc: vscode.TextDocument): Promise<void> {
-    this.trackedUri = doc.uri.toString();
-    if (this.panel) {
-      this.panel.title = `${this.panelTitle} — ${path.basename(doc.fileName)}`;
-      this.panel.reveal(vscode.ViewColumn.Beside, true);
-    } else {
-      this.panel = vscode.window.createWebviewPanel(
-        'processMapPreview',
-        `${this.panelTitle} — ${path.basename(doc.fileName)}`,
-        { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.changeTheme'] },
-      );
-      this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
-    }
-    await this.pushDocument(doc);
-  }
-
-  async refreshSaved(doc: vscode.TextDocument): Promise<void> {
-    if (!this.isShowingDocument(doc.uri)) return;
-    await this.pushDocument(doc);
-  }
-
-  async refreshConfig(): Promise<void> {
-    if (!this.panel || !this.trackedUri) return;
-    const doc = await vscode.workspace.openTextDocument(vscode.Uri.parse(this.trackedUri));
-    await this.pushDocument(doc);
-  }
-
-  private async pushDocument(doc: vscode.TextDocument): Promise<void> {
-    if (!this.panel) return;
-    this.panel.webview.html = this.buildHtml(doc.getText(), path.basename(doc.fileName));
-  }
-
-  private buildHtml(yamlText: string, filename: string): string {
+  protected renderHtml(yamlText: string, filename: string): string {
     let bodyContent = '';
     let errorMsg = '';
     let title: string | undefined;

--- a/extension/src/products-preview.ts
+++ b/extension/src/products-preview.ts
@@ -1,10 +1,10 @@
-import * as path from 'node:path';
 import { escHtml } from '../../packages/diagrams/src/webview/render-util.js';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, extractDiagramMeta, CATALOGUE_STYLES, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 import { validateProductsCatalogue } from '../../packages/diagrams/src/products/validate.js';
+import { StaticPreview } from './static-preview.js';
 
 // ── Types (used by render helpers) ───────────────────────────────────────────
 
@@ -107,49 +107,12 @@ function buildProductsTable(catalogue: ProductsCatalogueHeader): string {
 
 // ── ProductsPreview webview class ─────────────────────────────────────────────
 
-export class ProductsPreview {
+export class ProductsPreview extends StaticPreview {
   readonly panelTitle = 'Products Preview';
-  private panel: vscode.WebviewPanel | undefined;
-  private trackedUri: string | undefined;
+  protected readonly viewType = 'productsPreview';
+  protected readonly enableCommandUris = ['transitrixStudio.changeTheme'];
 
-  isShowingDocument(uri: vscode.Uri): boolean {
-    return this.panel != null && this.trackedUri === uri.toString();
-  }
-
-  async showOrReveal(doc: vscode.TextDocument): Promise<void> {
-    this.trackedUri = doc.uri.toString();
-    if (this.panel) {
-      this.panel.title = `${this.panelTitle} — ${path.basename(doc.fileName)}`;
-      this.panel.reveal(vscode.ViewColumn.Beside, true);
-    } else {
-      this.panel = vscode.window.createWebviewPanel(
-        'productsPreview',
-        `${this.panelTitle} — ${path.basename(doc.fileName)}`,
-        { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.changeTheme'] },
-      );
-      this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
-    }
-    await this.pushDocument(doc);
-  }
-
-  async refreshSaved(doc: vscode.TextDocument): Promise<void> {
-    if (!this.isShowingDocument(doc.uri)) return;
-    await this.pushDocument(doc);
-  }
-
-  async refreshConfig(): Promise<void> {
-    if (!this.panel || !this.trackedUri) return;
-    const doc = await vscode.workspace.openTextDocument(vscode.Uri.parse(this.trackedUri));
-    await this.pushDocument(doc);
-  }
-
-  private async pushDocument(doc: vscode.TextDocument): Promise<void> {
-    if (!this.panel) return;
-    this.panel.webview.html = this.buildHtml(doc.getText(), path.basename(doc.fileName));
-  }
-
-  private buildHtml(yamlText: string, filename: string): string {
+  protected renderHtml(yamlText: string, filename: string): string {
     let bodyContent = '';
     let errorMsg = '';
     let title: string | undefined;

--- a/extension/src/scenarios-preview.ts
+++ b/extension/src/scenarios-preview.ts
@@ -1,10 +1,10 @@
-import * as path from 'node:path';
 import { escHtml } from '../../packages/diagrams/src/webview/render-util.js';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, extractDiagramMeta, CATALOGUE_STYLES, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 import { validateScenario } from '../../packages/diagrams/src/scenarios/validate.js';
+import { StaticPreview } from './static-preview.js';
 
 // ── Types (used by render helpers) ───────────────────────────────────────────
 
@@ -112,49 +112,12 @@ function buildScenarioBody(scn: ScenarioHeader): string {
 
 // ── ScenariosPreview webview class ────────────────────────────────────────────
 
-export class ScenariosPreview {
+export class ScenariosPreview extends StaticPreview {
   readonly panelTitle = 'Scenario Preview';
-  private panel: vscode.WebviewPanel | undefined;
-  private trackedUri: string | undefined;
+  protected readonly viewType = 'scenariosPreview';
+  protected readonly enableCommandUris = ['transitrixStudio.changeTheme'];
 
-  isShowingDocument(uri: vscode.Uri): boolean {
-    return this.panel != null && this.trackedUri === uri.toString();
-  }
-
-  async showOrReveal(doc: vscode.TextDocument): Promise<void> {
-    this.trackedUri = doc.uri.toString();
-    if (this.panel) {
-      this.panel.title = `${this.panelTitle} — ${path.basename(doc.fileName)}`;
-      this.panel.reveal(vscode.ViewColumn.Beside, true);
-    } else {
-      this.panel = vscode.window.createWebviewPanel(
-        'scenariosPreview',
-        `${this.panelTitle} — ${path.basename(doc.fileName)}`,
-        { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
-        { enableScripts: false, retainContextWhenHidden: true, enableCommandUris: ['transitrixStudio.changeTheme'] },
-      );
-      this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
-    }
-    await this.pushDocument(doc);
-  }
-
-  async refreshSaved(doc: vscode.TextDocument): Promise<void> {
-    if (!this.isShowingDocument(doc.uri)) return;
-    await this.pushDocument(doc);
-  }
-
-  async refreshConfig(): Promise<void> {
-    if (!this.panel || !this.trackedUri) return;
-    const doc = await vscode.workspace.openTextDocument(vscode.Uri.parse(this.trackedUri));
-    await this.pushDocument(doc);
-  }
-
-  private async pushDocument(doc: vscode.TextDocument): Promise<void> {
-    if (!this.panel) return;
-    this.panel.webview.html = this.buildHtml(doc.getText(), path.basename(doc.fileName));
-  }
-
-  private buildHtml(yamlText: string, filename: string): string {
+  protected renderHtml(yamlText: string, filename: string): string {
     let bodyContent = '';
     let errorMsg = '';
     let title: string | undefined;

--- a/extension/src/static-preview.ts
+++ b/extension/src/static-preview.ts
@@ -1,0 +1,113 @@
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+import { prepareSvgForExport, type ThemeId } from './diagram-frame.js';
+import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
+
+/**
+ * Shared lifecycle for document-bound static webview previews. Subclasses
+ * either override {@link renderHtml} (simple case) or override
+ * {@link pushDocument} (when async loading is required before rendering).
+ */
+export abstract class StaticPreview {
+  protected panel: vscode.WebviewPanel | undefined;
+  protected trackedUri: string | undefined;
+
+  abstract readonly panelTitle: string;
+  protected abstract readonly viewType: string;
+  protected abstract readonly enableCommandUris: string[];
+
+  isShowingDocument(uri: vscode.Uri): boolean {
+    return this.panel != null && this.trackedUri === uri.toString();
+  }
+
+  async showOrReveal(doc: vscode.TextDocument): Promise<void> {
+    this.trackedUri = doc.uri.toString();
+    if (this.panel) {
+      this.panel.title = `${this.panelTitle} — ${path.basename(doc.fileName)}`;
+      this.panel.reveal(vscode.ViewColumn.Beside, true);
+    } else {
+      this.panel = vscode.window.createWebviewPanel(
+        this.viewType,
+        `${this.panelTitle} — ${path.basename(doc.fileName)}`,
+        { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
+        {
+          enableScripts: false,
+          retainContextWhenHidden: true,
+          enableCommandUris: this.enableCommandUris,
+        },
+      );
+      this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
+    }
+    await this.pushDocument(doc);
+  }
+
+  async refreshSaved(doc: vscode.TextDocument): Promise<void> {
+    if (!this.isShowingDocument(doc.uri)) return;
+    await this.pushDocument(doc);
+  }
+
+  async refreshConfig(): Promise<void> {
+    if (!this.panel || !this.trackedUri) return;
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.parse(this.trackedUri));
+    await this.pushDocument(doc);
+  }
+
+  protected async pushDocument(doc: vscode.TextDocument): Promise<void> {
+    if (!this.panel) return;
+    this.panel.webview.html = this.renderHtml(doc.getText(), path.basename(doc.fileName));
+  }
+
+  // Non-abstract: subclasses that override pushDocument don't need to implement this.
+  // Subclasses that use the default pushDocument must override this.
+  protected renderHtml(_yamlText: string, _filename: string): string {
+    throw new Error(`${this.constructor.name}: override pushDocument or renderHtml`);
+  }
+}
+
+/**
+ * Extends {@link StaticPreview} with SVG save/export helpers. Subclasses set
+ * {@link lastSvg} inside {@link renderHtml} before returning the HTML frame.
+ */
+export abstract class StaticSvgPreview extends StaticPreview {
+  protected lastSvg = '';
+
+  protected abstract readonly stripExt: RegExp;
+  protected abstract readonly emptyMessage: string;
+
+  protected pngTarget(): { rawSvg: string | undefined; themeId: ThemeId; emptyMessage: string } {
+    return {
+      rawSvg: this.lastSvg || undefined,
+      themeId: vscode.workspace.getConfiguration('transitrix').get<ThemeId>('theme', 'transitrix'),
+      emptyMessage: this.emptyMessage,
+    };
+  }
+
+  saveAsPng(): Promise<void> {
+    const sourceUri = this.trackedUri ? vscode.Uri.parse(this.trackedUri) : undefined;
+    return savePngFromSvg({ ...this.pngTarget(), sourceUri, stripExt: this.stripExt });
+  }
+
+  copyAsPng(): Promise<void> {
+    return copyPngFromSvg(this.pngTarget());
+  }
+
+  async saveAsSvg(): Promise<void> {
+    if (!this.lastSvg) {
+      vscode.window.showWarningMessage(this.emptyMessage);
+      return;
+    }
+    const sourceUri = this.trackedUri ? vscode.Uri.parse(this.trackedUri) : undefined;
+    const stem = sourceUri
+      ? path.basename(sourceUri.fsPath).replace(this.stripExt, '')
+      : 'diagram';
+    const defaultUri = sourceUri
+      ? vscode.Uri.file(path.join(path.dirname(sourceUri.fsPath), `${stem}.svg`))
+      : vscode.Uri.file(`${stem}.svg`);
+    const target = await vscode.window.showSaveDialog({ defaultUri, filters: { 'SVG Image': ['svg'] } });
+    if (!target) return;
+    const themeId = vscode.workspace.getConfiguration('transitrix').get<ThemeId>('theme', 'transitrix');
+    const svg = prepareSvgForExport(this.lastSvg, themeId);
+    await vscode.workspace.fs.writeFile(target, Buffer.from(svg, 'utf-8'));
+    vscode.window.showInformationMessage(`Saved: ${path.basename(target.fsPath)}`);
+  }
+}


### PR DESCRIPTION
## Summary

- Introduce `StaticPreview` and `StaticSvgPreview` abstract base classes in `extension/src/static-preview.ts`, centralising the repeated panel lifecycle across ~17 document-bound preview classes.
- Apply to 7 previews (two SVG, five HTML-body), removing ~390 lines of boilerplate while keeping behaviour identical.

`StaticPreview` owns: `showOrReveal`, `refreshSaved`, `refreshConfig`, `pushDocument`, panel/trackedUri fields, and the `isShowingDocument` helper. Subclasses declare `viewType` + `enableCommandUris` and override `renderHtml` (or `pushDocument` for async pre-loading).

`StaticSvgPreview` extends it with `lastSvg` tracking and the shared `saveAsSvg` / `saveAsPng` / `copyAsPng` implementations — subclasses add `stripExt` + `emptyMessage`.

**Converted previews:**
- `BlocksPreview` → `StaticSvgPreview`
- `ActivityCardPreview` → `StaticSvgPreview` (overrides `pushDocument` to await `loadCanon` before rendering; `refreshIfSiblingSaved` kept)
- `CapabilityMapPreview`, `ScenariosPreview`, `ProcessMapPreview`, `ApplicationsPreview`, `ProductsPreview` → `StaticPreview`

Interactive / repo-scan previews (Goals, FGCA, Activities, Compliance views) are not in scope — they require extra setup (scripts, message handlers, repo scanning) and are left for follow-on work.

## Test plan

- [x] `npm run compile` clean (root TypeScript)
- [x] `npm run compile:extension` clean
- [x] 921 tests pass (`npm test`)
- [ ] Visual smoke-test: open a `.blocks.transitrix.yaml` and a `.capability-map.transitrix.yaml` file in VS Code to confirm previews render, save-as-SVG/PNG work, and theme switching works

🤖 Generated with [Claude Code](https://claude.com/claude-code)