### PR TITLE
feat(cli): accept canonical notation extensions in validate without --ext

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,7 +18,13 @@ import { parseYamlToIr } from './parser.js';
 import { validateProcess } from './validator.js';
 import type { ProcessIr } from './ir.js';
 import { runRepoValidate, reportRepoFindings, repoScopeHasErrors } from './repo-validate.js';
-import { isFileValidatableNotation, loadNotationYaml, validateNotationDoc } from './validate-notation.js';
+import {
+  isFileValidatableNotation,
+  loadNotationYaml,
+  validateNotationDoc,
+  CANONICAL_NOTATION_FILE_EXTENSIONS,
+  inferNotationFromFilename,
+} from './validate-notation.js';
 import { handleExportComplianceCommand } from './export-compliance.js';
 
 function printUsage(): void {
@@ -265,7 +271,15 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
   }
 
   const { scope, root, positional, extList, wantsHelp } = parsed;
-  const exts = extList.length > 0 ? extList : DEFAULT_TRANSITRIX_FILE_EXTENSIONS;
+  // Default extension list for validate: BPMN + all canonical notation extensions.
+  // Notation files are already routed by their notation: field before the extension
+  // gate, so this expanded default mainly prevents a confusing error message when a
+  // canonical-extension file is missing its notation: field.
+  const validateDefaultExts = [
+    ...DEFAULT_TRANSITRIX_FILE_EXTENSIONS,
+    ...CANONICAL_NOTATION_FILE_EXTENSIONS,
+  ];
+  const exts = extList.length > 0 ? extList : validateDefaultExts;
   const useJson = argv.includes('--json');
 
   if (wantsHelp) {
@@ -273,9 +287,11 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
     console.error(`       transitrix validate --scope=repo [--root <dir>] [--json]`);
     console.error('');
     console.error('file scope — single-file structural/semantic validation (default).');
-    console.error('             BPMN, or a diagram notation routed by its notation: field');
-    console.error('             (goals, dgca, dga, activities, activity-card,');
-    console.error('             process-blueprint, blocks) — same checks as the preview.');
+    console.error('             BPMN, or any diagram notation routed by its notation: field');
+    console.error('             (goals, dgca, dga, fgca, fga, activities, activity-card,');
+    console.error('             process-blueprint, blocks, applications, capability-map,');
+    console.error('             products, scenarios, process-map) — same checks as the preview.');
+    console.error('             Canonical notation extensions are accepted without --ext.');
     console.error('repo scope — whole-canon checks (referential integrity, atomicity,');
     console.error('             id uniqueness, policy) over <root> (default: cwd).');
     console.error('Exits with code 1 if any findings.');
@@ -377,11 +393,38 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
   }
 
   // ----- BPMN / no-notation path -----
-  // The extension gate only applies here; diagram notations are routed above by
-  // their notation field regardless of filename.
+  // Diagram notations are routed above by their notation: field regardless of
+  // filename, so the extension gate here only affects BPMN files and files whose
+  // notation: field could not be determined (missing or not a string).
+  //
+  // Special case: if the filename has a canonical notation extension but the
+  // notation: field is absent or wrong, give a targeted error rather than the
+  // generic extension list.
+  const extNotation = inferNotationFromFilename(src);
+  if (extNotation && !probedNotation) {
+    if (useJson) {
+      console.log(
+        JSON.stringify(
+          {
+            valid: false,
+            message: `missing notation: field — add 'notation: ${extNotation}' to the file`,
+          },
+          null,
+          2,
+        ),
+      );
+    } else {
+      console.error(`✗ ${src}`);
+      console.error();
+      console.error(`Missing notation: field — add 'notation: ${extNotation}' to the file.`);
+      console.error();
+    }
+    process.exit(1);
+  }
   if (!inputMatchesExtension(src, exts)) {
+    const canonical = validateDefaultExts.join(', ');
     console.error(
-      `transitrix: input file must end with one of: ${exts.join(', ')} (or pass --ext)`,
+      `transitrix validate: unrecognised file extension — canonical extensions: ${canonical} (or use --ext)`,
     );
     process.exit(1);
   }

--- a/src/validate-notation.ts
+++ b/src/validate-notation.ts
@@ -74,6 +74,23 @@ const VALIDATORS: Record<string, NotationValidator> = {
 /** Notation field values the CLI can validate per file. */
 export const FILE_VALIDATABLE_NOTATIONS = Object.keys(VALIDATORS);
 
+/** Canonical file extensions the validate command accepts without `--ext`, one
+ *  per notation key: `.goals.transitrix.yaml`, `.dgca.transitrix.yaml`, etc. */
+export const CANONICAL_NOTATION_FILE_EXTENSIONS: readonly string[] =
+  FILE_VALIDATABLE_NOTATIONS.map((n) => `.${n}.transitrix.yaml`);
+
+/** Return the notation inferred from the file's canonical extension (e.g.
+ *  `foo.dgca.transitrix.yaml` → `"dgca"`), or `undefined` for non-canonical
+ *  names. Used by the validate command to give a helpful error when a canonical
+ *  extension file is missing its `notation:` field. */
+export function inferNotationFromFilename(filePath: string): string | undefined {
+  const lower = filePath.replace(/\\/g, '/').toLowerCase();
+  for (const notation of FILE_VALIDATABLE_NOTATIONS) {
+    if (lower.endsWith(`.${notation}.transitrix.yaml`)) return notation;
+  }
+  return undefined;
+}
+
 /** True when `transitrix validate <file>` has a per-notation validator for this
  *  notation — i.e. it can reproduce the preview's error block. */
 export function isFileValidatableNotation(notation: string): boolean {

--- a/tests/validate-notation.test.ts
+++ b/tests/validate-notation.test.ts
@@ -10,6 +10,8 @@ import {
   loadNotationYaml,
   notationOf,
   FILE_VALIDATABLE_NOTATIONS,
+  CANONICAL_NOTATION_FILE_EXTENSIONS,
+  inferNotationFromFilename,
 } from '../src/validate-notation.js';
 // Imported directly to prove the CLI dispatch mirrors the validator the VS Code
 // preview uses — same findings, no drift (vkgeorgia/strategy#258).
@@ -51,6 +53,31 @@ function fixtures(notation: string): string[] {
     .filter((f) => f.endsWith('.transitrix.yaml'))
     .map((f) => join(corpusRoot, notation, f));
 }
+
+describe('validate-notation — canonical extension helpers (#343)', () => {
+  it('CANONICAL_NOTATION_FILE_EXTENSIONS has one entry per validatable notation', () => {
+    expect(CANONICAL_NOTATION_FILE_EXTENSIONS).toHaveLength(FILE_VALIDATABLE_NOTATIONS.length);
+    for (const notation of FILE_VALIDATABLE_NOTATIONS) {
+      expect(CANONICAL_NOTATION_FILE_EXTENSIONS).toContain(`.${notation}.transitrix.yaml`);
+    }
+  });
+
+  it('inferNotationFromFilename matches canonical extensions', () => {
+    expect(inferNotationFromFilename('foo/bar.dgca.transitrix.yaml')).toBe('dgca');
+    expect(inferNotationFromFilename('foo/bar.goals.transitrix.yaml')).toBe('goals');
+    expect(inferNotationFromFilename('foo/bar.capability-map.transitrix.yaml')).toBe('capability-map');
+    expect(inferNotationFromFilename('foo/bar.activity-card.transitrix.yaml')).toBe('activity-card');
+    // Windows backslash paths
+    expect(inferNotationFromFilename('foo\\bar.dgca.transitrix.yaml')).toBe('dgca');
+  });
+
+  it('inferNotationFromFilename returns undefined for non-canonical names', () => {
+    expect(inferNotationFromFilename('foo.bpmn.transitrix.yaml')).toBeUndefined();
+    expect(inferNotationFromFilename('foo.yaml')).toBeUndefined();
+    expect(inferNotationFromFilename('foo.unknown.transitrix.yaml')).toBeUndefined();
+    expect(inferNotationFromFilename('foo.dgca.yaml')).toBeUndefined(); // missing .transitrix
+  });
+});
 
 describe('validate-notation — dispatch (#258)', () => {
   it('recognises all Group A and Group B notations', () => {


### PR DESCRIPTION
## Summary

- `CANONICAL_NOTATION_FILE_EXTENSIONS` and `inferNotationFromFilename` exported from `validate-notation.ts`, derived from the `VALIDATORS` map so they stay in sync automatically
- `handleValidateCommand`'s default extension list now includes all canonical notation extensions (`.goals.transitrix.yaml`, `.dgca.transitrix.yaml`, etc.) — no `--ext` required for standard view files
- When a file has a canonical notation extension but is missing the `notation:` field, the CLI emits a targeted error ("add 'notation: dgca' to the file") instead of the generic extension-list message
- Error message for genuinely unknown extensions lists all canonical extensions
- `validate --help` updated to enumerate all supported notations including Group B (applications, capability-map, products, scenarios, process-map)
- Unit tests for the new exports added to `validate-notation.test.ts`

## Test plan

- [ ] `transitrix validate <file>.dgca.transitrix.yaml` (with `notation: dgca`) → passes without `--ext`
- [ ] `transitrix validate <file>.goals.transitrix.yaml` (with `notation: goals`) → passes without `--ext`
- [ ] `transitrix validate <file>.goals.transitrix.yaml` (missing `notation:`) → helpful error naming the expected field and value
- [ ] `transitrix validate foo.unknown.yaml` → error lists all canonical extensions
- [ ] `npx vitest run tests/validate-notation.test.ts` → 35 tests pass (3 new for canonical extension helpers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)