### PR TITLE
fix(schema): add name + generated_at to BPMN root schema (CONTRACT §1.1)

### DIFF
--- a/organizations/acme_corp/canon/views/bpmn/data-subject-erasure.bpmn.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/bpmn/data-subject-erasure.bpmn.transitrix.yaml
@@ -70,7 +70,6 @@ process:
       to: GW-VERIFIED
     - from: GW-VERIFIED
       to: TASK-REJECT
-      condition: "identity not verified"
       default: true
     - from: TASK-REJECT
       to: EE-REJECTED
@@ -88,7 +87,6 @@ process:
       condition: "data present in 7-year archive (known gap)"
     - from: GW-ARCHIVE
       to: TASK-CONFIRM
-      condition: "active systems only"
       default: true
     - from: TASK-FLAG-GAP
       to: TASK-CONFIRM

--- a/schemas/bpmn-dsl.schema.json
+++ b/schemas/bpmn-dsl.schema.json
@@ -15,6 +15,14 @@
       "type": "string",
       "description": "Notation spec version this document conforms to. Reserved per CONTRACT.md; accepted but not enforced."
     },
+    "name": {
+      "type": "string",
+      "description": "Human-readable document name (CONTRACT.md §1.1)."
+    },
+    "generated_at": {
+      "type": "string",
+      "description": "Date generated or last revised — quoted ISO 8601 (CONTRACT.md §1.1)."
+    },
     "process": {
       "type": "object",
       "additionalProperties": false,


### PR DESCRIPTION
## Summary

- `schemas/bpmn-dsl.schema.json` had `additionalProperties: false` at the root but was missing `name` and `generated_at` — the two document-metadata fields mandated by CONTRACT.md §1.1. Any BPMN file carrying these standard headers failed validation with «must NOT have additional properties».
- `organizations/acme_corp/canon/views/bpmn/data-subject-erasure.bpmn.transitrix.yaml` had two flows with both `default: true` and `condition:` simultaneously — a contradiction per SF-007. Removed the redundant `condition` from both default-route flows.

## Test plan

- [ ] `transitrix validate organizations/acme_corp/canon/views/bpmn/data-subject-erasure.bpmn.transitrix.yaml` — should return clean (1 AP-IMPLICIT-JOIN advisory max)
- [ ] Full test suite (`npm test`) — 978/978 pass expected
- [ ] Any existing BPMN file without `name`/`generated_at` still validates (fields are optional in the schema)

🤖 Generated with [Claude Code](https://claude.com/claude-code)