### PR TITLE
feat(extension): route .dgca.transitrix.yaml to correct previews by notation

### DIFF
--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -630,7 +630,7 @@ export class ActivitiesPreview {
     const hasNetwork = Boolean(this.lastNetworkSvg);
     const hasGantt = Boolean(this.lastGanttSvg);
     if (!hasNetwork && !hasGantt) {
-      vscode.window.showWarningMessage('No diagram rendered yet. Open a *.activities.transitrix.yaml file first.');
+      vscode.window.showWarningMessage('No diagram rendered yet. Open a *.activities.transitrix.yaml or *.dgca.transitrix.yaml (with notation: activities) file first.');
       return undefined;
     }
     if (hasNetwork && hasGantt) {
@@ -659,7 +659,7 @@ export class ActivitiesPreview {
       sourceUri,
       stripExt: /\.activities\.transitrix\.yaml$/,
       viewSuffix: `-${view}`,
-      emptyMessage: 'No diagram rendered yet. Open a *.activities.transitrix.yaml file first.',
+      emptyMessage: 'No diagram rendered yet. Open a *.activities.transitrix.yaml or *.dgca.transitrix.yaml (with notation: activities) file first.',
     });
   }
 
@@ -672,7 +672,7 @@ export class ActivitiesPreview {
       rawSvg: rawSvg || undefined,
       themeId,
       notationCss: ACTIVITIES_DIAGRAM_CSS,
-      emptyMessage: 'No diagram rendered yet. Open a *.activities.transitrix.yaml file first.',
+      emptyMessage: 'No diagram rendered yet. Open a *.activities.transitrix.yaml or *.dgca.transitrix.yaml (with notation: activities) file first.',
     });
   }
 
@@ -680,7 +680,7 @@ export class ActivitiesPreview {
     const hasNetwork = Boolean(this.lastNetworkSvg);
     const hasGantt = Boolean(this.lastGanttSvg);
     if (!hasNetwork && !hasGantt) {
-      vscode.window.showWarningMessage('No diagram rendered yet. Open a *.activities.transitrix.yaml file first.');
+      vscode.window.showWarningMessage('No diagram rendered yet. Open a *.activities.transitrix.yaml or *.dgca.transitrix.yaml (with notation: activities) file first.');
       return;
     }
 

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -102,6 +102,13 @@ function isCoverageMetricFile(doc: vscode.TextDocument): boolean {
   return doc.fileName.endsWith('.coverage-metric.transitrix.yaml');
 }
 
+function probeDocNotation(doc: vscode.TextDocument): string | undefined {
+  const lines = Math.min(doc.lineCount, 20);
+  const header = doc.getText(new vscode.Range(0, 0, lines, 0));
+  const m = /^notation:\s+([^\s#]+)/m.exec(header);
+  return m?.[1];
+}
+
 async function loadCompiler(ext: vscode.ExtensionContext): Promise<CompileFn> {
   const compilerPath = path.join(ext.extensionPath, 'compiler', 'compiler.js');
   const metricsPath = path.join(ext.extensionPath, 'compiler', 'metrics.js');
@@ -271,8 +278,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     aliasOf('cervin.exportBpmn', 'transitrix.exportBpmn', () => notYet('.bpmn')),
     vscode.commands.registerCommand('transitrixStudio.previewGoals', async () => {
       const doc = vscode.window.activeTextEditor?.document;
-      if (!doc || !isGoalsFile(doc)) {
-        vscode.window.showWarningMessage('Open a *.goals.transitrix.yaml file first.');
+      const isGoals = doc && (isGoalsFile(doc) || (isDGCAFile(doc) && probeDocNotation(doc) === 'goals'));
+      if (!isGoals) {
+        vscode.window.showWarningMessage('Open a *.goals.transitrix.yaml or *.dgca.transitrix.yaml (with notation: goals) file first.');
         return;
       }
       await goalsPreview.showOrReveal(doc);
@@ -311,8 +319,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     }),
     vscode.commands.registerCommand('transitrixStudio.previewActivities', async () => {
       const doc = vscode.window.activeTextEditor?.document;
-      if (!doc || !isActivitiesFile(doc)) {
-        vscode.window.showWarningMessage('Open a *.activities.transitrix.yaml file first.');
+      const isActivities = doc && (isActivitiesFile(doc) || (isDGCAFile(doc) && probeDocNotation(doc) === 'activities'));
+      if (!isActivities) {
+        vscode.window.showWarningMessage('Open a *.activities.transitrix.yaml or *.dgca.transitrix.yaml (with notation: activities) file first.');
         return;
       }
       await activitiesPreview.showOrReveal(doc);
@@ -547,7 +556,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         void gapDashboardPreview.refresh();
       }
       if (isGoalsFile(doc)) { void goalsPreview.refreshSaved(doc); return; }
-      if (isDGCAFile(doc) || isFGCAFile(doc)) { void fgcaPreview.refreshSaved(doc); return; }
+      if (isDGCAFile(doc) || isFGCAFile(doc)) {
+        const notation = isDGCAFile(doc) ? probeDocNotation(doc) : undefined;
+        if (notation === 'goals') { void goalsPreview.refreshSaved(doc); return; }
+        if (notation === 'activities') { void activitiesPreview.refreshSaved(doc); return; }
+        void fgcaPreview.refreshSaved(doc); return;
+      }
       if (isDGAFile(doc) || isFGAFile(doc)) { void fgaPreview.refreshSaved(doc); return; }
       if (isActivitiesFile(doc)) { void activitiesPreview.refreshSaved(doc); return; }
       if (isBlocksFile(doc)) { void blocksPreview.refreshSaved(doc); return; }
@@ -565,7 +579,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     }),
     vscode.workspace.onDidOpenTextDocument(async (doc) => {
       if (isGoalsFile(doc)) { await goalsPreview.showOrReveal(doc); return; }
-      if (isDGCAFile(doc) || isFGCAFile(doc)) { await fgcaPreview.showOrReveal(doc); return; }
+      if (isDGCAFile(doc) || isFGCAFile(doc)) {
+        const notation = isDGCAFile(doc) ? probeDocNotation(doc) : undefined;
+        if (notation === 'goals') { await goalsPreview.showOrReveal(doc); return; }
+        if (notation === 'activities') { await activitiesPreview.showOrReveal(doc); return; }
+        await fgcaPreview.showOrReveal(doc); return;
+      }
       if (isDGAFile(doc) || isFGAFile(doc)) { await fgaPreview.showOrReveal(doc); return; }
       if (isActivitiesFile(doc)) { await activitiesPreview.showOrReveal(doc); return; }
       if (isBlocksFile(doc)) { await blocksPreview.showOrReveal(doc); return; }

--- a/extension/src/goals-preview.ts
+++ b/extension/src/goals-preview.ts
@@ -186,7 +186,7 @@ export class GoalsPreview {
     return {
       rawSvg: this.lastSvg || undefined,
       themeId: vscode.workspace.getConfiguration('transitrix').get<ThemeId>('theme', 'transitrix'),
-      emptyMessage: 'No diagram rendered yet. Open a *.goals.transitrix.yaml file first.',
+      emptyMessage: 'No diagram rendered yet. Open a *.goals.transitrix.yaml or *.dgca.transitrix.yaml (with notation: goals) file first.',
     };
   }
 
@@ -204,7 +204,7 @@ export class GoalsPreview {
 
   async saveAsSvg(): Promise<void> {
     if (!this.lastSvg) {
-      vscode.window.showWarningMessage('No diagram rendered yet. Open a *.goals.transitrix.yaml file first.');
+      vscode.window.showWarningMessage('No diagram rendered yet. Open a *.goals.transitrix.yaml or *.dgca.transitrix.yaml (with notation: goals) file first.');
       return;
     }
     const sourceUri = this.trackedUri ? vscode.Uri.parse(this.trackedUri) : undefined;


### PR DESCRIPTION
## Summary

- Add `probeDocNotation` helper in `extension.ts` that reads the `notation:` header from the first 20 lines of a document (regex, no YAML parser dependency)
- `onDidOpenTextDocument` and `onDidSaveTextDocument`: DGCA files with `notation: goals` route to GoalsPreview, `notation: activities` to ActivitiesPreview, all other DGCA files to FGCAPreview (unchanged)
- Goals and Activities command guards now also accept `.dgca.transitrix.yaml` files with the matching `notation:` value
- Update empty-state messages in `goals-preview.ts` and `activities-preview.ts` to mention the new extension

Old `.goals.transitrix.yaml` and `.activities.transitrix.yaml` routing is unchanged (backward compatible).

## Test plan

- [ ] All 978 tests green (`npm test`)
- [ ] `strategy-2026.dgca.transitrix.yaml` with `notation: goals` → Goals preview opens
- [ ] `activities.dgca.transitrix.yaml` with `notation: activities` → Activities preview opens
- [ ] `strategy-2026.dgca.transitrix.yaml` with `notation: dgca` → DGCA preview opens
- [ ] Old `.goals.transitrix.yaml` / `.activities.transitrix.yaml` files open as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)