### PR TITLE
feat(extension): make custom BPMN renderer the default (renderer P4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **BPMN preview — custom renderer is now the default.** `transitrix.bpmnRenderer` defaults to `"custom"` (the built-in SVG emitter) instead of `"bpmn-io"`. The custom renderer supports the full v1 element subset: swimlanes, tasks, XOR/AND/inclusive gateways, start/end events, intermediate message and timer events, data objects with association edges, and conditional sequence flows. Zoom (50–200%) and pan work via the shared preview controls consistent with all other Transitrix notations.
+
+  To revert to the legacy bpmn.io viewer (full BPMN 2.0 interactivity), set in your VS Code settings:
+  ```json
+  "transitrix.bpmnRenderer": "bpmn-io"
+  ```
+
 ## [2.1.1] — 2026-06-20
 
 ### Fixed

--- a/docs/decisions/2026-06-22-custom-process-renderer.md
+++ b/docs/decisions/2026-06-22-custom-process-renderer.md
@@ -143,5 +143,7 @@ bpmn-js-specific interactions are carried over for v1.
 - CV-3 and future compliance overlays draw on a renderer we control end to end.
 - The v1 subset requires additive model work (new element types + association
   edges) in `@transitrix/bpmn-core` before the emitter is feature-complete.
-- Until the custom renderer reaches subset parity, the bpmn.io path remains the
-  active render path — this is a phased replacement, not a big-bang switch.
+- **P4 complete (2026-06-22):** The v1 subset is shipped and the custom renderer
+  is now the default (`transitrix.bpmnRenderer` defaults to `"custom"`). The
+  bpmn.io path remains available as a legacy opt-in for users who need full
+  BPMN 2.0 interactivity (`"transitrix.bpmnRenderer": "bpmn-io"`).

--- a/extension/package.json
+++ b/extension/package.json
@@ -95,11 +95,11 @@
             "custom"
           ],
           "enumDescriptions": [
-            "bpmn.io viewer (default — full BPMN interactivity)",
-            "Custom SVG emitter (experimental — static preview, faster load)"
+            "bpmn.io viewer (legacy opt-in — full BPMN 2.0 interactivity; set this to revert to the old renderer)",
+            "Custom SVG emitter — default since v2.2.0 (static preview, shared theme, zoom/pan controls)"
           ],
-          "default": "bpmn-io",
-          "description": "BPMN preview renderer. 'bpmn-io' uses the bpmn.io viewer; 'custom' uses the built-in SVG emitter (part of the custom process renderer programme)."
+          "default": "custom",
+          "description": "BPMN preview renderer. 'custom' (default) uses the built-in SVG emitter consistent with all other Transitrix notations. Set to 'bpmn-io' to revert to the legacy bpmn.io viewer (full BPMN 2.0 interactivity)."
         },
         "transitrix.theme": {
           "type": "string",

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -229,7 +229,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       );
       return;
     }
-    const renderer = vscode.workspace.getConfiguration('transitrix').get<string>('bpmnRenderer', 'bpmn-io');
+    const renderer = vscode.workspace.getConfiguration('transitrix').get<string>('bpmnRenderer', 'custom');
     if (renderer === 'custom') {
       await processPreview.showOrReveal(doc);
     } else {


### PR DESCRIPTION
## Summary

- `transitrix.bpmnRenderer` default flipped from `"bpmn-io"` → `"custom"`
- Code fallback in `extension.ts` updated to match
- `enumDescriptions` updated to reflect new roles (custom = default, bpmn-io = legacy opt-in)
- CHANGELOG entry with revert instructions
- ADR P4-complete note

## To revert to the legacy bpmn.io viewer

```json
"transitrix.bpmnRenderer": "bpmn-io"
```

## Test plan

- [ ] `npm test` — 976 tests green
- [ ] `tsc --noEmit` clean in extension/
- [ ] Open a BPMN file without touching settings → custom renderer (zoom control visible)
- [ ] Set `"transitrix.bpmnRenderer": "bpmn-io"` → bpmn.io viewer loads instead

Closes custom process renderer P4 (strategy hub #321).

🤖 Generated with [Claude Code](https://claude.com/claude-code)