### PR TITLE
fix(schema): sync BPMN root schema — add performed_by_role + supported_by_application

### DIFF
--- a/schemas/bpmn-dsl.schema.json
+++ b/schemas/bpmn-dsl.schema.json
@@ -75,6 +75,14 @@
           "type": "array",
           "minItems": 1,
           "items": { "$ref": "#/definitions/element" }
+        },
+        "performed_by_role": {
+          "type": "string",
+          "description": "Canonical ROLE-… element ID for the actor responsible for this lane."
+        },
+        "supported_by_application": {
+          "type": "string",
+          "description": "Canonical APPLICATION-… element ID for the default supporting system in this lane."
         }
       }
     },
@@ -103,7 +111,11 @@
             "dataObject"
           ]
         },
-        "name": { "type": "string" }
+        "name": { "type": "string" },
+        "supported_by_application": {
+          "type": "string",
+          "description": "Canonical APPLICATION-… element ID for the supporting system for this specific element (overrides lane default)."
+        }
       },
       "allOf": [
         {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -42,7 +42,9 @@ export interface YamlDocumentRoot {
       lanes: {
         id: string;
         name: string;
-        elements: { id: string; type: string; name?: string }[];
+        elements: { id: string; type: string; name?: string; supported_by_application?: string }[];
+        performed_by_role?: string;
+        supported_by_application?: string;
       }[];
     }[];
     flows: { id?: string; from: string; to: string; condition?: string; default?: boolean; name?: string }[];


### PR DESCRIPTION
## Summary

- Add `performed_by_role` and `supported_by_application` to the `lane` definition in the canonical root `schemas/bpmn-dsl.schema.json`
- Add `supported_by_application` to the `element` definition (overrides lane default)
- Update `YamlDocumentRoot` interface in `src/parser.ts` with the same optional typed fields
- `extension/schemas/` and `packages/cli/schemas/` copies already had the fields; all three copies are now consistent

Purely additive — no behaviour change; existing BPMN tests pass.

## Test plan

- [ ] All 978 tests green (`npm test`)
- [ ] A BPMN YAML with `performed_by_role: ROLE-X` validates without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)