### PR TITLE
chore(release): 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [2.3.0] — 2026-06-24
+
+### Added
+
+- **`transitrix validate` — canonical notation extensions accepted without `--ext`.**
+  All canonical file extensions (`.goals.transitrix.yaml`, `.dgca.transitrix.yaml`, etc.) are now in the default accepted list, derived automatically from the validator registry.
+  When a file has a canonical extension but no `notation:` field, the CLI emits a targeted hint ("add `notation: dgca` to the file") instead of the generic extension error.
+- **Compliance-impact — PRODUCT/PROCESS subject type label invariant (§5.2, COMPIMP-009/010).**
+  `ImpactColumn` now carries `subjectType: 'product' | 'process' | 'capability'` end-to-end.
+  Combined views (both `subjects.products` and `subjects.processes` set) render column headers with `[PRODUCT]` / `[PROCESS]` badges so subject types are always distinguishable.
+  `ImpactGrouping.columns` accepts the three process-centric variants (`process`, `process-stage`, `process-stage-task`) for the §7.1 process compliance report.
+  `ImpactMatrix.findings` carries COMPIMP-009 (warning) and COMPIMP-010 (error) structural diagnostics.
+
+### Fixed
+
+- **Activity Card — PC-001 diagnostic is now actionable.** When the project activity element is absent from the canon scope, the error message discloses the paths searched (`canon/elements/**` and `canon/views/activities/**`) and suggests the exact YAML fields to add.
+- **IntelliJ plugin — version auto-derived from release tag.** The plugin version is no longer hardcoded; it is read from the `v2.x.y` release tag at build time. DGCA/DGA notation keys also registered.
+
 ## [2.2.0] — 2026-06-24
 
 ### Added

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Architecture-as-code for the modern enterprise. Author 17 notations — goals, processes, capabilities, BPMN, applications, more — as plain YAML, get live diagrams in VS Code. Diffable in git. AI-friendly. Open source. Built on ArchiMate 3.2 and BPMN 2.0.",
   "license": "MIT",
   "icon": "icon.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
## What's in this release

**Added**
- `transitrix validate` — canonical notation extensions accepted without `--ext` (#292)
- Compliance-impact — PRODUCT/PROCESS subject type label invariant; `[PRODUCT]`/`[PROCESS]` column badges; `process-stage-task` grouping; `ImpactMatrix.findings` with COMPIMP-009/010 (#294)

**Fixed**
- Activity Card PC-001 diagnostic discloses paths searched and suggests the exact fix (#293)
- IntelliJ plugin version auto-derived from release tag; DGCA/DGA notation keys registered (#291)

## Checklist

- [ ] `package.json` → `2.3.0`
- [ ] `extension/package.json` → `2.3.0`
- [ ] `CHANGELOG.md` entry added
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)