### PR TITLE
feat(diagrams): extended BPMN subset — inclusive gateway, intermediate events (renderer P2)

### DIFF
--- a/packages/diagrams/src/webview/__tests__/render-process.test.ts
+++ b/packages/diagrams/src/webview/__tests__/render-process.test.ts
@@ -292,6 +292,37 @@ describe('renderProcessLayoutSvg — gateways', () => {
     expect(svg).toContain('class="bpmn-gateway"');
     expect(svg).toContain('class="bpmn-gateway-marker"');
   });
+
+  it('renders inclusive gateway as diamond with circle marker', () => {
+    const layout = makeLayout();
+    addElement(layout, { id: 'gw3', type: 'inclusiveGateway', name: 'Any?' }, {
+      x: 180, y: 75, width: 50, height: 50,
+    });
+    const svg = renderProcessLayoutSvg(layout);
+    expect(svg).toContain('class="bpmn-gateway"');
+    expect(svg).toMatch(/<circle[^>]+class="bpmn-gateway-marker"/);
+  });
+
+  it('inclusive gateway circle marker uses gateway-marker class (no fill)', () => {
+    const layout = makeLayout();
+    addElement(layout, { id: 'gw3', type: 'inclusiveGateway' }, {
+      x: 180, y: 75, width: 50, height: 50,
+    });
+    const svg = renderProcessLayoutSvg(layout);
+    // CSS class bpmn-gateway-marker has fill:none — no inline fill on the element
+    const circle = svg.match(/<circle[^>]+bpmn-gateway-marker[^>]*/)?.[0] ?? '';
+    expect(circle).not.toContain('fill=');
+  });
+
+  it('inclusive gateway renders label below shape', () => {
+    const layout = makeLayout();
+    addElement(layout, { id: 'gw3', type: 'inclusiveGateway', name: 'Any path?' }, {
+      x: 180, y: 75, width: 50, height: 50,
+    });
+    const svg = renderProcessLayoutSvg(layout);
+    expect(svg).toContain('Any path?');
+    expect(svg).toContain('bpmn-gateway-label');
+  });
 });
 
 describe('renderProcessLayoutSvg — data objects', () => {
@@ -312,6 +343,116 @@ describe('renderProcessLayoutSvg — data objects', () => {
     const svg = renderProcessLayoutSvg(layout);
     expect(svg).toContain('Invoice');
     expect(svg).toContain('bpmn-data-obj-label');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Intermediate events (P2)
+// ---------------------------------------------------------------------------
+
+describe('renderProcessLayoutSvg — intermediate message event', () => {
+  it('renders outer ring with bpmn-event-start class', () => {
+    const layout = makeLayout();
+    addElement(layout, { id: 'me1', type: 'intermediateMessageEvent', name: 'Receive' }, {
+      x: 200, y: 72, width: 36, height: 36,
+    });
+    const svg = renderProcessLayoutSvg(layout);
+    // Outer ring reuses the start-event circle
+    expect(svg).toMatch(/<circle[^>]+class="bpmn-event bpmn-event-start"/);
+  });
+
+  it('renders inner ring with bpmn-event-intermediate class', () => {
+    const layout = makeLayout();
+    addElement(layout, { id: 'me1', type: 'intermediateMessageEvent' }, {
+      x: 200, y: 72, width: 36, height: 36,
+    });
+    const svg = renderProcessLayoutSvg(layout);
+    expect(svg).toContain('class="bpmn-event-intermediate"');
+  });
+
+  it('renders envelope rect and fold path as bpmn-event-icon', () => {
+    const layout = makeLayout();
+    addElement(layout, { id: 'me1', type: 'intermediateMessageEvent' }, {
+      x: 200, y: 72, width: 36, height: 36,
+    });
+    const svg = renderProcessLayoutSvg(layout);
+    expect(svg).toContain('class="bpmn-event-icon"');
+    // Envelope body is a rect
+    expect(svg).toMatch(/<rect[^>]+bpmn-event-icon/);
+    // Envelope flap is a path with at least 2 M/L points
+    const iconPath = svg.match(/class="bpmn-event-icon"[^>]*d="([^"]+)"/)?.[1] ?? '';
+    expect(iconPath).toBeTruthy();
+  });
+
+  it('renders label below the shape', () => {
+    const layout = makeLayout();
+    addElement(layout, { id: 'me1', type: 'intermediateMessageEvent', name: 'Order Received' }, {
+      x: 200, y: 72, width: 36, height: 36,
+    });
+    const svg = renderProcessLayoutSvg(layout);
+    expect(svg).toContain('Order Received');
+    expect(svg).toContain('bpmn-event-label');
+  });
+
+  it('no font-style italic in intermediate message event output', () => {
+    const layout = makeLayout();
+    addElement(layout, { id: 'me1', type: 'intermediateMessageEvent', name: 'Wait' }, {
+      x: 200, y: 72, width: 36, height: 36,
+    });
+    const svg = renderProcessLayoutSvg(layout);
+    expect(svg).not.toContain('font-style');
+  });
+});
+
+describe('renderProcessLayoutSvg — intermediate timer event', () => {
+  it('renders outer ring with bpmn-event-start class', () => {
+    const layout = makeLayout();
+    addElement(layout, { id: 'te1', type: 'intermediateTimerEvent', name: 'Wait 1h' }, {
+      x: 200, y: 72, width: 36, height: 36,
+    });
+    const svg = renderProcessLayoutSvg(layout);
+    expect(svg).toMatch(/<circle[^>]+class="bpmn-event bpmn-event-start"/);
+  });
+
+  it('renders inner ring with bpmn-event-intermediate class', () => {
+    const layout = makeLayout();
+    addElement(layout, { id: 'te1', type: 'intermediateTimerEvent' }, {
+      x: 200, y: 72, width: 36, height: 36,
+    });
+    const svg = renderProcessLayoutSvg(layout);
+    expect(svg).toContain('class="bpmn-event-intermediate"');
+  });
+
+  it('renders clock face circle and two hand lines', () => {
+    const layout = makeLayout();
+    addElement(layout, { id: 'te1', type: 'intermediateTimerEvent' }, {
+      x: 200, y: 72, width: 36, height: 36,
+    });
+    const svg = renderProcessLayoutSvg(layout);
+    // Clock face circle
+    expect(svg).toMatch(/<circle[^>]+class="bpmn-event-icon"/);
+    // Two hand lines
+    const lines = svg.match(/<line[^>]+class="bpmn-event-icon"/g) ?? [];
+    expect(lines.length).toBe(2);
+  });
+
+  it('renders label below the shape', () => {
+    const layout = makeLayout();
+    addElement(layout, { id: 'te1', type: 'intermediateTimerEvent', name: 'Delay' }, {
+      x: 200, y: 72, width: 36, height: 36,
+    });
+    const svg = renderProcessLayoutSvg(layout);
+    expect(svg).toContain('Delay');
+    expect(svg).toContain('bpmn-event-label');
+  });
+
+  it('no font-style italic in intermediate timer event output', () => {
+    const layout = makeLayout();
+    addElement(layout, { id: 'te1', type: 'intermediateTimerEvent', name: 'Wait' }, {
+      x: 200, y: 72, width: 36, height: 36,
+    });
+    const svg = renderProcessLayoutSvg(layout);
+    expect(svg).not.toContain('font-style');
   });
 });
 

--- a/packages/diagrams/src/webview/render-process.ts
+++ b/packages/diagrams/src/webview/render-process.ts
@@ -120,6 +120,8 @@ export const BPMN_PROCESS_CSS = `
 .bpmn-assoc { fill: none; stroke: var(--ts-edge-stroke,#64748b); stroke-width: 1; stroke-dasharray: 4 2; }
 .bpmn-data-obj { fill: var(--ts-bg,#ffffff); stroke: var(--ts-node-stroke,#94a3b8); stroke-width: 1; }
 .bpmn-data-obj-label { fill: var(--ts-text-secondary,#64748b); font-size: 10px; text-anchor: middle; }
+.bpmn-event-intermediate { fill: none; stroke: var(--ts-node-stroke,#94a3b8); stroke-width: 1; }
+.bpmn-event-icon { fill: none; stroke: var(--ts-node-stroke,#94a3b8); stroke-width: 1.5; stroke-linecap: round; stroke-linejoin: round; }
 `;
 
 // ---------------------------------------------------------------------------
@@ -217,6 +219,40 @@ function renderElement(el: ProcessFlowElement, b: ProcessBounds, ox: number, oy:
         `<path class="bpmn-gateway-marker" d="M ${r(cx)},${r(cy - 12)} L ${r(cx)},${r(cy + 12)} M ${r(cx - 12)},${r(cy)} L ${r(cx + 12)},${r(cy)}"/>`,
         belowLabelSvg(el.name, 'bpmn-gateway-label', cx, ey + b.height),
       ].join('\n');
+
+    case 'inclusiveGateway':
+      return [
+        `<path class="bpmn-gateway" d="M ${r(cx)},${r(ey)} L ${r(ex + b.width)},${r(cy)} L ${r(cx)},${r(ey + b.height)} L ${r(ex)},${r(cy)} Z"/>`,
+        `<circle class="bpmn-gateway-marker" cx="${r(cx)}" cy="${r(cy)}" r="${r(halfR * 0.4)}"/>`,
+        belowLabelSvg(el.name, 'bpmn-gateway-label', cx, ey + b.height),
+      ].join('\n');
+
+    case 'intermediateMessageEvent': {
+      const innerR = r(halfR - 4);
+      const eHW = r(halfR * 0.45);
+      const eHH = r(halfR * 0.3);
+      return [
+        `<circle class="bpmn-event bpmn-event-start" cx="${r(cx)}" cy="${r(cy)}" r="${r(halfR)}"/>`,
+        `<circle class="bpmn-event-intermediate" cx="${r(cx)}" cy="${r(cy)}" r="${innerR}"/>`,
+        `<rect class="bpmn-event-icon" x="${r(cx - eHW)}" y="${r(cy - eHH)}" width="${r(eHW * 2)}" height="${r(eHH * 2)}"/>`,
+        `<path class="bpmn-event-icon" d="M ${r(cx - eHW)},${r(cy - eHH)} L ${r(cx)},${r(cy)} L ${r(cx + eHW)},${r(cy - eHH)}"/>`,
+        belowLabelSvg(el.name, 'bpmn-event-label', cx, ey + b.height),
+      ].join('\n');
+    }
+
+    case 'intermediateTimerEvent': {
+      const innerR = r(halfR - 4);
+      const clockR = r(halfR * 0.5);
+      const handLen = r(halfR * 0.38);
+      return [
+        `<circle class="bpmn-event bpmn-event-start" cx="${r(cx)}" cy="${r(cy)}" r="${r(halfR)}"/>`,
+        `<circle class="bpmn-event-intermediate" cx="${r(cx)}" cy="${r(cy)}" r="${innerR}"/>`,
+        `<circle class="bpmn-event-icon" cx="${r(cx)}" cy="${r(cy)}" r="${clockR}"/>`,
+        `<line class="bpmn-event-icon" x1="${r(cx)}" y1="${r(cy)}" x2="${r(cx)}" y2="${r(cy - handLen)}"/>`,
+        `<line class="bpmn-event-icon" x1="${r(cx)}" y1="${r(cy)}" x2="${r(cx + r(handLen * 0.7))}" y2="${r(cy)}"/>`,
+        belowLabelSvg(el.name, 'bpmn-event-label', cx, ey + b.height),
+      ].join('\n');
+    }
 
     case 'dataObject': {
       const fold = Math.min(8, b.width / 3, b.height / 3);


### PR DESCRIPTION
## Summary

- **Inclusive gateway**: diamond + circle marker (`bpmn-gateway-marker` class, `fill:none`)
- **Intermediate message event**: outer ring + inner ring (`bpmn-event-intermediate`) + envelope rect/fold-path (`bpmn-event-icon`)
- **Intermediate timer event**: outer ring + inner ring + clock circle + two hand lines (`bpmn-event-icon`)
- Two new CSS classes added to `BPMN_PROCESS_CSS` — no italic, no ad-hoc inline styles
- 13 new tests; total render-process suite: 50 tests green

Closes custom process renderer P2 (strategy hub #319).

## Test plan

- [ ] `npm test` — 976 tests green
- [ ] Inclusive gateway renders diamond + circle, no fill on the marker circle
- [ ] Intermediate message event renders double ring + envelope icon + label
- [ ] Intermediate timer event renders double ring + clock face circle + 2 hand lines + label
- [ ] No `font-style` anywhere in the new element output

🤖 Generated with [Claude Code](https://claude.com/claude-code)