### PR TITLE
perf(compiler): cache .transitrixrc per process with mtime invalidation (review nit 4)

### DIFF
--- a/src/transitrixrc.ts
+++ b/src/transitrixrc.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs'
+import { readFileSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import { createRequire } from 'node:module'
 
@@ -72,9 +72,35 @@ function loadRcFile(rcPath: string, fileLabel: string): TransitrixrcConfig {
   }
 }
 
+interface RcCacheEntry {
+  mtimeMs: number
+  size: number
+  config: TransitrixrcConfig
+}
+
+/**
+ * Process-level cache keyed by the resolved `.transitrixrc` path. The compiler
+ * reads the config on every `compileTransitrixYamlWithLayout` call, so batch
+ * compiles (repo-validate over a whole tree, serve-ui, metrics regression) and
+ * the VS Code extension would otherwise re-read + JSON.parse + AJV-validate the
+ * same file hundreds of times. Cache hits are gated on the file's mtime+size so
+ * an edit in a long-lived host (the extension) is still picked up immediately.
+ */
+const rcCache = new Map<string, RcCacheEntry>()
+
+/**
+ * Drop the cached configs. Exported for tests, which write the same
+ * `.transitrixrc` path repeatedly and must not be subject to coarse filesystem
+ * mtime resolution.
+ */
+export function clearTransitrixrcCache(): void {
+  rcCache.clear()
+}
+
 /**
  * Load and parse the project config from `.transitrixrc` in the given
- * directory. Returns an empty config when the file is absent.
+ * directory. Returns an empty config when the file is absent. Results are
+ * cached per process and invalidated when the file's mtime or size changes.
  *
  * @param startPath Directory to search (default: current working directory)
  * @returns Validated config, or empty config if no file is found
@@ -82,10 +108,23 @@ function loadRcFile(rcPath: string, fileLabel: string): TransitrixrcConfig {
  */
 export function loadTransitrixrc(startPath: string = process.cwd()): TransitrixrcConfig {
   const transitrixPath = join(startPath, TRANSITRIXRC_FILE)
-  if (existsSync(transitrixPath)) {
-    return loadRcFile(transitrixPath, TRANSITRIXRC_FILE)
+  let stat: ReturnType<typeof statSync>
+  try {
+    stat = statSync(transitrixPath)
+  } catch {
+    // Absent (or unreadable) — behave as "no config" and forget any prior entry.
+    rcCache.delete(transitrixPath)
+    return {}
   }
-  return {}
+  const cached = rcCache.get(transitrixPath)
+  if (cached && cached.mtimeMs === stat.mtimeMs && cached.size === stat.size) {
+    return cached.config
+  }
+  // Parse/validate errors propagate without being cached, so they keep
+  // surfacing on every call until the file is fixed.
+  const config = loadRcFile(transitrixPath, TRANSITRIXRC_FILE)
+  rcCache.set(transitrixPath, { mtimeMs: stat.mtimeMs, size: stat.size, config })
+  return config
 }
 
 /**

--- a/tests/transitrixrc.test.ts
+++ b/tests/transitrixrc.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import {
   loadCervinrc,
   loadTransitrixrc,
+  clearTransitrixrcCache,
   assertNoCriticalRuleDowngrade,
   mergeConfigWithDefaults,
 } from '../src/transitrixrc.js'
@@ -13,6 +14,7 @@ describe('transitrixrc config loader', () => {
   const testDir = '/tmp/transitrixrc-loader-test'
 
   beforeEach(() => {
+    clearTransitrixrcCache()
     mkdirSync(testDir, { recursive: true })
   })
 
@@ -218,6 +220,7 @@ describe('loadTransitrixrc (Cervin deprecation P7)', () => {
   const testDir = '/tmp/transitrixrc-test'
 
   beforeEach(() => {
+    clearTransitrixrcCache()
     mkdirSync(testDir, { recursive: true })
   })
 
@@ -247,5 +250,30 @@ describe('loadTransitrixrc (Cervin deprecation P7)', () => {
   it('loadCervinrc is an alias that still resolves .transitrixrc', () => {
     writeFileSync(join(testDir, '.transitrixrc'), JSON.stringify({ rules: { 'AP-001': 'off' } }))
     expect(loadCervinrc(testDir).rules).toEqual({ 'AP-001': 'off' })
+  })
+
+  it('caches an unchanged file (same instance on repeat reads)', () => {
+    writeFileSync(join(testDir, '.transitrixrc'), JSON.stringify({ rules: { 'AP-001': 'off' } }))
+    const first = loadTransitrixrc(testDir)
+    const second = loadTransitrixrc(testDir)
+    expect(second).toBe(first)
+  })
+
+  it('re-reads when the file content changes', () => {
+    const rcPath = join(testDir, '.transitrixrc')
+    writeFileSync(rcPath, JSON.stringify({ rules: { 'AP-001': 'off' } }))
+    expect(loadTransitrixrc(testDir).rules).toEqual({ 'AP-001': 'off' })
+    // A different-sized payload invalidates the cache even at coarse mtime
+    // resolution.
+    writeFileSync(rcPath, JSON.stringify({ rules: { 'AP-001': 'warn', 'AP-002': 'off' } }))
+    expect(loadTransitrixrc(testDir).rules).toEqual({ 'AP-001': 'warn', 'AP-002': 'off' })
+  })
+
+  it('forgets the cached config once the file is removed', () => {
+    const rcPath = join(testDir, '.transitrixrc')
+    writeFileSync(rcPath, JSON.stringify({ rules: { 'AP-001': 'off' } }))
+    expect(loadTransitrixrc(testDir).rules).toEqual({ 'AP-001': 'off' })
+    rmSync(rcPath)
+    expect(loadTransitrixrc(testDir)).toEqual({})
   })
 })


### PR DESCRIPTION
## Summary

Review nit 4 — cache `.transitrixrc` per process on the compiler hot path.

`compileTransitrixYamlWithLayout` calls `loadTransitrixrc()` on every compile, re-reading + `JSON.parse` + AJV-validating the same file each time. Batch compiles (repo-validate over a whole tree, serve-ui, metrics regression) and the VS Code extension's preview re-renders pay this cost repeatedly.

- Process-level cache in `transitrixrc.ts`, keyed by the resolved rc path.
- Cache hits gated on file **mtime + size** (one `statSync` replaces `existsSync`), so an edit in a long-lived host (the extension) is picked up immediately — **no stale config**.
- Parse/validate errors are never cached (a broken file keeps surfacing its error every call); a removed file drops the entry and reverts to empty config.
- Exported `clearTransitrixrcCache()` for deterministic tests.

## Test plan

- [x] `npm run compile` (build:diagrams + root `tsc --noEmit`) — clean
- [x] `tests/transitrixrc.test.ts` — 20 passed (3 new: cache-hit identity, content-change re-read, file-removal invalidation)
- [x] root `vitest run` — 376 passed
- [x] no lint errors on touched files
