### PR TITLE
refactor(diagrams,src,extension): consume @transitrix/diagrams via package entry (review D)

### DIFF
--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -1,5 +1,5 @@
 import * as path from 'node:path';
-import { escXml } from '../../packages/diagrams/src/webview/render-util.js';
+import { escXml } from '@transitrix/diagrams/webview/render-util.js';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, prepareSvgForExport, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
@@ -15,10 +15,10 @@ import {
   type ActivitiesLayoutOptions,
   type GanttLayout,
   type GanttResult,
-} from '../../packages/diagrams/src/activities/index.js';
-import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
-import { DEFAULT_EDGE_CURVATURE } from '../../packages/diagrams/src/edge-path.js';
-import { renderActivitiesNetworkBody, ACTIVITIES_NETWORK_DEFS } from '../../packages/diagrams/src/webview/render-activities.js';
+} from '@transitrix/diagrams/activities';
+import { coerceDatesToIsoStrings } from '@transitrix/diagrams/yaml-normalize.js';
+import { DEFAULT_EDGE_CURVATURE } from '@transitrix/diagrams/edge-path.js';
+import { renderActivitiesNetworkBody, ACTIVITIES_NETWORK_DEFS } from '@transitrix/diagrams/webview/render-activities.js';
 import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
 import { readSpacing, readCurvature, readEntryCurvature, applyControlMessage, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND } from './spacing-config.js';
 import { genNonce, buildControlsPanel, buildControlsScript } from './preview-controls.js';

--- a/extension/src/activity-card-preview.ts
+++ b/extension/src/activity-card-preview.ts
@@ -10,9 +10,9 @@ import {
   layoutActivityCard,
   type ActivityCardDoc,
   type ActivityCardLayout,
-} from '../../packages/diagrams/src/activity-card/index.js';
-import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
-import { renderActivityCardBody } from '../../packages/diagrams/src/webview/render-activity-card.js';
+} from '@transitrix/diagrams/activity-card';
+import { coerceDatesToIsoStrings } from '@transitrix/diagrams/yaml-normalize.js';
+import { renderActivityCardBody } from '@transitrix/diagrams/webview/render-activity-card.js';
 import {
   type CanonDocs,
   findCanonRoot,

--- a/extension/src/applications-preview.ts
+++ b/extension/src/applications-preview.ts
@@ -1,9 +1,9 @@
-import { escHtml } from '../../packages/diagrams/src/webview/render-util.js';
+import { escHtml } from '@transitrix/diagrams/webview/render-util.js';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, extractDiagramMeta, CATALOGUE_STYLES, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
-import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
-import { validateApplicationsCatalogue } from '../../packages/diagrams/src/applications/validate.js';
+import { coerceDatesToIsoStrings } from '@transitrix/diagrams/yaml-normalize.js';
+import { validateApplicationsCatalogue } from '@transitrix/diagrams/applications/validate.js';
 import { StaticPreview } from './static-preview.js';
 
 // ── Types (used by render helpers) ───────────────────────────────────────────

--- a/extension/src/blocks-preview.ts
+++ b/extension/src/blocks-preview.ts
@@ -10,9 +10,9 @@ import {
   iterateBlocks,
   type BlocksFile,
   type BlocksLayout,
-} from '../../packages/diagrams/src/blocks/index.js';
-import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
-import { renderBlocksLayoutSvg } from '../../packages/diagrams/src/webview/render-blocks.js';
+} from '@transitrix/diagrams/blocks';
+import { coerceDatesToIsoStrings } from '@transitrix/diagrams/yaml-normalize.js';
+import { renderBlocksLayoutSvg } from '@transitrix/diagrams/webview/render-blocks.js';
 
 
 // Pad reserved around the diagram; mirrors `PAD` in the shared emitter

--- a/extension/src/canon-loader.ts
+++ b/extension/src/canon-loader.ts
@@ -1,7 +1,7 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
-import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
+import { coerceDatesToIsoStrings } from '@transitrix/diagrams/yaml-normalize.js';
 
 // Shared filesystem layer for the canon/ element + relation store.
 //

--- a/extension/src/capability-map-preview.ts
+++ b/extension/src/capability-map-preview.ts
@@ -1,9 +1,9 @@
-import { escHtml } from '../../packages/diagrams/src/webview/render-util.js';
+import { escHtml } from '@transitrix/diagrams/webview/render-util.js';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, extractDiagramMeta, CATALOGUE_STYLES, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
-import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
-import { validateCapabilityMap } from '../../packages/diagrams/src/capability-map/validate.js';
+import { coerceDatesToIsoStrings } from '@transitrix/diagrams/yaml-normalize.js';
+import { validateCapabilityMap } from '@transitrix/diagrams/capability-map/validate.js';
 import { StaticPreview } from './static-preview.js';
 
 // ── Types (used by render helpers) ───────────────────────────────────────────

--- a/extension/src/compliance-impact-preview.ts
+++ b/extension/src/compliance-impact-preview.ts
@@ -1,16 +1,16 @@
 import * as vscode from 'vscode';
-import { escXml } from '../../packages/diagrams/src/webview/render-util.js';
+import { escXml } from '@transitrix/diagrams/webview/render-util.js';
 import yaml from 'js-yaml';
-import { generateWebviewCss, type ThemeId } from '../../packages/diagrams/src/theme/index.js';
+import { generateWebviewCss, type ThemeId } from '@transitrix/diagrams/theme';
 import {
   buildImpactMatrix,
   type ImpactColumn,
   type ImpactViewConfig,
   type ImpactMatrix,
   type ImpactCell,
-} from '../../packages/diagrams/src/compliance/impact.js';
-import type { AssertionStatus } from '../../packages/diagrams/src/assertion/types.js';
-import type { IndexRequirement, DeadlineStatus } from '../../packages/diagrams/src/compliance/types.js';
+} from '@transitrix/diagrams/compliance/impact.js';
+import type { AssertionStatus } from '@transitrix/diagrams/assertion/types.js';
+import type { IndexRequirement, DeadlineStatus } from '@transitrix/diagrams/compliance/types.js';
 import { genNonce, colWidthPxFromSetting, colWidthRootCss } from './preview-controls.js';
 import { scanComplianceCanon, openComplianceFile } from './compliance-scan.js';
 import type { ScannedCanon } from './compliance-scan.js';

--- a/extension/src/compliance-matrix-preview.ts
+++ b/extension/src/compliance-matrix-preview.ts
@@ -1,13 +1,13 @@
 import * as vscode from 'vscode';
-import { escXml } from '../../packages/diagrams/src/webview/render-util.js';
-import { generateWebviewCss, type ThemeId } from '../../packages/diagrams/src/theme/index.js';
+import { escXml } from '@transitrix/diagrams/webview/render-util.js';
+import { generateWebviewCss, type ThemeId } from '@transitrix/diagrams/theme';
 import {
   buildComplianceMatrix,
   filterComplianceMatrix,
   type ComplianceMatrix,
   type MatrixFilter,
-} from '../../packages/diagrams/src/compliance-matrix/index.js';
-import type { AssertionStatus } from '../../packages/diagrams/src/assertion/types.js';
+} from '@transitrix/diagrams/compliance-matrix';
+import type { AssertionStatus } from '@transitrix/diagrams/assertion/types.js';
 import { genNonce, colWidthPxFromSetting, colWidthRootCss } from './preview-controls.js';
 import { scanComplianceCanon } from './compliance-scan.js';
 import type { ScannedCanon } from './compliance-scan.js';

--- a/extension/src/compliance-render.ts
+++ b/extension/src/compliance-render.ts
@@ -1,9 +1,9 @@
-import { generateWebviewCss, type ThemeId } from '../../packages/diagrams/src/theme/index.js';
-import { escXml } from '../../packages/diagrams/src/webview/render-util.js';
+import { generateWebviewCss, type ThemeId } from '@transitrix/diagrams/theme';
+import { escXml } from '@transitrix/diagrams/webview/render-util.js';
 export { escXml };
-import type { AssertionStatus } from '../../packages/diagrams/src/assertion/types.js';
-import type { ViewScore } from '../../packages/diagrams/src/confidence/index.js';
-import { computeDeadlineStatus } from '../../packages/diagrams/src/compliance/impact.js';
+import type { AssertionStatus } from '@transitrix/diagrams/assertion/types.js';
+import type { ViewScore } from '@transitrix/diagrams/confidence';
+import { computeDeadlineStatus } from '@transitrix/diagrams/compliance/impact.js';
 import { ERROR_BLOCK_CSS, buildErrorHtml, WARN_BLOCK_CSS, buildWarnHtml } from './diagram-frame.js';
 
 // Shared HTML rendering for the script-less compliance views — the single-law

--- a/extension/src/compliance-scan.ts
+++ b/extension/src/compliance-scan.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
-import { emptyCanon, ingestComplianceDoc, type ComplianceCanon } from '../../packages/diagrams/src/compliance/index.js';
+import { emptyCanon, ingestComplianceDoc, type ComplianceCanon } from '@transitrix/diagrams/compliance';
 
 // Workspace scanner for the compliance views (vkgeorgia/strategy#84). The
 // compliance matrix (Phase 2), the single-law / single-product views (Phase 3)

--- a/extension/src/coverage-metric-preview.ts
+++ b/extension/src/coverage-metric-preview.ts
@@ -1,14 +1,14 @@
 import * as vscode from 'vscode';
-import { escXml } from '../../packages/diagrams/src/webview/render-util.js';
+import { escXml } from '@transitrix/diagrams/webview/render-util.js';
 import yaml from 'js-yaml';
-import { generateWebviewCss, type ThemeId } from '../../packages/diagrams/src/theme/index.js';
+import { generateWebviewCss, type ThemeId } from '@transitrix/diagrams/theme';
 import {
   parseCoverageMetricConfig,
   buildCoverageMatrix,
   type CoverageMatrix,
   type CoverageRow,
   type RagStatus,
-} from '../../packages/diagrams/src/compliance/coverage-metric.js';
+} from '@transitrix/diagrams/compliance/coverage-metric.js';
 import { scanComplianceCanon, openComplianceFile } from './compliance-scan.js';
 import type { ScannedCanon } from './compliance-scan.js';
 import { WARN_BLOCK_CSS, buildWarnHtml, ERROR_BLOCK_CSS, buildErrorHtml } from './diagram-frame.js';

--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -1,7 +1,7 @@
-import type { ThemeId } from '../../packages/diagrams/src/theme/index.js';
-import { generateWebviewCss, generateSvgEmbedCss } from '../../packages/diagrams/src/theme/index.js';
+import type { ThemeId } from '@transitrix/diagrams/theme';
+import { generateWebviewCss, generateSvgEmbedCss } from '@transitrix/diagrams/theme';
 import { CONTROLS_PANEL_CSS, SNAPSHOT_TOOLBAR_CSS } from './preview-controls.js';
-import { escXml } from '../../packages/diagrams/src/webview/render-util.js';
+import { escXml } from '@transitrix/diagrams/webview/render-util.js';
 
 export type { ThemeId };
 

--- a/extension/src/fgca-preview.ts
+++ b/extension/src/fgca-preview.ts
@@ -1,12 +1,12 @@
 import * as path from 'node:path';
-import { escXml } from '../../packages/diagrams/src/webview/render-util.js';
+import { escXml } from '@transitrix/diagrams/webview/render-util.js';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, prepareSvgForExport, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
 import { TITLE_BLOCK_H, titleBlockSvg, todayIso } from './svg-title-block.js';
 import { loadCanon, findCanonRoot, isUnderCanon, type CanonDocs } from './canon-loader.js';
-import { parseCanonicalFGCA, parseCanonicalFGA } from '../../packages/diagrams/src/fgca/parse-canonical.js';
-import { resolveFGCA, isFGCAViewDoc } from '../../packages/diagrams/src/fgca/resolver.js';
+import { parseCanonicalFGCA, parseCanonicalFGA } from '@transitrix/diagrams/fgca/parse-canonical.js';
+import { resolveFGCA, isFGCAViewDoc } from '@transitrix/diagrams/fgca/resolver.js';
 import {
   layoutFGCAPreview,
   FGCA_NODE_W as NODE_W,
@@ -15,11 +15,11 @@ import {
   FGCA_PAD as PAD,
   FGCA_DEFAULT_COL_GAP,
   FGCA_DEFAULT_ROW_GAP,
-} from '../../packages/diagrams/src/fgca/preview-layout.js';
-import { horizontalCubicEdgePath, DEFAULT_EDGE_CURVATURE } from '../../packages/diagrams/src/edge-path.js';
-import { buildChainTable, type ChainTable, type ChainColumn } from '../../packages/diagrams/src/fgca/chain-table.js';
-import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
-import { checkScopeRoot, type Scope } from '../../packages/diagrams/src/scope.js';
+} from '@transitrix/diagrams/fgca/preview-layout.js';
+import { horizontalCubicEdgePath, DEFAULT_EDGE_CURVATURE } from '@transitrix/diagrams/edge-path.js';
+import { buildChainTable, type ChainTable, type ChainColumn } from '@transitrix/diagrams/fgca/chain-table.js';
+import { coerceDatesToIsoStrings } from '@transitrix/diagrams/yaml-normalize.js';
+import { checkScopeRoot, type Scope } from '@transitrix/diagrams/scope.js';
 import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
 import { readSpacing, readCurvature, readEntryCurvature, readScope, readView, applyControlMessage, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND } from './spacing-config.js';
 import { genNonce, buildControlsPanel, buildControlsScript, buildViewToggle, buildCaptureButton, buildTimelineStrip, type ControlsModel, type ScopeGoalOption, type SnapshotMarker, type SnapshotMessage } from './preview-controls.js';

--- a/extension/src/gap-dashboard-preview.ts
+++ b/extension/src/gap-dashboard-preview.ts
@@ -1,10 +1,10 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
-import { type ThemeId } from '../../packages/diagrams/src/theme/index.js';
-import { buildComplianceIndex, buildGapReport, scoreComplianceView, type GapReport } from '../../packages/diagrams/src/compliance/index.js';
+import { type ThemeId } from '@transitrix/diagrams/theme';
+import { buildComplianceIndex, buildGapReport, scoreComplianceView, type GapReport } from '@transitrix/diagrams/compliance';
 import { scanComplianceCanon } from './compliance-scan.js';
 import { complianceShell, deadlineBadge, escXml, openLink, statusBadge } from './compliance-render.js';
-import type { ViewScore } from '../../packages/diagrams/src/confidence/index.js';
+import type { ViewScore } from '@transitrix/diagrams/confidence';
 
 // Gap dashboard (vkgeorgia/strategy#84 Phase 4). A repo-wide operational view
 // for compliance owners: requirements with no assertion, assertions with a

--- a/extension/src/goals-preview.ts
+++ b/extension/src/goals-preview.ts
@@ -7,12 +7,12 @@ import { TITLE_BLOCK_H, titleBlockSvg, todayIso } from './svg-title-block.js';
 import {
   layoutGoalTree,
   type GoalTreeLayout,
-} from '../../packages/diagrams/src/goals/index.js';
-import { renderGoalsLayoutSvg } from '../../packages/diagrams/src/webview/render-goals.js';
-import { parseCanonicalGoals } from '../../packages/diagrams/src/goals/parse-canonical.js';
-import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
-import { DEFAULT_EDGE_CURVATURE } from '../../packages/diagrams/src/edge-path.js';
-import { checkScopeRoot } from '../../packages/diagrams/src/scope.js';
+} from '@transitrix/diagrams/goals';
+import { renderGoalsLayoutSvg } from '@transitrix/diagrams/webview/render-goals.js';
+import { parseCanonicalGoals } from '@transitrix/diagrams/goals/parse-canonical.js';
+import { coerceDatesToIsoStrings } from '@transitrix/diagrams/yaml-normalize.js';
+import { DEFAULT_EDGE_CURVATURE } from '@transitrix/diagrams/edge-path.js';
+import { checkScopeRoot } from '@transitrix/diagrams/scope.js';
 import { readSpacing, readCurvature, readEntryCurvature, readScope, applyControlMessage, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND } from './spacing-config.js';
 import { genNonce, buildControlsPanel, buildControlsScript, type ControlsModel, type ScopeGoalOption } from './preview-controls.js';
 

--- a/extension/src/preview-controls.ts
+++ b/extension/src/preview-controls.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from 'node:crypto';
-import { escXml } from '../../packages/diagrams/src/webview/render-util.js';
+import { escXml } from '@transitrix/diagrams/webview/render-util.js';
 
 // In-preview interactive control panel for the spacing / curvature / scope
 // previews (vkgeorgia/strategy#75 / #76 / #77 — PR2).

--- a/extension/src/preview.ts
+++ b/extension/src/preview.ts
@@ -1,7 +1,7 @@
 import * as path from 'node:path';
 import { promises as fsp } from 'node:fs';
 import * as vscode from 'vscode';
-import { getBaseResetCss } from '../../packages/diagrams/src/theme/index.js';
+import { getBaseResetCss } from '@transitrix/diagrams/theme';
 import { rasterizeSvgToPng } from './raster.js';
 
 import type { LayoutMetrics, ValidationReport } from './types.js';

--- a/extension/src/process-blueprint-preview.ts
+++ b/extension/src/process-blueprint-preview.ts
@@ -13,13 +13,13 @@ import {
   type ProcessBlueprintFile,
   type ProcessBlueprintLayout,
   type RowId,
-} from '../../packages/diagrams/src/process-blueprint/index.js';
-import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
+} from '@transitrix/diagrams/process-blueprint';
+import { coerceDatesToIsoStrings } from '@transitrix/diagrams/yaml-normalize.js';
 import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
 import { scanComplianceCanon, type ScannedCanon } from './compliance-scan.js';
 import { genNonce } from './preview-controls.js';
-import { escXml } from '../../packages/diagrams/src/webview/render-util.js';
-import { renderProcessBlueprintBody } from '../../packages/diagrams/src/webview/render-process-blueprint.js';
+import { escXml } from '@transitrix/diagrams/webview/render-util.js';
+import { renderProcessBlueprintBody } from '@transitrix/diagrams/webview/render-process-blueprint.js';
 
 /**
  * Wrap the shared canonical blueprint body (`renderProcessBlueprintBody`) with

--- a/extension/src/process-map-preview.ts
+++ b/extension/src/process-map-preview.ts
@@ -1,9 +1,9 @@
-import { escHtml } from '../../packages/diagrams/src/webview/render-util.js';
+import { escHtml } from '@transitrix/diagrams/webview/render-util.js';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, extractDiagramMeta, CATALOGUE_STYLES, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
-import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
-import { validateProcessMap } from '../../packages/diagrams/src/process-map/validate.js';
+import { coerceDatesToIsoStrings } from '@transitrix/diagrams/yaml-normalize.js';
+import { validateProcessMap } from '@transitrix/diagrams/process-map/validate.js';
 import { StaticPreview } from './static-preview.js';
 
 // ── Types (used by render helpers) ───────────────────────────────────────────

--- a/extension/src/products-preview.ts
+++ b/extension/src/products-preview.ts
@@ -1,9 +1,9 @@
-import { escHtml } from '../../packages/diagrams/src/webview/render-util.js';
+import { escHtml } from '@transitrix/diagrams/webview/render-util.js';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, extractDiagramMeta, CATALOGUE_STYLES, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
-import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
-import { validateProductsCatalogue } from '../../packages/diagrams/src/products/validate.js';
+import { coerceDatesToIsoStrings } from '@transitrix/diagrams/yaml-normalize.js';
+import { validateProductsCatalogue } from '@transitrix/diagrams/products/validate.js';
 import { StaticPreview } from './static-preview.js';
 
 // ── Types (used by render helpers) ───────────────────────────────────────────

--- a/extension/src/scenarios-preview.ts
+++ b/extension/src/scenarios-preview.ts
@@ -1,9 +1,9 @@
-import { escHtml } from '../../packages/diagrams/src/webview/render-util.js';
+import { escHtml } from '@transitrix/diagrams/webview/render-util.js';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, extractDiagramMeta, CATALOGUE_STYLES, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
-import { coerceDatesToIsoStrings } from '../../packages/diagrams/src/yaml-normalize.js';
-import { validateScenario } from '../../packages/diagrams/src/scenarios/validate.js';
+import { coerceDatesToIsoStrings } from '@transitrix/diagrams/yaml-normalize.js';
+import { validateScenario } from '@transitrix/diagrams/scenarios/validate.js';
 import { StaticPreview } from './static-preview.js';
 
 // ── Types (used by render helpers) ───────────────────────────────────────────

--- a/extension/src/single-law-preview.ts
+++ b/extension/src/single-law-preview.ts
@@ -1,8 +1,8 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
-import { type ThemeId } from '../../packages/diagrams/src/theme/index.js';
-import { buildComplianceIndex, buildLawTree, scoreComplianceView, type LawTree } from '../../packages/diagrams/src/compliance/index.js';
+import { type ThemeId } from '@transitrix/diagrams/theme';
+import { buildComplianceIndex, buildLawTree, scoreComplianceView, type LawTree } from '@transitrix/diagrams/compliance';
 import { scanComplianceCanon } from './compliance-scan.js';
 import { complianceShell, deadlineBadge, escXml, openLink, statusBadge } from './compliance-render.js';
 

--- a/extension/src/single-product-preview.ts
+++ b/extension/src/single-product-preview.ts
@@ -1,8 +1,8 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
-import { type ThemeId } from '../../packages/diagrams/src/theme/index.js';
-import { buildComplianceIndex, buildProductView, scoreComplianceView, type ProductView } from '../../packages/diagrams/src/compliance/index.js';
+import { type ThemeId } from '@transitrix/diagrams/theme';
+import { buildComplianceIndex, buildProductView, scoreComplianceView, type ProductView } from '@transitrix/diagrams/compliance';
 import { scanComplianceCanon } from './compliance-scan.js';
 import { complianceShell, deadlineBadge, escXml, openLink, statusBadge } from './compliance-render.js';
 

--- a/extension/src/spacing-config.ts
+++ b/extension/src/spacing-config.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import type { Scope } from '../../packages/diagrams/src/scope.js';
+import type { Scope } from '@transitrix/diagrams/scope.js';
 import type { ControlMessage, PreviewView } from './preview-controls.js';
 
 // Per-notation spacing controls (vkgeorgia/strategy#75). PR1 persists the

--- a/extension/src/svg-title-block.ts
+++ b/extension/src/svg-title-block.ts
@@ -14,7 +14,7 @@
 // interactive preview, and the right behaviour for exported SVG files
 // (the title travels with the diagram outside VS Code).
 
-import { escXml } from '../../packages/diagrams/src/webview/render-util.js';
+import { escXml } from '@transitrix/diagrams/webview/render-util.js';
 
 export const TITLE_BLOCK_H = 60;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "transitrix-studio",
-  "version": "1.4.2",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "transitrix-studio",
-      "version": "1.4.2",
+      "version": "2.2.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -19,7 +19,6 @@
         "xmlbuilder2": "^3.1.1"
       },
       "bin": {
-        "cervin": "dist/cli.js",
         "transitrix": "dist/cli.js"
       },
       "devDependencies": {
@@ -7114,7 +7113,7 @@
     },
     "packages/diagrams": {
       "name": "@transitrix/diagrams",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "^18.3.28",

--- a/package.json
+++ b/package.json
@@ -29,9 +29,10 @@
     "node": ">=20"
   },
   "scripts": {
-    "compile": "tsc --noEmit",
+    "compile": "npm run build:diagrams && tsc --noEmit",
     "compile:extension": "tsc -p extension/tsconfig.json --noEmit",
-    "build": "tsc -p tsconfig.build.json",
+    "build": "npm run build:diagrams && tsc -p tsconfig.build.json",
+    "build:diagrams": "npm --workspace packages/diagrams run build",
     "build:webview": "node scripts/build-webview.mjs",
     "build:webview-bundle": "node scripts/build-webview-bundle.mjs",
     "extension:bundle": "node scripts/build-extension-bundle.mjs",

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -15,6 +15,20 @@
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./*.js": {
+      "types": "./dist/*.d.ts",
+      "import": "./dist/*.js"
+    },
+    "./*": {
+      "types": "./dist/*/index.d.ts",
+      "import": "./dist/*/index.js"
+    }
+  },
   "files": [
     "dist",
     "src"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,6 +17,9 @@ import type { ValidationReport, ValidationFinding } from './validator-types.js';
 import { parseYamlToIr } from './parser.js';
 import { validateProcess } from './validator.js';
 import type { ProcessIr } from './ir.js';
+import { runRepoValidate, reportRepoFindings, repoScopeHasErrors } from './repo-validate.js';
+import { isFileValidatableNotation, loadNotationYaml, validateNotationDoc } from './validate-notation.js';
+import { handleExportComplianceCommand } from './export-compliance.js';
 
 function printUsage(): void {
   console.error(`Transitrix Studio CLI — usage:
@@ -282,29 +285,6 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
   // Repo scope (#141): whole-canon checks on the @transitrix/diagrams model.
   if (scope === 'repo') {
     const repoRoot = root ?? process.cwd();
-    // Lazy import keeps the @transitrix/diagrams source out of the
-    // rootDir-restricted emit build (see repo-validate.ts header).
-    const repoModule = './repo-validate.js';
-    type RepoFinding = { scope: 'repo'; id: string; message: string };
-    type ViewFinding = {
-      file: string;
-      notation: string;
-      ruleId: string;
-      severity: 'error' | 'warning';
-      message: string;
-    };
-    type RepoScopeResult = {
-      canon: RepoFinding[];
-      views: ViewFinding[];
-      skipped: Array<{ file: string; notation: string }>;
-    };
-    const { runRepoValidate, reportRepoFindings, repoScopeHasErrors } = (await import(
-      repoModule
-    )) as {
-      runRepoValidate: (root: string) => RepoScopeResult;
-      reportRepoFindings: (root: string, result: RepoScopeResult, useJson: boolean) => void;
-      repoScopeHasErrors: (result: RepoScopeResult) => boolean;
-    };
     const result = runRepoValidate(repoRoot);
     reportRepoFindings(repoRoot, result, useJson);
     if (repoScopeHasErrors(result)) {
@@ -348,19 +328,10 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
   // the IR path below.
   const probedNotation = probeNotation(fileText);
   if (probedNotation && probedNotation !== 'bpmn') {
-    // Hand-typed dynamic import (not `typeof import(...)`) so this @transitrix/
-    // diagrams-importing module stays out of the rootDir-restricted emit build —
-    // same pattern as the repo-scope handler above.
-    const nvModule = './validate-notation.js';
-    const nv = (await import(nvModule)) as {
-      isFileValidatableNotation: (notation: string) => boolean;
-      loadNotationYaml: (text: string) => unknown;
-      validateNotationDoc: (notation: string, data: unknown) => ValidationReport;
-    };
-    if (nv.isFileValidatableNotation(probedNotation)) {
+    if (isFileValidatableNotation(probedNotation)) {
       let data: unknown;
       try {
-        data = nv.loadNotationYaml(fileText);
+        data = loadNotationYaml(fileText);
       } catch (e) {
         const err = e as Error;
         if (useJson) {
@@ -379,7 +350,7 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
         }
         process.exit(1);
       }
-      const report = nv.validateNotationDoc(probedNotation, data);
+      const report = validateNotationDoc(probedNotation, data);
       emitFileReport(src, report, useJson, probedNotation);
       if (!report.isValid) {
         process.exit(1);
@@ -533,15 +504,6 @@ try {
   } else if (subcommand === 'validate') {
     await handleValidateCommand(process.argv.slice(3));
   } else if (subcommand === 'export-compliance') {
-    // Loaded lazily through a computed specifier: the handler imports the
-    // @transitrix/diagrams *source*, which the rootDir-restricted emit build
-    // (tsconfig.build.json) must not pull into its program. A non-literal
-    // specifier keeps tsc from statically including it; tsx transpiles it at
-    // dev runtime. (`npm run compile` still type-checks the handler file.)
-    const handlerModule = './export-compliance.js';
-    const { handleExportComplianceCommand } = (await import(handlerModule)) as {
-      handleExportComplianceCommand: (argv: string[]) => Promise<void>;
-    };
     await handleExportComplianceCommand(process.argv.slice(3));
   } else if (subcommand === 'migrate') {
     await handleMigrateCommand(process.argv.slice(3));

--- a/src/export-compliance.ts
+++ b/src/export-compliance.ts
@@ -24,7 +24,7 @@ import {
   renderImpactMarkdown,
   type ComplianceCanon,
   type ReportScope,
-} from '../packages/diagrams/src/compliance/index.js';
+} from '@transitrix/diagrams/compliance';
 
 function flagValue(argv: string[], name: string): string | undefined {
   const i = argv.indexOf(name);

--- a/src/repo-validate.ts
+++ b/src/repo-validate.ts
@@ -18,7 +18,7 @@ import {
   type RepoDoc,
   type RepoFinding,
   type RepoModelInput,
-} from '../packages/diagrams/src/repo-validate/index.js';
+} from '@transitrix/diagrams/repo-validate';
 import {
   validateNotationDoc,
   isFileValidatableNotation,

--- a/src/validate-notation.ts
+++ b/src/validate-notation.ts
@@ -23,21 +23,21 @@
 
 import yaml from 'js-yaml';
 import type { ValidationReport, ValidationFinding } from './validator-types.js';
-import { coerceDatesToIsoStrings } from '../packages/diagrams/src/yaml-normalize.js';
-import { parseCanonicalGoals } from '../packages/diagrams/src/goals/parse-canonical.js';
+import { coerceDatesToIsoStrings } from '@transitrix/diagrams/yaml-normalize.js';
+import { parseCanonicalGoals } from '@transitrix/diagrams/goals/parse-canonical.js';
 import {
   parseCanonicalFGCA,
   parseCanonicalFGA,
-} from '../packages/diagrams/src/fgca/parse-canonical.js';
-import { validateActivities } from '../packages/diagrams/src/activities/validate.js';
-import { validateActivityCard } from '../packages/diagrams/src/activity-card/validate.js';
-import { validateProcessBlueprint } from '../packages/diagrams/src/process-blueprint/validate.js';
-import { validateNestedBlocks } from '../packages/diagrams/src/blocks/validate.js';
-import { validateApplicationsCatalogue } from '../packages/diagrams/src/applications/validate.js';
-import { validateCapabilityMap } from '../packages/diagrams/src/capability-map/validate.js';
-import { validateProductsCatalogue } from '../packages/diagrams/src/products/validate.js';
-import { validateScenario } from '../packages/diagrams/src/scenarios/validate.js';
-import { validateProcessMap } from '../packages/diagrams/src/process-map/validate.js';
+} from '@transitrix/diagrams/fgca/parse-canonical.js';
+import { validateActivities } from '@transitrix/diagrams/activities/validate.js';
+import { validateActivityCard } from '@transitrix/diagrams/activity-card/validate.js';
+import { validateProcessBlueprint } from '@transitrix/diagrams/process-blueprint/validate.js';
+import { validateNestedBlocks } from '@transitrix/diagrams/blocks/validate.js';
+import { validateApplicationsCatalogue } from '@transitrix/diagrams/applications/validate.js';
+import { validateCapabilityMap } from '@transitrix/diagrams/capability-map/validate.js';
+import { validateProductsCatalogue } from '@transitrix/diagrams/products/validate.js';
+import { validateScenario } from '@transitrix/diagrams/scenarios/validate.js';
+import { validateProcessMap } from '@transitrix/diagrams/process-map/validate.js';
 
 /** The shape every notation validator returns: code/message findings split into
  *  blocking errors and advisory warnings. The concrete result types carry extra

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -7,6 +7,5 @@
     "sourceMap": true
   },
   "include": ["src/**/*.ts"],
-  "_comment_export_compliance": "src/export-compliance.ts, src/repo-validate.ts and src/validate-notation.ts are excluded here: they import @transitrix/diagrams source, which cannot be emitted under rootDir:src. They are type-checked by `npm run compile` and loaded by cli.ts via a runtime dynamic import (tsx transpiles them).",
-  "exclude": ["extension", "src/export-compliance.ts", "src/repo-validate.ts", "src/validate-notation.ts"]
+  "exclude": ["extension"]
 }


### PR DESCRIPTION
## Summary

- Add subpath `exports` to `packages/diagrams/package.json` (`.`, `./*.js`, `./*` patterns covering root, file, and directory forms) so consumers can import via the package name instead of deep source paths
- Replace all 65 deep relative imports (`../../packages/diagrams/src/…` in `extension/src/`, `../packages/diagrams/src/…` in `src/`) with `@transitrix/diagrams/<subpath>` package imports across 28 files
- Convert three computed-string dynamic import workarounds in `src/cli.ts` (`repo-validate.js`, `validate-notation.js`, `export-compliance.js`) to static imports at the top of the file — those workarounds existed only because the modules used cross-rootDir relative imports
- Remove `src/export-compliance.ts`, `src/repo-validate.ts`, and `src/validate-notation.ts` from `tsconfig.build.json`'s `exclude` list and drop the stale `_comment_export_compliance` key — all three now use package imports, so tsc can include them under `rootDir:src` without crossing directory boundaries
- Add `build:diagrams` script (`npm --workspace packages/diagrams run build`) and wire it as a prerequisite of `build` and `compile` so `dist/` is always fresh before type-checking or emitting

## Test plan

- [x] `npm run build` — builds `packages/diagrams` first, then emits root `dist/`; both clean
- [x] `npm run compile` — full type-check passes (no TS errors)
- [x] `npm run compile:extension` — extension type-check passes (pre-existing `@resvg/resvg-js` error unrelated to this PR)
- [x] `npm test` — 358 core tests + 921 diagrams tests all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)