### PR TITLE
fix(compliance-impact): report_type enforcement + subject-type column badges + scrollbar fix

### DIFF
--- a/extension/src/compliance-impact-preview.ts
+++ b/extension/src/compliance-impact-preview.ts
@@ -146,10 +146,14 @@ function parseViewConfigRaw(raw: unknown): ImpactViewConfig | null {
     v.empty_cells && typeof v.empty_cells === 'object' && !Array.isArray(v.empty_cells)
       ? (v.empty_cells as Record<string, unknown>)
       : {};
+  const VALID_RT = new Set(['product', 'process', 'combined']);
   return {
     id: v.id,
     name: v.name,
     description: typeof v.description === 'string' ? v.description : undefined,
+    report_type: typeof v.report_type === 'string' && VALID_RT.has(v.report_type)
+      ? (v.report_type as ImpactViewConfig['report_type'])
+      : undefined,
     subjects: {
       products: Array.isArray(subjects.products)
         ? (subjects.products as unknown[]).filter((x): x is string => typeof x === 'string')
@@ -592,16 +596,30 @@ export class ComplianceImpactPreview {
     obligationsLane: string[][],
     showObligationsLane: boolean,
   ): string {
+    // Show explicit type chips only in combined views where both PRODUCT and
+    // PROCESS columns are present — so the reader can distinguish types at a
+    // glance even when columns carry human-readable names (§5.2 invariant).
+    const hasProdCols = columns.some(c => c.subjectType === 'product');
+    const hasProcCols = columns.some(c => c.subjectType === 'process');
+    const isCombinedView = hasProdCols && hasProcCols;
+
     const head =
       '<tr>\n      <th class="ci-corner"></th>\n      ' +
       columns
-        .map(col =>
-          '<th class="ci-col"><div class="ci-col-name">' +
-          escXml(col.subjectName ?? col.label) +
-          '</div>' +
-          (col.subjectName ? '<div class="ci-col-id">' + escXml(col.label) + '</div>' : '') +
-          '</th>',
-        )
+        .map(col => {
+          const typeChip = isCombinedView && col.subjectType !== 'capability'
+            ? '<span class="ci-type-chip ci-type-' + col.subjectType + '">' + col.subjectType.toUpperCase() + '</span>'
+            : '';
+          return (
+            '<th class="ci-col">' +
+            typeChip +
+            '<div class="ci-col-name">' +
+            escXml(col.subjectName ?? col.label) +
+            '</div>' +
+            (col.subjectName ? '<div class="ci-col-id">' + escXml(col.label) + '</div>' : '') +
+            '</th>'
+          );
+        })
         .join('') +
       '\n    </tr>';
     const laneRow = showObligationsLane
@@ -740,8 +758,8 @@ export class ComplianceImpactPreview {
 }
 
 const IMPACT_CSS = `
-body { padding: 0; }
-#toolbar { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 8px 16px; border-bottom: 1px solid var(--ts-border, #cbd5e1); flex-wrap: wrap; }
+body { padding: 0; display: flex; flex-direction: column; height: 100vh; overflow: hidden; }
+#toolbar { flex-shrink: 0; display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 8px 16px; border-bottom: 1px solid var(--ts-border, #cbd5e1); flex-wrap: wrap; }
 .toolbar-label { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 13px; font-weight: 700; color: var(--ts-header-text, #0f172a); }
 .toolbar-actions { display: flex; gap: 4px; align-items: center; flex-wrap: wrap; justify-content: flex-end; }
 .toolbar-btn { cursor: pointer; user-select: none; font-size: 11px; padding: 1px 8px; border-radius: 4px; color: var(--ts-text-muted, #64748b); white-space: nowrap; text-decoration: none; }
@@ -751,12 +769,15 @@ body { padding: 0; }
 .ci-config { font-size: 11px; color: var(--ts-text-muted, #64748b); padding-left: 4px; border-left: 1px solid var(--ts-border, #cbd5e1); margin-left: 4px; }
 .ci-config code { background: var(--ts-bg-subtle, #f1f5f9); padding: 1px 4px; border-radius: 3px; }
 .ci-filter-sep { flex-basis: 100%; height: 0; }
-#ci-filters { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; padding: 8px 16px; border-bottom: 1px solid var(--ts-border, #cbd5e1); font-size: 11px; }
+#ci-filters { flex-shrink: 0; display: flex; align-items: center; gap: 8px; flex-wrap: wrap; padding: 8px 16px; border-bottom: 1px solid var(--ts-border, #cbd5e1); font-size: 11px; }
 .ci-filter-label { font-weight: 600; color: var(--ts-text, #0f172a); margin-left: 8px; }
 .ci-filter-label:first-child { margin-left: 0; }
 .ci-chip { display: inline-flex; align-items: center; gap: 4px; color: var(--ts-text-muted, #64748b); cursor: pointer; }
 .ci-col-width-select { font-size: 11px; font-family: var(--vscode-font-family, sans-serif); color: var(--vscode-input-foreground, #333); background: var(--vscode-input-background, #fff); border: 1px solid var(--vscode-input-border, var(--ts-border, #cbd5e1)); border-radius: 3px; padding: 1px 4px; }
-#ci-grid-wrap { overflow: auto; padding: 12px 16px 24px; }
+#ci-grid-wrap { flex: 1 1 0; overflow: auto; padding: 12px 16px 24px; min-height: 0; }
+.ci-type-chip { display: inline-block; padding: 1px 5px; border-radius: 3px; font-size: 9px; font-weight: 700; letter-spacing: 0.05em; text-transform: uppercase; margin-bottom: 3px; }
+.ci-type-product { color: #1e40af; background: #dbeafe; }
+.ci-type-process { color: #065f46; background: #d1fae5; }
 #ci-grid { border-collapse: collapse; font-size: 12px; }
 #ci-grid th, #ci-grid td { border: 1px solid var(--ts-border, #cbd5e1); }
 .ci-corner { background: transparent; border: none; }

--- a/packages/diagrams/src/compliance/__tests__/impact.test.ts
+++ b/packages/diagrams/src/compliance/__tests__/impact.test.ts
@@ -990,4 +990,71 @@ describe('COMPIMP-010 — subject type label invariant (#345)', () => {
     });
     expect(matrix.findings).toEqual([]);
   });
+
+  it('COMPIMP-011 error: report_type=product with subjects.processes strips process columns', () => {
+    const canon = emptyCanon();
+    canon.products.push({ id: 'PRODUCT-A-1', name: 'Product A' });
+    canon.subjects.push({ id: 'PROCESS-CS-1', name: 'Customer Support' });
+    const matrix = buildImpactMatrix(canon, {
+      id: 'V', name: 'V',
+      report_type: 'product',
+      subjects: { products: ['PRODUCT-A-1'], processes: ['PROCESS-CS-1'] },
+      obligations: {},
+    });
+    // COMPIMP-011 fires
+    const c011 = matrix.findings.find(f => f.code === 'COMPIMP-011');
+    expect(c011).toBeDefined();
+    expect(c011!.severity).toBe('error');
+    // Spurious PROCESS column is stripped
+    expect(matrix.columns).toHaveLength(1);
+    expect(matrix.columns[0].subjectType).toBe('product');
+    expect(matrix.columns[0].subjectId).toBe('PRODUCT-A-1');
+  });
+
+  it('COMPIMP-011 error: report_type=process with subjects.products strips product columns', () => {
+    const canon = emptyCanon();
+    canon.products.push({ id: 'PRODUCT-A-1', name: 'Product A' });
+    canon.subjects.push({ id: 'PROCESS-CS-1', name: 'Customer Support' });
+    const matrix = buildImpactMatrix(canon, {
+      id: 'V', name: 'V',
+      report_type: 'process',
+      subjects: { products: ['PRODUCT-A-1'], processes: ['PROCESS-CS-1'] },
+      obligations: {},
+    });
+    const c011 = matrix.findings.find(f => f.code === 'COMPIMP-011');
+    expect(c011).toBeDefined();
+    expect(c011!.severity).toBe('error');
+    // Spurious PRODUCT column is stripped
+    expect(matrix.columns).toHaveLength(1);
+    expect(matrix.columns[0].subjectType).toBe('process');
+    expect(matrix.columns[0].subjectId).toBe('PROCESS-CS-1');
+  });
+
+  it('report_type=combined allows both product and process columns without COMPIMP-011', () => {
+    const canon = emptyCanon();
+    canon.products.push({ id: 'PRODUCT-A-1', name: 'Product A' });
+    canon.subjects.push({ id: 'PROCESS-CS-1', name: 'Customer Support' });
+    const matrix = buildImpactMatrix(canon, {
+      id: 'V', name: 'V',
+      report_type: 'combined',
+      subjects: { products: ['PRODUCT-A-1'], processes: ['PROCESS-CS-1'] },
+      obligations: {},
+    });
+    expect(matrix.findings.some(f => f.code === 'COMPIMP-011')).toBe(false);
+    expect(matrix.columns).toHaveLength(2);
+  });
+
+  it('parseImpactViewConfig round-trips report_type', () => {
+    for (const rt of ['product', 'process', 'combined'] as const) {
+      const r = parseImpactViewConfig({ id: 'V', name: 'V', report_type: rt, subjects: {}, obligations: {} });
+      expect(r.ok).toBe(true);
+      if (r.ok) expect(r.config.report_type).toBe(rt);
+    }
+  });
+
+  it('parseImpactViewConfig ignores unknown report_type values', () => {
+    const r = parseImpactViewConfig({ id: 'V', name: 'V', report_type: 'unknown-type', subjects: {}, obligations: {} });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.config.report_type).toBeUndefined();
+  });
 });

--- a/packages/diagrams/src/compliance/impact.ts
+++ b/packages/diagrams/src/compliance/impact.ts
@@ -118,6 +118,15 @@ export interface ImpactViewConfig {
   name: string;
   description?: string;
   /**
+   * Declares the subject scope of the view (§4, COMPIMP-011 enforcement).
+   * `product`  — covers products only; `subjects.processes` MUST be absent.
+   * `process`  — covers processes directly; `subjects.products` MUST be absent.
+   * `combined` — both subject types allowed; column headers carry explicit badges.
+   * Omitting the field preserves backward-compatible behaviour (auto-detected
+   * from `subjects.*` presence).
+   */
+  report_type?: 'product' | 'process' | 'combined';
+  /**
    * ISO 8601 date of the last report snapshot (YYYY-MM-DD).
    * Populated automatically by the CLI on each run and stored back to the
    * view-config file, giving CV-3 its "new since last run" signal.
@@ -245,10 +254,16 @@ export function parseImpactViewConfig(raw: unknown): ParseImpactViewConfigResult
     : VALID_COLUMNS.has(rawColumns ?? '') ? (rawColumns as ImpactGrouping['columns'])
     : undefined;
 
+  const VALID_REPORT_TYPES = new Set(['product', 'process', 'combined']);
+  const rawReportType = typeof v.report_type === 'string' ? v.report_type : undefined;
+
   const config: ImpactViewConfig = {
     id: v.id as string,
     name: v.name as string,
     description: typeof v.description === 'string' ? v.description : undefined,
+    report_type: rawReportType && VALID_REPORT_TYPES.has(rawReportType)
+      ? (rawReportType as ImpactViewConfig['report_type'])
+      : undefined,
     snapshot_at: typeof v.snapshot_at === 'string' ? v.snapshot_at : undefined,
     subjects: {
       products: Array.isArray(subjects.products)
@@ -625,14 +640,14 @@ export function buildImpactMatrix(
   // Combined = both products and processes are explicit entry points (§7.1).
   const isCombined = hasProducts && hasProcesses;
 
-  const columns: ImpactColumn[] =
+  let columns: ImpactColumn[] =
     (grain === 'product-stage-task' || grain === 'process-stage-task') && hasDetails
       ? buildTaskColumns(config, objectDetails!, isCombined)
       : (grain === 'product-stage' || grain === 'process-stage' || (grain as string) === 'object-details') && hasDetails
         ? buildObjectDetailColumns(config, objectDetails!, isCombined)
         : buildProductColumns(config, [...(canon.products ?? []), ...(canon.subjects ?? [])], isCombined);
 
-  // ── Structural validation (COMPIMP-009, COMPIMP-010) ───────────────────
+  // ── Structural validation (COMPIMP-009, COMPIMP-010, COMPIMP-011) ──────
   const findings: ImpactFinding[] = [];
   if (!hasProducts && hasProcesses &&
       (grain === 'product' || grain === 'product-stage' || grain === 'product-stage-task')) {
@@ -648,6 +663,24 @@ export function buildImpactMatrix(
       severity: 'error',
       message: `view.grouping.columns is '${grain}' but view.subjects.processes has entries — product-stage semantics applied to process columns violate the subject type label invariant (§5.2). Use '${grain.replace('product', 'process')}' for process columns.`,
     });
+  }
+  // COMPIMP-011: report_type contract — strip cross-type columns and emit an
+  // error when the declared scope contradicts the subjects actually present.
+  if (config.report_type === 'product' && hasProcesses) {
+    findings.push({
+      code: 'COMPIMP-011',
+      severity: 'error',
+      message: `view.report_type is 'product' but view.subjects.processes has entries — process columns are excluded. Remove subjects.processes or set report_type to 'combined'.`,
+    });
+    columns = columns.filter(c => c.subjectType !== 'process');
+  }
+  if (config.report_type === 'process' && hasProducts) {
+    findings.push({
+      code: 'COMPIMP-011',
+      severity: 'error',
+      message: `view.report_type is 'process' but view.subjects.products has entries — product columns are excluded. Remove subjects.products or set report_type to 'combined'.`,
+    });
+    columns = columns.filter(c => c.subjectType !== 'product');
   }
 
   const allowedStatuses = new Set<AssertionStatus>(


### PR DESCRIPTION
## Summary

Three renderer correctness fixes for the compliance-impact matrix view, addressing issues found after the COMPIMP-009/010 work:

- **`report_type` enforcement (COMPIMP-011):** `ImpactViewConfig` gains `report_type?: 'product' | 'process' | 'combined'`. When set, `buildImpactMatrix` enforces the declared scope: `report_type: product` strips PROCESS columns and emits a new `COMPIMP-011` error finding; `report_type: process` strips PRODUCT columns. Prevents spurious cross-type columns in single-scope views. Five new unit tests.

- **Subject-type column badges (§5.2 label invariant):** In combined views (both PRODUCT and PROCESS columns present), the HTML webview now shows a coloured chip — **PRODUCT** (blue) or **PROCESS** (green) — above each column header name. Ensures types are distinguishable at a glance even when columns show human-readable names rather than bare IDs, as required by the subject-type label invariant.

- **Horizontal scrollbar at viewport edge:** The webview body is now a flex column (`height: 100vh; overflow: hidden`). Toolbar and filter bars are `flex-shrink: 0`; `#ci-grid-wrap` uses `flex: 1; min-height: 0`. The horizontal scrollbar now appears at the bottom of the visible viewport rather than mid-page inside a free-height container.

## Test plan

- [ ] All 995 `@transitrix/diagrams` tests pass (`npm run test --workspace packages/diagrams`)
- [ ] TypeScript clean for both `packages/diagrams` and `extension/` (`tsc --noEmit`)
- [ ] `parseImpactViewConfig` round-trips `report_type` for all three values
- [ ] `buildImpactMatrix` with `report_type: product` + `subjects.processes` → COMPIMP-011 error + process column stripped
- [ ] `buildImpactMatrix` with `report_type: process` + `subjects.products` → COMPIMP-011 error + product column stripped
- [ ] Combined view with named subjects shows PRODUCT/PROCESS chip above column name in webview
- [ ] Wide compliance-impact matrix: horizontal scrollbar at bottom of screen, not mid-page

🤖 Generated with [Claude Code](https://claude.com/claude-code)