### PR TITLE
feat(bpmn): tighter pool and lane layout defaults

### DIFF
--- a/src/layout-options.ts
+++ b/src/layout-options.ts
@@ -25,12 +25,12 @@ export interface LayoutDiagramOptions {
 }
 
 export const DEFAULT_LAYOUT_DIAGRAM_OPTIONS: LayoutDiagramOptions = {
-  poolPad: 40,
+  poolPad: 12,
   poolOriginX: 12,
   poolOriginY: 12,
-  participantLabelBand: 48,
-  laneLabelWidth: 72,
-  laneVerticalGap: 40,
+  participantLabelBand: 20,
+  laneLabelWidth: 44,
+  laneVerticalGap: 0,
   laneContentRightPad: 40,
   elkNodeSpacing: 52,
   elkLayerSpacing: 88,

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -437,7 +437,7 @@ export async function layoutProcess(
   //   causing vertical overlap.  A Y-sweep guarantees elkNodeSpacing between them.
   // Step C converts local Y to absolute positions and computes lane / pool bounds.
 
-  const laneOriginX = o.poolPad + o.participantLabelBand;
+  const laneOriginX = o.poolOriginX + o.participantLabelBand;
 
   // Step A — lane-local positions (Y relative to lane top).
   type LocalItem = { id: string; x: number; localY: number; width: number; height: number };
@@ -520,8 +520,8 @@ export async function layoutProcess(
 
   const innerBottom = yCursor - o.laneVerticalGap;
   const participantW =
-    o.poolPad * 2 + o.participantLabelBand + o.laneLabelWidth + contentW + o.laneContentRightPad;
-  const participantH = innerBottom + o.poolPad;
+    o.participantLabelBand + o.laneLabelWidth + contentW + o.laneContentRightPad;
+  const participantH = innerBottom - o.poolOriginY;
 
   const poolBounds: Bounds = {
     x: o.poolOriginX,
@@ -531,7 +531,7 @@ export async function layoutProcess(
   };
 
   for (const lb of laneBounds.values()) {
-    lb.width = participantW - 2 * o.poolPad;
+    lb.width = participantW - o.participantLabelBand;
   }
 
   // Step D — swimlane axis snap.


### PR DESCRIPTION
﻿## Summary
- Tighter default pool padding and participant label band.
- Narrower lane name column; default laneVerticalGap 0 (was 40).
- Fix laneOriginX and participant width/height bounds math.

## Test plan
- [ ] BPMN preview uses less whitespace; lanes stack without extra gap by default.
- [ ] `npm run test:core` — layout/integration tests green.

