### PR TITLE
fix(cli): add dgca/dga validator keys and update help text

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,7 +39,7 @@ function printUsage(): void {
   <compile> — YAML → BPMN 2.0 XML with layout metrics.
   metrics   — layout quality metrics (with --json for CI).
   validate  — validation only (no XML output; exit 1 on errors). Default scope
-              is a single file: BPMN, or a diagram notation (goals, fgca, fga,
+              is a single file: BPMN, or a diagram notation (goals, dgca, dga,
               activities, activity-card, process-blueprint, blocks) routed by its
               notation: field — the same checks the Studio preview shows.
               --scope=repo runs whole-canon checks (referential integrity,
@@ -274,7 +274,7 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
     console.error('');
     console.error('file scope — single-file structural/semantic validation (default).');
     console.error('             BPMN, or a diagram notation routed by its notation: field');
-    console.error('             (goals, fgca, fga, activities, activity-card,');
+    console.error('             (goals, dgca, dga, activities, activity-card,');
     console.error('             process-blueprint, blocks) — same checks as the preview.');
     console.error('repo scope — whole-canon checks (referential integrity, atomicity,');
     console.error('             id uniqueness, policy) over <root> (default: cwd).');

--- a/src/validate-notation.ts
+++ b/src/validate-notation.ts
@@ -55,7 +55,9 @@ type NotationValidator = (input: unknown) => NotationValidationResult;
 const VALIDATORS: Record<string, NotationValidator> = {
   // Group A — validator lives in the shared package and is the one the preview calls.
   goals: parseCanonicalGoals,
+  dgca: parseCanonicalFGCA,
   fgca: parseCanonicalFGCA,
+  dga: parseCanonicalFGA,
   fga: parseCanonicalFGA,
   activities: validateActivities,
   'activity-card': validateActivityCard,

--- a/tests/validate-notation.test.ts
+++ b/tests/validate-notation.test.ts
@@ -25,7 +25,9 @@ const corpusRoot = join(dirname(fileURLToPath(import.meta.url)), 'fixtures', 'no
 // Group A — shared package validators already used by the preview before Phase B.
 const GROUP_A = [
   'goals',
+  'dgca',
   'fgca',
+  'dga',
   'fga',
   'activities',
   'activity-card',


### PR DESCRIPTION
## Summary

- Register `dgca` and `dga` as canonical notation keys in `VALIDATORS` in `src/validate-notation.ts` (alongside deprecated `fgca`/`fga` aliases)
- Update help text in two places in `src/cli.ts` to advertise canonical names (`dgca`, `dga`) instead of deprecated ones
- Update `validate-notation.test.ts` to include `dgca` and `dga` in Group A

`transitrix validate *.dgca.transitrix.yaml` now routes to the validator instead of falling through to "not yet validated by the CLI". The deprecated `fgca`/`fga` aliases still work at runtime.

## Test plan

- [ ] All 978 tests green (`npm test`)
- [ ] `transitrix validate *.dgca.transitrix.yaml` runs the validator
- [ ] `transitrix validate *.fgca.transitrix.yaml` still works (emits `DEPRECATED_NOTATION` warning)
- [ ] `transitrix validate --help` shows `dgca, dga`

🤖 Generated with [Claude Code](https://claude.com/claude-code)