### PR TITLE
fix(diagrams): bump @transitrix/diagrams to 1.1.0 for npm publish

### DIFF
--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",


### PR DESCRIPTION
## Problem

The npm publish CI workflow failed for both v2.2.0 and v2.3.0 with:
```
npm error 403 You cannot publish over the previously published versions: 1.0.1.
```

`packages/diagrams/package.json` was not included in the release bump PRs — it was stuck at `1.0.1` which is already on npm.

## Fix

Bump `@transitrix/diagrams` to `1.1.0`.

## After merge

Move the `v2.3.0` tag to the new commit so the npm publish workflow picks up the correct version:
```
git tag -f v2.3.0 <new-sha>
git push --force origin v2.3.0
```
Or re-run the npm publish workflow manually via `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)