### PR TITLE
feat(diagrams,extension): custom process SVG emitter skeleton (renderer P1)

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -88,6 +88,19 @@
           "default": false,
           "description": "Show experimental BPMN/SVG/PNG export commands (not finished yet)."
         },
+        "transitrix.bpmnRenderer": {
+          "type": "string",
+          "enum": [
+            "bpmn-io",
+            "custom"
+          ],
+          "enumDescriptions": [
+            "bpmn.io viewer (default — full BPMN interactivity)",
+            "Custom SVG emitter (experimental — static preview, faster load)"
+          ],
+          "default": "bpmn-io",
+          "description": "BPMN preview renderer. 'bpmn-io' uses the bpmn.io viewer; 'custom' uses the built-in SVG emitter (part of the custom process renderer programme)."
+        },
         "transitrix.theme": {
           "type": "string",
           "enum": [

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 
 import type { CompileFn } from './preview.js';
 import { CervinPreview } from './preview.js';
+import { ProcessPreview, type ProcessLayoutFn } from './process-preview.js';
 import { GoalsPreview } from './goals-preview.js';
 import { FGCAPreview, FGAPreview } from './fgca-preview.js';
 import { ActivitiesPreview } from './activities-preview.js';
@@ -113,6 +114,22 @@ async function loadCompiler(ext: vscode.ExtensionContext): Promise<CompileFn> {
   };
 }
 
+async function loadProcessLayoutFn(ext: vscode.ExtensionContext): Promise<ProcessLayoutFn> {
+  const compilerPath = path.join(ext.extensionPath, 'compiler', 'compiler.js');
+  const compilerHref = pathToFileURL(compilerPath).href;
+  // Node.js module cache means this import() re-uses the already-loaded module
+  // when loadCompiler() has run first — no double-load overhead.
+  const mod = (await import(compilerHref)) as {
+    compileTransitrixYamlWithLayout: (yaml: string) => Promise<{ layout: unknown; validation: ValidationReport }>;
+  };
+  return async (yaml: string) => {
+    const result = await mod.compileTransitrixYamlWithLayout(yaml);
+    // LayoutIr is structurally compatible with ProcessDiagramLayout — safe cast.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return { layout: result.layout as any, validation: result.validation };
+  };
+}
+
 function notYet(label: string): void {
   void vscode.window.showInformationMessage(
     `${label} export isn't available for the BPMN preview yet. ` +
@@ -169,6 +186,21 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   const preview = new CervinPreview(context.extensionUri, (yaml: string) =>
     compiler().then((c) => c(yaml)),
   );
+
+  let processLayoutPromise: Promise<ProcessLayoutFn> | undefined;
+  function processLayoutFn(): Promise<ProcessLayoutFn> {
+    if (!processLayoutPromise) {
+      processLayoutPromise = loadProcessLayoutFn(context).catch((err) => {
+        processLayoutPromise = undefined;
+        throw err;
+      });
+    }
+    return processLayoutPromise;
+  }
+  const processPreview = new ProcessPreview((yaml: string) =>
+    processLayoutFn().then((fn) => fn(yaml)),
+  );
+
   const goalsPreview = new GoalsPreview(context.extensionUri);
   const fgcaPreview = new FGCAPreview(context.extensionUri);
   const fgaPreview = new FGAPreview(context.extensionUri);
@@ -197,7 +229,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       );
       return;
     }
-    await preview.showOrReveal(doc);
+    const renderer = vscode.workspace.getConfiguration('transitrix').get<string>('bpmnRenderer', 'bpmn-io');
+    if (renderer === 'custom') {
+      await processPreview.showOrReveal(doc);
+    } else {
+      await preview.showOrReveal(doc);
+    }
   };
 
   // Command namespaces (intentional split, kept for compatibility):
@@ -487,6 +524,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       if (isCoverageMetricFile(doc)) { void coverageMetricPreview.refreshSaved(doc); return; }
       if (!documentMatchesCervinSource(doc)) return;
       void preview.refreshSaved(doc);
+      void processPreview.refreshSaved(doc);
     }),
     vscode.workspace.onDidOpenTextDocument(async (doc) => {
       if (isGoalsFile(doc)) { await goalsPreview.showOrReveal(doc); return; }

--- a/extension/src/process-preview.ts
+++ b/extension/src/process-preview.ts
@@ -1,0 +1,125 @@
+/**
+ * VS Code preview panel for the BPMN process notation using the custom SVG
+ * emitter from @transitrix/diagrams (custom process renderer programme, P1).
+ *
+ * Active when `transitrix.bpmnRenderer` is set to `"custom"`. The default
+ * bpmn.io path (CervinPreview) is unaffected.
+ */
+
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+import { renderProcessLayoutSvg, type ProcessDiagramLayout } from '@transitrix/diagrams/webview/render-process.js';
+import { escXml } from '@transitrix/diagrams/webview/render-util.js';
+import { getBaseResetCss } from '@transitrix/diagrams/theme';
+import type { ValidationReport } from './types.js';
+
+/** Function that parses + lays out a BPMN YAML document. */
+export type ProcessLayoutFn = (yaml: string) => Promise<{
+  layout: ProcessDiagramLayout;
+  validation: ValidationReport;
+}>;
+
+/** VS Code static preview panel backed by the custom SVG emitter. */
+export class ProcessPreview {
+  readonly panelTitle = 'BPMN Preview';
+
+  private panel: vscode.WebviewPanel | undefined;
+  private trackedUri: string | undefined;
+
+  constructor(private readonly layoutFn: ProcessLayoutFn) {}
+
+  isShowingDocument(uri: vscode.Uri): boolean {
+    return this.panel != null && this.trackedUri === uri.toString();
+  }
+
+  async showOrReveal(doc: vscode.TextDocument): Promise<void> {
+    this.trackedUri = doc.uri.toString();
+
+    if (this.panel) {
+      this.panel.title = `${this.panelTitle} — ${path.basename(doc.fileName)}`;
+      this.panel.reveal(vscode.ViewColumn.Beside, true);
+    } else {
+      this.panel = vscode.window.createWebviewPanel(
+        'processCustomPreview',
+        `${this.panelTitle} — ${path.basename(doc.fileName)}`,
+        { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
+        { enableScripts: false, retainContextWhenHidden: true },
+      );
+      this.panel.onDidDispose(() => {
+        this.panel = undefined;
+        this.trackedUri = undefined;
+      });
+    }
+
+    await this.pushDocument(doc);
+  }
+
+  async refreshSaved(doc: vscode.TextDocument): Promise<void> {
+    if (!this.isShowingDocument(doc.uri)) return;
+    await this.pushDocument(doc);
+  }
+
+  private async pushDocument(doc: vscode.TextDocument): Promise<void> {
+    if (!this.panel) return;
+    const filename = path.basename(doc.fileName);
+    try {
+      const { layout, validation } = await this.layoutFn(doc.getText());
+      const title = `<text class="text-header" x="16" y="22">${escXml(filename)}</text>`;
+      const svg = renderProcessLayoutSvg(layout, { title, topInset: 32 });
+      this.panel.webview.html = this.buildHtml(svg, filename, validation);
+    } catch (err) {
+      const msg = err instanceof Error ? escXml(err.message) : escXml(String(err));
+      this.panel.webview.html = this.buildErrorHtml(filename, msg);
+    }
+  }
+
+  private buildHtml(svg: string, filename: string, report: ValidationReport): string {
+    const errors = report.findings.filter((f) => f.severity === 'error');
+    const warns = report.findings.filter((f) => f.severity === 'warning');
+
+    const errorBanner =
+      errors.length > 0
+        ? `<div class="banner banner-error"><strong>${errors.length} error${errors.length > 1 ? 's' : ''}:</strong> ${errors.map((e) => escXml(e.message)).join(' · ')}</div>`
+        : '';
+    const warnBanner =
+      warns.length > 0
+        ? `<div class="banner banner-warn">${warns.length} warning${warns.length > 1 ? 's' : ''}</div>`
+        : '';
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${escXml(filename)}</title>
+<style>
+${getBaseResetCss()}
+body { margin: 0; overflow: auto; background: var(--vscode-editor-background, #fff); }
+.banner { padding: 6px 12px; font-size: 12px; font-family: var(--vscode-font-family, sans-serif); }
+.banner-error { background: var(--vscode-inputValidation-errorBackground, #f8d7da); color: var(--vscode-inputValidation-errorForeground, #721c24); }
+.banner-warn  { background: var(--vscode-inputValidation-warningBackground, #fff3cd); color: var(--vscode-inputValidation-warningForeground, #856404); }
+.diagram-wrap { padding: 0; }
+</style>
+</head>
+<body>
+${errorBanner}${warnBanner}
+<div class="diagram-wrap">${svg}</div>
+</body>
+</html>`;
+  }
+
+  private buildErrorHtml(filename: string, message: string): string {
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>${escXml(filename)}</title>
+<style>body { margin: 16px; font-family: monospace; }</style>
+</head>
+<body>
+<p style="color:red"><strong>Compile error</strong></p>
+<pre>${message}</pre>
+</body>
+</html>`;
+  }
+}

--- a/packages/diagrams/src/webview/__tests__/render-process.test.ts
+++ b/packages/diagrams/src/webview/__tests__/render-process.test.ts
@@ -1,0 +1,395 @@
+import { describe, it, expect } from 'vitest';
+import {
+  renderProcessLayoutSvg,
+  renderProcessBody,
+  type ProcessDiagramLayout,
+  type ProcessFlowElement,
+} from '../render-process.js';
+
+// ---------------------------------------------------------------------------
+// Test fixture helpers
+// ---------------------------------------------------------------------------
+
+function makeLayout(overrides: Partial<ProcessDiagramLayout> = {}): ProcessDiagramLayout {
+  const elements = new Map<string, { x: number; y: number; width: number; height: number }>([
+    ['start', { x: 160, y: 72, width: 36, height: 36 }],
+    ['task1', { x: 250, y: 60, width: 100, height: 80 }],
+    ['end', { x: 410, y: 72, width: 36, height: 36 }],
+  ]);
+
+  const laneBounds = new Map([
+    ['lane1', { x: 88, y: 40, width: 400, height: 200 }],
+  ]);
+
+  const poolBounds = { x: 12, y: 12, width: 500, height: 280 };
+
+  const process = {
+    id: 'proc1',
+    name: 'Test Process',
+    poolId: 'pool1',
+    poolName: 'Test Pool',
+    lanes: [
+      {
+        id: 'lane1',
+        name: 'Lane One',
+        elements: [
+          { id: 'start', type: 'startEvent', name: 'Start' },
+          { id: 'task1', type: 'task', name: 'Do Work' },
+          { id: 'end', type: 'endEvent', name: 'End' },
+        ] as ProcessFlowElement[],
+      },
+    ],
+  };
+
+  const flows = [
+    {
+      id: 'f1',
+      from: 'start',
+      to: 'task1',
+      waypoints: [
+        { x: 196, y: 90 },
+        { x: 250, y: 100 },
+      ],
+    },
+    {
+      id: 'f2',
+      from: 'task1',
+      to: 'end',
+      waypoints: [
+        { x: 350, y: 100 },
+        { x: 410, y: 90 },
+      ],
+    },
+  ];
+
+  return { process, elements, laneBounds, poolBounds, flows, associations: [], ...overrides };
+}
+
+function addElement(
+  layout: ProcessDiagramLayout,
+  el: ProcessFlowElement,
+  bounds: { x: number; y: number; width: number; height: number },
+): ProcessDiagramLayout {
+  layout.process.lanes[0].elements.push(el);
+  layout.elements.set(el.id, bounds);
+  return layout;
+}
+
+// ---------------------------------------------------------------------------
+// SVG root and structure
+// ---------------------------------------------------------------------------
+
+describe('renderProcessLayoutSvg — root', () => {
+  it('opens and closes an SVG element', () => {
+    const svg = renderProcessLayoutSvg(makeLayout());
+    expect(svg).toMatch(/^<svg xmlns="http:\/\/www\.w3\.org\/2000\/svg"/);
+    expect(svg.trimEnd().endsWith('</svg>')).toBe(true);
+  });
+
+  it('sets width and height from pool bounds plus padding', () => {
+    const layout = makeLayout();
+    const svg = renderProcessLayoutSvg(layout);
+    // poolBounds x=12, width=500 → svgW = 12+500+16 = 528
+    expect(svg).toContain('width="528"');
+  });
+
+  it('expands height for topInset', () => {
+    const svg = renderProcessLayoutSvg(makeLayout(), { title: '<text>T</text>', topInset: 32 });
+    // poolBounds y=12, height=280 + padding 16 + inset 32 = 340
+    expect(svg).toContain('height="340"');
+  });
+
+  it('injects title markup when provided', () => {
+    const svg = renderProcessLayoutSvg(makeLayout(), {
+      title: '<text class="text-header" x="16" y="20">My Title</text>',
+    });
+    expect(svg).toContain('My Title');
+    expect(svg).toContain('text-header');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CSS embedding
+// ---------------------------------------------------------------------------
+
+describe('renderProcessLayoutSvg — CSS', () => {
+  it('embeds a <style> block', () => {
+    const svg = renderProcessLayoutSvg(makeLayout());
+    expect(svg).toContain('<style>');
+    expect(svg).toContain('</style>');
+  });
+
+  it('includes shared theme CSS custom properties', () => {
+    const svg = renderProcessLayoutSvg(makeLayout());
+    expect(svg).toContain('--ts-');
+  });
+
+  it('includes BPMN-specific CSS classes', () => {
+    const svg = renderProcessLayoutSvg(makeLayout());
+    expect(svg).toContain('bpmn-pool');
+    expect(svg).toContain('bpmn-lane');
+    expect(svg).toContain('bpmn-task');
+    expect(svg).toContain('bpmn-event');
+    expect(svg).toContain('bpmn-gateway');
+    expect(svg).toContain('bpmn-seq-flow');
+  });
+
+  it('has no font-style italic', () => {
+    const svg = renderProcessLayoutSvg(makeLayout());
+    expect(svg.toLowerCase()).not.toContain('font-style');
+    expect(svg.toLowerCase()).not.toContain('italic');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pool and lane structure
+// ---------------------------------------------------------------------------
+
+describe('renderProcessLayoutSvg — pool / lanes', () => {
+  it('renders pool background rect', () => {
+    const svg = renderProcessLayoutSvg(makeLayout());
+    expect(svg).toContain('class="bpmn-pool"');
+  });
+
+  it('renders pool name band rect', () => {
+    const svg = renderProcessLayoutSvg(makeLayout());
+    expect(svg).toContain('class="bpmn-pool-name"');
+  });
+
+  it('renders pool name text', () => {
+    const svg = renderProcessLayoutSvg(makeLayout());
+    expect(svg).toContain('Test Pool');
+    expect(svg).toContain('bpmn-pool-label');
+  });
+
+  it('renders pool name rotated -90 degrees', () => {
+    const svg = renderProcessLayoutSvg(makeLayout());
+    expect(svg).toContain('rotate(-90,');
+  });
+
+  it('renders lane background rect', () => {
+    const svg = renderProcessLayoutSvg(makeLayout());
+    expect(svg).toContain('class="bpmn-lane"');
+  });
+
+  it('renders lane header rect', () => {
+    const svg = renderProcessLayoutSvg(makeLayout());
+    expect(svg).toContain('class="bpmn-lane-header"');
+  });
+
+  it('renders lane name text', () => {
+    const svg = renderProcessLayoutSvg(makeLayout());
+    expect(svg).toContain('Lane One');
+    expect(svg).toContain('bpmn-lane-label');
+  });
+
+  it('XML-escapes special characters in pool and lane names', () => {
+    const layout = makeLayout();
+    layout.process.poolName = 'Pool & <Co>';
+    layout.process.lanes[0].name = 'Lane "A"';
+    const svg = renderProcessLayoutSvg(layout);
+    expect(svg).not.toContain('<Co>');
+    expect(svg).toContain('&lt;Co&gt;');
+    expect(svg).toContain('&amp;');
+    expect(svg).toContain('&quot;');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Flow elements
+// ---------------------------------------------------------------------------
+
+describe('renderProcessLayoutSvg — start / end events', () => {
+  it('renders start event as circle with bpmn-event-start class', () => {
+    const svg = renderProcessLayoutSvg(makeLayout());
+    expect(svg).toMatch(/<circle[^>]+class="bpmn-event bpmn-event-start"/);
+  });
+
+  it('renders end event as circle with bpmn-event-end class', () => {
+    const svg = renderProcessLayoutSvg(makeLayout());
+    expect(svg).toMatch(/<circle[^>]+class="bpmn-event bpmn-event-end"/);
+  });
+
+  it('renders event labels below the shape', () => {
+    const svg = renderProcessLayoutSvg(makeLayout());
+    expect(svg).toContain('class="bpmn-event-label"');
+    expect(svg).toContain('>Start<');
+    expect(svg).toContain('>End<');
+  });
+});
+
+describe('renderProcessLayoutSvg — tasks', () => {
+  it('renders task as rect with bpmn-task class', () => {
+    const svg = renderProcessLayoutSvg(makeLayout());
+    expect(svg).toContain('class="diagram-node bpmn-task"');
+  });
+
+  it('renders task with rounded corners', () => {
+    const svg = renderProcessLayoutSvg(makeLayout());
+    expect(svg).toContain('rx="4"');
+  });
+
+  it('renders task name text', () => {
+    const svg = renderProcessLayoutSvg(makeLayout());
+    expect(svg).toContain('Do Work');
+    expect(svg).toContain('bpmn-task-name');
+  });
+
+  it('renders userTask and serviceTask the same as task', () => {
+    const layout = makeLayout();
+    addElement(layout, { id: 'ut', type: 'userTask', name: 'User Step' }, { x: 200, y: 60, width: 100, height: 80 });
+    addElement(layout, { id: 'st', type: 'serviceTask', name: 'Service Step' }, { x: 320, y: 60, width: 100, height: 80 });
+    const svg = renderProcessLayoutSvg(layout);
+    expect(svg).toContain('User Step');
+    expect(svg).toContain('Service Step');
+  });
+
+  it('wraps long task names across multiple tspans', () => {
+    const layout = makeLayout();
+    layout.process.lanes[0].elements[1].name = 'A Very Long Task Name Here';
+    const svg = renderProcessLayoutSvg(layout);
+    expect(svg).toContain('<tspan');
+  });
+
+  it('XML-escapes special characters in task names', () => {
+    const layout = makeLayout();
+    layout.process.lanes[0].elements[1].name = 'Send <email> & notify';
+    const svg = renderProcessLayoutSvg(layout);
+    expect(svg).not.toContain('<email>');
+    expect(svg).toContain('&lt;email&gt;');
+    expect(svg).toContain('&amp;');
+  });
+});
+
+describe('renderProcessLayoutSvg — gateways', () => {
+  it('renders XOR gateway as diamond path', () => {
+    const layout = makeLayout();
+    addElement(layout, { id: 'gw1', type: 'exclusiveGateway', name: 'Choice?' }, {
+      x: 180, y: 75, width: 50, height: 50,
+    });
+    const svg = renderProcessLayoutSvg(layout);
+    expect(svg).toContain('class="bpmn-gateway"');
+  });
+
+  it('renders XOR gateway with × marker lines', () => {
+    const layout = makeLayout();
+    addElement(layout, { id: 'gw1', type: 'exclusiveGateway' }, {
+      x: 180, y: 75, width: 50, height: 50,
+    });
+    const svg = renderProcessLayoutSvg(layout);
+    expect(svg).toContain('class="bpmn-gateway-marker"');
+    // The × marker has two crossing diagonals — check for the double-M path
+    const markerSection = svg.match(/class="bpmn-gateway-marker"[^>]*d="([^"]+)"/)?.[1] ?? '';
+    expect(markerSection.match(/M/g)?.length).toBe(2);
+  });
+
+  it('renders AND gateway as diamond path', () => {
+    const layout = makeLayout();
+    addElement(layout, { id: 'gw2', type: 'parallelGateway' }, {
+      x: 180, y: 75, width: 50, height: 50,
+    });
+    const svg = renderProcessLayoutSvg(layout);
+    expect(svg).toContain('class="bpmn-gateway"');
+    expect(svg).toContain('class="bpmn-gateway-marker"');
+  });
+});
+
+describe('renderProcessLayoutSvg — data objects', () => {
+  it('renders data object with fold-corner path', () => {
+    const layout = makeLayout();
+    addElement(layout, { id: 'do1', type: 'dataObject', name: 'Invoice' }, {
+      x: 160, y: 50, width: 36, height: 50,
+    });
+    const svg = renderProcessLayoutSvg(layout);
+    expect(svg).toContain('class="bpmn-data-obj"');
+  });
+
+  it('renders data object name below shape', () => {
+    const layout = makeLayout();
+    addElement(layout, { id: 'do1', type: 'dataObject', name: 'Invoice' }, {
+      x: 160, y: 50, width: 36, height: 50,
+    });
+    const svg = renderProcessLayoutSvg(layout);
+    expect(svg).toContain('Invoice');
+    expect(svg).toContain('bpmn-data-obj-label');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sequence flows
+// ---------------------------------------------------------------------------
+
+describe('renderProcessLayoutSvg — sequence flows', () => {
+  it('renders flows as polylines with arrow marker', () => {
+    const svg = renderProcessLayoutSvg(makeLayout());
+    expect(svg).toContain('class="bpmn-seq-flow"');
+    expect(svg).toContain('marker-end="url(#bpmn-arrow)"');
+  });
+
+  it('defines the bpmn-arrow marker', () => {
+    const svg = renderProcessLayoutSvg(makeLayout());
+    expect(svg).toContain('id="bpmn-arrow"');
+    expect(svg).toContain('class="arrow-fill"');
+  });
+
+  it('adds dashed class to conditional flows', () => {
+    const layout = makeLayout();
+    layout.flows[0] = { ...layout.flows[0], condition: 'approved == true' };
+    const svg = renderProcessLayoutSvg(layout);
+    expect(svg).toContain('bpmn-seq-flow bpmn-seq-cond');
+  });
+
+  it('skips flows with fewer than 2 waypoints', () => {
+    const layout = makeLayout();
+    layout.flows.push({ id: 'bad', from: 'start', to: 'end', waypoints: [{ x: 100, y: 100 }] });
+    expect(() => renderProcessLayoutSvg(layout)).not.toThrow();
+    const svg = renderProcessLayoutSvg(layout);
+    // Should still render the 2 valid flows
+    const matches = svg.match(/class="bpmn-seq-flow"/g);
+    expect(matches?.length).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Associations
+// ---------------------------------------------------------------------------
+
+describe('renderProcessLayoutSvg — associations', () => {
+  it('renders associations as dashed polylines without arrowhead', () => {
+    const layout = makeLayout();
+    addElement(layout, { id: 'do1', type: 'dataObject' }, { x: 160, y: 50, width: 36, height: 50 });
+    layout.associations.push({
+      id: 'a1',
+      from: 'task1',
+      to: 'do1',
+      waypoints: [{ x: 300, y: 100 }, { x: 178, y: 75 }],
+    });
+    const svg = renderProcessLayoutSvg(layout);
+    expect(svg).toContain('class="bpmn-assoc"');
+    // Associations must NOT have arrowheads
+    const assocLine = svg.match(/class="bpmn-assoc"[^/]*/)?.[0] ?? '';
+    expect(assocLine).not.toContain('marker-end');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderProcessBody offset
+// ---------------------------------------------------------------------------
+
+describe('renderProcessBody', () => {
+  it('shifts all coordinates by ox/oy', () => {
+    const layout = makeLayout();
+    const bodyAt0 = renderProcessBody(layout, 0, 0);
+    const bodyAt50 = renderProcessBody(layout, 50, 0);
+    // Pool at ox=0 has x=12; at ox=50 should be x=62
+    expect(bodyAt0).toContain('x="12"');
+    expect(bodyAt50).toContain('x="62"');
+    expect(bodyAt50).not.toContain('x="12"');
+  });
+
+  it('includes defs block with arrow marker', () => {
+    const body = renderProcessBody(makeLayout(), 0, 0);
+    expect(body).toContain('<defs>');
+    expect(body).toContain('id="bpmn-arrow"');
+  });
+});

--- a/packages/diagrams/src/webview/render-process.ts
+++ b/packages/diagrams/src/webview/render-process.ts
@@ -1,0 +1,375 @@
+/**
+ * Host-neutral SVG emitter for the BPMN process notation.
+ *
+ * Part of the custom process renderer programme (ADR 2026-06-22).
+ * P1: skeleton emitter — current DSL element subset: tasks, user/service tasks,
+ * XOR/AND gateways, start/end events, data objects, sequence flows (with
+ * optional conditional dashes), and association edges.
+ *
+ * Single-emitter unification (review C): `renderProcessBody` is the canonical
+ * body shared by every host. Callers wrap it with a host-specific title block
+ * or a standalone SVG shell.
+ *
+ * No VS Code APIs. No Node.js built-ins. Browser-safe.
+ */
+
+import { generateSvgEmbedCss } from '../theme/index.js';
+import { escXml } from './render-util.js';
+
+// ---------------------------------------------------------------------------
+// Structural interface — mirrors LayoutIr from the BPMN core without taking a
+// build-time dependency on that package. TypeScript structural typing ensures
+// any LayoutIr value satisfies ProcessDiagramLayout.
+// ---------------------------------------------------------------------------
+
+export interface ProcessBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface ProcessFlowElement {
+  id: string;
+  type: string;
+  name?: string;
+}
+
+export interface ProcessLane {
+  id: string;
+  name: string;
+  elements: ProcessFlowElement[];
+}
+
+export interface ProcessInfo {
+  id: string;
+  name: string;
+  poolId: string;
+  poolName: string;
+  lanes: ProcessLane[];
+}
+
+export interface ProcessFlow {
+  id: string;
+  from: string;
+  to: string;
+  condition?: string;
+  default?: boolean;
+  name?: string;
+  waypoints: { x: number; y: number }[];
+}
+
+export interface ProcessAssociation {
+  id: string;
+  from: string;
+  to: string;
+  waypoints: { x: number; y: number }[];
+}
+
+export interface ProcessDiagramLayout {
+  process: ProcessInfo;
+  elements: Map<string, ProcessBounds>;
+  laneBounds: Map<string, ProcessBounds>;
+  poolBounds: ProcessBounds;
+  flows: ProcessFlow[];
+  associations: ProcessAssociation[];
+}
+
+export interface RenderProcessOptions {
+  /** Raw SVG injected after `<style>` — a title line or full title block. */
+  title?: string;
+  /** Extra vertical space (px) reserved above the pool for a title block. */
+  topInset?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Constants — match DEFAULT_LAYOUT_DIAGRAM_OPTIONS in src/layout-options.ts
+// ---------------------------------------------------------------------------
+
+/** Width of the lane-name column (px). Matches the laneLabelWidth default. */
+const LANE_LABEL_BAND = 72;
+
+/** Maximum characters per wrapped line inside a task box. */
+const TASK_CHARS = 14;
+
+/** Line height for wrapped task-name text (px). */
+const TASK_LINE_H = 14;
+
+// ---------------------------------------------------------------------------
+// BPMN-specific CSS — no font-style:italic per CLAUDE.md design rule
+// ---------------------------------------------------------------------------
+
+export const BPMN_PROCESS_CSS = `
+.bpmn-pool { fill: var(--ts-bg-surface,#f8fafc); stroke: var(--ts-node-stroke,#94a3b8); stroke-width: 1.5; }
+.bpmn-pool-name { fill: var(--ts-bg-elevated,#f1f5f9); stroke: var(--ts-node-stroke,#94a3b8); stroke-width: 0.75; }
+.bpmn-lane { fill: var(--ts-bg,#ffffff); stroke: var(--ts-node-stroke,#94a3b8); stroke-width: 0.75; }
+.bpmn-lane-header { fill: var(--ts-bg-elevated,#f1f5f9); stroke: var(--ts-node-stroke,#94a3b8); stroke-width: 0.75; }
+.bpmn-pool-label { fill: var(--ts-text-primary,#1e293b); font-size: 11px; font-weight: 700; }
+.bpmn-lane-label { fill: var(--ts-text-primary,#1e293b); font-size: 11px; font-weight: 600; }
+.bpmn-task { fill: var(--ts-bg,#ffffff); stroke: var(--ts-node-stroke,#94a3b8); stroke-width: 1.5; }
+.bpmn-task-name { fill: var(--ts-text-primary,#1e293b); font-size: 11px; text-anchor: middle; }
+.bpmn-event { fill: var(--ts-bg,#ffffff); stroke: var(--ts-node-stroke,#94a3b8); }
+.bpmn-event-start { stroke-width: 1.5; }
+.bpmn-event-end { stroke-width: 4; }
+.bpmn-event-label { fill: var(--ts-text-secondary,#64748b); font-size: 10px; text-anchor: middle; }
+.bpmn-gateway { fill: var(--ts-bg,#ffffff); stroke: var(--ts-node-stroke,#94a3b8); stroke-width: 1.5; }
+.bpmn-gateway-marker { stroke: var(--ts-node-stroke,#94a3b8); stroke-width: 2.5; stroke-linecap: round; fill: none; }
+.bpmn-gateway-label { fill: var(--ts-text-secondary,#64748b); font-size: 10px; text-anchor: middle; }
+.bpmn-seq-flow { fill: none; stroke: var(--ts-edge-stroke,#64748b); stroke-width: 1.5; }
+.bpmn-seq-cond { stroke-dasharray: 6 3; }
+.bpmn-assoc { fill: none; stroke: var(--ts-edge-stroke,#64748b); stroke-width: 1; stroke-dasharray: 4 2; }
+.bpmn-data-obj { fill: var(--ts-bg,#ffffff); stroke: var(--ts-node-stroke,#94a3b8); stroke-width: 1; }
+.bpmn-data-obj-label { fill: var(--ts-text-secondary,#64748b); font-size: 10px; text-anchor: middle; }
+`;
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function r(n: number): number {
+  return Math.round(n);
+}
+
+function wrapTaskName(name: string): string[] {
+  if (!name) return [];
+  const words = name.split(/\s+/);
+  const lines: string[] = [];
+  let cur = '';
+  for (const w of words) {
+    const token = w.length > TASK_CHARS ? w.slice(0, TASK_CHARS - 1) + '…' : w;
+    if (!cur) {
+      cur = token;
+    } else if (cur.length + 1 + token.length <= TASK_CHARS) {
+      cur += ' ' + token;
+    } else {
+      lines.push(cur);
+      if (lines.length === 3) {
+        if (lines[2].length > TASK_CHARS - 1) lines[2] = lines[2].slice(0, TASK_CHARS - 1) + '…';
+        return lines;
+      }
+      cur = token;
+    }
+  }
+  if (cur && lines.length < 3) lines.push(cur);
+  if (lines.length === 0) lines.push(name.slice(0, TASK_CHARS));
+  return lines;
+}
+
+function taskNameSvg(name: string | undefined, cx: number, cy: number): string {
+  if (!name) return '';
+  const lines = wrapTaskName(name);
+  const totalH = lines.length * TASK_LINE_H;
+  const startY = cy - totalH / 2 + TASK_LINE_H * 0.8;
+  const tspans = lines
+    .map((ln, i) => `<tspan x="${r(cx)}" y="${r(startY + i * TASK_LINE_H)}">${escXml(ln)}</tspan>`)
+    .join('');
+  return `<text class="bpmn-task-name">${tspans}</text>`;
+}
+
+function belowLabelSvg(name: string | undefined, cls: string, cx: number, belowY: number): string {
+  if (!name) return '';
+  const label = name.length > 18 ? name.slice(0, 17) + '…' : name;
+  return `<text class="${cls}" x="${r(cx)}" y="${r(belowY + 12)}">${escXml(label)}</text>`;
+}
+
+// ---------------------------------------------------------------------------
+// Element renderer
+// ---------------------------------------------------------------------------
+
+function renderElement(el: ProcessFlowElement, b: ProcessBounds, ox: number, oy: number): string {
+  const ex = b.x + ox;
+  const ey = b.y + oy;
+  const cx = ex + b.width / 2;
+  const cy = ey + b.height / 2;
+  const halfR = Math.min(b.width, b.height) / 2;
+
+  switch (el.type) {
+    case 'startEvent':
+      return [
+        `<circle class="bpmn-event bpmn-event-start" cx="${r(cx)}" cy="${r(cy)}" r="${r(halfR)}"/>`,
+        belowLabelSvg(el.name, 'bpmn-event-label', cx, ey + b.height),
+      ].join('\n');
+
+    case 'endEvent':
+      return [
+        `<circle class="bpmn-event bpmn-event-end" cx="${r(cx)}" cy="${r(cy)}" r="${r(halfR - 2)}"/>`,
+        belowLabelSvg(el.name, 'bpmn-event-label', cx, ey + b.height),
+      ].join('\n');
+
+    case 'task':
+    case 'userTask':
+    case 'serviceTask':
+      return [
+        `<rect class="diagram-node bpmn-task" x="${r(ex)}" y="${r(ey)}" width="${r(b.width)}" height="${r(b.height)}" rx="4" ry="4"/>`,
+        taskNameSvg(el.name, cx, cy),
+      ].join('\n');
+
+    case 'exclusiveGateway':
+      return [
+        `<path class="bpmn-gateway" d="M ${r(cx)},${r(ey)} L ${r(ex + b.width)},${r(cy)} L ${r(cx)},${r(ey + b.height)} L ${r(ex)},${r(cy)} Z"/>`,
+        `<path class="bpmn-gateway-marker" d="M ${r(cx - 10)},${r(cy - 10)} L ${r(cx + 10)},${r(cy + 10)} M ${r(cx + 10)},${r(cy - 10)} L ${r(cx - 10)},${r(cy + 10)}"/>`,
+        belowLabelSvg(el.name, 'bpmn-gateway-label', cx, ey + b.height),
+      ].join('\n');
+
+    case 'parallelGateway':
+      return [
+        `<path class="bpmn-gateway" d="M ${r(cx)},${r(ey)} L ${r(ex + b.width)},${r(cy)} L ${r(cx)},${r(ey + b.height)} L ${r(ex)},${r(cy)} Z"/>`,
+        `<path class="bpmn-gateway-marker" d="M ${r(cx)},${r(cy - 12)} L ${r(cx)},${r(cy + 12)} M ${r(cx - 12)},${r(cy)} L ${r(cx + 12)},${r(cy)}"/>`,
+        belowLabelSvg(el.name, 'bpmn-gateway-label', cx, ey + b.height),
+      ].join('\n');
+
+    case 'dataObject': {
+      const fold = Math.min(8, b.width / 3, b.height / 3);
+      return [
+        `<path class="bpmn-data-obj" d="M ${r(ex)},${r(ey)} L ${r(ex + b.width - fold)},${r(ey)} L ${r(ex + b.width)},${r(ey + fold)} L ${r(ex + b.width)},${r(ey + b.height)} L ${r(ex)},${r(ey + b.height)} Z"/>`,
+        `<path class="bpmn-data-obj" fill="none" d="M ${r(ex + b.width - fold)},${r(ey)} L ${r(ex + b.width - fold)},${r(ey + fold)} L ${r(ex + b.width)},${r(ey + fold)}"/>`,
+        belowLabelSvg(el.name, 'bpmn-data-obj-label', cx, ey + b.height),
+      ].join('\n');
+    }
+
+    default:
+      return [
+        `<rect class="diagram-node" x="${r(ex)}" y="${r(ey)}" width="${r(b.width)}" height="${r(b.height)}"/>`,
+        el.name
+          ? `<text class="text-primary" x="${r(cx)}" y="${r(cy)}" text-anchor="middle" dominant-baseline="central">${escXml(el.name)}</text>`
+          : '',
+      ].join('\n');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pool / lane structure
+// ---------------------------------------------------------------------------
+
+function renderPoolLanes(layout: ProcessDiagramLayout, ox: number, oy: number): string {
+  const { process, laneBounds, poolBounds: pb } = layout;
+  const parts: string[] = [];
+  const px = r(pb.x + ox);
+  const py = r(pb.y + oy);
+  const pw = r(pb.width);
+  const ph = r(pb.height);
+
+  // Pool name band width: distance from pool left edge to first lane left edge
+  const firstLb = laneBounds.size > 0 ? [...laneBounds.values()][0] : undefined;
+  const poolNameW = firstLb ? r(firstLb.x - pb.x) : 48;
+
+  parts.push(`<rect class="bpmn-pool" x="${px}" y="${py}" width="${pw}" height="${ph}"/>`);
+  parts.push(`<rect class="bpmn-pool-name" x="${px}" y="${py}" width="${poolNameW}" height="${ph}"/>`);
+
+  const pLX = r(px + poolNameW / 2);
+  const pLY = r(py + ph / 2);
+  parts.push(
+    `<text class="bpmn-pool-label" text-anchor="middle" dominant-baseline="central"` +
+    ` transform="rotate(-90,${pLX},${pLY})" x="${pLX}" y="${pLY}">${escXml(process.poolName)}</text>`,
+  );
+
+  for (const lane of process.lanes) {
+    const lb = laneBounds.get(lane.id);
+    if (!lb) continue;
+    const lx = r(lb.x + ox);
+    const ly = r(lb.y + oy);
+    const lw = r(lb.width);
+    const lh = r(lb.height);
+
+    parts.push(`<rect class="bpmn-lane" x="${lx}" y="${ly}" width="${lw}" height="${lh}"/>`);
+    parts.push(`<rect class="bpmn-lane-header" x="${lx}" y="${ly}" width="${LANE_LABEL_BAND}" height="${lh}"/>`);
+
+    const lLX = r(lx + LANE_LABEL_BAND / 2);
+    const lLY = r(ly + lh / 2);
+    parts.push(
+      `<text class="bpmn-lane-label" text-anchor="middle" dominant-baseline="central"` +
+      ` transform="rotate(-90,${lLX},${lLY})" x="${lLX}" y="${lLY}">${escXml(lane.name)}</text>`,
+    );
+  }
+
+  return parts.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical body emitter, shared by every host (VS Code, JCEF, static export).
+ *
+ * Renders: pool + lane structure, all flow elements, sequence flows (with
+ * optional conditional dashes), and association edges. The `<defs>` block
+ * containing the arrowhead marker is included so the body is self-contained.
+ *
+ * @param layout - Positioned process layout (output of `layoutProcess`).
+ * @param ox - Horizontal canvas offset (px) applied to all coordinates.
+ * @param oy - Vertical canvas offset (px) applied to all coordinates.
+ */
+export function renderProcessBody(
+  layout: ProcessDiagramLayout,
+  ox: number,
+  oy: number,
+): string {
+  const parts: string[] = [];
+
+  parts.push(
+    `<defs>\n` +
+    `  <marker id="bpmn-arrow" viewBox="0 0 10 10" refX="9" refY="5"` +
+    ` markerWidth="8" markerHeight="8" orient="auto">\n` +
+    `    <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-fill"/>\n` +
+    `  </marker>\n` +
+    `</defs>`,
+  );
+
+  parts.push(renderPoolLanes(layout, ox, oy));
+
+  for (const lane of layout.process.lanes) {
+    for (const el of lane.elements) {
+      const b = layout.elements.get(el.id);
+      if (!b) continue;
+      parts.push(renderElement(el, b, ox, oy));
+    }
+  }
+
+  for (const flow of layout.flows) {
+    if (flow.waypoints.length < 2) continue;
+    const pts = flow.waypoints.map((p) => `${r(p.x + ox)},${r(p.y + oy)}`).join(' ');
+    const condCls = flow.condition ? ' bpmn-seq-cond' : '';
+    parts.push(`<polyline class="bpmn-seq-flow${condCls}" points="${pts}" marker-end="url(#bpmn-arrow)"/>`);
+  }
+
+  for (const assoc of layout.associations) {
+    if (assoc.waypoints.length < 2) continue;
+    const pts = assoc.waypoints.map((p) => `${r(p.x + ox)},${r(p.y + oy)}`).join(' ');
+    parts.push(`<polyline class="bpmn-assoc" points="${pts}"/>`);
+  }
+
+  return parts.join('\n');
+}
+
+/**
+ * Self-contained SVG for the BPMN process notation.
+ *
+ * Embeds the shared Transitrix theme CSS plus BPMN-specific rules so the
+ * output can be dropped into a static webview panel or saved as an `.svg`
+ * file. VS Code's dynamic preview (which supplies CSS separately via a
+ * webview stylesheet) should call `renderProcessBody` directly and wrap it
+ * with its own HTML shell.
+ */
+export function renderProcessLayoutSvg(
+  layout: ProcessDiagramLayout,
+  options: RenderProcessOptions = {},
+): string {
+  const { title = '', topInset = title ? 32 : 0 } = options;
+  const pb = layout.poolBounds;
+  const PAD = 16;
+
+  const svgW = r(pb.x + pb.width + PAD);
+  const svgH = r(pb.y + pb.height + PAD + topInset);
+
+  const embedCss = generateSvgEmbedCss('transitrix') + BPMN_PROCESS_CSS;
+  const body = renderProcessBody(layout, 0, topInset);
+
+  return (
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${svgW}" height="${svgH}" viewBox="0 0 ${svgW} ${svgH}">\n` +
+    `<style>${embedCss}</style>\n` +
+    (title ? `${title}\n` : '') +
+    `${body}\n` +
+    `</svg>`
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `renderProcessBody` / `renderProcessLayoutSvg` in `@transitrix/diagrams/webview/render-process` — a host-neutral SVG emitter for the BPMN process notation covering the current DSL subset: tasks, userTask, serviceTask, XOR/AND gateways, start/end events, data objects, sequence flows (with conditional dashes), and association edges
- Defines `ProcessDiagramLayout` as a structural interface (mirrors `LayoutIr` without a build-time dependency on the BPMN core package — TypeScript structural typing bridges them)
- Embeds shared Transitrix theme CSS via `generateSvgEmbedCss` plus BPMN-specific rules; no `font-style:italic` anywhere per design rule
- Adds 37 tests covering SVG structure, CSS embedding, all element types, XML escaping, offset coordinates, and edge cases
- Wires the emitter into the VS Code extension behind `transitrix.bpmnRenderer` (`"bpmn-io"` default / `"custom"` experimental); new `ProcessPreview` class replaces the bpmn.io webview with a static SVG panel when the flag is active; bpmn.io path is fully untouched

## Test plan

- [ ] 963 tests green (`npm test`)
- [ ] `npx tsc -p extension/tsconfig.json --noEmit` clean
- [ ] Manual: open a `.bpmn.transitrix.yaml` file — default bpmn.io preview unchanged
- [ ] Manual: set `"transitrix.bpmnRenderer": "custom"` in VS Code settings → reopen preview → custom SVG renders pool/lanes/elements/flows
