### PR TITLE
feat(extension): transitrix.bpmn.laneGap setting for BPMN preview

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -92,6 +92,13 @@
           "default": false,
           "description": "Show experimental BPMN/SVG/PNG export commands (not finished yet)."
         },
+        "transitrix.bpmn.laneGap": {
+          "type": "number",
+          "default": 40,
+          "minimum": 0,
+          "maximum": 200,
+          "description": "Vertical gap (px) between swimlanes in the BPMN preview. Change takes effect on the next file save or when the preview re-renders."
+        },
         "transitrix.bpmnRenderer": {
           "type": "string",
           "enum": [

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -4,7 +4,7 @@ import * as vscode from 'vscode';
 
 import type { CompileFn } from './preview.js';
 import { CervinPreview } from './preview.js';
-import { ProcessPreview, type ProcessLayoutFn, SAVE_BPMN_PROCESS_SVG_COMMAND } from './process-preview.js';
+import { ProcessPreview, type ProcessLayoutFn, SAVE_BPMN_PROCESS_SVG_COMMAND, OPEN_BPMN_SETTINGS_COMMAND } from './process-preview.js';
 import { GoalsPreview } from './goals-preview.js';
 import { FGCAPreview, FGAPreview } from './fgca-preview.js';
 import { ActivitiesPreview } from './activities-preview.js';
@@ -148,10 +148,17 @@ async function loadProcessLayoutFn(ext: vscode.ExtensionContext): Promise<Proces
   // Node.js module cache means this import() re-uses the already-loaded module
   // when loadCompiler() has run first — no double-load overhead.
   const mod = (await import(compilerHref)) as {
-    compileTransitrixYamlWithLayout: (yaml: string) => Promise<{ layout: unknown; validation: ValidationReport }>;
+    compileTransitrixYamlWithLayout: (
+      yaml: string,
+      options?: { layout?: { laneVerticalGap?: number } },
+    ) => Promise<{ layout: unknown; validation: ValidationReport }>;
   };
   return async (yaml: string) => {
-    const result = await mod.compileTransitrixYamlWithLayout(yaml);
+    const laneGap = vscode.workspace.getConfiguration('transitrix').get<number>('bpmn.laneGap');
+    const layoutOptions = (laneGap !== undefined && Number.isFinite(laneGap))
+      ? { layout: { laneVerticalGap: laneGap } }
+      : undefined;
+    const result = await mod.compileTransitrixYamlWithLayout(yaml, layoutOptions);
     // LayoutIr is structurally compatible with ProcessDiagramLayout — safe cast.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return { layout: result.layout as any, validation: result.validation };
@@ -500,6 +507,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       const doc = vscode.window.activeTextEditor?.document;
       if (doc && isCoverageMetricFile(doc)) await coverageMetricPreview.showOrReveal(doc);
     }),
+    vscode.commands.registerCommand(OPEN_BPMN_SETTINGS_COMMAND, () =>
+      vscode.commands.executeCommand('workbench.action.openSettings', 'transitrix.bpmn'),
+    ),
     vscode.commands.registerCommand(OPEN_SPACING_SETTINGS_COMMAND, () =>
       vscode.commands.executeCommand('workbench.action.openSettings', SPACING_CONFIG_SECTION),
     ),
@@ -530,8 +540,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     // and this handler rebuilds the webview HTML from the tracked document.
     vscode.workspace.onDidChangeConfiguration((e) => {
       const isThemeChange = e.affectsConfiguration('transitrix.theme');
+      const isBpmnChange = e.affectsConfiguration('transitrix.bpmn');
+      if (isBpmnChange) void processPreview.refreshConfig();
       if (
         !isThemeChange &&
+        !isBpmnChange &&
         !e.affectsConfiguration(SPACING_CONFIG_SECTION) &&
         !e.affectsConfiguration(CURVATURE_CONFIG_SECTION) &&
         !e.affectsConfiguration(ENTRY_CURVATURE_CONFIG_SECTION) &&

--- a/extension/src/process-preview.ts
+++ b/extension/src/process-preview.ts
@@ -25,6 +25,7 @@ import {
 import type { ValidationReport } from './types.js';
 
 export const SAVE_BPMN_PROCESS_SVG_COMMAND = 'transitrixStudio.saveBpmnProcessAsSvg';
+export const OPEN_BPMN_SETTINGS_COMMAND = 'transitrixStudio.openBpmnSettings';
 
 /** Function that parses + lays out a BPMN YAML document. */
 export type ProcessLayoutFn = (yaml: string) => Promise<{
@@ -59,7 +60,7 @@ export class ProcessPreview {
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
         {
           enableScripts: false,
-          enableCommandUris: true,
+          enableCommandUris: [SAVE_BPMN_PROCESS_SVG_COMMAND, OPEN_BPMN_SETTINGS_COMMAND, OPEN_THEME_COMMAND],
           retainContextWhenHidden: true,
         },
       );
@@ -76,6 +77,12 @@ export class ProcessPreview {
   async refreshSaved(doc: vscode.TextDocument): Promise<void> {
     if (!this.isShowingDocument(doc.uri)) return;
     await this.pushDocument(doc);
+  }
+
+  async refreshConfig(): Promise<void> {
+    if (!this.panel || !this.trackedUri) return;
+    const doc = vscode.workspace.textDocuments.find((d) => d.uri.toString() === this.trackedUri);
+    if (doc) await this.pushDocument(doc);
   }
 
   async saveAsSvg(): Promise<void> {
@@ -122,11 +129,14 @@ export class ProcessPreview {
         warnings: warningMsgs,
         themeId,
         saveSvgCommand: SAVE_BPMN_PROCESS_SVG_COMMAND,
+        spacingCommand: OPEN_BPMN_SETTINGS_COMMAND,
         themeCommand: OPEN_THEME_COMMAND,
       });
     } catch (err) {
       this.lastSvg = '';
-      const msg = err instanceof Error ? err.message : String(err);
+      const base = err instanceof Error ? err.message : String(err);
+      const details = (err as { errors?: string[] }).errors;
+      const msg = details?.length ? `${base}\n${details.join('\n')}` : base;
       this.panel.webview.html = buildDiagramFrame({
         filename,
         notation: 'BPMN Process',


### PR DESCRIPTION
﻿## Summary
- Add `transitrix.bpmn.laneGap` workspace setting (0–200 px) for swimlane vertical spacing.
- Pass laneGap into `compileTransitrixYamlWithLayout` on each BPMN preview render.
- BPMN preview toolbar Spacing link opens BPMN settings; preview refreshes when `transitrix.bpmn.*` changes.
- Surface multi-line compile errors in the preview panel.

## Test plan
- [ ] Change `transitrix.bpmn.laneGap` in Settings — BPMN preview re-layouts without reload.
- [ ] Spacing toolbar button opens BPMN settings filter.
- [ ] `npm run compile:extension` green.

