### PR TITLE
refactor(diagrams,extension): rename factor → driver across FGCA column and element notation

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -150,7 +150,7 @@
           "minimum": 20,
           "maximum": 300,
           "default": 160,
-          "description": "FGCA preview: horizontal gap (px) between the Factor/Goal/Change/Activity columns."
+          "description": "FGCA preview: horizontal gap (px) between the Driver/Goal/Change/Activity columns."
         },
         "transitrix.spacing.fgca.verticalGap": {
           "type": "number",
@@ -164,7 +164,7 @@
           "minimum": 20,
           "maximum": 300,
           "default": 160,
-          "description": "FGA preview: horizontal gap (px) between the Factor/Goal/Activity columns."
+          "description": "FGA preview: horizontal gap (px) between the Driver/Goal/Activity columns."
         },
         "transitrix.spacing.fga.verticalGap": {
           "type": "number",

--- a/extension/src/compliance-scan.ts
+++ b/extension/src/compliance-scan.ts
@@ -67,7 +67,7 @@ export async function scanComplianceCanon(): Promise<ScannedCanon> {
 const SILENT_NOTATIONS = new Set([
   // Element notations
   'activity', 'actor', 'assessment', 'business_object', 'change', 'constraint',
-  'equipment', 'factor', 'goal', 'registry', 'relation', 'role', 'rule',
+  'driver', 'equipment', 'factor', 'goal', 'registry', 'relation', 'role', 'rule',
   'stakeholder', 'target-state',
   // View / diagram notations
   'activities', 'activity-card', 'applications', 'blocks', 'bpmn',

--- a/extension/src/fgca-preview.ts
+++ b/extension/src/fgca-preview.ts
@@ -33,14 +33,14 @@ import { snapshotFilename, buildSnapshotContent, extractViewMeta, listSnapshotFi
 // singular `goal_id`, `activity_ids`). This file only renders that doc —
 // FGA reuses the FGCA renderer with the Changes column hidden.
 
-interface FactorItem { id: number | string; name: string; }
+interface DriverItem { id: number | string; name: string; }
 interface GoalItem { id: number | string; name: string; level?: number; factor?: Array<{ id: number | string }>; }
 interface ChangeItem { id: number | string; name: string; goal_id: number | string; activity_ids: Array<number | string>; }
 interface ActivityItem { id: number | string; name: string; goal_id?: number | string | null; }
 
 interface FGCADoc {
   notation: string;
-  factors: FactorItem[];
+  factors: DriverItem[];
   goals: GoalItem[];
   changes?: ChangeItem[];
   activities: ActivityItem[];
@@ -70,7 +70,7 @@ function scopeInputsFromDoc(doc: FGCADoc): { goals: ScopeGoalOption[]; maxLevelP
 // is a no-op in table view (per #137) — the table always shows the full doc.
 
 const CHAIN_COLUMN_HEADERS: Record<ChainColumn, string> = {
-  factor: 'Factor', goal: 'Goal', change: 'Change', activity: 'Activity',
+  driver: 'Driver', goal: 'Goal', change: 'Change', activity: 'Activity',
 };
 
 const CHAIN_TABLE_CSS = `

--- a/extension/src/scenarios-preview.ts
+++ b/extension/src/scenarios-preview.ts
@@ -9,9 +9,9 @@ import { StaticPreview } from './static-preview.js';
 // ── Types (used by render helpers) ───────────────────────────────────────────
 
 type ScenarioStatus = 'Draft' | 'Active' | 'Archived';
-type FactorRelevance = 'High' | 'Medium' | 'Low';
+type DriverRelevance = 'High' | 'Medium' | 'Low';
 
-interface FactorView { factor_id: string; relevance?: FactorRelevance; impact?: string }
+interface DriverView { factor_id: string; relevance?: DriverRelevance; impact?: string }
 
 interface ScenarioHeader {
   id: string;
@@ -20,7 +20,7 @@ interface ScenarioHeader {
   status: ScenarioStatus;
   created_at?: string;
   vision?: string;
-  factors_view?: FactorView[];
+  factors_view?: DriverView[];
   goals?: Array<{ goal_id: string }>;
   capabilities?: Array<{ capability_id: string }>;
   activities?: Array<{ activity_id: string }>;
@@ -43,7 +43,7 @@ const RELEVANCE_BADGE: Record<string, string> = {
   Low:    'badge-low',
 };
 
-function buildFactorsTable(factors: FactorView[] | undefined): string {
+function buildDriversTable(factors: DriverView[] | undefined): string {
   if (!factors || factors.length === 0) return '';
   const rows = factors.map(f => `<tr>
   <td class="col-factor-id">${escHtml(f.factor_id)}</td>
@@ -85,7 +85,7 @@ function buildScenarioBody(scn: ScenarioHeader): string {
 </section>`);
   }
 
-  blocks.push(buildFactorsTable(scn.factors_view));
+  blocks.push(buildDriversTable(scn.factors_view));
   blocks.push(buildRefSection('Goals',        extractIds(scn.goals, 'goal_id')));
   blocks.push(buildRefSection('Capabilities', extractIds(scn.capabilities, 'capability_id')));
   blocks.push(buildRefSection('Activities',   extractIds(scn.activities, 'activity_id')));

--- a/organizations/acme_corp/.templates/elements/01_motivation_template.yaml
+++ b/organizations/acme_corp/.templates/elements/01_motivation_template.yaml
@@ -4,7 +4,7 @@
 #   canon/elements/01_motivation/<plural-type>/<ID>.yaml
 #
 # TYPEs in this layer:
-#   FACTOR       notation: factor        folder factors/       fields: ELEMENT_PRIMITIVES.md §7.1
+#   FACTOR       notation: driver        folder factors/       fields: ELEMENT_PRIMITIVES.md §7.1
 #   GOAL         notation: goal          folder goals/         fields: §7.2
 #   CONSTRAINT   notation: constraint    folder constraints/   fields: §7.13
 #   REQUIREMENT  notation: requirement   folder requirements/  fields: notations/elements/15-requirement.md

--- a/organizations/acme_corp/canon/elements/01_motivation/factors/FACTOR-COMP-1.yaml
+++ b/organizations/acme_corp/canon/elements/01_motivation/factors/FACTOR-COMP-1.yaml
@@ -9,7 +9,7 @@
 # for the worked "8h and degrading" finding.
 # No PESTLE category — PESTLE applies to external factors only.
 
-notation: factor
+notation: driver
 id: FACTOR-COMP-1
 name: "Support response time"
 type: internal

--- a/organizations/acme_corp/canon/elements/01_motivation/factors/FACTOR-EU-REG-1.yaml
+++ b/organizations/acme_corp/canon/elements/01_motivation/factors/FACTOR-EU-REG-1.yaml
@@ -8,7 +8,7 @@
 # a moving timeline) would live on ASSESSMENT records that assesses this FACTOR.
 # `category: legal` per PESTLE — binding regulations / law.
 
-notation: factor
+notation: driver
 id: FACTOR-EU-REG-1
 name: "EU regulatory window for market entry"
 type: external

--- a/packages/diagrams/src/activity-card/__tests__/resolver.test.ts
+++ b/packages/diagrams/src/activity-card/__tests__/resolver.test.ts
@@ -41,7 +41,7 @@ const UNRELATED = {
   name: 'Other',
   parent: 'ACTIVITY-SOMETHING-ELSE-1',
 };
-const FACTOR = { notation: 'factor', id: 'FACTOR-EU-MDR-1', name: 'EU MDR regulation' };
+const FACTOR = { notation: 'driver', id: 'FACTOR-EU-MDR-1', name: 'EU MDR regulation' };
 const GOAL = { notation: 'goal', id: 'GOAL-EU-MARKET-1', name: 'Access EU market', factors: ['FACTOR-EU-MDR-1'] };
 const CHANGE = {
   notation: 'change',

--- a/packages/diagrams/src/activity-card/resolver.ts
+++ b/packages/diagrams/src/activity-card/resolver.ts
@@ -268,9 +268,10 @@ export function resolveActivityCard(
   }
 
   // ── Motivation chain — expand against canon DRIVER / GOAL / CHANGE elements ──
-  // Note: YAML corpus still uses `notation: factor` and `goal.factors` field names;
-  // the YAML keys are stable. The resolved TypeScript API uses "driver/driverIds".
-  const driverElems = collectByNotation(sources.elements, 'factor');
+  // Canon elements use `notation: driver`; `notation: factor` accepted for backward compat.
+  const driverElemsLegacy = collectByNotation(sources.elements, 'factor');
+  const driverElemsNew = collectByNotation(sources.elements, 'driver');
+  const driverElems = new Map([...driverElemsLegacy, ...driverElemsNew]);
   const goalElems = collectByNotation(sources.elements, 'goal');
   const changeElems = collectByNotation(sources.elements, 'change');
 

--- a/packages/diagrams/src/fgca/__tests__/chain-table.test.ts
+++ b/packages/diagrams/src/fgca/__tests__/chain-table.test.ts
@@ -36,7 +36,7 @@ describe('buildChainTable — worked example (FGCA)', () => {
 
   it('produces the spec grid with F1 spanning 3 and G2/C2 spanning 2', () => {
     const t = buildChainTable(doc);
-    expect(t.columns).toEqual<ChainColumn[]>(['factor', 'goal', 'change', 'activity']);
+    expect(t.columns).toEqual<ChainColumn[]>(['driver', 'goal', 'change', 'activity']);
     expect(asGrid(t)).toEqual([
       ['F1×3', 'G1', 'C1', 'A1'],
       ['·', 'G2×2', 'C2×2', 'A2'],
@@ -67,7 +67,7 @@ describe('buildChainTable — FGA (no Change column)', () => {
 
   it('emits three columns and merges Factor/Goal across the two activities', () => {
     const t = buildChainTable(doc, { hideChanges: true });
-    expect(t.columns).toEqual<ChainColumn[]>(['factor', 'goal', 'activity']);
+    expect(t.columns).toEqual<ChainColumn[]>(['driver', 'goal', 'activity']);
     expect(asGrid(t)).toEqual([
       ['F1×2', 'G1×2', 'A1'],
       ['·', '·', 'A2'],

--- a/packages/diagrams/src/fgca/__tests__/layout.test.ts
+++ b/packages/diagrams/src/fgca/__tests__/layout.test.ts
@@ -9,12 +9,12 @@ beforeAll(() => {
 });
 
 import { buildFGCALayout } from "../layout";
-import type { FactorItem, GoalItem, BdnChangeWithActivities, ActivityItem } from "../types";
+import type { DriverItem, GoalItem, BdnChangeWithActivities, ActivityItem } from "../types";
 import { ALL_FGCA_COLUMNS } from "../types";
 
 const ALL_COLS = new Set(ALL_FGCA_COLUMNS);
 
-const factors: FactorItem[] = [
+const factors: DriverItem[] = [
   { id: 1, name: "Digital growth" },
   { id: 2, name: "Talent shortage" },
 ];
@@ -50,16 +50,16 @@ describe("buildFGCALayout — all columns visible", () => {
 
   it("assigns correct node types", () => {
     const types = nodes.map((n) => n.type);
-    expect(types.filter((t) => t === "fgcaFactor")).toHaveLength(factors.length);
+    expect(types.filter((t) => t === "fgcaDriver")).toHaveLength(factors.length);
     expect(types.filter((t) => t === "fgcaGoal")).toHaveLength(goals.length);
     expect(types.filter((t) => t === "fgcaChange")).toHaveLength(changes.length);
     expect(types.filter((t) => t === "fgcaActivity")).toHaveLength(activities.length);
   });
 
   it("creates Factor→Goal edges", () => {
-    const fgEdges = edges.filter((e) => e.source.startsWith("factor_") && e.target.startsWith("goal_"));
+    const fgEdges = edges.filter((e) => e.source.startsWith("driver_") && e.target.startsWith("goal_"));
     expect(fgEdges).toHaveLength(2);
-    expect(fgEdges.find((e) => e.source === "factor_1" && e.target === "goal_10")).toBeTruthy();
+    expect(fgEdges.find((e) => e.source === "driver_1" && e.target === "goal_10")).toBeTruthy();
   });
 
   it("creates Goal→Change edges", () => {
@@ -85,7 +85,7 @@ describe("buildFGCALayout — all columns visible", () => {
   });
 
   it("encodes F-XXXX label format via id in node data", () => {
-    const factorNode = nodes.find((n) => n.id === "factor_1");
+    const factorNode = nodes.find((n) => n.id === "driver_1");
     expect(String(factorNode?.data.id).padStart(4, "0")).toBe("0001");
   });
 
@@ -95,16 +95,16 @@ describe("buildFGCALayout — all columns visible", () => {
   });
 });
 
-describe("buildFGCALayout — Factor column hidden", () => {
-  const cols = new Set(ALL_FGCA_COLUMNS.filter((c) => c !== "factor"));
+describe("buildFGCALayout — Driver column hidden", () => {
+  const cols = new Set(ALL_FGCA_COLUMNS.filter((c) => c !== "driver"));
   const { nodes, edges } = buildFGCALayout({ factors, goals, changes, activities, visibleColumns: cols });
 
-  it("produces no factor nodes", () => {
-    expect(nodes.filter((n) => n.type === "fgcaFactor")).toHaveLength(0);
+  it("produces no driver nodes", () => {
+    expect(nodes.filter((n) => n.type === "fgcaDriver")).toHaveLength(0);
   });
 
-  it("produces no Factor→Goal edges", () => {
-    expect(edges.filter((e) => e.source.startsWith("factor_"))).toHaveLength(0);
+  it("produces no Driver→Goal edges", () => {
+    expect(edges.filter((e) => e.source.startsWith("driver_"))).toHaveLength(0);
   });
 
   it("still produces Goal and downstream nodes", () => {
@@ -150,7 +150,7 @@ describe("buildFGCALayout — columns are positioned left to right", () => {
   const { nodes } = buildFGCALayout({ factors, goals, changes, activities, visibleColumns: ALL_COLS });
 
   it("factor column x < goal column x", () => {
-    const f = nodes.find((n) => n.type === "fgcaFactor")!;
+    const f = nodes.find((n) => n.type === "fgcaDriver")!;
     const g = nodes.find((n) => n.type === "fgcaGoal")!;
     expect(f.position.x).toBeLessThan(g.position.x);
   });

--- a/packages/diagrams/src/fgca/__tests__/preview-layout.test.ts
+++ b/packages/diagrams/src/fgca/__tests__/preview-layout.test.ts
@@ -25,7 +25,7 @@ const doc: FGCAPreviewDoc = {
 describe('layoutFGCAPreview', () => {
   it('lays out all four columns in order (FGCA)', () => {
     const layout = layoutFGCAPreview(doc);
-    expect(layout.columns.map(c => c.col)).toEqual(['factor', 'goal', 'change', 'activity']);
+    expect(layout.columns.map(c => c.col)).toEqual(['driver', 'goal', 'change', 'activity']);
     // 2 factors + 2 goals + 1 change + 2 activities
     expect(layout.nodes).toHaveLength(7);
     expect(layout.width).toBeGreaterThan(0);
@@ -40,7 +40,7 @@ describe('layoutFGCAPreview', () => {
 
   it('hideChanges (FGA) drops the Changes column and links goals to activities', () => {
     const layout = layoutFGCAPreview(doc, { hideChanges: true });
-    expect(layout.columns.map(c => c.col)).toEqual(['factor', 'goal', 'activity']);
+    expect(layout.columns.map(c => c.col)).toEqual(['driver', 'goal', 'activity']);
     // 2 factors + 2 goals + 2 activities
     expect(layout.nodes).toHaveLength(6);
     // F1→G1, F2→G2 (2), G1→A1, G2→A2 (2) = 4
@@ -70,7 +70,7 @@ describe('layoutFGCAPreview', () => {
 
   it('larger rowGap increases the gap between stacked nodes', () => {
     const gapOf = (rowGap: number) => {
-      const factors = layoutFGCAPreview(doc, { rowGap }).nodes.filter(n => n.col === 'factor');
+      const factors = layoutFGCAPreview(doc, { rowGap }).nodes.filter(n => n.col === 'driver');
       return factors[1].y - factors[0].y;
     };
     expect(gapOf(120)).toBeGreaterThan(gapOf(20));
@@ -86,15 +86,15 @@ describe('layoutFGCAPreview', () => {
       // root 10 → factor 1 (referenced by G10), change 20 (goal_id 10),
       // activity 30 (via change 20). G11/F2/A31 are dropped.
       const layout = layoutFGCAPreview(doc, { scope: { mode: 'root', rootGoalId: '10' } });
-      expect(idsOf(layout)).toEqual(new Set(['factor_1', 'goal_10', 'change_20', 'activity_30']));
+      expect(idsOf(layout)).toEqual(new Set(['driver_1', 'goal_10', 'change_20', 'activity_30']));
     });
 
     it("mode 'root' filters factors and activities to those touching the visible goal", () => {
       // root 11 → factor 2, activity 31 (direct goal link); no change touches G11.
       const layout = layoutFGCAPreview(doc, { scope: { mode: 'root', rootGoalId: '11' } });
-      expect(idsOf(layout)).toEqual(new Set(['factor_2', 'goal_11', 'activity_31']));
+      expect(idsOf(layout)).toEqual(new Set(['driver_2', 'goal_11', 'activity_31']));
       // F1, A30, C20 (which only touch the hidden G10) are excluded.
-      expect(layout.nodes.some(n => n.id === 'factor_1')).toBe(false);
+      expect(layout.nodes.some(n => n.id === 'driver_1')).toBe(false);
       expect(layout.nodes.some(n => n.id === 'activity_30')).toBe(false);
     });
 
@@ -112,7 +112,7 @@ describe('layoutFGCAPreview', () => {
         ],
       };
       const layout = layoutFGCAPreview(leveled, { scope: { mode: 'level', maxLevel: 0 } });
-      expect(idsOf(layout)).toEqual(new Set(['factor_1', 'goal_10', 'activity_30']));
+      expect(idsOf(layout)).toEqual(new Set(['driver_1', 'goal_10', 'activity_30']));
     });
 
     it("mode 'root' returns an empty layout when the root is absent", () => {

--- a/packages/diagrams/src/fgca/__tests__/resolver.test.ts
+++ b/packages/diagrams/src/fgca/__tests__/resolver.test.ts
@@ -8,8 +8,8 @@ import { parseCanonicalFGCA } from '../parse-canonical.js';
 // ── Inline canon element store (mirrors strategy-2026 data split into per-element form) ─
 
 const ELEMENTS = [
-  { notation: 'factor', id: 'FACTOR-1', name: 'Competitive market pressure', type: 'external' },
-  { notation: 'factor', id: 'FACTOR-2', name: 'Digital adoption acceleration', type: 'external' },
+  { notation: 'driver', id: 'FACTOR-1', name: 'Competitive market pressure', type: 'external' },
+  { notation: 'driver', id: 'FACTOR-2', name: 'Digital adoption acceleration', type: 'external' },
   { notation: 'goal', id: 'GOAL-1', name: 'Grow revenue by 20%', factors: ['FACTOR-1', 'FACTOR-2'] },
   { notation: 'goal', id: 'GOAL-2', name: 'Reduce operational costs', factors: ['FACTOR-2'] },
   { notation: 'goal', id: 'GOAL-3', name: 'Improve customer retention', factors: ['FACTOR-1'] },

--- a/packages/diagrams/src/fgca/chain-table.ts
+++ b/packages/diagrams/src/fgca/chain-table.ts
@@ -1,6 +1,6 @@
 // Chain-table model for the FGCA / FGA previews (vkgeorgia/strategy#137).
 //
-// The tree/chain preview (`layoutFGCAPreview`) shows Factor → Goal → Change →
+// The tree/chain preview (`layoutFGCAPreview`) shows Driver → Goal → Change →
 // Activity as columns of nodes joined by edges. This module produces the
 // *tabular* alternative: the same chain flattened into rows, with shared
 // parents collapsed into vertically-merged (rowspan) cells.
@@ -23,7 +23,7 @@
 
 import type { FGCAPreviewDoc } from './preview-layout.js';
 
-export type ChainColumn = 'factor' | 'goal' | 'change' | 'activity';
+export type ChainColumn = 'driver' | 'goal' | 'change' | 'activity';
 
 export interface ChainCell {
   /** Column-qualified identity (e.g. "goal:3") — stable, unique across columns. */
@@ -76,8 +76,8 @@ function sameCell(a: ChainCell | null, b: ChainCell | null): boolean {
 export function buildChainTable(doc: FGCAPreviewDoc, options: ChainTableOptions = {}): ChainTable {
   const { hideChanges = false } = options;
   const columns: ChainColumn[] = hideChanges
-    ? ['factor', 'goal', 'activity']
-    : ['factor', 'goal', 'change', 'activity'];
+    ? ['driver', 'goal', 'activity']
+    : ['driver', 'goal', 'change', 'activity'];
 
   const changes = doc.changes ?? [];
   const factorIds = new Set(doc.factors.map(f => f.id));
@@ -146,7 +146,7 @@ export function buildChainTable(doc: FGCAPreviewDoc, options: ChainTableOptions 
 
   // Phase 1 — factor-rooted paths.
   for (const f of doc.factors) {
-    const factorCell = cellOf('factor', f.id, f.name);
+    const factorCell = cellOf('driver', f.id, f.name);
     const goalsOfFactor = doc.goals.filter(g => (g.factor ?? []).some(ref => ref.id === f.id));
     if (goalsOfFactor.length === 0) {
       paths.push(pad([factorCell]));

--- a/packages/diagrams/src/fgca/index.ts
+++ b/packages/diagrams/src/fgca/index.ts
@@ -28,7 +28,7 @@ export {
   FGCA_COLUMN_LABELS,
 } from "./types";
 export type {
-  FactorItem,
+  DriverItem,
   GoalItem,
   BdnChangeWithActivities,
   ActivityItem,
@@ -38,7 +38,7 @@ export type {
 } from "./types";
 export { resolveFGCA, isFGCAViewDoc } from './resolver.js';
 export type { FGCAViewConfig, FGCACanonSources } from './resolver.js';
-export { default as FGCAFactorNode } from "./nodes/FGCAFactorNode";
+export { default as FGCADriverNode } from "./nodes/FGCAFactorNode";
 export { default as FGCAGoalNode } from "./nodes/FGCAGoalNode";
 export { default as FGCAChangeNode } from "./nodes/FGCAChangeNode";
 export { default as FGCAActivityNode } from "./nodes/FGCAActivityNode";

--- a/packages/diagrams/src/fgca/layout.ts
+++ b/packages/diagrams/src/fgca/layout.ts
@@ -1,7 +1,7 @@
 import type { Node, Edge } from "reactflow";
 import { Position, MarkerType } from "reactflow";
 import type {
-  FactorItem,
+  DriverItem,
   GoalItem,
   BdnChangeWithActivities,
   ActivityItem,
@@ -18,14 +18,14 @@ export const ROW_GAP = 24;
 
 /** Default background colours per column. */
 export const COLUMN_BG: Record<FGCAColumn, string> = {
-  factor: "#fef3c7",
+  driver: "#fef3c7",
   goal: "#e0e7ff",
   change: "#dbeafe",
   activity: "#d4edda",
 };
 
 export interface FGCALayoutInput {
-  factors: FactorItem[];
+  factors: DriverItem[];
   goals: GoalItem[];
   changes: BdnChangeWithActivities[];
   activities: ActivityItem[];
@@ -66,12 +66,12 @@ export function buildFGCALayout({
   const edgeStyle = { strokeWidth: edgeWidth, stroke: edgeColor };
   const baseNodeStyle = { borderColor: nodeBorderColor, borderWidth: nodeBorderWidth, borderStyle: "solid" };
 
-  if (visibleColumns.has("factor")) {
+  if (visibleColumns.has("driver")) {
     factors.forEach((f, i) => {
       nodes.push({
-        id: `factor_${f.id}`,
-        type: "fgcaFactor",
-        position: { x: colX["factor"]!, y: i * (NODE_HEIGHT + ROW_GAP) },
+        id: `driver_${f.id}`,
+        type: "fgcaDriver",
+        position: { x: colX["driver"]!, y: i * (NODE_HEIGHT + ROW_GAP) },
         data: { id: f.id, name: f.name, ...baseNodeStyle },
         sourcePosition: Position.Right,
         targetPosition: Position.Left,
@@ -132,13 +132,13 @@ export function buildFGCALayout({
     });
   }
 
-  // Factor→Goal edges (via embedded factor[] on each goal)
-  if (visibleColumns.has("factor") && visibleColumns.has("goal")) {
+  // Driver→Goal edges (via embedded factor[] on each goal)
+  if (visibleColumns.has("driver") && visibleColumns.has("goal")) {
     goals.forEach((g) => {
       g.factor?.forEach((f) => {
         edges.push({
-          id: `edge_f${f.id}_g${g.id}`,
-          source: `factor_${f.id}`,
+          id: `edge_d${f.id}_g${g.id}`,
+          source: `driver_${f.id}`,
           target: `goal_${g.id}`,
           markerEnd: { type: MarkerType.ArrowClosed },
           type: "smoothstep",

--- a/packages/diagrams/src/fgca/nodeTypes.ts
+++ b/packages/diagrams/src/fgca/nodeTypes.ts
@@ -1,10 +1,10 @@
-import FGCAFactorNode from "./nodes/FGCAFactorNode";
+import FGCADriverNode from "./nodes/FGCAFactorNode";
 import FGCAGoalNode from "./nodes/FGCAGoalNode";
 import FGCAChangeNode from "./nodes/FGCAChangeNode";
 import FGCAActivityNode from "./nodes/FGCAActivityNode";
 
 export const FGCA_NODE_TYPES = {
-  fgcaFactor: FGCAFactorNode,
+  fgcaDriver: FGCADriverNode,
   fgcaGoal: FGCAGoalNode,
   fgcaChange: FGCAChangeNode,
   fgcaActivity: FGCAActivityNode,

--- a/packages/diagrams/src/fgca/nodes/FGCAFactorNode.tsx
+++ b/packages/diagrams/src/fgca/nodes/FGCAFactorNode.tsx
@@ -4,7 +4,7 @@ import { Handle, Position } from "reactflow";
 const NODE_WIDTH = 250;
 const NODE_HEIGHT = 80;
 
-export interface FGCAFactorNodeProps {
+export interface FGCADriverNodeProps {
   data: {
     id: number;
     name: string;
@@ -14,7 +14,7 @@ export interface FGCAFactorNodeProps {
   isConnectable?: boolean;
 }
 
-const FGCAFactorNode = memo(({ data, isConnectable }: FGCAFactorNodeProps) => (
+const FGCADriverNode = memo(({ data, isConnectable }: FGCADriverNodeProps) => (
   <div
     style={{
       background: "var(--ts-layer-factor)",
@@ -54,11 +54,11 @@ const FGCAFactorNode = memo(({ data, isConnectable }: FGCAFactorNodeProps) => (
       {data.name}
     </div>
     <div style={{ fontSize: "10px", color: "var(--ts-text-secondary)", marginTop: 2 }}>
-      F-{String(data.id).padStart(4, "0")}
+      D-{String(data.id).padStart(4, "0")}
     </div>
   </div>
 ));
 
-FGCAFactorNode.displayName = "FGCAFactorNode";
+FGCADriverNode.displayName = "FGCADriverNode";
 
-export default FGCAFactorNode;
+export default FGCADriverNode;

--- a/packages/diagrams/src/fgca/parse-canonical.ts
+++ b/packages/diagrams/src/fgca/parse-canonical.ts
@@ -27,7 +27,7 @@
 import type {
   ActivityItem,
   BdnChangeWithActivities,
-  FactorItem,
+  DriverItem,
   GoalItem,
 } from './types.js';
 import type { FGCADoc } from './validate.js';
@@ -46,6 +46,8 @@ export interface CanonicalFGCAResult extends ValidationResult {
 // is fixed per layer; middle segments are optional; the terminal is a
 // positive integer with no leading zeros.
 const FACTOR_ID_RE = /^FACTOR(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
+const DRIVER_ID_RE = /^DRIVER(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
+const FACTOR_OR_DRIVER_ID_RE = /^(FACTOR|DRIVER)(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
 const GOAL_ID_RE = /^GOAL(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
 const CHANGE_ID_RE = /^CHANGE(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
 const ACTIVITY_ID_RE = /^ACTIVITY(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
@@ -173,7 +175,7 @@ export function parseCanonicalFGCA(input: unknown): CanonicalFGCAResult {
     return { id, name: isNonEmptyString(name) ? name : '' };
   }
 
-  factors.forEach((el, i) => checkLayerElement(el, `factors[${i}]`, FACTOR_ID_RE, factorIds));
+  factors.forEach((el, i) => checkLayerElement(el, `factors[${i}]`, FACTOR_OR_DRIVER_ID_RE, factorIds));
   goals.forEach((el, i) => checkLayerElement(el, `goals[${i}]`, GOAL_ID_RE, goalIds));
   changes.forEach((el, i) => checkLayerElement(el, `changes[${i}]`, CHANGE_ID_RE, changeIds));
   activities.forEach((el, i) => checkLayerElement(el, `activities[${i}]`, ACTIVITY_ID_RE, activityIds));
@@ -229,13 +231,13 @@ export function parseCanonicalFGCA(input: unknown): CanonicalFGCAResult {
   }
 
   // Layer entries (internal form).
-  const internalFactors: FactorItem[] = factors.map((el) => ({
+  const internalFactors: DriverItem[] = factors.map((el) => ({
     id: intId(String(el!['id'])),
     name: String(el!['name'] ?? ''),
   }));
 
   const internalGoals: GoalItem[] = goals.map((el, i) => {
-    const refIds = checkRefArray(el!, 'factors', factorIds, FACTOR_ID_RE, 'FGCA-008', `goals[${i}]`);
+    const refIds = checkRefArray(el!, 'factors', factorIds, FACTOR_OR_DRIVER_ID_RE, 'FGCA-008', `goals[${i}]`);
     return {
       id: intId(String(el!['id'])),
       name: String(el!['name'] ?? ''),

--- a/packages/diagrams/src/fgca/preview-layout.ts
+++ b/packages/diagrams/src/fgca/preview-layout.ts
@@ -9,7 +9,7 @@
 
 import type { Scope } from '../scope.js';
 
-export type FGCAPreviewColumn = 'factor' | 'goal' | 'change' | 'activity';
+export type FGCAPreviewColumn = 'driver' | 'goal' | 'change' | 'activity';
 
 export interface FGCAPreviewFactor {
   id: number | string;
@@ -144,11 +144,11 @@ export function layoutFGCAPreview(
 
   const colStride = FGCA_NODE_W + colGap;
   const cols: FGCAPreviewColumn[] = hideChanges
-    ? ['factor', 'goal', 'activity']
-    : ['factor', 'goal', 'change', 'activity'];
+    ? ['driver', 'goal', 'activity']
+    : ['driver', 'goal', 'change', 'activity'];
   const changes = doc.changes ?? [];
   const colItems: Record<FGCAPreviewColumn, Array<{ id: string; label: string }>> = {
-    factor:   doc.factors.map(f => ({ id: `factor_${f.id}`,     label: f.name })),
+    driver:   doc.factors.map(f => ({ id: `driver_${f.id}`,     label: f.name })),
     goal:     doc.goals.map(g   => ({ id: `goal_${g.id}`,       label: g.name })),
     change:   changes.map(c     => ({ id: `change_${c.id}`,     label: c.name })),
     activity: doc.activities.map(a => ({ id: `activity_${a.id}`, label: a.name })),
@@ -180,7 +180,7 @@ export function layoutFGCAPreview(
   }
 
   for (const g of doc.goals) {
-    for (const f of (g.factor ?? [])) addEdge(`factor_${f.id}`, `goal_${g.id}`);
+    for (const f of (g.factor ?? [])) addEdge(`driver_${f.id}`, `goal_${g.id}`);
   }
   if (hideChanges) {
     const connectedViaChange = new Set<number | string>();

--- a/packages/diagrams/src/fgca/resolver.ts
+++ b/packages/diagrams/src/fgca/resolver.ts
@@ -86,7 +86,9 @@ export function resolveFGCA(
   const changesConf = isObject(vc['changes']) ? vc['changes'] : {};
   const activitiesConf = isObject(vc['activities']) ? vc['activities'] : {};
 
-  const factorElems = collectByNotation(sources.elements, 'factor');
+  const factorElemsLegacy = collectByNotation(sources.elements, 'factor');
+  const factorElemsNew = collectByNotation(sources.elements, 'driver');
+  const factorElems = new Map([...factorElemsLegacy, ...factorElemsNew]);
   const goalElems = collectByNotation(sources.elements, 'goal');
   const changeElems = collectByNotation(sources.elements, 'change');
   const activityElems = collectByNotation(sources.elements, 'activity');

--- a/packages/diagrams/src/fgca/types.ts
+++ b/packages/diagrams/src/fgca/types.ts
@@ -1,4 +1,4 @@
-export interface FactorItem {
+export interface DriverItem {
   id: number | string;
   name: string;
 }
@@ -38,12 +38,12 @@ export interface DiagramStyle {
 }
 
 /** The four columns of the FGCA diagram. */
-export type FGCAColumn = "factor" | "goal" | "change" | "activity";
+export type FGCAColumn = "driver" | "goal" | "change" | "activity";
 
-export const ALL_FGCA_COLUMNS: FGCAColumn[] = ["factor", "goal", "change", "activity"];
+export const ALL_FGCA_COLUMNS: FGCAColumn[] = ["driver", "goal", "change", "activity"];
 
 export const FGCA_COLUMN_LABELS: Record<FGCAColumn, string> = {
-  factor: "F",
+  driver: "D",
   goal: "G",
   change: "C",
   activity: "A",

--- a/packages/diagrams/src/fgca/validate.ts
+++ b/packages/diagrams/src/fgca/validate.ts
@@ -1,4 +1,4 @@
-import type { FactorItem, GoalItem, BdnChangeWithActivities, ActivityItem } from './types.js';
+import type { DriverItem, GoalItem, BdnChangeWithActivities, ActivityItem } from './types.js';
 import type {
   ValidationError,
   ValidationWarning,
@@ -15,7 +15,7 @@ export type FGCAValidationResult = ValidationResult;
 export interface FGCADoc {
   notation: string;
   spec_version?: string;
-  factors: FactorItem[];
+  factors: DriverItem[];
   goals: GoalItem[];
   changes: BdnChangeWithActivities[];
   activities: ActivityItem[];

--- a/packages/diagrams/src/scenarios/index.ts
+++ b/packages/diagrams/src/scenarios/index.ts
@@ -1,7 +1,7 @@
 export type {
   ScenarioStatus,
-  FactorRelevance,
-  FactorView,
+  DriverRelevance,
+  DriverView,
   GoalRef,
   CapabilityRef,
   ActivityRef,

--- a/packages/diagrams/src/scenarios/types.ts
+++ b/packages/diagrams/src/scenarios/types.ts
@@ -1,9 +1,9 @@
 export type ScenarioStatus = 'Draft' | 'Active' | 'Archived';
-export type FactorRelevance = 'High' | 'Medium' | 'Low';
+export type DriverRelevance = 'High' | 'Medium' | 'Low';
 
-export interface FactorView {
+export interface DriverView {
   factor_id: string;
-  relevance?: FactorRelevance;
+  relevance?: DriverRelevance;
   impact?: string;
 }
 
@@ -21,7 +21,7 @@ export interface ScenarioHeader {
   status: ScenarioStatus;
   created_at?: string;
   vision?: string;
-  factors_view?: FactorView[];
+  factors_view?: DriverView[];
   goals?: GoalRef[];
   capabilities?: CapabilityRef[];
   activities?: ActivityRef[];

--- a/packages/diagrams/src/scenarios/validate.ts
+++ b/packages/diagrams/src/scenarios/validate.ts
@@ -1,10 +1,10 @@
-import type { ScenarioStatus, FactorRelevance } from './types.js';
+import type { ScenarioStatus, DriverRelevance } from './types.js';
 import type { ValidationError, ValidationWarning, ValidationResult } from '../validation-types.js';
 
 export type { ValidationError, ValidationWarning, ValidationResult };
 
 const VALID_STATUSES = new Set<ScenarioStatus>(['Draft', 'Active', 'Archived']);
-const VALID_RELEVANCE = new Set<FactorRelevance>(['High', 'Medium', 'Low']);
+const VALID_RELEVANCE = new Set<DriverRelevance>(['High', 'Medium', 'Low']);
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 interface RefSpec {
@@ -84,7 +84,7 @@ export function validateScenario(input: unknown): ValidationResult {
           if (seen.has(fid)) errors.push({ code: 'SCN-013', message: `Duplicate factor_id: "${fid}"` });
           seen.add(fid);
         }
-        if (f['relevance'] !== undefined && !VALID_RELEVANCE.has(f['relevance'] as FactorRelevance)) {
+        if (f['relevance'] !== undefined && !VALID_RELEVANCE.has(f['relevance'] as DriverRelevance)) {
           errors.push({ code: 'SCN-006', message: `${idx}: relevance "${f['relevance']}" must be one of: High, Medium, Low` });
         }
       }

--- a/packages/diagrams/src/webview/render-fgca.ts
+++ b/packages/diagrams/src/webview/render-fgca.ts
@@ -26,7 +26,7 @@ import { generateSvgEmbedCss } from '../theme/index.js';
 import { escXml } from './render-util.js';
 
 const COL_LABELS: Record<FGCAPreviewColumn, string> = {
-  factor: 'Factors (F)',
+  driver: 'Drivers (D)',
   goal: 'Goals (G)',
   change: 'Changes (C)',
   activity: 'Activities (A)',

--- a/packages/diagrams/src/webview/render-scenarios.ts
+++ b/packages/diagrams/src/webview/render-scenarios.ts
@@ -3,7 +3,7 @@
  * Mirrors `extension/src/scenarios-preview.ts`; emits a self-contained HTML
  * fragment for the JCEF host (Step 4 of ADR 0001).
  */
-import type { FactorView, ScenarioHeader } from '../scenarios/types.js';
+import type { DriverView, ScenarioHeader } from '../scenarios/types.js';
 import { escHtml } from './render-util.js';
 
 const STATUS_BADGE: Record<string, string> = {
@@ -18,7 +18,7 @@ const RELEVANCE_BADGE: Record<string, string> = {
   Low: 'badge-low',
 };
 
-function buildFactorsTable(factors: FactorView[] | undefined): string {
+function buildDriversTable(factors: DriverView[] | undefined): string {
   if (!factors || factors.length === 0) return '';
   const rows = factors
     .map(
@@ -63,7 +63,7 @@ export function renderScenarioHtml(scn: ScenarioHeader): string {
   <p class="scn-vision-text">${escHtml(scn.vision)}</p>
 </section>`);
   }
-  blocks.push(buildFactorsTable(scn.factors_view));
+  blocks.push(buildDriversTable(scn.factors_view));
   blocks.push(buildRefSection('Goals', extractIds(scn.goals, 'goal_id')));
   blocks.push(buildRefSection('Capabilities', extractIds(scn.capabilities, 'capability_id')));
   blocks.push(buildRefSection('Activities', extractIds(scn.activities, 'activity_id')));

--- a/tests/fixtures/notation-corpus/activity-card/canon/elements/01_motivation/factors/FACTOR-EU-MDR-1.yaml
+++ b/tests/fixtures/notation-corpus/activity-card/canon/elements/01_motivation/factors/FACTOR-EU-MDR-1.yaml
@@ -1,4 +1,4 @@
-notation: factor
+notation: driver
 id: FACTOR-EU-MDR-1
 name: "EU Medical Device Regulation in force"
 type: external

--- a/tests/fixtures/notation-corpus/factor/FACTOR-COMP-1.yaml
+++ b/tests/fixtures/notation-corpus/factor/FACTOR-COMP-1.yaml
@@ -9,7 +9,7 @@
 # for the worked "8h and degrading" finding.
 # No PESTLE category — PESTLE applies to external factors only.
 
-notation: factor
+notation: driver
 id: FACTOR-COMP-1
 name: "Support response time"
 type: internal

--- a/tests/fixtures/notation-corpus/factor/FACTOR-EU-REG-1.yaml
+++ b/tests/fixtures/notation-corpus/factor/FACTOR-EU-REG-1.yaml
@@ -8,7 +8,7 @@
 # a moving timeline) would live on ASSESSMENT records that assesses this FACTOR.
 # `category: legal` per PESTLE — binding regulations / law.
 
-notation: factor
+notation: driver
 id: FACTOR-EU-REG-1
 name: "EU regulatory window for market entry"
 type: external

--- a/tests/fixtures/notation-corpus/fgca/canon/elements/factors/FACTOR-1.yaml
+++ b/tests/fixtures/notation-corpus/fgca/canon/elements/factors/FACTOR-1.yaml
@@ -1,4 +1,4 @@
-notation: factor
+notation: driver
 id: FACTOR-1
 name: "Competitive market pressure"
 type: external

--- a/tests/fixtures/notation-corpus/fgca/canon/elements/factors/FACTOR-2.yaml
+++ b/tests/fixtures/notation-corpus/fgca/canon/elements/factors/FACTOR-2.yaml
@@ -1,4 +1,4 @@
-notation: factor
+notation: driver
 id: FACTOR-2
 name: "Digital adoption acceleration"
 type: external


### PR DESCRIPTION
## Summary

- Renames the FGCA "factor" column to "driver" throughout `@transitrix/diagrams` and the extension: `FGCAColumn`, `ChainColumn`, `FGCAPreviewColumn`, `FGCA_COLUMN_LABELS`, `COLUMN_BG`, `FGCAFactorNode` → `FGCADriverNode`, `fgcaFactor` nodeType key → `fgcaDriver`, `FactorItem` → `DriverItem`, `FactorRelevance`/`FactorView` → `DriverRelevance`/`DriverView`
- Canon element YAML fixtures updated: `notation: factor` → `notation: driver`; both resolvers (FGCA + activity-card) accept both notations for backward compat
- `parse-canonical.ts` gains `DRIVER_ID_RE` + `FACTOR_OR_DRIVER_ID_RE`; the factor layer now accepts `DRIVER-*` IDs alongside legacy `FACTOR-*`
- `compliance-scan.ts` adds `'driver'` to `SILENT_NOTATIONS` (keeps `'factor'`)

## Test plan

- [x] `npm run test` in `packages/diagrams` — 976 tests pass
- [x] `npm run test:core` — 398 integration tests pass
- [x] `npx tsc --noEmit` on both `packages/diagrams` and `extension` — clean
- [x] No `notation: 'factor'` left in non-archive, non-backward-compat source (except the `factor/__tests__/validate.test.ts:74` negative test and the compat collectors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)