### PR TITLE
fix(extension): drop broad https: from BPMN preview connect-src CSP (review nit 5)

### DIFF
--- a/extension/src/preview.ts
+++ b/extension/src/preview.ts
@@ -181,7 +181,7 @@ export class CervinPreview {
 <head>
   <meta charset="UTF-8" />
   <meta http-equiv="Content-Security-Policy"
-    content="default-src 'none'; style-src ${cspSource} 'unsafe-inline'; script-src ${cspSource}; font-src ${cspSource}; img-src ${cspSource} blob: data:; connect-src ${cspSource} https:;">
+    content="default-src 'none'; style-src ${cspSource} 'unsafe-inline'; script-src ${cspSource}; font-src ${cspSource}; img-src ${cspSource} blob: data:; connect-src ${cspSource};">
   <link rel="stylesheet" href="${cssDiagram}" />
   <link rel="stylesheet" href="${cssBpmn}" />
   <style>


### PR DESCRIPTION
## Summary

Review nit 5 — tighten the BPMN preview webview CSP.

`connect-src ${cspSource} https:` allowed fetch/XHR/WebSocket to **any** https origin. The preview makes no network requests:

- `viewer.js` (bpmn-js bundle), `diagram-js.css`, `bpmn-js.css` all load from the extension media (`${cspSource}`).
- The compiled BPMN XML arrives via `postMessage` and renders in-memory.
- PNG export goes through a `<canvas>`, not the network.

`viewer.ts` has no `fetch`/`XMLHttpRequest`/`WebSocket`/`EventSource`/remote-URL usage. So the `https:` allowance is dead breadth — narrowed `connect-src` to `${cspSource}` only.

## Test plan

- [x] `npm run compile:extension` — clean
- [x] No CSP regression tests exist; change is a one-line directive narrowing, verified by type-check. No outbound connections exist to break.
