### PR TITLE
refactor(diagrams,extension): single fgca/fga SVG body (review C)

### DIFF
--- a/extension/src/fgca-preview.ts
+++ b/extension/src/fgca-preview.ts
@@ -9,14 +9,12 @@ import { parseCanonicalFGCA, parseCanonicalFGA } from '../../packages/diagrams/s
 import { resolveFGCA, isFGCAViewDoc } from '../../packages/diagrams/src/fgca/resolver.js';
 import {
   layoutFGCAPreview,
-  FGCA_NODE_W as NODE_W,
-  FGCA_NODE_H as NODE_H,
-  FGCA_HEADER_H as HEADER_H,
   FGCA_PAD as PAD,
   FGCA_DEFAULT_COL_GAP,
   FGCA_DEFAULT_ROW_GAP,
 } from '../../packages/diagrams/src/fgca/preview-layout.js';
-import { horizontalCubicEdgePath, DEFAULT_EDGE_CURVATURE } from '../../packages/diagrams/src/edge-path.js';
+import { DEFAULT_EDGE_CURVATURE } from '../../packages/diagrams/src/edge-path.js';
+import { renderFgcaBody } from '../../packages/diagrams/src/webview/render-fgca.js';
 import { buildChainTable, type ChainTable, type ChainColumn } from '../../packages/diagrams/src/fgca/chain-table.js';
 import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
 import { checkScopeRoot, type Scope } from '../../packages/diagrams/src/scope.js';
@@ -54,13 +52,6 @@ interface FGCADoc {
 // (`layoutFGCAPreview`) so the configurable-gap behaviour (vkgeorgia/strategy#75)
 // is unit-tested. This file owns only the SVG presentation of that layout and
 // the column header labels.
-
-const COL_LABELS: Record<string, string> = {
-  factor: 'Factors (F)',
-  goal: 'Goals (G)',
-  change: 'Changes (C)',
-  activity: 'Activities (A)',
-};
 
 // ── SVG renderer ──────────────────────────────────────────────────────────────
 /** Goal options + deepest level for the scope control, from a parsed doc. FGCA
@@ -243,46 +234,7 @@ function buildSvg(
   const showTitle = heading != null && filename != null && date != null;
   const titleH = showTitle ? TITLE_BLOCK_H : 0;
 
-  const headerSvg = columns.map(({ col, x }) => {
-    return [
-      `<rect class="diagram-node layer-${col}" x="${x}" y="${PAD}" width="${NODE_W}" height="${HEADER_H}" rx="6"/>`,
-      `<text class="text-header" x="${x + NODE_W / 2}" y="${PAD + HEADER_H / 2}" text-anchor="middle" dominant-baseline="central">${escXml(COL_LABELS[col])}</text>`,
-    ].join('\n');
-  }).join('\n');
-
-  // Cubic bezier with horizontal control handles (shared geometry in
-  // @transitrix/diagrams). `curvature` scales the handle length: 1 = default,
-  // 0 = straight, higher = stronger arc (vkgeorgia/strategy#76).
-  const edgeSvg = edges.map(e =>
-    `<path d="${horizontalCubicEdgePath(e.sx, e.sy, e.tx, e.ty, curvature, entryCurvature)}" class="diagram-edge" marker-end="url(#arrow)"/>`
-  ).join('\n');
-
-  const nodeSvg = nodes.map(n => {
-    const words = n.label.split(' ');
-    let line1 = '';
-    let line2 = '';
-    for (const w of words) {
-      if ((line1 + ' ' + w).trim().length <= 26) {
-        line1 = (line1 + ' ' + w).trim();
-      } else if ((line2 + ' ' + w).trim().length <= 26) {
-        line2 = (line2 + ' ' + w).trim();
-      } else if (!line2) {
-        line2 = w.slice(0, 24) + '…';
-        break;
-      }
-    }
-    const twoLines = line2.length > 0;
-    const y1 = twoLines ? n.y + 16 : n.y + 26;
-    const y2 = n.y + 32;
-    const idY = twoLines ? n.y + 54 : n.y + 50;
-    const entityId = n.id.slice(n.id.indexOf('_') + 1);
-    return [
-      `<rect class="diagram-node layer-${n.col}" x="${n.x}" y="${n.y}" width="${NODE_W}" height="${NODE_H}" rx="8"/>`,
-      `<text class="text-primary" x="${n.x + NODE_W / 2}" y="${y1}" text-anchor="middle" dominant-baseline="central">${escXml(line1)}</text>`,
-      twoLines ? `<text class="text-secondary" x="${n.x + NODE_W / 2}" y="${y2}" text-anchor="middle" dominant-baseline="central">${escXml(line2)}</text>` : '',
-      `<text class="text-id" x="${n.x + NODE_W / 2}" y="${idY}" text-anchor="middle" dominant-baseline="central">${escXml(entityId)}</text>`,
-    ].filter(Boolean).join('\n');
-  }).join('\n');
+  const body = renderFgcaBody(columns, nodes, edges, curvature, entryCurvature);
 
   const totalH = height + titleH;
   const titleSvg = showTitle ? titleBlockSvg(heading!, filename!, date!, PAD, PAD, version) : '';
@@ -296,9 +248,7 @@ function buildSvg(
 </defs>
 ${titleSvg}
 <g transform="translate(0, ${titleH})">
-${headerSvg}
-${nodeSvg}
-${edgeSvg}
+${body}
 </g>
 </svg>`;
 }

--- a/packages/diagrams/src/webview/render-fgca.ts
+++ b/packages/diagrams/src/webview/render-fgca.ts
@@ -32,27 +32,24 @@ const COL_LABELS: Record<FGCAPreviewColumn, string> = {
   activity: 'Activities (A)',
 };
 
-export interface RenderFgcaOptions {
-  /** `'fga'` hides the Changes column; defaults to `'fgca'`. */
-  variant?: 'fgca' | 'fga';
-  /** Optional heading rendered as a left-anchored `text-header` line. */
-  title?: string;
-  /** Exit edge curvature; 1 = default, 0 = straight, higher = stronger arc. */
-  curvature?: number;
-  /** Entry curvature at the target node; defaults to `curvature` when omitted. */
-  entryCurvature?: number;
-}
+type FgcaLayout = ReturnType<typeof layoutFGCAPreview>;
 
-export function renderFgcaSvg(doc: FGCADoc, options: RenderFgcaOptions = {}): string {
-  const { variant = 'fgca', title = '', curvature = DEFAULT_EDGE_CURVATURE, entryCurvature } = options;
-  const hideChanges = variant === 'fga';
-
-  const { nodes, edges, columns, width, height } = layoutFGCAPreview(doc, { hideChanges });
-
-  if (nodes.length === 0) {
-    return `<svg xmlns="http://www.w3.org/2000/svg" width="0" height="0" viewBox="0 0 0 0"></svg>`;
-  }
-
+/**
+ * Canonical FGCA/FGA body — the column headers, node rects and edge paths that
+ * go inside the `<svg>`, shared verbatim by the VS Code preview (`buildSvg`)
+ * and the host-neutral wrapper below. Excludes the host-specific title block
+ * and the (identical) `<defs>` arrow marker. Coordinates are absolute (the
+ * layout's own); the VS Code path wraps this in a `translate(0, titleH)` group
+ * to make room for its title block, while the host-neutral wrapper renders it
+ * untranslated.
+ */
+export function renderFgcaBody(
+  columns: FgcaLayout['columns'],
+  nodes: FgcaLayout['nodes'],
+  edges: FgcaLayout['edges'],
+  curvature: number,
+  entryCurvature: number | undefined,
+): string {
   const headerSvg = columns
     .map(({ col, x }) =>
       [
@@ -102,6 +99,32 @@ export function renderFgcaSvg(doc: FGCADoc, options: RenderFgcaOptions = {}): st
     })
     .join('\n');
 
+  return `${headerSvg}\n${nodeSvg}\n${edgeSvg}`;
+}
+
+export interface RenderFgcaOptions {
+  /** `'fga'` hides the Changes column; defaults to `'fgca'`. */
+  variant?: 'fgca' | 'fga';
+  /** Optional heading rendered as a left-anchored `text-header` line. */
+  title?: string;
+  /** Exit edge curvature; 1 = default, 0 = straight, higher = stronger arc. */
+  curvature?: number;
+  /** Entry curvature at the target node; defaults to `curvature` when omitted. */
+  entryCurvature?: number;
+}
+
+export function renderFgcaSvg(doc: FGCADoc, options: RenderFgcaOptions = {}): string {
+  const { variant = 'fgca', title = '', curvature = DEFAULT_EDGE_CURVATURE, entryCurvature } = options;
+  const hideChanges = variant === 'fga';
+
+  const { nodes, edges, columns, width, height } = layoutFGCAPreview(doc, { hideChanges });
+
+  if (nodes.length === 0) {
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="0" height="0" viewBox="0 0 0 0"></svg>`;
+  }
+
+  const body = renderFgcaBody(columns, nodes, edges, curvature, entryCurvature);
+
   const titleSvg = title
     ? `<text class="text-header" x="${PAD}" y="${PAD - 6}">${escXml(title)}</text>`
     : '';
@@ -119,8 +142,6 @@ export function renderFgcaSvg(doc: FGCADoc, options: RenderFgcaOptions = {}): st
   </marker>
 </defs>
 ${titleSvg}
-${headerSvg}
-${nodeSvg}
-${edgeSvg}
+${body}
 </svg>`;
 }


### PR DESCRIPTION
## Summary

Single SVG emitter for the **fgca / fga** notation (architecture review, epic C — final slice). Unlike the earlier drifted notations, the FGCA/FGA bodies were already byte-identical between the two hosts — only the chrome differed — so this is a **pure extraction with no output change for either host**.

- Extract `renderFgcaBody(columns, nodes, edges, curvature, entryCurvature)` into `packages/diagrams/src/webview/render-fgca.ts` — the one emitter both hosts call (column headers + node rects + edge paths).
- `renderFgcaSvg` wraps it with the embedded-CSS chrome (IntelliJ/JCEF); `extension/src/fgca-preview.ts` `buildSvg` wraps it with the VS Code title block + `translate(0, titleH)` group.
- Drop the now-duplicated `COL_LABELS` and the unused `NODE_W`/`NODE_H`/`HEADER_H` + `horizontalCubicEdgePath` imports from the preview.

## Behaviour

- **Both hosts: byte-identical.** The bodies had not drifted; verified with a temporary parity test over a synthetic layout (four columns; short / two-line / truncated / special-char nodes; three edges; three curvature combos). Test removed before commit. No visual change expected for either VS Code or IntelliJ.

## Test plan

- [x] `npm run compile` + `npm run compile:extension` clean
- [x] `npm run test:diagrams` (921) + core vitest (373) green
