### PR TITLE
chore: run build:diagrams in extension:prep

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "build:webview": "node scripts/build-webview.mjs",
     "build:webview-bundle": "node scripts/build-webview-bundle.mjs",
     "extension:bundle": "node scripts/build-extension-bundle.mjs",
-    "extension:prep": "npm run build:webview && node scripts/build-compiler-bundle.mjs && npm run extension:bundle",
+    "extension:prep": "npm run build:webview && npm run build:diagrams && node scripts/build-compiler-bundle.mjs && npm run extension:bundle",
     "pretest": "npm run build",
     "test": "npm run test:core && npm run test:diagrams",
     "test:core": "vitest run",


### PR DESCRIPTION
﻿## Summary
- Add `npm run build:diagrams` to `extension:prep` so VSIX builds include fresh diagram webview bundles before compiler/extension bundle steps.

## Test plan
- [ ] `npm run extension:prep` completes successfully.
- [ ] After merging renderer PR, VSIX reflects updated `render-process` without a manual `build:diagrams`.

