### PR TITLE
fix(schema): add performed_by_role to BPMN element definition

### DIFF
--- a/schemas/bpmn-dsl.schema.json
+++ b/schemas/bpmn-dsl.schema.json
@@ -120,6 +120,11 @@
           ]
         },
         "name": { "type": "string" },
+        "performed_by_role": {
+          "type": "string",
+          "pattern": "^ROLE-",
+          "description": "Canonical ROLE-… element ID for the actor performing this specific element (overrides lane default)."
+        },
         "supported_by_application": {
           "type": "string",
           "description": "Canonical APPLICATION-… element ID for the supporting system for this specific element (overrides lane default)."


### PR DESCRIPTION
## Summary

- Adds `performed_by_role` (optional string, pattern `^ROLE-`) to the `element` definition in `schemas/bpmn-dsl.schema.json`
- The field was already present on the `lane` object; this brings `element` in line with the same pattern, allowing per-element role overrides alongside the existing `supported_by_application` field

## Test plan

- [x] `tests/validator.test.ts` — 72 tests green
- [x] `tests/validate-notation.test.ts` — 29 tests green
- [x] `tests/integration.test.ts` — 39 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)