### PR TITLE
refactor(diagrams,extension): single activities network SVG body (review C)

### DIFF
--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -17,7 +17,8 @@ import {
   type GanttResult,
 } from '../../packages/diagrams/src/activities/index.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
-import { horizontalCubicEdgePath, DEFAULT_EDGE_CURVATURE } from '../../packages/diagrams/src/edge-path.js';
+import { DEFAULT_EDGE_CURVATURE } from '../../packages/diagrams/src/edge-path.js';
+import { renderActivitiesNetworkBody, ACTIVITIES_NETWORK_DEFS } from '../../packages/diagrams/src/webview/render-activities.js';
 import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
 import { readSpacing, readCurvature, readEntryCurvature, applyControlMessage, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND } from './spacing-config.js';
 import { genNonce, buildControlsPanel, buildControlsScript } from './preview-controls.js';
@@ -38,8 +39,6 @@ function truncate(s: string, maxLen: number): string {
 // Consumes layoutActivities + computeCpm from @transitrix/diagrams. Studio
 // supplies the SVG presentation layer only.
 
-const N_NODE_W = 200;
-const N_NODE_H = 80;
 const N_PAD = 24;
 
 function networkSvg(doc: ActivityDoc, gaps: ActivitiesLayoutOptions = {}, curvature: number = DEFAULT_EDGE_CURVATURE, entryCurvature?: number, heading?: string, filename?: string, date?: string, version?: string): string {
@@ -56,75 +55,13 @@ function networkSvg(doc: ActivityDoc, gaps: ActivitiesLayoutOptions = {}, curvat
   const ox = -layout.bounds.x + N_PAD;
   const oy = -layout.bounds.y + N_PAD + titleH;
 
-  const nodeMap = new Map(layout.nodes.map(n => [n.id, n]));
-  // SVG paints later siblings over earlier ones. Sort non-critical first so
-  // the bright orange critical-path edges land on top — a gray edge crossing
-  // an orange one shouldn't bury the critical signal.
-  const orderedEdges = [...layout.edges].sort(
-    (a, b) => Number(Boolean(a.isCritical)) - Number(Boolean(b.isCritical)),
-  );
-  // Edge path = a single cubic Bézier with horizontal control handles (shared
-  // geometry in @transitrix/diagrams). The control points share their
-  // endpoint's Y so the tangent is horizontal at both ends — the curve meets
-  // the vertical node edge at a right angle and the marker-end arrow reads as
-  // perpendicular. `curvature` scales the handle length: 1 = default, 0 =
-  // straight, higher = stronger arc (vkgeorgia/strategy#76).
-  const edgeSvg = orderedEdges.map(e => {
-    const s = nodeMap.get(e.sourceId);
-    const t = nodeMap.get(e.targetId);
-    if (!s || !t) return '';
-    const sx = s.x + ox + s.width;
-    const sy = s.y + oy + s.height / 2;
-    const tx = t.x + ox;
-    const ty = t.y + oy + t.height / 2;
-    const cls = e.isCritical ? 'diagram-edge critical-edge' : 'diagram-edge';
-    const marker = `url(#${e.isCritical ? 'arrow-crit' : 'arrow'})`;
-    return `<path d="${horizontalCubicEdgePath(sx, sy, tx, ty, curvature, entryCurvature)}" class="${cls}" marker-end="${marker}"/>`;
-  }).join('\n');
-
-  const nodeSvg = layout.nodes.map(n => {
-    const x = n.x + ox;
-    const y = n.y + oy;
-    const isCritical = cpm.get(n.id)?.isCritical ?? false;
-    const durVal = n.data.duration;
-    const isMilestone = (durVal ?? -1) === 0;
-    const cls = `diagram-node act-node ${isCritical ? 'critical-node' : ''} ${isMilestone ? 'milestone-node' : ''}`.trim();
-    const idLabel = escXml(n.id);
-    const words = n.data.name.split(' ');
-    let line1 = '';
-    let line2 = '';
-    for (const w of words) {
-      if ((line1 + ' ' + w).trim().length <= 24) line1 = (line1 + ' ' + w).trim();
-      else if ((line2 + ' ' + w).trim().length <= 24) line2 = (line2 + ' ' + w).trim();
-      else if (!line2) { line2 = w.slice(0, 22) + '…'; break; }
-    }
-    const twoLines = line2.length > 0;
-    const nameY1 = twoLines ? y + 18 : y + 28;
-    const nameY2 = y + 34;
-    const idY = twoLines ? y + 54 : y + 50;
-    const durLabel = (durVal !== undefined && durVal > 0) ? `${durVal}d` : '';
-    return [
-      `<rect class="${cls}" x="${x}" y="${y}" width="${N_NODE_W}" height="${N_NODE_H}" rx="8"/>`,
-      `<text class="text-primary" x="${x + N_NODE_W / 2}" y="${nameY1}" text-anchor="middle" dominant-baseline="central">${escXml(line1)}</text>`,
-      twoLines ? `<text class="text-primary" x="${x + N_NODE_W / 2}" y="${nameY2}" text-anchor="middle" dominant-baseline="central">${escXml(line2)}</text>` : '',
-      `<text class="text-id" x="${x + N_NODE_W / 2}" y="${idY}" text-anchor="middle" dominant-baseline="central">${idLabel}</text>`,
-      durLabel ? `<text class="text-secondary" x="${x + N_NODE_W - 8}" y="${y + N_NODE_H - 8}" text-anchor="end">${durLabel}</text>` : '',
-    ].filter(Boolean).join('\n');
-  }).join('\n');
+  const body = renderActivitiesNetworkBody(layout, cpm, ox, oy, curvature, entryCurvature);
 
   const titleSvg = showTitle ? titleBlockSvg(heading!, filename!, date!, N_PAD, N_PAD, version) : '';
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">
-<defs>
-  <marker id="arrow" markerWidth="8" markerHeight="8" refX="8" refY="3" orient="auto">
-    <path d="M0,0 L0,6 L8,3 z" class="arrow-fill"/>
-  </marker>
-  <marker id="arrow-crit" markerWidth="8" markerHeight="8" refX="8" refY="3" orient="auto">
-    <path d="M0,0 L0,6 L8,3 z" class="arrow-fill-critical"/>
-  </marker>
-</defs>
+${ACTIVITIES_NETWORK_DEFS}
 ${titleSvg}
-${nodeSvg}
-${edgeSvg}
+${body}
 </svg>`;
 }
 

--- a/packages/diagrams/src/webview/render-activities.ts
+++ b/packages/diagrams/src/webview/render-activities.ts
@@ -11,6 +11,10 @@
  * Only the DEFAULT network view (Project Schedule Network Diagram) is ported.
  * The Gantt view, the CSS-only tab switcher and the interactive spacing /
  * curvature controls stay in the VS Code preview.
+ *
+ * Single-emitter unification (review C): the canonical network body lives here
+ * in `renderActivitiesNetworkBody` and is shared verbatim with the VS Code
+ * preview's `networkSvg`.
  */
 import { layoutActivities } from '../activities/layout.js';
 import { computeCpm } from '../activities/cpm.js';
@@ -27,20 +31,108 @@ const N_NODE_W = 200;
 const N_NODE_H = 80;
 const N_PAD = 24;
 
-// Activities-specific diagram CSS. Mirrors `ACTIVITIES_DIAGRAM_CSS` from the
-// VS Code preview — the rules that shape the network diagram itself (critical
-// path, milestones, edge colours). Embedded alongside the shared theme CSS so
-// the SVG is self-contained for the JCEF host.
-const ACTIVITIES_DIAGRAM_CSS = `
-  .act-node { fill: var(--ts-bg-surface, #f8fafc); stroke: var(--ts-border, #94a3b8); stroke-width: 1.5; }
+/**
+ * Network-view diagram CSS (critical path, milestones, edge colours) — the
+ * canonical rules shared with the VS Code preview's `ACTIVITIES_DIAGRAM_CSS`
+ * network subset. Embedded alongside the shared theme CSS so the SVG is
+ * self-contained for the JCEF host.
+ */
+export const ACTIVITIES_NETWORK_CSS = `
+  .act-node { fill: var(--ts-layer-activity, #d4edda); stroke: var(--ts-node-stroke, #94a3b8); stroke-width: 1; }
   .critical-node { fill: #fff7ed; stroke: var(--ts-brand-orange, #ff4d00); stroke-width: 2.5; }
   .milestone-node { fill: #ecfeff; stroke: var(--ts-text-muted, #64748b); stroke-dasharray: 4 2; }
   .critical-edge { stroke: var(--ts-brand-orange, #ff4d00); stroke-width: 2; }
   .arrow-fill-critical { fill: var(--ts-brand-orange, #ff4d00); }
 `;
 
+/** Arrowhead marker defs shared by both hosts for the network view. */
+export const ACTIVITIES_NETWORK_DEFS = `<defs>
+  <marker id="arrow" markerWidth="8" markerHeight="8" refX="8" refY="3" orient="auto">
+    <path d="M0,0 L0,6 L8,3 z" class="arrow-fill"/>
+  </marker>
+  <marker id="arrow-crit" markerWidth="8" markerHeight="8" refX="8" refY="3" orient="auto">
+    <path d="M0,0 L0,6 L8,3 z" class="arrow-fill-critical"/>
+  </marker>
+</defs>`;
+
 function truncate(s: string, maxLen: number): string {
   return s.length > maxLen ? s.slice(0, maxLen - 1) + '…' : s;
+}
+
+/**
+ * Canonical Network (PSND) body — the node rects and edge paths that go inside
+ * the `<svg>`, shared verbatim by the VS Code preview and the host-neutral
+ * wrapper below. Excludes the host-specific title block and the (identical)
+ * marker defs (`ACTIVITIES_NETWORK_DEFS`).
+ *
+ * `ox`/`oy` are the canvas offsets (the caller folds in padding + any title
+ * height); `curvature`/`entryCurvature` scale the exit/entry edge handles.
+ */
+export function renderActivitiesNetworkBody(
+  layout: ActivitiesLayout,
+  cpm: ReturnType<typeof computeCpm>,
+  ox: number,
+  oy: number,
+  curvature: number,
+  entryCurvature: number | undefined,
+): string {
+  const nodeMap = new Map(layout.nodes.map((n) => [n.id, n]));
+
+  // SVG paints later siblings over earlier ones. Sort non-critical first so the
+  // bright orange critical-path edges land on top — a gray edge crossing an
+  // orange one shouldn't bury the critical signal.
+  const orderedEdges = [...layout.edges].sort(
+    (a, b) => Number(Boolean(a.isCritical)) - Number(Boolean(b.isCritical)),
+  );
+
+  const edgeSvg = orderedEdges
+    .map((e) => {
+      const s = nodeMap.get(e.sourceId);
+      const t = nodeMap.get(e.targetId);
+      if (!s || !t) return '';
+      const sx = s.x + ox + s.width;
+      const sy = s.y + oy + s.height / 2;
+      const tx = t.x + ox;
+      const ty = t.y + oy + t.height / 2;
+      const cls = e.isCritical ? 'diagram-edge critical-edge' : 'diagram-edge';
+      const marker = `url(#${e.isCritical ? 'arrow-crit' : 'arrow'})`;
+      return `<path d="${horizontalCubicEdgePath(sx, sy, tx, ty, curvature, entryCurvature)}" class="${cls}" marker-end="${marker}"/>`;
+    })
+    .join('\n');
+
+  const nodeSvg = layout.nodes
+    .map((n) => {
+      const x = n.x + ox;
+      const y = n.y + oy;
+      const isCritical = cpm.get(n.id)?.isCritical ?? false;
+      const durVal = n.data.duration;
+      const isMilestone = (durVal ?? -1) === 0;
+      const cls = `diagram-node act-node ${isCritical ? 'critical-node' : ''} ${isMilestone ? 'milestone-node' : ''}`.trim();
+      const idLabel = escXml(n.id);
+      const words = n.data.name.split(' ');
+      let line1 = '';
+      let line2 = '';
+      for (const w of words) {
+        if ((line1 + ' ' + w).trim().length <= 24) line1 = (line1 + ' ' + w).trim();
+        else if ((line2 + ' ' + w).trim().length <= 24) line2 = (line2 + ' ' + w).trim();
+        else if (!line2) { line2 = w.slice(0, 22) + '…'; break; }
+      }
+      const twoLines = line2.length > 0;
+      const nameY1 = twoLines ? y + 18 : y + 28;
+      const nameY2 = y + 34;
+      const idY = twoLines ? y + 54 : y + 50;
+      const durLabel = (durVal !== undefined && durVal > 0) ? `${durVal}d` : '';
+      return [
+        `<rect class="${cls}" x="${x}" y="${y}" width="${N_NODE_W}" height="${N_NODE_H}" rx="8"/>`,
+        `<text class="text-primary" x="${x + N_NODE_W / 2}" y="${nameY1}" text-anchor="middle" dominant-baseline="central">${escXml(line1)}</text>`,
+        twoLines ? `<text class="text-primary" x="${x + N_NODE_W / 2}" y="${nameY2}" text-anchor="middle" dominant-baseline="central">${escXml(line2)}</text>` : '',
+        `<text class="text-id" x="${x + N_NODE_W / 2}" y="${idY}" text-anchor="middle" dominant-baseline="central">${idLabel}</text>`,
+        durLabel ? `<text class="text-secondary" x="${x + N_NODE_W - 8}" y="${y + N_NODE_H - 8}" text-anchor="end">${durLabel}</text>` : '',
+      ].filter(Boolean).join('\n');
+    })
+    .join('\n');
+
+  return `${nodeSvg}\n${edgeSvg}`;
 }
 
 export interface RenderActivitiesOptions {
@@ -84,88 +176,23 @@ export function renderActivitiesSvg(doc: ActivityDoc, options: RenderActivitiesO
   const ox = -layout.bounds.x + N_PAD;
   const oy = -layout.bounds.y + N_PAD + titleH;
 
-  const nodeMap = new Map(layout.nodes.map((n) => [n.id, n]));
-
-  // SVG paints later siblings over earlier ones. Sort non-critical first so the
-  // bright orange critical-path edges land on top — a gray edge crossing an
-  // orange one shouldn't bury the critical signal.
-  const orderedEdges = [...layout.edges].sort(
-    (a, b) => Number(Boolean(a.isCritical)) - Number(Boolean(b.isCritical)),
-  );
-
-  // Edge path = a single cubic Bézier with horizontal control handles (shared
-  // geometry in `edge-path.js`), so the curve meets the vertical node edge at a
-  // right angle and the marker-end arrow reads as perpendicular.
-  const edgeSvg = orderedEdges
-    .map((e) => {
-      const s = nodeMap.get(e.sourceId);
-      const t = nodeMap.get(e.targetId);
-      if (!s || !t) return '';
-      const sx = s.x + ox + s.width;
-      const sy = s.y + oy + s.height / 2;
-      const tx = t.x + ox;
-      const ty = t.y + oy + t.height / 2;
-      const cls = e.isCritical ? 'diagram-edge critical-edge' : 'diagram-edge';
-      const marker = `url(#${e.isCritical ? 'arrow-crit' : 'arrow'})`;
-      return `<path d="${horizontalCubicEdgePath(sx, sy, tx, ty, curvature, entryCurvature)}" class="${cls}" marker-end="${marker}"/>`;
-    })
-    .join('\n');
-
-  const nodeSvg = layout.nodes
-    .map((n) => {
-      const x = n.x + ox;
-      const y = n.y + oy;
-      const isCritical = cpm.get(n.id)?.isCritical ?? false;
-      const durVal = n.data.duration;
-      const isMilestone = (durVal ?? -1) === 0;
-      const cls = `diagram-node act-node ${isCritical ? 'critical-node' : ''} ${isMilestone ? 'milestone-node' : ''}`.trim();
-      const idLabel = escXml(n.id);
-      const words = n.data.name.split(' ');
-      let line1 = '';
-      let line2 = '';
-      for (const w of words) {
-        if ((line1 + ' ' + w).trim().length <= 24) line1 = (line1 + ' ' + w).trim();
-        else if ((line2 + ' ' + w).trim().length <= 24) line2 = (line2 + ' ' + w).trim();
-        else if (!line2) { line2 = w.slice(0, 22) + '…'; break; }
-      }
-      const twoLines = line2.length > 0;
-      const nameY1 = twoLines ? y + 18 : y + 28;
-      const nameY2 = y + 34;
-      const idY = twoLines ? y + 54 : y + 50;
-      const durLabel = (durVal !== undefined && durVal > 0) ? `${durVal}d` : '';
-      return [
-        `<rect class="${cls}" x="${x}" y="${y}" width="${N_NODE_W}" height="${N_NODE_H}" rx="6"/>`,
-        `<text class="text-primary" x="${x + N_NODE_W / 2}" y="${nameY1}" text-anchor="middle" dominant-baseline="central">${escXml(line1)}</text>`,
-        twoLines ? `<text class="text-primary" x="${x + N_NODE_W / 2}" y="${nameY2}" text-anchor="middle" dominant-baseline="central">${escXml(line2)}</text>` : '',
-        `<text class="text-id" x="${x + N_NODE_W / 2}" y="${idY}" text-anchor="middle" dominant-baseline="central">${idLabel}</text>`,
-        durLabel ? `<text class="text-secondary" x="${x + N_NODE_W - 8}" y="${y + N_NODE_H - 8}" text-anchor="end">${durLabel}</text>` : '',
-      ].filter(Boolean).join('\n');
-    })
-    .join('\n');
+  const body = renderActivitiesNetworkBody(layout, cpm, ox, oy, curvature, entryCurvature);
 
   const titleSvg = title
     ? `<text class="text-header" x="${N_PAD}" y="${N_PAD - 6}">${escXml(title)}</text>`
     : '';
 
-  // Embed the shared theme CSS plus the activities-specific diagram CSS inside
-  // the SVG so the rendered output is self-contained — the JCEF host page only
-  // needs to drop the SVG into the DOM and styling resolves without any
-  // cooperation from the host stylesheet. Matches what the VS Code path
-  // produces via `prepareSvgForExport`.
-  const embedCss = generateSvgEmbedCss('transitrix') + ACTIVITIES_DIAGRAM_CSS;
+  // Embed the shared theme CSS plus the network diagram CSS inside the SVG so
+  // the rendered output is self-contained — the JCEF host page only needs to
+  // drop the SVG into the DOM and styling resolves without any cooperation from
+  // the host stylesheet. Matches what the VS Code path produces via
+  // `prepareSvgForExport`.
+  const embedCss = generateSvgEmbedCss('transitrix') + ACTIVITIES_NETWORK_CSS;
 
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">
 <style>${embedCss}</style>
-<defs>
-  <marker id="arrow" markerWidth="8" markerHeight="8" refX="8" refY="3" orient="auto">
-    <path d="M0,0 L0,6 L8,3 z" class="arrow-fill"/>
-  </marker>
-  <marker id="arrow-crit" markerWidth="8" markerHeight="8" refX="8" refY="3" orient="auto">
-    <path d="M0,0 L0,6 L8,3 z" class="arrow-fill-critical"/>
-  </marker>
-</defs>
+${ACTIVITIES_NETWORK_DEFS}
 ${titleSvg}
-${nodeSvg}
-${edgeSvg}
+${body}
 </svg>`;
 }


### PR DESCRIPTION
## Summary

Single SVG emitter for the **activities** network (PSND) view (architecture review, epic C — 5th slice). The VS Code preview and the host-neutral package renderer had drifted on the network body; this unifies them on the richer VS Code rendering.

- Extract `renderActivitiesNetworkBody(layout, cpm, ox, oy, curvature, entryCurvature)` into `packages/diagrams/src/webview/render-activities.ts` — the one network emitter both hosts call (canonical `rx="8"`).
- Export `ACTIVITIES_NETWORK_DEFS` (shared arrow markers) and `ACTIVITIES_NETWORK_CSS` (canonical network rules, matching the editor's `.act-node` fill/stroke).
- `extension/src/activities-preview.ts` `networkSvg` drops its inline node/edge builders and duplicated `<defs>`; it now wraps the shared body with the VS Code title block. Removed the now-unused `horizontalCubicEdgePath` import and `N_NODE_W`/`N_NODE_H` constants.

## Behaviour

- **VS Code network: byte-identical.** Verified with a temporary parity test over a synthetic layout (critical / milestone / multi-line / truncated / special-char nodes, critical + dangling edges, three offset/curvature combos). Test removed before commit.
- **IntelliJ/JCEF network: output changes intentionally** — node corner radius 6 → 8 and `.act-node` fill/stroke now match the editor. Visual review appreciated.
- **Gantt view, CSS-only tab switcher and interactive controls remain VS Code-only** (no package counterpart), unchanged by this slice.

## Test plan

- [x] `npm run compile` + `npm run compile:extension` clean
- [x] `npm run test:diagrams` (921) + core vitest (373) green
- [ ] Visual check of the IntelliJ/JCEF activities network preview
