### PR TITLE
fix(activity-card): PC-001 recursive resolver scope + diagnostic

### DIFF
--- a/extension/src/canon-loader.ts
+++ b/extension/src/canon-loader.ts
@@ -69,14 +69,21 @@ export function findCanonRootPath(filePath: string): string | undefined {
 }
 
 /**
- * Returns true when `savedFilePath` is inside the `elements/` or `relations/`
- * subtrees of `canonRootPath`.
+ * Returns true when `savedFilePath` is inside the `elements/`, `relations/`,
+ * or `views/activities/` subtrees of `canonRootPath`.
+ * The `views/activities/` subtree is the secondary fallback for activity
+ * elements (§6.1) — changes there trigger an activity-card re-render too.
  */
 export function isUnderCanonPath(canonRootPath: string, savedFilePath: string): boolean {
   const elementsRoot = path.join(canonRootPath, 'elements');
   const relationsRoot = path.join(canonRootPath, 'relations');
+  const viewActivitiesRoot = path.join(canonRootPath, 'views', 'activities');
   const savedDir = path.dirname(savedFilePath);
-  return savedDir.startsWith(elementsRoot) || savedDir.startsWith(relationsRoot);
+  return (
+    savedDir.startsWith(elementsRoot) ||
+    savedDir.startsWith(relationsRoot) ||
+    savedDir.startsWith(viewActivitiesRoot)
+  );
 }
 
 // ── vscode.Uri wrappers ────────────────────────────────────────────────────
@@ -99,6 +106,26 @@ export function isUnderCanon(canonRoot: vscode.Uri, savedUri: vscode.Uri): boole
 }
 
 // ── FS loader ─────────────────────────────────────────────────────────────
+
+/**
+ * Extract individual activity objects from an activities VIEW document
+ * (`notation: activities`). Each item in the top-level `activities:` array is
+ * returned as a synthetic element with `notation: 'activity'` added, so the
+ * activity-card resolver's `collectByNotation` can find them.
+ * Files that are NOT activities-view documents are returned as-is (they may
+ * be standalone `notation: activity` element files placed under views/).
+ *
+ * Used for the `canon/views/activities/**` secondary fallback (§6.1).
+ */
+export function extractViewActivities(doc: unknown): unknown[] {
+  if (!doc || typeof doc !== 'object' || Array.isArray(doc)) return [doc];
+  const d = doc as Record<string, unknown>;
+  if (d['notation'] !== 'activities') return [doc]; // standalone element — return as-is
+  const arr = d['activities'];
+  if (!Array.isArray(arr)) return []; // malformed view — nothing to extract
+  return arr.filter((item) => item && typeof item === 'object' && !Array.isArray(item))
+    .map((item) => ({ notation: 'activity', ...(item as Record<string, unknown>) }));
+}
 
 /** Recursively read + parse every `*.yaml` document under `root` into `out`. */
 export async function readYamlDocsUnder(
@@ -146,6 +173,30 @@ export async function loadCanon(fileUri: vscode.Uri): Promise<CanonDocs> {
 
   await readYamlDocsUnder(vscode.Uri.joinPath(canonRoot, 'elements'), elements, warnings);
   await readYamlDocsUnder(vscode.Uri.joinPath(canonRoot, 'relations'), relations, warnings);
+
+  // Secondary fallback (§6.1): if the org keeps activities in view files under
+  // canon/views/activities/, extract individual activity items and add them to
+  // the element pool so the resolver can find them. A warning is emitted for
+  // each view-sourced activity found — the canonical home is canon/elements/.
+  const viewActivityDocs: unknown[] = [];
+  await readYamlDocsUnder(
+    vscode.Uri.joinPath(canonRoot, 'views', 'activities'),
+    viewActivityDocs,
+    warnings,
+  );
+  for (const doc of viewActivityDocs) {
+    const extracted = extractViewActivities(doc);
+    for (const act of extracted) {
+      elements.push(act);
+      const a = act as Record<string, unknown>;
+      if (typeof a['id'] === 'string') {
+        warnings.push(
+          `Activity "${a['id']}" resolved via canon/views/activities/ (secondary fallback) — ` +
+          `move the element to canon/elements/ for canonical storage.`,
+        );
+      }
+    }
+  }
 
   if (elements.length === 0) {
     warnings.push('No element documents found under canon/elements — element references cannot resolve.');

--- a/packages/diagrams/src/activity-card/__tests__/resolver.test.ts
+++ b/packages/diagrams/src/activity-card/__tests__/resolver.test.ts
@@ -233,6 +233,29 @@ describe('resolveActivityCard', () => {
     expect(r.errors.some((e) => e.code === 'PC-001')).toBe(true);
   });
 
+  it('PC-001 diagnostic discloses paths searched and actionable hint (#344)', () => {
+    const r = resolveActivityCard(CARD, { elements: [FACTOR, GOAL, CHANGE], relations });
+    const pc001 = r.errors.find((e) => e.code === 'PC-001');
+    expect(pc001).toBeDefined();
+    // Must disclose both searched paths (§7 PC-001)
+    expect(pc001!.message).toContain('canon/elements/**');
+    expect(pc001!.message).toContain('canon/views/activities/**');
+    // Must include actionable hint with expected file pattern (§7 PC-001)
+    expect(pc001!.message).toContain('notation: activity');
+    expect(pc001!.message).toContain(`id: "${CARD.activity_card.project}"`);
+  });
+
+  it('resolves without PC-001 when project activity lives in a deep canon/elements subfolder (#344)', () => {
+    // Regression: the resolver must accept elements regardless of which subfolder
+    // they were loaded from (e.g. canon/elements/05_implementation/activities/).
+    // The resolver is filesystem-free, so we simulate the deep-path scenario by
+    // including the PROJECT element in the elements pool — just as loadCanon does
+    // after walking canon/elements/** recursively.
+    const r = resolveActivityCard(CARD, sources);
+    expect(r.valid, JSON.stringify(r.errors)).toBe(true);
+    expect(r.errors.some((e) => e.code === 'PC-001')).toBe(false);
+  });
+
   it('resolves activity_type and status from the Activity element', () => {
     const r = resolveActivityCard(CARD, {
       elements: [{ ...PROJECT, activity_type: 'programme', status: 'on_track' }, CHILD, FACTOR, GOAL, CHANGE],

--- a/packages/diagrams/src/activity-card/resolver.ts
+++ b/packages/diagrams/src/activity-card/resolver.ts
@@ -168,11 +168,17 @@ export function resolveActivityCard(
   const activities = collectByNotation(sources.elements, 'activity');
   const projectRec = activities.get(projectId);
 
-  // PC-001 — project must resolve to an admitted ACTIVITY element in canon.
+  // PC-001 — project must resolve to an admitted ACTIVITY element after
+  // exhausting the canonical resolution scope (§6.1): canon/elements/**
+  // recursively first, then canon/views/activities/** as secondary fallback.
   if (!projectRec) {
     errors.push({
       code: 'PC-001',
-      message: `activity_card.project "${projectId}" does not resolve to an ACTIVITY element in the canon element store`,
+      message:
+        `activity_card.project "${projectId}" not found after searching ` +
+        `canon/elements/** and canon/views/activities/** — ` +
+        `add a YAML file with notation: activity and id: "${projectId}" ` +
+        `(e.g. canon/elements/05_implementation/activities/${projectId}.yaml)`,
     });
     return { valid: false, errors, warnings };
   }

--- a/tests/canon-loader.test.ts
+++ b/tests/canon-loader.test.ts
@@ -14,6 +14,7 @@ import {
   relationsOfType,
   relationsFrom,
   relationsTo,
+  extractViewActivities,
   type CanonDocs,
 } from '../extension/src/canon-loader.js';
 
@@ -87,7 +88,12 @@ describe('isUnderCanonPath', () => {
     expect(isUnderCanonPath(canonRoot, saved)).toBe(true);
   });
 
-  it('returns false for a file outside elements/ and relations/', () => {
+  it('returns true for a file inside views/activities/ (#344 fallback)', () => {
+    const saved = join(canonRoot, 'views', 'activities', 'q1.activities.transitrix.yaml');
+    expect(isUnderCanonPath(canonRoot, saved)).toBe(true);
+  });
+
+  it('returns false for a file outside elements/, relations/, or views/activities/', () => {
     const saved = join(canonRoot, 'cards', 'my-card.yaml');
     expect(isUnderCanonPath(canonRoot, saved)).toBe(false);
   });
@@ -95,6 +101,43 @@ describe('isUnderCanonPath', () => {
   it('returns false for a sibling of canon/', () => {
     const saved = ['', 'org', 'views', 'my-card.yaml'].join(sep);
     expect(isUnderCanonPath(canonRoot, saved)).toBe(false);
+  });
+});
+
+// ── extractViewActivities (#344) ─────────────────────────────────────────────
+
+describe('extractViewActivities', () => {
+  it('extracts items from an activities view doc with notation: activity added', () => {
+    const doc = {
+      notation: 'activities',
+      activities: [
+        { id: 'ACTIVITY-EU-GAP-1', name: 'Gap analysis', duration: 5 },
+        { id: 'ACTIVITY-EU-AUDIT-1', name: 'NB audit', start_date: '2026-06-01' },
+      ],
+    };
+    const out = extractViewActivities(doc);
+    expect(out).toHaveLength(2);
+    expect(out[0]).toMatchObject({ notation: 'activity', id: 'ACTIVITY-EU-GAP-1', name: 'Gap analysis' });
+    expect(out[1]).toMatchObject({ notation: 'activity', id: 'ACTIVITY-EU-AUDIT-1' });
+  });
+
+  it('returns the doc as-is when notation is not activities (standalone element file)', () => {
+    const doc = { notation: 'activity', id: 'ACTIVITY-EU-1', name: 'Project', valid_from: '2026-01-01' };
+    const out = extractViewActivities(doc);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toBe(doc);
+  });
+
+  it('returns empty array when activities: is missing or not an array', () => {
+    expect(extractViewActivities({ notation: 'activities' })).toHaveLength(0);
+    expect(extractViewActivities({ notation: 'activities', activities: null })).toHaveLength(0);
+  });
+
+  it('skips non-object items in the activities array', () => {
+    const doc = { notation: 'activities', activities: ['bad', null, { id: 'ACTIVITY-OK-1' }] };
+    const out = extractViewActivities(doc);
+    expect(out).toHaveLength(1);
+    expect((out[0] as Record<string, unknown>)['id']).toBe('ACTIVITY-OK-1');
   });
 });
 


### PR DESCRIPTION
## Summary

Implements methodology §6.1 / §7 PC-001 spec from [methodology#251](https://github.com/transitrix/methodology/pull/251) (already merged).

- **`resolver.ts`**: PC-001 error now discloses both canonical search paths (`canon/elements/**`, `canon/views/activities/**`) and includes an actionable hint naming the expected file pattern
- **`canon-loader.ts`**: New `extractViewActivities()` helper extracts individual activity objects from `notation: activities` view docs; `loadCanon()` reads `canon/views/activities/**` as a secondary fallback (§6.1), emitting per-activity warnings when resolved via fallback; `isUnderCanonPath()` now covers `views/activities/` for preview re-rendering
- **`resolver.test.ts`**: Two new cases — PC-001 diagnostic format; regression for deep `canon/elements/` path
- **`canon-loader.test.ts`**: `isUnderCanonPath` covers `views/activities/`; four cases for `extractViewActivities`

## Test plan

- [ ] `resolveActivityCard` with missing project → PC-001 error message contains `canon/elements/**`, `canon/views/activities/**`, `notation: activity`, and the project id
- [ ] `resolveActivityCard` with project in nested `canon/elements/05_implementation/activities/` → no PC-001
- [ ] Activity in `canon/views/activities/` view file → found without PC-001, with warning "resolved via canon/views/activities/ (secondary fallback)"
- [ ] File saved in `canon/views/activities/` triggers preview re-render (isUnderCanonPath returns true)
- [ ] `npx vitest run tests/canon-loader.test.ts` → 24+ tests pass
- [ ] `packages/diagrams: npx vitest run` → 980+ tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)