### PR TITLE
feat(bpmn): equalize lane heights toggle in BPMN preview Controls

### DIFF
--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -4,7 +4,7 @@ import * as vscode from 'vscode';
 
 import type { CompileFn } from './preview.js';
 import { CervinPreview } from './preview.js';
-import { ProcessPreview, type ProcessLayoutFn, SAVE_BPMN_PROCESS_SVG_COMMAND, OPEN_BPMN_SETTINGS_COMMAND } from './process-preview.js';
+import { ProcessPreview, type ProcessLayoutFn, type BpmnDisplayOpts, SAVE_BPMN_PROCESS_SVG_COMMAND, OPEN_BPMN_SETTINGS_COMMAND } from './process-preview.js';
 import { GoalsPreview } from './goals-preview.js';
 import { FGCAPreview, FGAPreview } from './fgca-preview.js';
 import { ActivitiesPreview } from './activities-preview.js';
@@ -150,15 +150,15 @@ async function loadProcessLayoutFn(ext: vscode.ExtensionContext): Promise<Proces
   const mod = (await import(compilerHref)) as {
     compileTransitrixYamlWithLayout: (
       yaml: string,
-      options?: { layout?: { laneVerticalGap?: number } },
+      options?: { layout?: { laneVerticalGap?: number; uniformLaneHeight?: boolean } },
     ) => Promise<{ layout: unknown; validation: ValidationReport }>;
   };
-  return async (yaml: string) => {
+  return async (yaml: string, opts?: BpmnDisplayOpts) => {
     const laneGap = vscode.workspace.getConfiguration('transitrix').get<number>('bpmn.laneGap');
-    const layoutOptions = (laneGap !== undefined && Number.isFinite(laneGap))
-      ? { layout: { laneVerticalGap: laneGap } }
-      : undefined;
-    const result = await mod.compileTransitrixYamlWithLayout(yaml, layoutOptions);
+    const layout: { laneVerticalGap?: number; uniformLaneHeight?: boolean } = {};
+    if (laneGap !== undefined && Number.isFinite(laneGap)) layout.laneVerticalGap = laneGap;
+    if (opts?.uniformLaneHeight) layout.uniformLaneHeight = true;
+    const result = await mod.compileTransitrixYamlWithLayout(yaml, Object.keys(layout).length ? { layout } : undefined);
     // LayoutIr is structurally compatible with ProcessDiagramLayout — safe cast.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return { layout: result.layout as any, validation: result.validation };

--- a/extension/src/process-preview.ts
+++ b/extension/src/process-preview.ts
@@ -22,24 +22,51 @@ import {
   OPEN_THEME_COMMAND,
   type ThemeId,
 } from './diagram-frame.js';
+import { genNonce } from './preview-controls.js';
 import type { ValidationReport } from './types.js';
 
 export const SAVE_BPMN_PROCESS_SVG_COMMAND = 'transitrixStudio.saveBpmnProcessAsSvg';
 export const OPEN_BPMN_SETTINGS_COMMAND = 'transitrixStudio.openBpmnSettings';
 
+export interface BpmnDisplayOpts {
+  uniformLaneHeight?: boolean;
+}
+
 /** Function that parses + lays out a BPMN YAML document. */
-export type ProcessLayoutFn = (yaml: string) => Promise<{
+export type ProcessLayoutFn = (yaml: string, opts?: BpmnDisplayOpts) => Promise<{
   layout: ProcessDiagramLayout;
   validation: ValidationReport;
 }>;
 
-/** VS Code static preview panel backed by the custom SVG emitter. */
+function buildBpmnControls(nonce: string, uniformLaneHeight: boolean): { panel: string; script: string } {
+  const checked = uniformLaneHeight ? ' checked' : '';
+  const panel = `<details class="tx-ctl" id="tx-bpmn-ctl">
+  <summary>Display</summary>
+  <div class="tx-ctl-body">
+    <div class="tx-ctl-row"><label><input type="checkbox" id="tx-bpmn-uniform-lanes"${checked}> Equalize lane heights</label></div>
+  </div>
+</details>`;
+  const script = `<script nonce="${nonce}">
+(function(){
+var vscode=acquireVsCodeApi();
+var cb=document.getElementById('tx-bpmn-uniform-lanes');
+if(cb){cb.addEventListener('change',function(){vscode.postMessage({type:'transitrix:bpmn-toggle',kind:'uniform-lane-height',value:cb.checked});});}
+var det=document.getElementById('tx-bpmn-ctl');
+if(det){var st=vscode.getState()||{};if(st.txBpCtlOpen)det.open=true;
+  det.addEventListener('toggle',function(){var s=vscode.getState()||{};s.txBpCtlOpen=det.open;vscode.setState(s);});}
+}());
+<\/script>`;
+  return { panel, script };
+}
+
+/** VS Code interactive preview panel backed by the custom SVG emitter. */
 export class ProcessPreview {
   readonly panelTitle = 'BPMN Preview';
 
   private panel: vscode.WebviewPanel | undefined;
   private trackedUri: string | undefined;
   private lastSvg = '';
+  private uniformLaneHeight = false;
 
   constructor(private readonly layoutFn: ProcessLayoutFn) {}
 
@@ -59,7 +86,7 @@ export class ProcessPreview {
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
         {
-          enableScripts: false,
+          enableScripts: true,
           enableCommandUris: [SAVE_BPMN_PROCESS_SVG_COMMAND, OPEN_BPMN_SETTINGS_COMMAND, OPEN_THEME_COMMAND],
           retainContextWhenHidden: true,
         },
@@ -68,6 +95,18 @@ export class ProcessPreview {
         this.panel = undefined;
         this.trackedUri = undefined;
         this.lastSvg = '';
+      });
+      this.panel.webview.onDidReceiveMessage(async (msg: unknown) => {
+        if (!msg || typeof msg !== 'object') return;
+        const m = msg as Record<string, unknown>;
+        if (m['type'] !== 'transitrix:bpmn-toggle') return;
+        if (m['kind'] === 'uniform-lane-height') {
+          this.uniformLaneHeight = Boolean(m['value']);
+        }
+        if (this.panel && this.trackedUri) {
+          const doc = vscode.workspace.textDocuments.find((d) => d.uri.toString() === this.trackedUri);
+          if (doc) await this.pushDocument(doc);
+        }
       });
     }
 
@@ -110,7 +149,7 @@ export class ProcessPreview {
     const filename = path.basename(doc.fileName);
     const themeId = vscode.workspace.getConfiguration('transitrix').get<ThemeId>('theme', 'transitrix');
     try {
-      const { layout, validation } = await this.layoutFn(doc.getText());
+      const { layout, validation } = await this.layoutFn(doc.getText(), { uniformLaneHeight: this.uniformLaneHeight });
       const svg = renderProcessLayoutSvg(layout);
       this.lastSvg = svg;
 
@@ -120,6 +159,8 @@ export class ProcessPreview {
         ? errors.map((e) => escXml(e.message)).join('\n')
         : '';
       const warningMsgs = warnings.map((w) => w.message);
+      const nonce = genNonce();
+      const { panel: controlsPanel, script: controlsScript } = buildBpmnControls(nonce, this.uniformLaneHeight);
 
       this.panel.webview.html = buildDiagramFrame({
         filename,
@@ -131,6 +172,7 @@ export class ProcessPreview {
         saveSvgCommand: SAVE_BPMN_PROCESS_SVG_COMMAND,
         spacingCommand: OPEN_BPMN_SETTINGS_COMMAND,
         themeCommand: OPEN_THEME_COMMAND,
+        interactive: { nonce, controlsPanel, controlsScript },
       });
     } catch (err) {
       this.lastSvg = '';

--- a/src/layout-options.ts
+++ b/src/layout-options.ts
@@ -24,6 +24,8 @@ export interface LayoutDiagramOptions {
   elkLayerSpacing: number;
   /** Uniform `elk.padding` around the subgraph inside a lane. */
   elkDiagramPadding: number;
+  /** When true, all swimlanes in a pool are rendered at the same height (max of individual heights). */
+  uniformLaneHeight: boolean;
 }
 
 export const DEFAULT_LAYOUT_DIAGRAM_OPTIONS: LayoutDiagramOptions = {
@@ -38,6 +40,7 @@ export const DEFAULT_LAYOUT_DIAGRAM_OPTIONS: LayoutDiagramOptions = {
   elkNodeSpacing: 52,
   elkLayerSpacing: 88,
   elkDiagramPadding: 44,
+  uniformLaneHeight: false,
 };
 
 const BOUNDS = { min: 0, max: 800 } as const;
@@ -52,7 +55,8 @@ export function mergeLayoutDiagramOptions(
 ): LayoutDiagramOptions {
   const d = DEFAULT_LAYOUT_DIAGRAM_OPTIONS;
   if (!partial) return { ...d };
-  const pick = (k: keyof LayoutDiagramOptions): number => {
+  type NumericKey = keyof Omit<LayoutDiagramOptions, 'uniformLaneHeight'>;
+  const pick = (k: NumericKey): number => {
     const v = partial[k];
     if (v === undefined) return d[k];
     if (typeof v !== 'number' || !Number.isFinite(v)) return d[k];
@@ -70,6 +74,7 @@ export function mergeLayoutDiagramOptions(
     elkNodeSpacing: pick('elkNodeSpacing'),
     elkLayerSpacing: pick('elkLayerSpacing'),
     elkDiagramPadding: pick('elkDiagramPadding'),
+    uniformLaneHeight: typeof partial.uniformLaneHeight === 'boolean' ? partial.uniformLaneHeight : d.uniformLaneHeight,
   };
 }
 
@@ -82,7 +87,7 @@ function asFiniteNumber(value: unknown): number | undefined {
   return undefined;
 }
 
-const LAYOUT_KEYS: (keyof LayoutDiagramOptions)[] = [
+const LAYOUT_KEYS: (keyof Omit<LayoutDiagramOptions, 'uniformLaneHeight'>)[] = [
   'poolPad',
   'poolOriginX',
   'poolOriginY',

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -494,13 +494,30 @@ export async function layoutProcess(
   }
 
   // Step C — absolute positions, lane bounds, pool bounds.
+  // Sub-pass C1: compute individual lane heights to allow optional equalization.
+  const rawLaneHeights = new Map<string, number>();
+  for (const ld of laneData) {
+    const items = laneLocalItems.get(ld.laneId) ?? [];
+    const laneDef = ir.lanes.find((l) => l.id === ld.laneId);
+    const contentBottom = items.length > 0
+      ? Math.max(...items.map((item) => item.localY + item.height))
+      : 0;
+    const labelMinH = laneDef ? minLaneHeightForLabel(laneDef.name) : 0;
+    rawLaneHeights.set(ld.laneId, Math.max(ld.height, contentBottom + ld.envY, labelMinH));
+  }
+  // When uniformLaneHeight is on, all lanes in the pool share the tallest height.
+  const uniformH = o.uniformLaneHeight && rawLaneHeights.size > 0
+    ? Math.max(...rawLaneHeights.values())
+    : undefined;
+
+  // Sub-pass C2: set absolute element positions and lane bounds using final heights.
   let yCursor = o.poolPad;
   const elements = new Map<string, Bounds>();
   const laneBounds = new Map<string, Bounds>();
 
   for (const ld of laneData) {
     const items = laneLocalItems.get(ld.laneId) ?? [];
-    const laneDef = ir.lanes.find((l) => l.id === ld.laneId);
+    const laneHeight = uniformH ?? rawLaneHeights.get(ld.laneId)!;
 
     for (const item of items) {
       elements.set(item.id, {
@@ -510,13 +527,6 @@ export async function layoutProcess(
         height: item.height,
       });
     }
-
-    const contentBottom = items.length > 0
-      ? Math.max(...items.map((item) => item.localY + item.height))
-      : 0;
-    // Add bottom padding matching the top padding (envY) to keep lanes symmetric.
-    const labelMinH = laneDef ? minLaneHeightForLabel(laneDef.name) : 0;
-    const laneHeight = Math.max(ld.height, contentBottom + ld.envY, labelMinH);
 
     laneBounds.set(ld.laneId, {
       x: laneOriginX,


### PR DESCRIPTION
## Summary

- Adds an **"Equalize lane heights"** checkbox to the BPMN Process diagram Controls panel (`<details>Display</details>`)
- When enabled, all swimlanes in a pool render at the same height — the max of all individual content-driven heights
- When disabled, lanes keep per-lane content-driven heights (existing behaviour, default)
- Matches the behaviour of standard BPMN tools (Visio, Lucidchart, Enterprise Architect)

## Implementation

| File | Change |
|------|--------|
| `src/layout-options.ts` | New `uniformLaneHeight: boolean` field (default `false`); `mergeLayoutDiagramOptions` handles it as a passthrough boolean; `LAYOUT_KEYS` and `pick` restricted to numeric keys only |
| `src/layout.ts` Step C | Two-pass: C1 collects raw per-lane heights; C2 uses `max(all)` when flag is set, then sets absolute positions — Step D unchanged (benefits automatically: axis positions become uniformly spaced) |
| `extension/src/process-preview.ts` | Enables `enableScripts: true` with nonce-based CSP; `buildBpmnControls()` renders the `<details>` panel + wiring script; `onDidReceiveMessage` updates `uniformLaneHeight` state and re-renders; `pushDocument` passes the option to `layoutFn` |
| `extension/src/extension.ts` | `loadProcessLayoutFn` threads `uniformLaneHeight` through `compileTransitrixYamlWithLayout` |

## Test plan

- [ ] Open a `.bpmn.transitrix.yaml` with multiple swimlanes of unequal content
- [ ] Open Controls panel → check "Equalize lane heights" → lanes become equal height
- [ ] Uncheck → lanes return to content-driven heights
- [ ] Toggle state persists across file saves (re-render via `refreshSaved`)
- [ ] Single-lane pool: no visible change
- [ ] All integration tests green (pre-existing `cli-migrate` failure is unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)