### PR TITLE
fix(bpmn): preview layout polish + chore(release): 2.2.0 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,27 @@
 # Changelog
 
-## [Unreleased]
+## [2.2.0] — 2026-06-24
 
-### Changed
+### Added
 
-- **BPMN preview — custom renderer is now the default.** `transitrix.bpmnRenderer` defaults to `"custom"` (the built-in SVG emitter) instead of `"bpmn-io"`. The custom renderer supports the full v1 element subset: swimlanes, tasks, XOR/AND/inclusive gateways, start/end events, intermediate message and timer events, data objects with association edges, and conditional sequence flows. Zoom (50–200%) and pan work via the shared preview controls consistent with all other Transitrix notations.
+- **BPMN preview — custom SVG renderer is the default** (`transitrix.bpmnRenderer`: `"custom"`). Set `"bpmn-io"` to revert to the legacy bpmn.io viewer.
+- **BPMN preview — `transitrix.bpmn.laneGap` setting** (0–200 px between swimlanes).
+- **BPMN SVG renderer** — default-flow marker, word-wrapped below-element labels, lane clip-path; solid conditional sequence flows.
+- **Blocks preview** — block IDs in nested block diagrams.
+- **Auto-open previews** for BPMN, compliance-impact, single law, and single product files.
+- **DGCA / DGA notation** (renamed from FGCA / FGA); legacy keys accepted with deprecation warnings through 1.x.
+- **Driver terminology** (factor → driver) in DGCA column validators and rendering.
+- **BPMN Save as PNG** from the preview toolbar.
+- **Entity IDs** below node names in DGCA/DGA, FGA/DGA, and Activities diagrams.
 
-  To revert to the legacy bpmn.io viewer (full BPMN 2.0 interactivity), set in your VS Code settings:
-  ```json
-  "transitrix.bpmnRenderer": "bpmn-io"
-  ```
+### Fixed
+
+- BPMN **Open Preview** from the editor title bar when webview has focus.
+- DGCA files routed to the correct preview by `notation:` header.
+- BPMN layout polish: compact pool/lane geometry, start-event label inset, rotated header caption padding, min lane height for long lane names, `laneGap` default 0.
+- BPMN cross-lane routing, `defaultFlow` XML, Activities node styling, preview title pattern, Process Blueprint PNG export.
+- BPMN DSL schema: `name`, `generated_at`, `performed_by_role`, `supported_by_application`.
+- CLI `dgca` / `dga` validator keys; `extension:prep` runs `build:diagrams` before VSIX packaging.
 
 ## [2.1.1] — 2026-06-20
 

--- a/docs/release-notes-2.2.0.md
+++ b/docs/release-notes-2.2.0.md
@@ -1,0 +1,28 @@
+# Transitrix Studio 2.2.0
+
+Release date: **2026-06-24** · supersedes [2.1.1](https://github.com/transitrix/transitrix-studio/releases/tag/v2.1.1)
+
+## Highlights
+
+- **Custom BPMN SVG preview is the default** — shared theme, zoom/pan, default-flow markers, compact layout. Legacy bpmn.io viewer: `"transitrix.bpmnRenderer": "bpmn-io"`.
+- **DGCA / DGA notation** — canonical rename from FGCA / FGA (legacy keys still read in 1.x with warnings).
+- **Blocks IDs**, **BPMN auto-open**, **preview-from-title-bar fix** when the webview has focus.
+- **Hand-test layout polish** — pool/lane header padding, start-event inset, `transitrix.bpmn.laneGap` (default 0).
+
+## Upgrade notes
+
+1. **Rename FGCA/FGA files** (optional but recommended): `*.fgca.transitrix.yaml` → `*.dgca.transitrix.yaml`, `*.fga.transitrix.yaml` → `*.dga.transitrix.yaml`; update `notation:` headers accordingly.
+2. **BPMN workspace settings:** if you set `transitrix.bpmn.laneGap` to `40` during 2.2.0 previews, reset to **0** for flush lanes (new default).
+3. **Cursor / VS Code 2.1+:** editor title-bar preview icons may be hidden under `…` → **Configure Icon Visibility**.
+
+## Full changelog
+
+See [extension/CHANGELOG.md](https://github.com/transitrix/transitrix-studio/blob/main/extension/CHANGELOG.md#220--2026-06-24).
+
+## Publish checklist (maintainer)
+
+- [ ] Merge [#290](https://github.com/transitrix/transitrix-studio/pull/290) into `main`
+- [ ] Verify CI green on `main`
+- [ ] Retag this draft to `main` @ merge commit (or recreate release from `main`)
+- [ ] Publish release → triggers [VS Code Marketplace multi-platform publish](https://github.com/transitrix/transitrix-studio/actions/workflows/vscode-marketplace-publish.yml)
+- [ ] Smoke-test: BPMN + Blocks previews on `organizations/acme_corp/canon/views/`

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,21 +1,38 @@
 # Transitrix Studio — changelog
 
-## 2.2.0 — 2026-06-21
+## 2.2.0 — 2026-06-24
 
-BPMN diagram polish: PNG export, unified diagram styles, left-face entry for cross-lane flows, entity IDs in nodes.
+Custom BPMN renderer by default, DGCA/DGA notation rename, Blocks IDs, and BPMN preview layout polish from hand-testing.
 
 ### Added
 
-- **BPMN preview — Save as PNG.** Export the rendered BPMN diagram to a `.png` file directly from the preview toolbar.
-- **Entity IDs in diagram nodes.** FGCA, FGA, and Activities nodes now show the entity ID below the name in grey, matching the Goal tree convention.
+- **BPMN preview — custom SVG renderer is the default.** `transitrix.bpmnRenderer` defaults to `"custom"` (built-in emitter with shared theme, zoom/pan). Set `"bpmn-io"` to revert to the legacy interactive viewer.
+- **BPMN preview — `transitrix.bpmn.laneGap` setting.** Vertical spacing between swimlanes (0–200 px); toolbar **Spacing…** opens BPMN settings.
+- **BPMN SVG renderer — default-flow marker, label wrap, lane clip.** Per BPMN 2.0, default outflows show a perpendicular slash; conditional flows are solid; below-element labels word-wrap; lane clip-path prevents label bleed into the header column.
+- **Blocks preview — block IDs in the diagram.** Leaf blocks show name + ID; container blocks show `(ID)` in the header line.
+- **Auto-open previews** for BPMN, compliance-impact, single law, and single product files on open (in addition to existing notations).
+- **DGCA / DGA notation** (renamed from FGCA / FGA). New canonical file extensions `*.dgca.transitrix.yaml` and `*.dga.transitrix.yaml`; legacy `fgca` / `fga` keys still accepted with deprecation warnings through 1.x.
+- **Driver terminology** in FGCA/DGCA column (factor → driver) — validator, types, and CSS class alignment.
+- **BPMN preview — Save as PNG.** Export the rendered BPMN diagram to a `.png` file from the preview toolbar.
+- **Entity IDs in diagram nodes.** FGCA/DGA, FGA/DGA, and Activities nodes show the entity ID below the name in grey.
 
 ### Fixed
 
-- **BPMN cross-lane gateway flows — left-face entry.** Arrows from gateway bottom/top exit ports now always enter the target block from the left face. Previously they could enter from the top or bottom depending on the gateway's position relative to the target.
-- **BPMN edge routing polish.** Corrected kinks in same-lane top/bottom exit routes, fixed `defaultFlow` attribute handling, and tightened preview layout.
-- **Activities diagram — unified node style.** Fill colour, stroke colour, stroke width, and corner radius now match Goal tree / FGA / FGCA out of the box.
-- **Preview panel titles** — standardised to `[Type] Preview — filename` pattern across all notations.
-- **Process Blueprint** — restored correct PNG export layout; uniform title block across all previews.
+- **BPMN preview title-bar action** uses `registerTextEditorCommand` so **Open Preview** works when focus is in the webview panel.
+- **`.dgca.transitrix.yaml` routing** — goals/activities files open the correct preview by `notation:` header, not always the DGCA tree.
+- **BPMN layout — compact pool/lane defaults** and **`laneContentLeftPad`** so start-event labels centre under the shape.
+- **BPMN header captions** — wider pool band, end padding on rotated pool/lane titles, min lane height from caption length when the name is longer than the content row.
+- **`transitrix.bpmn.laneGap` default is 0** (was 40 via settings override of layout).
+- **CLI** — `dgca` / `dga` validator keys and help text.
+- **BPMN cross-lane gateway flows — left-face entry** and same-lane routing kinks / `defaultFlow` XML attribute handling.
+- **Activities diagram — unified node style** with Goal tree / DGCA / DGA previews.
+- **Preview panel titles** — `[Type] Preview — filename` pattern; Process Blueprint PNG export layout restored.
+- **BPMN DSL schema** — root `name` / `generated_at` (CONTRACT §1.1); lane/element `performed_by_role` and `supported_by_application`.
+- **VSIX build** — `extension:prep` runs `build:diagrams` so packaged previews include fresh `@transitrix/diagrams` bundles.
+
+### Changed
+
+- **Tighter BPMN pool/lane geometry** — reduced outer padding and lane-name column; sequence-flow rendering no longer uses dashed condition styling.
 
 ## 2.1.1 — 2026-06-20
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -94,7 +94,7 @@
         },
         "transitrix.bpmn.laneGap": {
           "type": "number",
-          "default": 40,
+          "default": 0,
           "minimum": 0,
           "maximum": 200,
           "description": "Vertical gap (px) between swimlanes in the BPMN preview. Change takes effect on the next file save or when the preview re-renders."

--- a/packages/diagrams/src/webview/render-process.ts
+++ b/packages/diagrams/src/webview/render-process.ts
@@ -89,8 +89,8 @@ export interface RenderProcessOptions {
 /** Width of the lane-name column (px). Matches the laneLabelWidth default. */
 const LANE_LABEL_BAND = 44;
 
-/** End margin (px) along the pool-height axis for the rotated pool caption. */
-const POOL_LABEL_AXIS_PAD = 12;
+/** End margin (px) along the header height axis for rotated pool/lane captions. */
+const HEADER_LABEL_AXIS_PAD = 24;
 
 /** Maximum characters per wrapped line inside a task box. */
 const TASK_CHARS = 14;
@@ -334,8 +334,8 @@ function renderPoolLanes(layout: ProcessDiagramLayout, ox: number, oy: number): 
   parts.push(`<rect class="bpmn-pool-name" x="${px}" y="${py}" width="${poolNameW}" height="${ph}"/>`);
 
   const pLX = r(px + poolNameW / 2);
-  const labelSpan = Math.max(ph - 2 * POOL_LABEL_AXIS_PAD, 0);
-  const pLY = r(py + POOL_LABEL_AXIS_PAD + labelSpan / 2);
+  const poolLabelSpan = Math.max(ph - 2 * HEADER_LABEL_AXIS_PAD, 0);
+  const pLY = r(py + HEADER_LABEL_AXIS_PAD + poolLabelSpan / 2);
   parts.push(
     `<text class="bpmn-pool-label" text-anchor="middle" dominant-baseline="central"` +
     ` transform="rotate(-90,${pLX},${pLY})" x="${pLX}" y="${pLY}">${escXml(process.poolName)}</text>`,
@@ -353,7 +353,8 @@ function renderPoolLanes(layout: ProcessDiagramLayout, ox: number, oy: number): 
     parts.push(`<rect class="bpmn-lane-header" x="${lx}" y="${ly}" width="${LANE_LABEL_BAND}" height="${lh}"/>`);
 
     const lLX = r(lx + LANE_LABEL_BAND / 2);
-    const lLY = r(ly + lh / 2);
+    const laneLabelSpan = Math.max(lh - 2 * HEADER_LABEL_AXIS_PAD, 0);
+    const lLY = r(ly + HEADER_LABEL_AXIS_PAD + laneLabelSpan / 2);
     parts.push(
       `<text class="bpmn-lane-label" text-anchor="middle" dominant-baseline="central"` +
       ` transform="rotate(-90,${lLX},${lLY})" x="${lLX}" y="${lLY}">${escXml(lane.name)}</text>`,

--- a/packages/diagrams/src/webview/render-process.ts
+++ b/packages/diagrams/src/webview/render-process.ts
@@ -90,7 +90,10 @@ export interface RenderProcessOptions {
 const LANE_LABEL_BAND = 44;
 
 /** End margin (px) along the header height axis for rotated pool/lane captions. */
-const HEADER_LABEL_AXIS_PAD = 24;
+const HEADER_LABEL_AXIS_PAD = 32;
+
+/** Estimated horizontal advance (px) per character at the header label font size. */
+const HEADER_LABEL_CHAR_W = 6.5;
 
 /** Maximum characters per wrapped line inside a task box. */
 const TASK_CHARS = 14;
@@ -139,6 +142,19 @@ export const BPMN_PROCESS_CSS = `
 
 function r(n: number): number {
   return Math.round(n);
+}
+
+/** Truncate at a word boundary so rotated header labels never break mid-word. */
+function wordTruncate(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  const cut = text.slice(0, maxChars - 1);
+  const lastSpace = cut.lastIndexOf(' ');
+  return (lastSpace > maxChars / 2 ? cut.slice(0, lastSpace) : cut) + '…';
+}
+
+function fitRotatedHeaderText(name: string, spanPx: number): string {
+  const maxChars = Math.max(4, Math.floor(spanPx / HEADER_LABEL_CHAR_W));
+  return wordTruncate(name, maxChars);
 }
 
 function wrapTaskName(name: string): string[] {
@@ -338,7 +354,7 @@ function renderPoolLanes(layout: ProcessDiagramLayout, ox: number, oy: number): 
   const pLY = r(py + HEADER_LABEL_AXIS_PAD + poolLabelSpan / 2);
   parts.push(
     `<text class="bpmn-pool-label" text-anchor="middle" dominant-baseline="central"` +
-    ` transform="rotate(-90,${pLX},${pLY})" x="${pLX}" y="${pLY}">${escXml(process.poolName)}</text>`,
+    ` transform="rotate(-90,${pLX},${pLY})" x="${pLX}" y="${pLY}">${escXml(fitRotatedHeaderText(process.poolName, poolLabelSpan))}</text>`,
   );
 
   for (const lane of process.lanes) {
@@ -357,7 +373,7 @@ function renderPoolLanes(layout: ProcessDiagramLayout, ox: number, oy: number): 
     const lLY = r(ly + HEADER_LABEL_AXIS_PAD + laneLabelSpan / 2);
     parts.push(
       `<text class="bpmn-lane-label" text-anchor="middle" dominant-baseline="central"` +
-      ` transform="rotate(-90,${lLX},${lLY})" x="${lLX}" y="${lLY}">${escXml(lane.name)}</text>`,
+      ` transform="rotate(-90,${lLX},${lLY})" x="${lLX}" y="${lLY}">${escXml(fitRotatedHeaderText(lane.name, laneLabelSpan))}</text>`,
     );
   }
 

--- a/packages/diagrams/src/webview/render-process.ts
+++ b/packages/diagrams/src/webview/render-process.ts
@@ -87,7 +87,10 @@ export interface RenderProcessOptions {
 // ---------------------------------------------------------------------------
 
 /** Width of the lane-name column (px). Matches the laneLabelWidth default. */
-const LANE_LABEL_BAND = 28;
+const LANE_LABEL_BAND = 44;
+
+/** End margin (px) along the pool-height axis for the rotated pool caption. */
+const POOL_LABEL_AXIS_PAD = 12;
 
 /** Maximum characters per wrapped line inside a task box. */
 const TASK_CHARS = 14;
@@ -331,7 +334,8 @@ function renderPoolLanes(layout: ProcessDiagramLayout, ox: number, oy: number): 
   parts.push(`<rect class="bpmn-pool-name" x="${px}" y="${py}" width="${poolNameW}" height="${ph}"/>`);
 
   const pLX = r(px + poolNameW / 2);
-  const pLY = r(py + ph / 2);
+  const labelSpan = Math.max(ph - 2 * POOL_LABEL_AXIS_PAD, 0);
+  const pLY = r(py + POOL_LABEL_AXIS_PAD + labelSpan / 2);
   parts.push(
     `<text class="bpmn-pool-label" text-anchor="middle" dominant-baseline="central"` +
     ` transform="rotate(-90,${pLX},${pLY})" x="${pLX}" y="${pLY}">${escXml(process.poolName)}</text>`,

--- a/src/layout-options.ts
+++ b/src/layout-options.ts
@@ -16,6 +16,8 @@ export interface LayoutDiagramOptions {
   laneVerticalGap: number;
   /** Extra padding inside a lane strip on the right (after ELK content). */
   laneContentRightPad: number;
+  /** Extra padding before the first ELK column inside a lane (after the lane-name column). */
+  laneContentLeftPad: number;
   /** `elk.spacing.nodeNode` — horizontal spacing between nodes. */
   elkNodeSpacing: number;
   /** `elk.layered.spacing.nodeNodeBetweenLayers` — spacing between Sugiyama layers. */
@@ -28,10 +30,11 @@ export const DEFAULT_LAYOUT_DIAGRAM_OPTIONS: LayoutDiagramOptions = {
   poolPad: 12,
   poolOriginX: 12,
   poolOriginY: 12,
-  participantLabelBand: 20,
+  participantLabelBand: 44,
   laneLabelWidth: 44,
   laneVerticalGap: 0,
   laneContentRightPad: 40,
+  laneContentLeftPad: 32,
   elkNodeSpacing: 52,
   elkLayerSpacing: 88,
   elkDiagramPadding: 44,
@@ -63,6 +66,7 @@ export function mergeLayoutDiagramOptions(
     laneLabelWidth: pick('laneLabelWidth'),
     laneVerticalGap: pick('laneVerticalGap'),
     laneContentRightPad: pick('laneContentRightPad'),
+    laneContentLeftPad: pick('laneContentLeftPad'),
     elkNodeSpacing: pick('elkNodeSpacing'),
     elkLayerSpacing: pick('elkLayerSpacing'),
     elkDiagramPadding: pick('elkDiagramPadding'),
@@ -86,6 +90,7 @@ const LAYOUT_KEYS: (keyof LayoutDiagramOptions)[] = [
   'laneLabelWidth',
   'laneVerticalGap',
   'laneContentRightPad',
+  'laneContentLeftPad',
   'elkNodeSpacing',
   'elkLayerSpacing',
   'elkDiagramPadding',

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -21,6 +21,14 @@ const CROSS_LANE_EDGE_OVERLAP_EPSILON_PX = 4;
  *  `elkDiagramPadding` (default 44 px) so the arc stays inside the lane band. */
 const BACKWARD_LOOP_CLEARANCE_PX = 32;
 
+/** Rotated lane/pool caption sizing — keep in sync with render-process.ts HEADER_* constants. */
+const LANE_LABEL_AXIS_PAD = 32;
+const LANE_LABEL_CHAR_W = 6.5;
+
+function minLaneHeightForLabel(name: string): number {
+  return name.length * LANE_LABEL_CHAR_W + 2 * LANE_LABEL_AXIS_PAD;
+}
+
 /** Vertical spread step between multiple forward flows leaving the same source
  *  element in the same lane.  Prevents arrows from overlapping at split gateways. */
 const MULTI_EXIT_OFFSET_STEP_PX = 8;
@@ -492,6 +500,7 @@ export async function layoutProcess(
 
   for (const ld of laneData) {
     const items = laneLocalItems.get(ld.laneId) ?? [];
+    const laneDef = ir.lanes.find((l) => l.id === ld.laneId);
 
     for (const item of items) {
       elements.set(item.id, {
@@ -506,7 +515,8 @@ export async function layoutProcess(
       ? Math.max(...items.map((item) => item.localY + item.height))
       : 0;
     // Add bottom padding matching the top padding (envY) to keep lanes symmetric.
-    const laneHeight = Math.max(ld.height, contentBottom + ld.envY);
+    const labelMinH = laneDef ? minLaneHeightForLabel(laneDef.name) : 0;
+    const laneHeight = Math.max(ld.height, contentBottom + ld.envY, labelMinH);
 
     laneBounds.set(ld.laneId, {
       x: laneOriginX,

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -451,7 +451,7 @@ export async function layoutProcess(
       if (!gb) continue;
       items.push({
         id: el.id,
-        x: laneOriginX + o.laneLabelWidth + (gb.x - globalMinX),
+        x: laneOriginX + o.laneLabelWidth + o.laneContentLeftPad + (gb.x - globalMinX),
         // Ensure at least elkDiagramPadding of top margin so backward arc clearance
         // (BACKWARD_LOOP_CLEARANCE_PX = 32) always stays inside the lane boundary.
         localY: Math.max((ld.localY.get(el.id) ?? 0) + ld.envY, o.elkDiagramPadding),
@@ -511,7 +511,7 @@ export async function layoutProcess(
     laneBounds.set(ld.laneId, {
       x: laneOriginX,
       y: yCursor,
-      width: o.laneLabelWidth + contentW + o.laneContentRightPad,
+      width: o.laneLabelWidth + o.laneContentLeftPad + contentW + o.laneContentRightPad,
       height: laneHeight,
     });
 
@@ -520,7 +520,7 @@ export async function layoutProcess(
 
   const innerBottom = yCursor - o.laneVerticalGap;
   const participantW =
-    o.participantLabelBand + o.laneLabelWidth + contentW + o.laneContentRightPad;
+    o.participantLabelBand + o.laneLabelWidth + o.laneContentLeftPad + contentW + o.laneContentRightPad;
   const participantH = innerBottom - o.poolOriginY;
 
   const poolBounds: Bounds = {


### PR DESCRIPTION
## Summary
Final BPMN preview layout polish for **2.2.0** release + changelog/release notes.

### Code (#290)
- Wider pool caption band (`participantLabelBand` 44px); rotated header end padding (32px).
- `laneContentLeftPad` 32px — start-event labels centre under the shape.
- `transitrix.bpmn.laneGap` default **0** (was 40).
- Min lane height from rotated caption length when name exceeds content height.

### Release docs
- `extension/CHANGELOG.md` — consolidated **2.2.0** (2026-06-24)
- `CHANGELOG.md` — root mirror
- `docs/release-notes-2.2.0.md` — maintainer + marketplace draft

## Merge order
Merge into `main` **before** publishing GitHub release `v2.2.0`.

## Test plan
- [ ] `data-subject-erasure.bpmn.transitrix.yaml` — pool/lane headers, start event, flush lanes (`laneGap` 0)
- [ ] `personal-data-landscape.blocks.transitrix.yaml` — block IDs
- [ ] Reset workspace `transitrix.bpmn.laneGap` if still 40
- [ ] `npm run test:core` + `npm run test:diagrams`

## After merge
1. Point draft release [v2.2.0](https://github.com/transitrix/transitrix-studio/releases) at `main` merge commit
2. Publish → Marketplace matrix workflow
