### PR TITLE
feat(bpmn): inclusive gateway + intermediate message/timer events (process renderer P0a)

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -406,9 +406,9 @@ Semantic validation for BPMN 2.0 sequence flow constraints, including routing re
 
 ### SF-005: Condition expressions only on Activity or XOR gateway outgoing flows (RD-104)
 - **Severity**: error
-- **Description**: Sequence flows with condition expressions are only allowed when sourced from Activity elements (tasks: task, userTask, serviceTask) or XOR (exclusive) gateways. Conditions on flows from other element types (events, parallel/inclusive gateways, etc.) are not evaluated and indicate a modeling error.
-- **BPMN Rule**: Per BPMN 2.0 specification, conditions are evaluated at split points (XOR gateways and activities with outgoing conditional flows).
-- **Implementation**: For each flow with a condition expression, checks that the source element type is one of: `task`, `userTask`, `serviceTask`, `exclusiveGateway`.
+- **Description**: Sequence flows with condition expressions are only allowed when sourced from Activity elements (tasks: task, userTask, serviceTask) or XOR (exclusive) / inclusive gateways. Conditions on flows from other element types (events, parallel gateways, etc.) are not evaluated and indicate a modeling error.
+- **BPMN Rule**: Per BPMN 2.0 specification, conditions are evaluated at split points (XOR/inclusive gateways and activities with outgoing conditional flows).
+- **Implementation**: For each flow with a condition expression, checks that the source element type is one of: `task`, `userTask`, `serviceTask`, `exclusiveGateway`, `inclusiveGateway`.
 - **Remediation**: Either (a) remove the condition expression from the flow, or (b) ensure the flow originates from an Activity or XOR gateway.
 - **Example Finding**:
   ```json
@@ -423,9 +423,9 @@ Semantic validation for BPMN 2.0 sequence flow constraints, including routing re
 
 ### SF-006: Default flow marker only on Activity or XOR gateway outgoing flows (RD-104)
 - **Severity**: error
-- **Description**: The default flow marker (the flow that routes tokens when no conditions match) is only valid on flows sourced from Activity elements or XOR gateways. Other element types do not have conditional branching semantics.
-- **BPMN Rule**: Per BPMN 2.0, the default attribute is evaluated at split points (XOR gateways and conditional activities).
-- **Implementation**: For each flow marked as default (`flow.default === true`), checks that the source element type is one of: `task`, `userTask`, `serviceTask`, `exclusiveGateway`.
+- **Description**: The default flow marker (the flow that routes tokens when no conditions match) is only valid on flows sourced from Activity elements or XOR / inclusive gateways. Other element types do not have conditional branching semantics.
+- **BPMN Rule**: Per BPMN 2.0, the default attribute is evaluated at split points (XOR/inclusive gateways and conditional activities).
+- **Implementation**: For each flow marked as default (`flow.default === true`), checks that the source element type is one of: `task`, `userTask`, `serviceTask`, `exclusiveGateway`, `inclusiveGateway`.
 - **Remediation**: Remove the default marker from the flow, or move the flow to originate from an Activity or XOR gateway.
 - **Example Finding**:
   ```json
@@ -452,6 +452,27 @@ Semantic validation for BPMN 2.0 sequence flow constraints, including routing re
     "elementId": "flow-conflict",
     "message": "Flow \"flow-conflict\" cannot have both default marker and condition expression",
     "hint": "A flow must be either the default route (default: true) or have a condition, not both"
+  }
+  ```
+
+## Intermediate Event Rules (IE)
+
+Semantic validation for BPMN 2.0 intermediate (catch) events — `intermediateMessageEvent`, `intermediateTimerEvent`.
+
+### IE-001: Intermediate events have incoming and outgoing flows
+- **Severity**: error
+- **Description**: Intermediate catch events sit mid-flow, so they must have at least one incoming and at least one outgoing flow. A missing endpoint strands the token. This is distinct from start events (no incoming) and end events (no outgoing), which are intentionally one-sided.
+- **BPMN Rule**: Per BPMN 2.0, intermediate catch events have exactly one incoming and one outgoing sequence flow in normal (non-boundary) usage.
+- **Implementation**: For each intermediate event, counts incoming and outgoing flows; fails if either is zero.
+- **Remediation**: Connect the intermediate event to both a predecessor and a successor.
+- **Example Finding**:
+  ```json
+  {
+    "ruleId": "IE-001",
+    "severity": "error",
+    "elementId": "wait",
+    "message": "Intermediate event \"Wait\" must have incoming and outgoing flows (no outgoing)",
+    "hint": "Connect a flow from this intermediate event to the next element"
   }
   ```
 

--- a/schemas/bpmn-dsl.schema.json
+++ b/schemas/bpmn-dsl.schema.json
@@ -92,7 +92,10 @@
             "userTask",
             "serviceTask",
             "exclusiveGateway",
-            "parallelGateway"
+            "parallelGateway",
+            "inclusiveGateway",
+            "intermediateMessageEvent",
+            "intermediateTimerEvent"
           ]
         },
         "name": { "type": "string" }
@@ -100,7 +103,16 @@
       "allOf": [
         {
           "if": {
-            "properties": { "type": { "enum": ["startEvent", "endEvent"] } }
+            "properties": {
+              "type": {
+                "enum": [
+                  "startEvent",
+                  "endEvent",
+                  "intermediateMessageEvent",
+                  "intermediateTimerEvent"
+                ]
+              }
+            }
           },
           "then": { "properties": { "name": {} } },
           "else": {

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -1,7 +1,13 @@
 import { create } from 'xmlbuilder2';
 
-import type { FlowElement, LayoutIr } from './ir.js';
+import type { ElementType, FlowElement, LayoutIr } from './ir.js';
 import { transitrixPackageVersion } from './package-version.js';
+
+/** Intermediate catch events emit as `<intermediateCatchEvent>` with a typed event definition child. */
+const INTERMEDIATE_EVENT_DEFINITIONS: Partial<Record<ElementType, string>> = {
+  intermediateMessageEvent: 'messageEventDefinition',
+  intermediateTimerEvent: 'timerEventDefinition',
+};
 
 const BPMN_MODEL = 'http://www.omg.org/spec/BPMN/20100524/MODEL';
 const BPMN_DI = 'http://www.omg.org/spec/BPMN/20100524/DI';
@@ -25,6 +31,11 @@ function appendFlowNode(
   if (el.name) attrs.name = el.name;
   if (defaultFlowMap?.has(el.id)) {
     attrs.default = defaultFlowMap.get(el.id)!;
+  }
+  const eventDefinition = INTERMEDIATE_EVENT_DEFINITIONS[el.type];
+  if (eventDefinition) {
+    parent.ele('intermediateCatchEvent', attrs).ele(eventDefinition);
+    return;
   }
   parent.ele(el.type, attrs);
 }

--- a/src/ir.ts
+++ b/src/ir.ts
@@ -5,9 +5,22 @@ export type ElementType =
   | 'userTask'
   | 'serviceTask'
   | 'exclusiveGateway'
-  | 'parallelGateway';
+  | 'parallelGateway'
+  | 'inclusiveGateway'
+  | 'intermediateMessageEvent'
+  | 'intermediateTimerEvent';
 
-export const GATEWAY_TYPES = new Set(['exclusiveGateway', 'parallelGateway']);
+export const GATEWAY_TYPES = new Set([
+  'exclusiveGateway',
+  'parallelGateway',
+  'inclusiveGateway',
+]);
+
+/** Intermediate catch events render as a circle and route like ordinary mid-flow nodes. */
+export const INTERMEDIATE_EVENT_TYPES = new Set([
+  'intermediateMessageEvent',
+  'intermediateTimerEvent',
+]);
 
 export interface FlowElement {
   id: string;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -158,9 +158,12 @@ export function elkNodeSize(kind: ElementType): Bounds {
   switch (kind) {
     case 'startEvent':
     case 'endEvent':
+    case 'intermediateMessageEvent':
+    case 'intermediateTimerEvent':
       return { x: 0, y: 0, width: 36, height: 36 };
     case 'exclusiveGateway':
     case 'parallelGateway':
+    case 'inclusiveGateway':
       return { x: 0, y: 0, width: 50, height: 50 };
     default:
       return { x: 0, y: 0, width: 100, height: 80 };

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -1,4 +1,5 @@
 import type { ProcessIr } from './ir.js'
+import { INTERMEDIATE_EVENT_TYPES } from './ir.js'
 import type {
   ValidationFinding,
   ValidationReport,
@@ -559,13 +560,13 @@ const rule_SF_005_ConditionSourceRestriction: ValidationRule = {
     for (const flow of ir.flows) {
       if (flow.condition) {
         const sourceEl = elementMap.get(flow.from)
-        if (sourceEl && !['task', 'userTask', 'serviceTask', 'exclusiveGateway'].includes(sourceEl.type)) {
+        if (sourceEl && !['task', 'userTask', 'serviceTask', 'exclusiveGateway', 'inclusiveGateway'].includes(sourceEl.type)) {
           findings.push({
             ruleId: 'SF-005',
             severity: 'error',
             elementId: flow.id,
             message: `Flow "${flow.id}" with condition cannot originate from "${sourceEl.type}"`,
-            hint: 'Condition expressions are only allowed on flows from Activities (task, userTask, serviceTask) or XOR gateways',
+            hint: 'Condition expressions are only allowed on flows from Activities (task, userTask, serviceTask) or XOR/inclusive gateways',
             docUrl: 'docs/validation.md#sf-005',
           })
         }
@@ -591,13 +592,13 @@ const rule_SF_006_DefaultFlowSourceRestriction: ValidationRule = {
     for (const flow of ir.flows) {
       if (flow.default) {
         const sourceEl = elementMap.get(flow.from)
-        if (sourceEl && !['task', 'userTask', 'serviceTask', 'exclusiveGateway'].includes(sourceEl.type)) {
+        if (sourceEl && !['task', 'userTask', 'serviceTask', 'exclusiveGateway', 'inclusiveGateway'].includes(sourceEl.type)) {
           findings.push({
             ruleId: 'SF-006',
             severity: 'error',
             elementId: flow.id,
             message: `Flow "${flow.id}" marked as default cannot originate from "${sourceEl.type}"`,
-            hint: 'Default flow marker is only allowed on flows from Activities (task, userTask, serviceTask) or XOR gateways',
+            hint: 'Default flow marker is only allowed on flows from Activities (task, userTask, serviceTask) or XOR/inclusive gateways',
             docUrl: 'docs/validation.md#sf-006',
           })
         }
@@ -757,6 +758,55 @@ const rule_GW_AND_004_NoConditionsOnParallelSplit: ValidationRule = {
 validator.register(rule_GW_XOR_001_SingleInSingleOutForbidden)
 validator.register(rule_GW_XOR_002_SplitConstraints)
 validator.register(rule_GW_AND_004_NoConditionsOnParallelSplit)
+
+// ============================================================================
+// Intermediate Event Rules (IE-NNN)
+// ============================================================================
+
+/**
+ * IE-001: Intermediate (catch) events must have at least one incoming and one
+ * outgoing flow. They sit mid-flow, so a missing endpoint means the token is
+ * stranded — distinct from start/end events which are intentionally one-sided.
+ */
+const rule_IE_001_IntermediateConnectivity: ValidationRule = {
+  ruleId: 'IE-001',
+  severity: 'error',
+  description: 'Intermediate events must have at least one incoming and one outgoing flow',
+  validate(ir: ProcessIr): ValidationFinding[] {
+    const intermediateEvents = ir.lanes
+      .flatMap((lane) => lane.elements)
+      .filter((el) => INTERMEDIATE_EVENT_TYPES.has(el.type))
+
+    const findings: ValidationFinding[] = []
+    for (const event of intermediateEvents) {
+      const incoming = ir.flows.filter((flow) => flow.to === event.id).length
+      const outgoing = ir.flows.filter((flow) => flow.from === event.id).length
+
+      if (incoming === 0 || outgoing === 0) {
+        const issues: string[] = []
+        if (incoming === 0) issues.push('no incoming')
+        if (outgoing === 0) issues.push('no outgoing')
+        findings.push({
+          ruleId: 'IE-001',
+          severity: 'error',
+          elementId: event.id,
+          message: `Intermediate event "${event.name || event.id}" must have incoming and outgoing flows (${issues.join(', ')})`,
+          hint:
+            incoming === 0 && outgoing === 0
+              ? 'Connect this intermediate event to both a predecessor and successor'
+              : incoming === 0
+                ? 'Connect a flow from the previous element to this intermediate event'
+                : 'Connect a flow from this intermediate event to the next element',
+          docUrl: 'docs/validation.md#ie-001',
+        })
+      }
+    }
+    return findings
+  },
+}
+
+// Register intermediate event rules
+validator.register(rule_IE_001_IntermediateConnectivity)
 
 // ============================================================================
 // Anti-pattern Warning Rules (RD-107 onwards)

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1007,6 +1007,99 @@ process:
   });
 });
 
+describe('extended subset — inclusive gateway + intermediate events (P0a)', () => {
+  const extendedYaml = `
+process:
+  id: extended-subset
+  name: Extended Subset
+  pools:
+    - id: pool1
+      name: Pool 1
+      lanes:
+        - id: lane1
+          name: Lane 1
+          elements:
+            - id: start
+              type: startEvent
+              name: Start
+            - id: split
+              type: inclusiveGateway
+              name: Split
+            - id: taskA
+              type: task
+              name: Task A
+            - id: taskB
+              type: task
+              name: Task B
+            - id: join
+              type: inclusiveGateway
+              name: Join
+            - id: notify
+              type: intermediateMessageEvent
+              name: Await message
+            - id: wait
+              type: intermediateTimerEvent
+              name: Wait
+            - id: end
+              type: endEvent
+              name: End
+  flows:
+    - id: f1
+      from: start
+      to: split
+    - id: f2
+      from: split
+      to: taskA
+      condition: 'needsA'
+    - id: f3
+      from: split
+      to: taskB
+      condition: 'needsB'
+    - id: f4
+      from: taskA
+      to: join
+    - id: f5
+      from: taskB
+      to: join
+    - id: f6
+      from: join
+      to: notify
+    - id: f7
+      from: notify
+      to: wait
+    - id: f8
+      from: wait
+      to: end
+`;
+
+  it('parses inclusive gateways and intermediate events into the IR', () => {
+    const ir = parseYamlToIr(extendedYaml);
+    const byId = new Map(ir.lanes.flatMap((l) => l.elements).map((e) => [e.id, e]));
+    expect(byId.get('split')?.type).toBe('inclusiveGateway');
+    expect(byId.get('notify')?.type).toBe('intermediateMessageEvent');
+    expect(byId.get('wait')?.type).toBe('intermediateTimerEvent');
+  });
+
+  it('emits inclusive gateway and intermediate catch events as valid BPMN 2.0', async () => {
+    const xml = await compileTransitrixYaml(extendedYaml);
+    expect(xml).toContain('inclusiveGateway');
+    expect(xml).toContain('intermediateCatchEvent');
+    expect(xml).toContain('messageEventDefinition');
+    expect(xml).toContain('timerEventDefinition');
+
+    const moddle = new BpmnModdle();
+    const { rootElement, warnings } = await moddle.fromXML(xml, 'bpmn:Definitions');
+    expect(rootElement).toBeDefined();
+    expect(warnings ?? []).toEqual([]);
+  });
+
+  it('allows conditional flows out of an inclusive gateway', async () => {
+    const xml = await compileTransitrixYaml(extendedYaml);
+    expect(xml).toContain('sourceRef="split"');
+    expect(xml).toContain('conditionExpression');
+  });
+});
+
 describe('schema consistency (RD-098)', () => {
   it('bpmn-dsl.schema.json is identical in root and extension directories', () => {
     const rootSchema = readFileSync(join(repoRoot, 'schemas', 'bpmn-dsl.schema.json'), 'utf8');

--- a/tests/validator.test.ts
+++ b/tests/validator.test.ts
@@ -1152,3 +1152,85 @@ describe('Validator', () => {
       expect(report.summary.infoCount).toBe(0)
     })
   })
+
+describe('Extended subset rules (P0a)', () => {
+  test('SF-005 allows condition on flow from inclusive gateway', () => {
+    const ir: ProcessIr = {
+      id: 't', name: 'T', poolId: 'p1', poolName: 'P',
+      lanes: [{
+        id: 'l1', name: 'L',
+        elements: [
+          { id: 's1', name: 'S', type: 'startEvent', poolId: 'p1', laneId: 'l1' },
+          { id: 'ig', name: 'Split', type: 'inclusiveGateway', poolId: 'p1', laneId: 'l1' },
+          { id: 'e1', name: 'E', type: 'endEvent', poolId: 'p1', laneId: 'l1' },
+        ],
+      }],
+      flows: [
+        { id: 'f1', from: 's1', to: 'ig' },
+        { id: 'f2', from: 'ig', to: 'e1', condition: 'needsIt' },
+      ],
+    }
+    const report = validateProcess(ir, { enabledRules: new Set(['SF-005']) })
+    expect(report.findings.filter(f => f.ruleId === 'SF-005')).toHaveLength(0)
+  })
+
+  test('SF-006 allows default flow from inclusive gateway', () => {
+    const ir: ProcessIr = {
+      id: 't', name: 'T', poolId: 'p1', poolName: 'P',
+      lanes: [{
+        id: 'l1', name: 'L',
+        elements: [
+          { id: 's1', name: 'S', type: 'startEvent', poolId: 'p1', laneId: 'l1' },
+          { id: 'ig', name: 'Split', type: 'inclusiveGateway', poolId: 'p1', laneId: 'l1' },
+          { id: 'e1', name: 'E', type: 'endEvent', poolId: 'p1', laneId: 'l1' },
+        ],
+      }],
+      flows: [
+        { id: 'f1', from: 's1', to: 'ig' },
+        { id: 'f2', from: 'ig', to: 'e1', default: true },
+      ],
+    }
+    const report = validateProcess(ir, { enabledRules: new Set(['SF-006']) })
+    expect(report.findings.filter(f => f.ruleId === 'SF-006')).toHaveLength(0)
+  })
+
+  test('IE-001 passes when intermediate event has incoming and outgoing', () => {
+    const ir: ProcessIr = {
+      id: 't', name: 'T', poolId: 'p1', poolName: 'P',
+      lanes: [{
+        id: 'l1', name: 'L',
+        elements: [
+          { id: 's1', name: 'S', type: 'startEvent', poolId: 'p1', laneId: 'l1' },
+          { id: 'm1', name: 'Await', type: 'intermediateMessageEvent', poolId: 'p1', laneId: 'l1' },
+          { id: 'e1', name: 'E', type: 'endEvent', poolId: 'p1', laneId: 'l1' },
+        ],
+      }],
+      flows: [
+        { id: 'f1', from: 's1', to: 'm1' },
+        { id: 'f2', from: 'm1', to: 'e1' },
+      ],
+    }
+    const report = validateProcess(ir, { enabledRules: new Set(['IE-001']) })
+    expect(report.findings.filter(f => f.ruleId === 'IE-001')).toHaveLength(0)
+  })
+
+  test('IE-001 fails when intermediate event has no outgoing', () => {
+    const ir: ProcessIr = {
+      id: 't', name: 'T', poolId: 'p1', poolName: 'P',
+      lanes: [{
+        id: 'l1', name: 'L',
+        elements: [
+          { id: 's1', name: 'S', type: 'startEvent', poolId: 'p1', laneId: 'l1' },
+          { id: 'tm', name: 'Wait', type: 'intermediateTimerEvent', poolId: 'p1', laneId: 'l1' },
+        ],
+      }],
+      flows: [
+        { id: 'f1', from: 's1', to: 'tm' },
+      ],
+    }
+    const report = validateProcess(ir, { enabledRules: new Set(['IE-001']) })
+    const findings = report.findings.filter(f => f.ruleId === 'IE-001')
+    expect(findings).toHaveLength(1)
+    expect(findings[0].message).toMatch(/no outgoing/)
+  })
+})


### PR DESCRIPTION
## Summary

P0a of the custom cross-functional process-renderer programme (ADR `docs/decisions/2026-06-22-custom-process-renderer.md`). **Additive, backward-compatible model extension only — no renderer yet.** Existing `*.bpmn.transitrix.yaml` files are unaffected; both the future custom path and the legacy bpmn.io path stay in sync.

Adds three BPMN element types to the model:

- **Inclusive gateway** (`inclusiveGateway`) — joins `GATEWAY_TYPES`; conditional & default outgoing flows now allowed (per BPMN 2.0).
- **Intermediate message event** (`intermediateMessageEvent`) and **intermediate timer event** (`intermediateTimerEvent`) — emit as `<intermediateCatchEvent>` with the matching event definition.

## Changes

- **IR** (`src/ir.ts`): new `ElementType` members; `INTERMEDIATE_EVENT_TYPES` set; `inclusiveGateway` added to `GATEWAY_TYPES` (so existing gateway routing applies).
- **Schema** (`schemas/bpmn-dsl.schema.json`): new types in the enum; intermediate events allow optional `name` (like start/end events).
- **Parser** (`src/parser.ts`): `elkNodeSize` — inclusive gateway 50×50, intermediate events 36×36.
- **Emitter** (`src/emitter.ts`): intermediate events → `intermediateCatchEvent` + `messageEventDefinition`/`timerEventDefinition`; inclusive gateway maps directly.
- **Validator** (`src/validator.ts`): SF-005/SF-006 allow conditional/default flows out of inclusive gateways; new **IE-001** (intermediate events need incoming + outgoing flows).
- **Docs** (`docs/validation.md`): IE-001 section + SF-005/006 inclusive-gateway notes.

## Test plan

- [x] `npx vitest run` — 387 core tests pass (incl. new parser/emit + validator cases).
- [x] `npm run test:diagrams` — 926 pass.
- [x] `npm run compile` and `npm run compile:extension` — clean.
- [x] New process with inclusive gateway + intermediate events round-trips through `bpmn-moddle` with **zero warnings**.