### PR TITLE
fix(intellij): auto-derive plugin version from release tag + add dgca/dga notations

### DIFF
--- a/.github/workflows/jetbrains-publish.yml
+++ b/.github/workflows/jetbrains-publish.yml
@@ -1,11 +1,11 @@
 name: JetBrains Marketplace — publish
 
-# Triggered on every GitHub Release to sign and publish the IntelliJ plugin
-# via `./gradlew publishPlugin`.
+# Triggered on every GitHub Release. Derives pluginVersion automatically from
+# the release tag (v2.2.0 → 2.2.0) so the JetBrains plugin version always
+# mirrors the VS Code extension version — no manual bump needed.
 #
-# The IntelliJ plugin version is set in intellij/gradle.properties
-# (pluginVersion) and is versioned independently from the VS Code extension.
-# Bump it there before cutting a release that includes IntelliJ changes.
+# For manual dispatch, supply the `version` input explicitly (e.g. "2.2.0").
+# If omitted on dispatch, the value in intellij/gradle.properties is used as-is.
 #
 # Prerequisites (one-time maintainer setup — see intellij/PUBLISHING.md):
 #   - CERTIFICATE_CHAIN      — contents of chain.crt (PEM)
@@ -20,7 +20,11 @@ name: JetBrains Marketplace — publish
 on:
   release:
     types: [published]
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Plugin version to publish (e.g. 2.2.0). Leave blank to use gradle.properties value.'
+        required: false
 
 permissions:
   contents: read
@@ -33,6 +37,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Set plugin version
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          elif [ -n "${{ inputs.version }}" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            echo "Using version from gradle.properties (workflow_dispatch, no version input)"
+            exit 0
+          fi
+          sed -i "s/^pluginVersion = .*/pluginVersion = $VERSION/" intellij/gradle.properties
+          echo "Plugin version set to: $VERSION"
 
       - name: Verify secrets are set
         env:

--- a/intellij/gradle.properties
+++ b/intellij/gradle.properties
@@ -1,7 +1,8 @@
 pluginGroup = com.transitrix.intellij
 pluginName = transitrix-intellij
-# Versioned independently from the VS Code extension's package.json.
-pluginVersion = 0.2.1
+# Mirrors the VS Code extension version. The release workflow sets this
+# automatically from the GitHub Release tag — no manual bump needed.
+pluginVersion = 2.2.0
 
 # IntelliJ IDEA Community 2024.2 — JCEF-bearing baseline (JCEF requires 2020.2+).
 platformVersion = 2024.2

--- a/intellij/src/main/kotlin/com/transitrix/intellij/TransitrixNotation.kt
+++ b/intellij/src/main/kotlin/com/transitrix/intellij/TransitrixNotation.kt
@@ -21,6 +21,8 @@ object TransitrixNotation {
      */
     private val SUFFIX_TO_KIND: List<Pair<String, String>> = listOf(
         ".goals.transitrix.yaml" to "goals",
+        ".dgca.transitrix.yaml" to "dgca",
+        ".dga.transitrix.yaml" to "dga",
         ".fgca.transitrix.yaml" to "fgca",
         ".fga.transitrix.yaml" to "fga",
         ".activities.transitrix.yaml" to "activities",


### PR DESCRIPTION
## Summary

- **Workflow**: `jetbrains-publish.yml` now derives `pluginVersion` from the GitHub Release tag automatically (`v2.2.0` → `2.2.0`). No manual bump in `gradle.properties` needed on each release. `workflow_dispatch` gains an optional `version` input for one-off publishes.
- **TransitrixNotation.kt**: adds `.dgca.transitrix.yaml` → `dgca` and `.dga.transitrix.yaml` → `dga` — these were missing, so DGCA/DGA files silently didn't open a preview in IntelliJ.
- **gradle.properties**: base `pluginVersion` updated to `2.2.0` to match the current VS Code release; comment updated to reflect auto-versioning.

## Test plan

- [ ] Merge and run workflow_dispatch with `version: 2.2.0` to publish 2.2.0 to JetBrains Marketplace
- [ ] On the next GitHub Release, verify the workflow sets version from the tag automatically (no manual bump)
- [ ] Open a `.dgca.transitrix.yaml` file in IntelliJ IDEA — confirm preview opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)