### PR TITLE
docs(adr): accept bpmn-core (workspace-only) + propose custom process renderer

### DIFF
--- a/docs/decisions/2026-06-22-bpmn-core-package-home.md
+++ b/docs/decisions/2026-06-22-bpmn-core-package-home.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 date: 2026-06-22
 scope: transitrix-studio
 supersedes: none
@@ -67,13 +67,22 @@ does not over-promise.
 
 ## Decision
 
-**This ADR records direction only — no code moves here. Status is `proposed`;
-Valerii gates the move and its release timing.**
+**Accepted. This ADR records direction only — no code moves here. Valerii gates
+the move's execution and its release timing.**
 
-Adopt a **dedicated workspace package `@transitrix/bpmn-core`** (under
+Adopt a **dedicated, workspace-only package `@transitrix/bpmn-core`** (under
 `packages/bpmn-core/`) as the home for the BPMN compile/layout/emit/validate
 core, mirroring the structure and packaging conventions of
 `@transitrix/diagrams`.
+
+**Workspace-only — not a published library.** Unlike `@transitrix/diagrams`,
+`@transitrix/bpmn-core` is **not published to npm** and is **not versioned as a
+public library**. It exists purely as the in-repo home for the existing
+bpmn.io (bpmn-js) render path and as the **legacy / compatibility layer** for
+scenarios that require full BPMN 2.0 interoperability (e.g. Camunda
+import/export, should adopters ever request it). The primary render path for new
+process diagrams becomes a custom renderer — see
+[`2026-06-22-custom-process-renderer.md`](2026-06-22-custom-process-renderer.md).
 
 Rationale for a *separate* package rather than folding into
 `@transitrix/diagrams`:
@@ -103,10 +112,14 @@ findings) unchanged.
 
 ## Consequences
 
-- A new published-shape package joins the workspace; its version tracks the
-  methodology release like `@transitrix/diagrams` (the `SCHEMA_VERSION` contract
-  in [`../adr/0003-diagrams-schema-version-contract.md`](../adr/0003-diagrams-schema-version-contract.md)
-  may be extended to cover it).
+- A new **workspace-only** package joins the monorepo. It is not published to
+  npm and carries no public-library version contract — the `SCHEMA_VERSION`
+  contract ([`../adr/0003-diagrams-schema-version-contract.md`](../adr/0003-diagrams-schema-version-contract.md))
+  applies to the methodology-notation library, not to this BPMN tooling layer.
+- A custom cross-functional diagram renderer (see ADR
+  [`2026-06-22-custom-process-renderer.md`](2026-06-22-custom-process-renderer.md))
+  becomes the primary render path for new process diagrams. This package is the
+  fallback for full BPMN 2.0 compatibility only.
 - The extension gains a type-checked dependency on the core: breaking changes
   fail at build time instead of in the installed VSIX.
 - The packaging script still installs runtime deps into `extension/node_modules/`;

--- a/docs/decisions/2026-06-22-custom-process-renderer.md
+++ b/docs/decisions/2026-06-22-custom-process-renderer.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 date: 2026-06-22
 scope: transitrix-studio
 supersedes: none
@@ -33,28 +33,87 @@ In practice the vast majority of users draw a small subset of BPMN — swimlanes
 tasks, gateways, sequence flows, start/end events. Full BPMN 2.0 breadth
 (every event sub-type, choreography, conversation, etc.) is rarely used.
 
+A key observation that shaped the decision below: **the hard part is already
+ours.** `src/layout.ts` is a custom two-phase layout engine (ELK.js for global
+X-ordering, then bespoke Y-placement, lane bounds, and orthogonal sequence-flow
+routing) producing a fully-resolved `LayoutIr` with absolute geometry. bpmn.io is
+used essentially as a *viewer* over BPMN XML, not as our layout brain. So a
+"custom renderer" is mostly a new **SVG emitter over the existing geometry**, not
+a new layout engine.
+
 ## Decision
 
-**Status `proposed`. Valerii gates the build start and the release timing.**
+**Status `accepted`.** The build start and release timing remain Valerii-gated;
+this ADR records the design, not a schedule.
 
 Introduce a **custom cross-functional algorithmic diagram renderer** as the
 **primary render path** for process diagrams in Studio. It renders the same
-`*.process.transitrix.yaml` input files through a custom SVG emitter, consistent
+`*.bpmn.transitrix.yaml` input files through a custom SVG emitter, consistent
 with the `@transitrix/diagrams` pattern — giving full SVG control, clean
 packaging, and no dynamic-require constraints. The bpmn.io path is retained in
 `@transitrix/bpmn-core` as a legacy option for full BPMN 2.0 export / interop.
 
-### Supported subset (sufficient for 95%+ of real-world use)
+### Approach — reuse the layout engine, add an emitter (Variant A)
+
+We **reuse the existing ELK-backed layout engine** (`src/layout.ts`, moving with
+the BPMN core into `@transitrix/bpmn-core`) and add **only a new SVG emitter**.
+The emitter consumes the engine's `LayoutIr` (absolute element bounds, lane/pool
+bounds, routed flow waypoints) and emits SVG the same way every other
+`@transitrix/diagrams` notation does. No second layout engine is introduced.
+
+### Package boundaries (resolves the prior open question)
+
+- **`@transitrix/bpmn-core`** — owns the model (IR, parser, validator), the
+  ELK-backed **layout engine**, BPMN-XML emit, and the legacy bpmn.io render path.
+  Workspace-only package; no public-library version contract.
+- **`@transitrix/diagrams`** — owns the **SVG emitter** for the process diagram,
+  alongside the other custom-notation emitters, reusing the shared theme + single-
+  emitter conventions. It depends on `@transitrix/bpmn-core` for geometry only.
+
+### Styling is centralized (visual unity)
+
+There is **one source of truth for process-diagram styling**, living in the
+shared theme of `@transitrix/diagrams` (the theme CSS + per-notation CSS consumed
+by the single emitter), exactly like every other notation. Consequences:
+
+- No per-host (VS Code / IntelliJ / UI) and no per-path (custom vs legacy bpmn.io)
+  style forks — the emitter is the only place that decides geometry-to-style.
+- The no-italic rule, spacing, colours, edge markers, and title block come from
+  the shared theme, not inline ad-hoc styles.
+- This continues the review-C ("single emitter per notation") and review-E1
+  ("single metadata reader") direction: one reader, one emitter, one theme.
+
+### Supported subset (v1)
+
+All of the following are **required in the first version**:
 
 - Swimlanes (pools + lanes)
 - Tasks / sub-processes
 - Sequence flows (including conditional)
-- Gateways: XOR, AND, Inclusive
-- Start and End events; intermediate Message and Timer events (optional — can be
-  phased in)
-- Data objects (optional)
+- Gateways: XOR, AND, **Inclusive**
+- Start and End events; **intermediate Message and Timer events**
+- **Data objects** (with their `association` connections)
 
-### Motivation
+The last three lines extend the current model and therefore require **additive,
+backward-compatible** work across `@transitrix/bpmn-core` before the emitter can
+draw them:
+
+- IR: new element types (inclusive gateway, intermediate message/timer event,
+  data object) and a new **association** edge kind (data objects connect via
+  dotted associations, not sequence flows).
+- Parser + validator: accept and validate the new types/edges.
+- BPMN-XML emit + layout sizing/routing: size the new nodes and route
+  associations (so the legacy path and export stay in sync).
+
+Existing `*.bpmn.transitrix.yaml` files keep rendering identically — the new
+types are purely additive.
+
+### Interactivity
+
+Zoom / pan parity with the other notations (the shared preview controls). No
+bpmn-js-specific interactions are carried over for v1.
+
+## Motivation
 
 - **Full SVG / PNG control** — consistent with all other notation renderers.
 - **Unblocks CV-3** (compliance blueprint lane overlay) without bpmn-js
@@ -64,32 +123,25 @@ packaging, and no dynamic-require constraints. The bpmn.io path is retained in
 - **Consistent with the `@transitrix/diagrams` rendering pattern** — one
   layout-engine + single-emitter shape across every notation.
 
-### What this does NOT change
+## What this does NOT change
 
-- **Input file format** (`*.process.transitrix.yaml`) — unchanged. The renderer
-  is a new presentation over the existing model, not a new authoring format.
+- **Input file format** (`*.bpmn.transitrix.yaml`) — unchanged for existing
+  files. The renderer is a new presentation over the existing model; the v1
+  subset adds new optional element/edge types additively, never breaking files
+  that don't use them.
 - **The existing bpmn.io render path** — stays in `@transitrix/bpmn-core` as the
   legacy / full-BPMN-2.0-export option.
-
-## Open question (for the implementation PR)
-
-Where the custom renderer lives:
-
-- in **`@transitrix/diagrams`** — alongside the other custom notations, reusing
-  the shared layout + single-emitter conventions; or
-- in **`@transitrix/bpmn-core`** — co-located with the legacy bpmn.io path so all
-  process-diagram rendering sits in one package.
-
-Recorded as an open question; Valerii decides when the build starts.
 
 ## Consequences
 
 - New process diagrams render through a Studio-owned emitter; the design rules
-  (no italic, spacing, edge markers, title block) are enforced in one place,
-  like every other notation.
+  (no italic, spacing, edge markers, title block) are enforced in one place via
+  the shared theme, like every other notation.
 - The bpmn.io dependency moves off the primary path and onto the explicit
   legacy / export path in `@transitrix/bpmn-core`, simplifying the default
   packaging story.
 - CV-3 and future compliance overlays draw on a renderer we control end to end.
+- The v1 subset requires additive model work (new element types + association
+  edges) in `@transitrix/bpmn-core` before the emitter is feature-complete.
 - Until the custom renderer reaches subset parity, the bpmn.io path remains the
   active render path — this is a phased replacement, not a big-bang switch.

--- a/docs/decisions/2026-06-22-custom-process-renderer.md
+++ b/docs/decisions/2026-06-22-custom-process-renderer.md
@@ -1,0 +1,95 @@
+---
+status: proposed
+date: 2026-06-22
+scope: transitrix-studio
+supersedes: none
+superseded_by: none
+tags: [bpmn, process, renderer, svg, diagrams, packaging, compliance, cv-3]
+---
+
+# A custom cross-functional process-diagram renderer
+
+## Context
+
+Every Transitrix custom notation (`@transitrix/diagrams`) produces its SVG via a
+custom layout engine + SVG emitter that the project fully controls — and, after
+the review-C work, a *single* emitter per notation shared across hosts. The BPMN
+process diagram is the one exception: it renders through **bpmn.io (bpmn-js /
+bpmn-moddle)**, an external library. That exception costs us in three places:
+
+- **SVG output control.** bpmn-js owns its own rendering; we cannot freely
+  shape the SVG the way every other notation's emitter lets us (theme classes,
+  title block, edge markers, no-italic rule, spacing).
+- **Packaging.** The BPMN path pulls `bpmn-moddle` and `ajv`, which use dynamic
+  `require` patterns esbuild cannot cleanly inline. That is exactly why the
+  extension ships the compiler as a bundled `extension/compiler/*.js` loaded by a
+  runtime path-based `import()`, with the deps installed separately into
+  `extension/node_modules/` (see
+  [`2026-06-22-bpmn-core-package-home.md`](2026-06-22-bpmn-core-package-home.md)).
+- **Compliance overlay.** The CV-3 compliance blueprint lane overlay work is
+  constrained by what bpmn-js will let us draw on top of its rendering.
+
+In practice the vast majority of users draw a small subset of BPMN — swimlanes,
+tasks, gateways, sequence flows, start/end events. Full BPMN 2.0 breadth
+(every event sub-type, choreography, conversation, etc.) is rarely used.
+
+## Decision
+
+**Status `proposed`. Valerii gates the build start and the release timing.**
+
+Introduce a **custom cross-functional algorithmic diagram renderer** as the
+**primary render path** for process diagrams in Studio. It renders the same
+`*.process.transitrix.yaml` input files through a custom SVG emitter, consistent
+with the `@transitrix/diagrams` pattern — giving full SVG control, clean
+packaging, and no dynamic-require constraints. The bpmn.io path is retained in
+`@transitrix/bpmn-core` as a legacy option for full BPMN 2.0 export / interop.
+
+### Supported subset (sufficient for 95%+ of real-world use)
+
+- Swimlanes (pools + lanes)
+- Tasks / sub-processes
+- Sequence flows (including conditional)
+- Gateways: XOR, AND, Inclusive
+- Start and End events; intermediate Message and Timer events (optional — can be
+  phased in)
+- Data objects (optional)
+
+### Motivation
+
+- **Full SVG / PNG control** — consistent with all other notation renderers.
+- **Unblocks CV-3** (compliance blueprint lane overlay) without bpmn-js
+  constraints.
+- **Removes `bpmn-moddle` / `ajv` from the hot packaging path** — the primary
+  render path no longer drags the dynamic-require deps into the bundle.
+- **Consistent with the `@transitrix/diagrams` rendering pattern** — one
+  layout-engine + single-emitter shape across every notation.
+
+### What this does NOT change
+
+- **Input file format** (`*.process.transitrix.yaml`) — unchanged. The renderer
+  is a new presentation over the existing model, not a new authoring format.
+- **The existing bpmn.io render path** — stays in `@transitrix/bpmn-core` as the
+  legacy / full-BPMN-2.0-export option.
+
+## Open question (for the implementation PR)
+
+Where the custom renderer lives:
+
+- in **`@transitrix/diagrams`** — alongside the other custom notations, reusing
+  the shared layout + single-emitter conventions; or
+- in **`@transitrix/bpmn-core`** — co-located with the legacy bpmn.io path so all
+  process-diagram rendering sits in one package.
+
+Recorded as an open question; Valerii decides when the build starts.
+
+## Consequences
+
+- New process diagrams render through a Studio-owned emitter; the design rules
+  (no italic, spacing, edge markers, title block) are enforced in one place,
+  like every other notation.
+- The bpmn.io dependency moves off the primary path and onto the explicit
+  legacy / export path in `@transitrix/bpmn-core`, simplifying the default
+  packaging story.
+- CV-3 and future compliance overlays draw on a renderer we control end to end.
+- Until the custom renderer reaches subset parity, the bpmn.io path remains the
+  active render path — this is a phased replacement, not a big-bang switch.

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -17,4 +17,4 @@ implementation PRs follow) · **superseded** (replaced by a later ADR).
 | 2026-06-11 | [Validation runtime convergence (Studio side)](2026-06-11-validation-runtime-convergence.md) | accepted | transitrix-studio |
 | 2026-06-14 | [Migrate CLI: recipe-source transport](2026-06-14-migrate-recipe-source.md) | accepted | hub #201 |
 | 2026-06-22 | [A package home for the BPMN core](2026-06-22-bpmn-core-package-home.md) | accepted | transitrix-studio |
-| 2026-06-22 | [A custom cross-functional process-diagram renderer](2026-06-22-custom-process-renderer.md) | proposed | transitrix-studio |
+| 2026-06-22 | [A custom cross-functional process-diagram renderer](2026-06-22-custom-process-renderer.md) | accepted | transitrix-studio |

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -16,4 +16,5 @@ implementation PRs follow) · **superseded** (replaced by a later ADR).
 |---|---|---|---|
 | 2026-06-11 | [Validation runtime convergence (Studio side)](2026-06-11-validation-runtime-convergence.md) | accepted | transitrix-studio |
 | 2026-06-14 | [Migrate CLI: recipe-source transport](2026-06-14-migrate-recipe-source.md) | accepted | hub #201 |
-| 2026-06-22 | [A package home for the BPMN core](2026-06-22-bpmn-core-package-home.md) | proposed | transitrix-studio |
+| 2026-06-22 | [A package home for the BPMN core](2026-06-22-bpmn-core-package-home.md) | accepted | transitrix-studio |
+| 2026-06-22 | [A custom cross-functional process-diagram renderer](2026-06-22-custom-process-renderer.md) | proposed | transitrix-studio |


### PR DESCRIPTION
## Summary

Acts on the orchestrator decision relayed 2026-06-22 (two coupled ADR changes). Follows the now-merged ADR #269.

**1. Accept the BPMN-core ADR with workspace-only scope** (`2026-06-22-bpmn-core-package-home.md`):
- `status: proposed` → `accepted`.
- `@transitrix/bpmn-core` scoped as a **workspace-only** package — not published to npm, no public-library version contract. It is the home for the existing bpmn.io render path and the legacy / full-BPMN-2.0-interop layer.
- Dropped the `SCHEMA_VERSION`-contract consequence (that contract is for the methodology-notation library, not the BPMN tooling layer); added a consequence pointing at the new custom renderer as the primary path.

**2. New ADR — custom cross-functional process renderer** (`2026-06-22-custom-process-renderer.md`, status `proposed`):
- A Studio-owned custom SVG renderer becomes the **primary** render path for process diagrams, emitting from the unchanged `*.process.transitrix.yaml` input in the `@transitrix/diagrams` pattern; bpmn.io stays as the legacy/export path.
- Records the supported BPMN subset (swimlanes, tasks, sequence flows, XOR/AND/Inclusive gateways, start/end + optional intermediate events, optional data objects), the motivation (SVG control, CV-3 unblock, packaging — drops `bpmn-moddle`/`ajv` from the hot path), what does not change, and the **open question** of which package hosts the renderer.

INDEX updated: bpmn-core row → accepted; custom-renderer row added.

## Test plan

- [x] Docs-only (`docs/decisions/`); no code/tests affected.
