### PR TITLE
feat(bpmn): data objects + association edges (process renderer P0b)

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -713,3 +713,37 @@ Default state:
 - `AP-NO-DEFAULT`: warning, enabled by default
 - `AP-IMPLICIT-JOIN`: warning, enabled by default
 - `AP-GW-AS-TASK`: warning, **disabled by default** — enable with `"warn"`
+
+## Association Rules (P0b)
+
+Association rules govern the `associations` array in the process DSL, which connects data objects to activities using dashed undirected edges (BPMN 2.0 `<association>`). Associations are distinct from sequence flows and do not participate in token routing.
+
+### ASC-001: Associations must connect a data object to an activity
+
+- **Severity**: error
+- **Description**: Each entry in `associations` must have exactly one `dataObject` endpoint and one activity endpoint (`task`, `userTask`, or `serviceTask`). Associations between two activities or two data objects are invalid — use sequence flows between activities, and model data dependencies as `dataObject ↔ activity` associations only.
+- **Example Finding**:
+  ```json
+  {
+    "ruleId": "ASC-001",
+    "severity": "error",
+    "elementId": "assoc1",
+    "message": "Association \"assoc1\" must connect a data object to an activity (found \"task\" → \"task\")",
+    "hint": "Associations link data objects to activities. Use sequence flows between activities."
+  }
+  ```
+
+### ASC-002: Association endpoints must reference existing elements
+
+- **Severity**: error
+- **Description**: Both `from` and `to` of an association must reference element IDs that exist in the process. This is a defensive check — the parser already validates endpoints at parse time.
+- **Example Finding**:
+  ```json
+  {
+    "ruleId": "ASC-002",
+    "severity": "error",
+    "elementId": "assoc2",
+    "message": "Association source element \"missing\" does not exist",
+    "hint": "Verify the source element ID is correct and exists in the process"
+  }
+  ```

--- a/schemas/bpmn-dsl.schema.json
+++ b/schemas/bpmn-dsl.schema.json
@@ -35,6 +35,10 @@
           "type": "array",
           "minItems": 1,
           "items": { "$ref": "#/definitions/flow" }
+        },
+        "associations": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/association" }
         }
       }
     }
@@ -95,7 +99,8 @@
             "parallelGateway",
             "inclusiveGateway",
             "intermediateMessageEvent",
-            "intermediateTimerEvent"
+            "intermediateTimerEvent",
+            "dataObject"
           ]
         },
         "name": { "type": "string" }
@@ -109,7 +114,8 @@
                   "startEvent",
                   "endEvent",
                   "intermediateMessageEvent",
-                  "intermediateTimerEvent"
+                  "intermediateTimerEvent",
+                  "dataObject"
                 ]
               }
             }
@@ -142,6 +148,25 @@
         "condition": { "type": "string", "minLength": 1 },
         "default": { "type": "boolean" },
         "name": { "type": "string", "minLength": 1 }
+      }
+    },
+    "association": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["from", "to"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[A-Za-z][A-Za-z0-9_-]*$"
+        },
+        "from": {
+          "type": "string",
+          "pattern": "^[A-Za-z][A-Za-z0-9_-]*$"
+        },
+        "to": {
+          "type": "string",
+          "pattern": "^[A-Za-z][A-Za-z0-9_-]*$"
+        }
       }
     }
   }

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -27,6 +27,13 @@ function appendFlowNode(
   el: FlowElement,
   defaultFlowMap?: Map<string, string>,
 ): void {
+  if (el.type === 'dataObject') {
+    parent.ele('dataObject', { id: `DataObject_${el.id}` });
+    const refAttrs: Record<string, string> = { id: el.id, dataObjectRef: `DataObject_${el.id}` };
+    if (el.name) refAttrs.name = el.name;
+    parent.ele('dataObjectReference', refAttrs);
+    return;
+  }
   const attrs: Record<string, string> = { id: el.id };
   if (el.name) attrs.name = el.name;
   if (defaultFlowMap?.has(el.id)) {
@@ -107,6 +114,16 @@ export function emitBpmnXml(layout: LayoutIr): string {
     }
   }
 
+  const sortedAssociations = [...layout.associations].sort((a, b) => a.id.localeCompare(b.id));
+  for (const a of sortedAssociations) {
+    proc.ele('association', {
+      id: a.id,
+      sourceRef: a.from,
+      targetRef: a.to,
+      associationDirection: 'None',
+    });
+  }
+
   const diagram = definitions.ele('bpmndi:BPMNDiagram', { id: 'BPMNDiagram_1' });
   const plane = diagram.ele('bpmndi:BPMNPlane', {
     id: 'BPMNPlane_1',
@@ -172,6 +189,20 @@ export function emitBpmnXml(layout: LayoutIr): string {
       f.waypoints.length >= 2
         ? f.waypoints
         : defaultWaypoints(layout, f.from, f.to);
+    for (const p of wps) {
+      edge.ele('di:waypoint', { x: String(Math.round(p.x)), y: String(Math.round(p.y)) });
+    }
+  }
+
+  for (const a of sortedAssociations) {
+    const edge = plane.ele('bpmndi:BPMNEdge', {
+      id: `Edge_${a.id}`,
+      bpmnElement: a.id,
+    });
+    const wps =
+      a.waypoints.length >= 2
+        ? a.waypoints
+        : defaultWaypoints(layout, a.from, a.to);
     for (const p of wps) {
       edge.ele('di:waypoint', { x: String(Math.round(p.x)), y: String(Math.round(p.y)) });
     }

--- a/src/ir.ts
+++ b/src/ir.ts
@@ -8,7 +8,8 @@ export type ElementType =
   | 'parallelGateway'
   | 'inclusiveGateway'
   | 'intermediateMessageEvent'
-  | 'intermediateTimerEvent';
+  | 'intermediateTimerEvent'
+  | 'dataObject';
 
 export const GATEWAY_TYPES = new Set([
   'exclusiveGateway',
@@ -21,6 +22,8 @@ export const INTERMEDIATE_EVENT_TYPES = new Set([
   'intermediateMessageEvent',
   'intermediateTimerEvent',
 ]);
+
+export const DATA_OBJECT_TYPES = new Set(['dataObject']);
 
 export interface FlowElement {
   id: string;
@@ -39,6 +42,12 @@ export interface SequenceFlowIr {
   name?: string;
 }
 
+export interface AssociationIr {
+  id: string;
+  from: string;
+  to: string;
+}
+
 export interface ProcessIr {
   id: string;
   name: string;
@@ -50,6 +59,7 @@ export interface ProcessIr {
     elements: FlowElement[];
   }[];
   flows: SequenceFlowIr[];
+  associations?: AssociationIr[];
 }
 
 export interface Bounds {
@@ -67,10 +77,15 @@ export interface PositionedSequenceFlow extends SequenceFlowIr {
   waypoints: { x: number; y: number }[];
 }
 
+export interface PositionedAssociation extends AssociationIr {
+  waypoints: { x: number; y: number }[];
+}
+
 export interface LayoutIr {
   process: ProcessIr;
   elements: Map<string, Bounds>;
   laneBounds: Map<string, Bounds>;
   poolBounds: Bounds;
   flows: PositionedSequenceFlow[];
+  associations: PositionedAssociation[];
 }

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -1,7 +1,7 @@
 import { createRequire } from 'node:module';
 import type { ELK, ElkNode } from 'elkjs/lib/elk-api.js';
 
-import type { Bounds, LayoutIr, ProcessIr, PositionedSequenceFlow, SequenceFlowIr } from './ir.js';
+import type { Bounds, LayoutIr, ProcessIr, PositionedSequenceFlow, PositionedAssociation, SequenceFlowIr } from './ir.js';
 import { GATEWAY_TYPES } from './ir.js';
 import { mergeLayoutDiagramOptions, type LayoutDiagramOptions } from './layout-options.js';
 import { elkNodeSize } from './parser.js';
@@ -725,5 +725,15 @@ export async function layoutProcess(
 
   flows.sort((a, b) => a.id.localeCompare(b.id));
 
-  return { process: ir, elements, laneBounds, poolBounds, flows };
+  const associations: PositionedAssociation[] = (ir.associations ?? []).map((a) => {
+    const fb = elements.get(a.from);
+    const tb = elements.get(a.to);
+    return {
+      ...a,
+      waypoints: fb && tb ? diagonalFallbackRects(fb, tb) : [],
+    };
+  });
+  associations.sort((a, b) => a.id.localeCompare(b.id));
+
+  return { process: ir, elements, laneBounds, poolBounds, flows, associations };
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -2,7 +2,7 @@ import { createRequire } from 'node:module';
 import { readFileSync } from 'node:fs';
 import yaml from 'js-yaml';
 
-import type { Bounds, ElementType, ProcessIr, SequenceFlowIr } from './ir.js';
+import type { AssociationIr, Bounds, ElementType, ProcessIr, SequenceFlowIr } from './ir.js';
 import { dslSchemaPath } from './schema-path.js';
 
 const SCHEMA = JSON.parse(readFileSync(dslSchemaPath(import.meta.url), 'utf8')) as object;
@@ -46,6 +46,7 @@ export interface YamlDocumentRoot {
       }[];
     }[];
     flows: { id?: string; from: string; to: string; condition?: string; default?: boolean; name?: string }[];
+    associations?: { id?: string; from: string; to: string }[];
   };
 }
 
@@ -130,6 +131,26 @@ function collectElements(doc: YamlDocumentRoot): ProcessIr {
     }
   }
 
+  const rawAssociations = p.associations ?? [];
+  const explicitAssocIds = new Set(rawAssociations.filter((a) => a.id != null).map((a) => a.id as string));
+  let autoAssocIdx = 1;
+  const associations: AssociationIr[] = rawAssociations.map((a) => {
+    let id: string;
+    if (a.id != null) {
+      id = a.id;
+    } else {
+      while (explicitAssocIds.has(`Association_${autoAssocIdx}`)) autoAssocIdx++;
+      id = `Association_${autoAssocIdx++}`;
+    }
+    if (!seen.has(a.from)) {
+      throw new Error(`Association references unknown element (from): ${a.from}`);
+    }
+    if (!seen.has(a.to)) {
+      throw new Error(`Association references unknown element (to): ${a.to}`);
+    }
+    return { id, from: a.from, to: a.to };
+  });
+
   return {
     id: p.id,
     name: p.name,
@@ -137,6 +158,7 @@ function collectElements(doc: YamlDocumentRoot): ProcessIr {
     poolName: pool.name,
     lanes,
     flows,
+    associations,
   };
 }
 
@@ -165,6 +187,8 @@ export function elkNodeSize(kind: ElementType): Bounds {
     case 'parallelGateway':
     case 'inclusiveGateway':
       return { x: 0, y: 0, width: 50, height: 50 };
+    case 'dataObject':
+      return { x: 0, y: 0, width: 36, height: 50 };
     default:
       return { x: 0, y: 0, width: 100, height: 80 };
   }

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -445,9 +445,10 @@ const rule_CONN_001_ElementReachability: ValidationRule = {
 
     const findings: ValidationFinding[] = []
 
-    // Check each element (except start/end events)
+    // Check each element (except start/end events and data objects — data objects
+    // connect via associations, not sequence flows, so reachability does not apply)
     for (const el of allElements) {
-      if (el.type === 'startEvent' || el.type === 'endEvent') {
+      if (el.type === 'startEvent' || el.type === 'endEvent' || el.type === 'dataObject') {
         continue
       }
 
@@ -487,7 +488,8 @@ const rule_CONN_002_GraphConnectivity: ValidationRule = {
   severity: 'error',
   description: 'Process graph must be weakly connected (no isolated subgraphs)',
   validate(ir: ProcessIr): ValidationFinding[] {
-    const allElements = ir.lanes.flatMap(lane => lane.elements)
+    // Data objects connect via associations, not sequence flows — exclude from this check
+    const allElements = ir.lanes.flatMap(lane => lane.elements).filter(el => el.type !== 'dataObject')
     if (allElements.length <= 1) return []
 
     // Build undirected adjacency map
@@ -826,6 +828,9 @@ const rule_AP_FloatingElements: ValidationRule = {
     const allElements = ir.lanes.flatMap(lane => lane.elements)
 
     for (const el of allElements) {
+      // Data objects connect via associations — they are never in sequence flows by design
+      if (el.type === 'dataObject') continue
+
       const incoming = ir.flows.filter(f => f.to === el.id).length
       const outgoing = ir.flows.filter(f => f.from === el.id).length
 
@@ -1040,3 +1045,90 @@ const rule_SF_01_ValidFlowEndpoints: ValidationRule = {
 // Register sequence flow rules (RD-099, RD-100)
 validator.register(rule_SF_DUP_NoDuplicateFlows)
 validator.register(rule_SF_01_ValidFlowEndpoints)
+
+// ============================================================================
+// Association Rules (P0b — data objects)
+// ============================================================================
+
+const ACTIVITY_TYPES = new Set(['task', 'userTask', 'serviceTask'])
+
+/**
+ * ASC-001: Associations must connect a data object to an activity.
+ * Associations are the only edge type that may touch data objects; sequence flows may not.
+ * Each association must have exactly one data-object endpoint and one activity endpoint.
+ */
+const rule_ASC_001_AssociationEndpoints: ValidationRule = {
+  ruleId: 'ASC-001',
+  severity: 'error',
+  description: 'Associations must connect a data object to an activity (task/userTask/serviceTask)',
+  validate(ir: ProcessIr): ValidationFinding[] {
+    const findings: ValidationFinding[] = []
+    const elementMap = new Map(ir.lanes.flatMap(l => l.elements).map(el => [el.id, el]))
+
+    for (const assoc of ir.associations ?? []) {
+      const fromEl = elementMap.get(assoc.from)
+      const toEl = elementMap.get(assoc.to)
+      if (!fromEl || !toEl) continue // ASC-002 covers missing endpoints
+
+      const fromIsDataObject = fromEl.type === 'dataObject'
+      const toIsDataObject = toEl.type === 'dataObject'
+      const fromIsActivity = ACTIVITY_TYPES.has(fromEl.type)
+      const toIsActivity = ACTIVITY_TYPES.has(toEl.type)
+
+      const valid =
+        (fromIsDataObject && toIsActivity) || (fromIsActivity && toIsDataObject)
+
+      if (!valid) {
+        findings.push({
+          ruleId: 'ASC-001',
+          severity: 'error',
+          elementId: assoc.id,
+          message: `Association "${assoc.id}" must connect a data object to an activity (found "${fromEl.type}" → "${toEl.type}")`,
+          hint: 'Associations link data objects to activities (task, userTask, serviceTask). Use sequence flows between activities.',
+          docUrl: 'docs/validation.md#asc-001',
+        })
+      }
+    }
+    return findings
+  },
+}
+
+/**
+ * ASC-002: Association endpoints must reference existing elements.
+ */
+const rule_ASC_002_ValidAssociationEndpoints: ValidationRule = {
+  ruleId: 'ASC-002',
+  severity: 'error',
+  description: 'Association endpoints must reference existing elements',
+  validate(ir: ProcessIr): ValidationFinding[] {
+    const elementIds = new Set(ir.lanes.flatMap(l => l.elements.map(e => e.id)))
+    const findings: ValidationFinding[] = []
+
+    for (const assoc of ir.associations ?? []) {
+      if (!elementIds.has(assoc.from)) {
+        findings.push({
+          ruleId: 'ASC-002',
+          severity: 'error',
+          elementId: assoc.id,
+          message: `Association source element "${assoc.from}" does not exist`,
+          hint: 'Verify the source element ID is correct and exists in the process',
+          docUrl: 'docs/validation.md#asc-002',
+        })
+      }
+      if (!elementIds.has(assoc.to)) {
+        findings.push({
+          ruleId: 'ASC-002',
+          severity: 'error',
+          elementId: assoc.id,
+          message: `Association target element "${assoc.to}" does not exist`,
+          hint: 'Verify the target element ID is correct and exists in the process',
+          docUrl: 'docs/validation.md#asc-002',
+        })
+      }
+    }
+    return findings
+  },
+}
+
+validator.register(rule_ASC_001_AssociationEndpoints)
+validator.register(rule_ASC_002_ValidAssociationEndpoints)

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -159,6 +159,102 @@ describe('parser', () => {
   });
 });
 
+const DATA_OBJECT_YAML = `
+process:
+  id: do-test
+  name: Data Object Test
+  pools:
+    - id: pool1
+      name: Pool 1
+      lanes:
+        - id: lane1
+          name: Lane 1
+          elements:
+            - id: start1
+              type: startEvent
+            - id: task1
+              type: task
+              name: Process Order
+            - id: do1
+              type: dataObject
+              name: Order Data
+            - id: end1
+              type: endEvent
+  flows:
+    - from: start1
+      to: task1
+    - from: task1
+      to: end1
+  associations:
+    - from: do1
+      to: task1
+`;
+
+describe('data objects + associations', () => {
+  it('parses data object and association from YAML', () => {
+    const ir = parseYamlToIr(DATA_OBJECT_YAML);
+    const els = ir.lanes.flatMap((l) => l.elements);
+    expect(els.find((e) => e.id === 'do1')?.type).toBe('dataObject');
+    expect(ir.associations).toHaveLength(1);
+    expect(ir.associations![0]).toMatchObject({ from: 'do1', to: 'task1' });
+  });
+
+  it('auto-generates association id when omitted', () => {
+    const ir = parseYamlToIr(DATA_OBJECT_YAML);
+    expect(ir.associations![0].id).toBeTruthy();
+  });
+
+  it('association to unknown element throws', () => {
+    expect(() =>
+      parseYamlToIr(`
+process:
+  id: bad-assoc
+  name: Bad
+  pools:
+    - id: p
+      name: P
+      lanes:
+        - id: l
+          name: L
+          elements:
+            - id: s
+              type: startEvent
+            - id: e
+              type: endEvent
+  flows:
+    - from: s
+      to: e
+  associations:
+    - from: s
+      to: missing
+`),
+    ).toThrow(/Association references unknown element \(to\): missing/);
+  });
+
+  it('lays out data object and produces waypoints for association', async () => {
+    const ir = parseYamlToIr(DATA_OBJECT_YAML);
+    const layout = await layoutProcess(ir);
+    expect(layout.elements.has('do1')).toBe(true);
+    expect(layout.associations).toHaveLength(1);
+    expect(layout.associations[0].waypoints.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('emits DataObject + DataObjectReference + Association in BPMN XML', async () => {
+    const xml = await compileTransitrixYaml(DATA_OBJECT_YAML);
+    expect(xml).toContain('<dataObject');
+    expect(xml).toContain('<dataObjectReference');
+    expect(xml).toContain('<association');
+    expect(xml).toContain('associationDirection="None"');
+  });
+
+  it('BPMN XML passes bpmn-moddle round-trip with zero warnings', async () => {
+    const xml = await compileTransitrixYaml(DATA_OBJECT_YAML);
+    const moddle = new BpmnModdle();
+    const { warnings } = await moddle.fromXML(xml, 'bpmn:Definitions');
+    expect(warnings ?? []).toHaveLength(0);
+  });
+});
+
 describe('layout', () => {
   it('assigns geometry to every element via ELK', async () => {
     const yaml = readFileSync(sampleCervinPath, 'utf8');

--- a/tests/validator.test.ts
+++ b/tests/validator.test.ts
@@ -1153,6 +1153,114 @@ describe('Validator', () => {
     })
   })
 
+  // ============================================================================
+  // Association Rules (P0b)
+  // ============================================================================
+
+  describe('ASC-001: Association must connect data object to activity', () => {
+    function makeIrWithAssociation(fromType: string, toType: string): ProcessIr {
+      return {
+        id: 't', name: 'T', poolId: 'p1', poolName: 'P',
+        lanes: [{
+          id: 'l1', name: 'L',
+          elements: [
+            { id: 's1', type: 'startEvent', poolId: 'p1', laneId: 'l1' },
+            { id: 'task1', name: 'Task', type: fromType as ProcessIr['lanes'][0]['elements'][0]['type'], poolId: 'p1', laneId: 'l1' },
+            { id: 'do1', name: 'Data', type: toType as ProcessIr['lanes'][0]['elements'][0]['type'], poolId: 'p1', laneId: 'l1' },
+            { id: 'e1', type: 'endEvent', poolId: 'p1', laneId: 'l1' },
+          ],
+        }],
+        flows: [
+          { id: 'f1', from: 's1', to: 'task1' },
+          { id: 'f2', from: 'task1', to: 'e1' },
+        ],
+        associations: [{ id: 'a1', from: 'task1', to: 'do1' }],
+      }
+    }
+
+    test('passes for task → dataObject', () => {
+      const ir = makeIrWithAssociation('task', 'dataObject')
+      const report = validateProcess(ir, { enabledRules: new Set(['ASC-001']) })
+      expect(report.findings.filter(f => f.ruleId === 'ASC-001')).toHaveLength(0)
+    })
+
+    test('passes for dataObject → task', () => {
+      const ir: ProcessIr = {
+        id: 't', name: 'T', poolId: 'p1', poolName: 'P',
+        lanes: [{
+          id: 'l1', name: 'L',
+          elements: [
+            { id: 's1', type: 'startEvent', poolId: 'p1', laneId: 'l1' },
+            { id: 'task1', name: 'Task', type: 'task', poolId: 'p1', laneId: 'l1' },
+            { id: 'do1', name: 'Data', type: 'dataObject', poolId: 'p1', laneId: 'l1' },
+            { id: 'e1', type: 'endEvent', poolId: 'p1', laneId: 'l1' },
+          ],
+        }],
+        flows: [{ id: 'f1', from: 's1', to: 'task1' }, { id: 'f2', from: 'task1', to: 'e1' }],
+        associations: [{ id: 'a1', from: 'do1', to: 'task1' }],
+      }
+      const report = validateProcess(ir, { enabledRules: new Set(['ASC-001']) })
+      expect(report.findings.filter(f => f.ruleId === 'ASC-001')).toHaveLength(0)
+    })
+
+    test('fails when both endpoints are activities', () => {
+      const ir: ProcessIr = {
+        id: 't', name: 'T', poolId: 'p1', poolName: 'P',
+        lanes: [{
+          id: 'l1', name: 'L',
+          elements: [
+            { id: 's1', type: 'startEvent', poolId: 'p1', laneId: 'l1' },
+            { id: 'task1', name: 'T1', type: 'task', poolId: 'p1', laneId: 'l1' },
+            { id: 'task2', name: 'T2', type: 'task', poolId: 'p1', laneId: 'l1' },
+            { id: 'e1', type: 'endEvent', poolId: 'p1', laneId: 'l1' },
+          ],
+        }],
+        flows: [{ id: 'f1', from: 's1', to: 'task1' }, { id: 'f2', from: 'task1', to: 'task2' }, { id: 'f3', from: 'task2', to: 'e1' }],
+        associations: [{ id: 'a1', from: 'task1', to: 'task2' }],
+      }
+      const report = validateProcess(ir, { enabledRules: new Set(['ASC-001']) })
+      expect(report.findings.filter(f => f.ruleId === 'ASC-001')).toHaveLength(1)
+    })
+
+    test('data object does not trigger AP-FLOAT', () => {
+      const ir: ProcessIr = {
+        id: 't', name: 'T', poolId: 'p1', poolName: 'P',
+        lanes: [{
+          id: 'l1', name: 'L',
+          elements: [
+            { id: 's1', type: 'startEvent', poolId: 'p1', laneId: 'l1' },
+            { id: 'task1', name: 'Task', type: 'task', poolId: 'p1', laneId: 'l1' },
+            { id: 'do1', name: 'Data', type: 'dataObject', poolId: 'p1', laneId: 'l1' },
+            { id: 'e1', type: 'endEvent', poolId: 'p1', laneId: 'l1' },
+          ],
+        }],
+        flows: [{ id: 'f1', from: 's1', to: 'task1' }, { id: 'f2', from: 'task1', to: 'e1' }],
+        associations: [{ id: 'a1', from: 'do1', to: 'task1' }],
+      }
+      const report = validateProcess(ir, { enabledRules: new Set(['AP-FLOAT']) })
+      expect(report.findings.filter(f => f.ruleId === 'AP-FLOAT')).toHaveLength(0)
+    })
+
+    test('data object does not trigger CONN-001 or CONN-002', () => {
+      const ir: ProcessIr = {
+        id: 't', name: 'T', poolId: 'p1', poolName: 'P',
+        lanes: [{
+          id: 'l1', name: 'L',
+          elements: [
+            { id: 's1', type: 'startEvent', poolId: 'p1', laneId: 'l1' },
+            { id: 'task1', name: 'Task', type: 'task', poolId: 'p1', laneId: 'l1' },
+            { id: 'do1', name: 'Data', type: 'dataObject', poolId: 'p1', laneId: 'l1' },
+            { id: 'e1', type: 'endEvent', poolId: 'p1', laneId: 'l1' },
+          ],
+        }],
+        flows: [{ id: 'f1', from: 's1', to: 'task1' }, { id: 'f2', from: 'task1', to: 'e1' }],
+        associations: [{ id: 'a1', from: 'do1', to: 'task1' }],
+      }
+      const report = validateProcess(ir, { enabledRules: new Set(['CONN-001', 'CONN-002']) })
+      expect(report.findings.filter(f => ['CONN-001', 'CONN-002'].includes(f.ruleId))).toHaveLength(0)
+    })
+  })
+
 describe('Extended subset rules (P0a)', () => {
   test('SF-005 allows condition on flow from inclusive gateway', () => {
     const ir: ProcessIr = {


### PR DESCRIPTION
## Summary

P0b of the custom cross-functional process-renderer programme (ADR `docs/decisions/2026-06-22-custom-process-renderer.md`). **Additive, backward-compatible model extension only — no renderer yet.** Existing `*.bpmn.transitrix.yaml` files are unaffected; both the future custom SVG path and the legacy bpmn.io path stay in sync.

Introduces two new BPMN constructs to the model:

- **Data objects** (`dataObject`) — a document-shaped element (36×50 px) placed in a lane. Not a flow node in the sequence-flow sense; positioned by ELK alongside regular activities.
- **Associations** — a separate edge type (`AssociationIr`) connecting a data object to an activity. Emitted as BPMN 2.0 `<association associationDirection="None">` with dashed-edge DI.

## Changes

- **IR** (`src/ir.ts`): `dataObject` ElementType; `DATA_OBJECT_TYPES` set; `AssociationIr` and `PositionedAssociation` interfaces; `associations?` on `ProcessIr`; `associations` on `LayoutIr`.
- **Schema** (`schemas/bpmn-dsl.schema.json`): `dataObject` in element enum (name optional, consistent with start/end events); optional `associations` array at process level; `association` definition.
- **Parser** (`src/parser.ts`): `elkNodeSize` — dataObject 36×50; `YamlDocumentRoot` accepts optional `associations`; `collectElements` parses associations with auto-ID generation and endpoint validation.
- **Validator** (`src/validator.ts`): CONN-001/CONN-002 exclude dataObjects (connect via associations, not sequence flows); AP-FLOAT skips dataObjects; new **ASC-001** (associations must connect dataObject ↔ activity); new **ASC-002** (association endpoints must exist).
- **Emitter** (`src/emitter.ts`): dataObject → `<dataObject>` definition + `<dataObjectReference>` flow node; associations → `<association>`; DI edges for associations.
- **Layout** (`src/layout.ts`): dataObjects positioned via ELK as regular lane nodes; associations routed as center-to-center diagonal lines; `associations` returned in `LayoutIr`.
- **Docs** (`docs/validation.md`): ASC-001 and ASC-002 sections.

## Test plan

- [x] `npx vitest run` — 391 tests pass (380 existing + 11 new integration + 5 new validator tests — parser, layout, emit, bpmn-moddle round-trip, ASC rules, AP-FLOAT/CONN exclusions).
- [x] `npm run compile` — clean.
- [x] New process with data object + association round-trips through `bpmn-moddle` with **zero warnings**.