### PR TITLE
refactor(diagrams,extension): single host-neutral diagram-meta reader (review E)

### DIFF
--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -1,38 +1,17 @@
 import type { ThemeId } from '@transitrix/diagrams/theme';
 import { generateWebviewCss, generateSvgEmbedCss } from '@transitrix/diagrams/theme';
 import { CONTROLS_PANEL_CSS, SNAPSHOT_TOOLBAR_CSS } from './preview-controls.js';
-import { escXml } from '@transitrix/diagrams/webview/render-util.js';
+import { escXml, extractDiagramMeta } from '@transitrix/diagrams/webview/render-util.js';
 
 export type { ThemeId };
 
 /** Command ID for the "Theme…" toolbar button — opens a QuickPick to change the global diagram theme. */
 export const OPEN_THEME_COMMAND = 'transitrixStudio.changeTheme';
 
-/**
- * Extracts standard diagram-level metadata from a raw parsed YAML object.
- *
- * Per CONTRACT §1.1, every notation stores its canonical metadata at the root level:
- *   name:         "Human-readable diagram title"  # required
- *   generated_at: "YYYY-MM-DD"                    # optional
- *
- * Backward-compat reads: `title` (legacy alias for `name`), `date` (legacy alias
- * for `generated_at`), and `description`/`version` which are not in the standard
- * but widely present in existing files.
- */
-export function extractDiagramMeta(raw: Record<string, unknown>): {
-  title: string | undefined;
-  subtitle: string | undefined;
-  date: string | undefined;
-  version: string | undefined;
-} {
-  const name = typeof raw['name'] === 'string' ? raw['name'] : undefined;
-  const title = name ?? (typeof raw['title'] === 'string' ? raw['title'] : undefined);
-  const subtitle = typeof raw['description'] === 'string' ? raw['description'] : undefined;
-  const genAt = typeof raw['generated_at'] === 'string' ? raw['generated_at'] : undefined;
-  const date = genAt ?? (typeof raw['date'] === 'string' ? raw['date'] : undefined);
-  const version = raw['version'] !== undefined ? String(raw['version']) : undefined;
-  return { title, subtitle, date, version };
-}
+// Diagram-level metadata reading now lives host-neutrally in @transitrix/diagrams
+// (review E) so the VS Code chrome and the webview bundle share one reader.
+// Re-exported here so the *-preview.ts callers keep their existing import site.
+export { extractDiagramMeta };
 
 /**
  * Injects a <style> block with all --ts-* CSS variable definitions into an SVG string,

--- a/packages/diagrams/src/webview/__tests__/render-util.test.ts
+++ b/packages/diagrams/src/webview/__tests__/render-util.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for the host-neutral metadata reader shared by the VS Code preview
+ * chrome and the IntelliJ JCEF webview bundle (review E — single metadata
+ * reader). Locks the CONTRACT §1.1 precedence: `name` over legacy `title`, and
+ * `generated_at` over legacy `date`.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { escHtml, escXml, extractDiagramMeta } from '../render-util.js';
+
+describe('escXml / escHtml', () => {
+  it('escapes XML-significant characters and aliases escHtml', () => {
+    expect(escXml('a & b < c > d "e"')).toBe('a &amp; b &lt; c &gt; d &quot;e&quot;');
+    expect(escHtml).toBe(escXml);
+  });
+});
+
+describe('extractDiagramMeta', () => {
+  it('reads canonical name/generated_at and version/description', () => {
+    expect(
+      extractDiagramMeta({
+        name: 'Quarterly goals',
+        description: 'Q3 plan',
+        generated_at: '2026-06-22',
+        version: 3,
+      }),
+    ).toEqual({
+      title: 'Quarterly goals',
+      subtitle: 'Q3 plan',
+      date: '2026-06-22',
+      version: '3',
+    });
+  });
+
+  it('prefers name over legacy title and generated_at over legacy date', () => {
+    expect(
+      extractDiagramMeta({
+        name: 'Canonical',
+        title: 'Legacy title',
+        generated_at: '2026-01-01',
+        date: '2020-12-31',
+      }),
+    ).toMatchObject({ title: 'Canonical', date: '2026-01-01' });
+  });
+
+  it('falls back to legacy title/date when canonical keys are absent', () => {
+    expect(
+      extractDiagramMeta({ title: 'Legacy title', date: '2020-12-31' }),
+    ).toMatchObject({ title: 'Legacy title', date: '2020-12-31' });
+  });
+
+  it('returns all-undefined for non-object input', () => {
+    expect(extractDiagramMeta(null)).toEqual({
+      title: undefined,
+      subtitle: undefined,
+      date: undefined,
+      version: undefined,
+    });
+    expect(extractDiagramMeta('not a doc')).toEqual({
+      title: undefined,
+      subtitle: undefined,
+      date: undefined,
+      version: undefined,
+    });
+  });
+});

--- a/packages/diagrams/src/webview/render-util.ts
+++ b/packages/diagrams/src/webview/render-util.ts
@@ -16,19 +16,32 @@ export function escXml(s: string): string {
 /** Same encoding as `escXml`; aliased so HTML-table renderers read clearly. */
 export const escHtml = escXml;
 
-/** Pull common frontmatter for the optional preview heading. */
-export function readDocHeader(doc: unknown): {
-  title?: string;
-  subtitle?: string;
-  version?: string;
-  date?: string;
+/**
+ * Extracts standard diagram-level metadata from a raw parsed YAML document.
+ *
+ * Per CONTRACT §1.1, every notation stores its canonical metadata at the root level:
+ *   name:         "Human-readable diagram title"  # required
+ *   generated_at: "YYYY-MM-DD"                    # optional
+ *
+ * Backward-compat reads: `title` (legacy alias for `name`), `date` (legacy alias
+ * for `generated_at`), and `description`/`version` which are not in the standard
+ * but widely present in existing files.
+ *
+ * Host-neutral so both the VS Code preview chrome and the webview bundle share a
+ * single metadata reader (review E). Accepts `unknown` and guards internally.
+ */
+export function extractDiagramMeta(doc: unknown): {
+  title: string | undefined;
+  subtitle: string | undefined;
+  date: string | undefined;
+  version: string | undefined;
 } {
-  if (!doc || typeof doc !== 'object') return {};
-  const raw = doc as Record<string, unknown>;
-  const out: { title?: string; subtitle?: string; version?: string; date?: string } = {};
-  if (typeof raw['title'] === 'string') out.title = raw['title'];
-  if (typeof raw['description'] === 'string') out.subtitle = raw['description'];
-  if (raw['version'] !== undefined) out.version = String(raw['version']);
-  if (typeof raw['date'] === 'string') out.date = raw['date'];
-  return out;
+  const raw = (doc && typeof doc === 'object' ? doc : {}) as Record<string, unknown>;
+  const name = typeof raw['name'] === 'string' ? raw['name'] : undefined;
+  const title = name ?? (typeof raw['title'] === 'string' ? raw['title'] : undefined);
+  const subtitle = typeof raw['description'] === 'string' ? raw['description'] : undefined;
+  const genAt = typeof raw['generated_at'] === 'string' ? raw['generated_at'] : undefined;
+  const date = genAt ?? (typeof raw['date'] === 'string' ? raw['date'] : undefined);
+  const version = raw['version'] !== undefined ? String(raw['version']) : undefined;
+  return { title, subtitle, date, version };
 }


### PR DESCRIPTION
## Summary

First slice of review-E ("unify metadata reading"). The repo had two near-duplicate diagram-frontmatter readers:

- `extractDiagramMeta` (extension, `diagram-frame.ts`) — the richer one: honours CONTRACT 1.1 canonical keys (`name` for title, `generated_at` for date) with legacy `title`/`date` as fallbacks.
- `readDocHeader` (package, `webview/render-util.ts`) — read only the legacy keys and had **no callers** (dead export).

This promotes the richer reader into `@transitrix/diagrams/webview/render-util.ts` as a host-neutral `extractDiagramMeta(doc: unknown)`, so the VS Code chrome and the JCEF webview bundle share one reader, and drops the dead `readDocHeader`. `diagram-frame.ts` re-exports it, so the five `*-preview.ts` call sites keep their existing import unchanged.

**No behaviour change** — the extension previews already used the richer reader; this only removes the duplicate and gives it a host-neutral home.

## Test plan

- [x] `npm run compile` (package) + `npm run compile:extension` — clean
- [x] `npm run test:diagrams` — 926 passed (incl. 5 new `render-util` tests locking name>title / generated_at>date precedence + non-object guard)
- [x] root `vitest run` — 373 passed
- [x] no lint errors on touched files
