### PR TITLE
fix(activities): card borders + branch lines in Tree view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [2.4.0] — 2026-06-25
+
+### Added
+
+- **Activities preview — Tree tab.** Third view alongside Network and Gantt. Renders ACTIVITY elements as a collapsible tree (Initiative → Programme → Project → Task) via the `parent` field. Each node shows name, ID below in monospace grey, `activity_type` badge colour-coded by level, owner, and date range. Initiative/Programme/Project nodes default-expanded; Tasks collapsed.
+
+- **Process Blueprint — compliance legend in PNG/SVG export.** When the Legend toggle is enabled in the preview, exporting (Save PNG, Copy PNG, Save SVG) appends a four-chip legend strip at the bottom of the diagram. When the legend is hidden, export is unchanged.
+
+- **BPMN Process — equalize lane heights toggle.** New checkbox in the BPMN Controls panel (`Display` section). When enabled, all swimlanes in a pool render at the same height (max of per-lane content heights). Matches standard BPMN tool behaviour; default off.
+
+### Fixed
+
+- **Compliance-impact — `report_type` enforcement (COMPIMP-011).** `ImpactViewConfig` gains `report_type?: 'product' | 'process' | 'combined'`. When set, `buildImpactMatrix` strips columns of the wrong subject type and emits `COMPIMP-011`. Prevents spurious cross-type columns in single-scope views.
+
+- **Compliance-impact — subject-type column badges in combined views.** When both PRODUCT and PROCESS columns are present, each column header now shows a coloured chip (blue PRODUCT / green PROCESS), matching the §5.2 label invariant.
+
+- **Compliance-impact — horizontal scrollbar at viewport edge.** The scrollbar now appears at the bottom of the visible viewport rather than mid-page inside a free-height container.
+
 ## [2.3.0] — 2026-06-24
 
 ### Added

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Architecture-as-code for the modern enterprise. Author 17 notations — goals, processes, capabilities, BPMN, applications, more — as plain YAML, get live diagrams in VS Code. Diffable in git. AI-friendly. Open source. Built on ArchiMate 3.2 and BPMN 2.0.",
   "license": "MIT",
   "icon": "icon.png",

--- a/extension/src/activities-preview.ts
+++ b/extension/src/activities-preview.ts
@@ -411,9 +411,8 @@ function buildTreeHtml(doc: ActivityDoc, filename: string, date: string, version
   };
   for (const [, kids] of childrenOf) kids.sort(sortFn);
 
-  function renderNode(act: Activity, depth: number): string {
+  function renderNode(act: Activity): string {
     const kids = childrenOf.get(act.id) ?? [];
-    const indent = `padding-left:${8 + depth * 20}px`;
     const badgeClass = activityTypeBadgeClass(act.activity_type);
     const badge = act.activity_type
       ? `<span class="${badgeClass}">${escXml(act.activity_type)}</span>`
@@ -428,11 +427,11 @@ function buildTreeHtml(doc: ActivityDoc, filename: string, date: string, version
     const label = `<div class="tree-node-label"><span class="tree-node-name">${escXml(act.name)}</span><span class="tree-node-id">${escXml(act.id)}</span></div>`;
 
     if (kids.length === 0) {
-      return `<div class="tree-node tree-leaf" style="${indent}"><div class="tree-node-row">${label}${badge}${meta}</div></div>`;
+      return `<div class="tree-node tree-leaf"><div class="tree-node-row">${label}${badge}${meta}</div></div>`;
     }
     const openAttr = activityTypeLevel(act.activity_type) <= 3 ? ' open' : '';
-    const kidsHtml = kids.map((k) => renderNode(k, depth + 1)).join('');
-    return `<details class="tree-node"${openAttr}><summary class="tree-node-row" style="${indent}">${label}${badge}${meta}</summary>${kidsHtml}</details>`;
+    const kidsHtml = `<div class="tree-children">${kids.map((k) => renderNode(k)).join('')}</div>`;
+    return `<details class="tree-node"${openAttr}><summary class="tree-node-row">${label}${badge}${meta}</summary>${kidsHtml}</details>`;
   }
 
   const allIds = new Set(activities.map((a) => a.id));
@@ -450,7 +449,7 @@ function buildTreeHtml(doc: ActivityDoc, filename: string, date: string, version
   <div class="text-secondary">${escXml(date)}${versionPart}</div>
 </div>`;
 
-  return `${titleHtml}<div class="tree-view">${roots.map((r) => renderNode(r, 0)).join('')}</div>`;
+  return `${titleHtml}<div class="tree-view">${roots.map((r) => renderNode(r)).join('')}</div>`;
 }
 
 function buildActivityViews(doc: ActivityDoc, gaps: ActivitiesLayoutOptions, curvature: number, entryCurvature: number | undefined, filename: string, date: string, version?: string): ActivityViews {
@@ -582,26 +581,39 @@ const ACTIVITIES_WEBVIEW_CSS = `
 
   /* ── Tree view ───────────────────────────────────────────────────────── */
   .tree-view { padding: 4px 8px 16px; }
-  .tree-node { margin: 1px 0; }
+  .tree-node { margin: 3px 0; }
   .tree-node-row {
     display: flex;
     align-items: center;
     gap: 8px;
-    padding: 5px 8px;
-    border-radius: 4px;
+    padding: 7px 10px;
+    border-radius: 6px;
+    border: 1px solid var(--ts-border, #e2e8f0);
+    background: var(--ts-bg-surface, #ffffff);
     list-style: none;
   }
+  .tree-node-row:hover { background: var(--ts-bg-subtle, #f8fafc); }
+  /* Expandable nodes */
   details.tree-node > summary.tree-node-row { cursor: pointer; }
   details.tree-node > summary.tree-node-row::-webkit-details-marker { display: none; }
   details.tree-node > summary.tree-node-row::before {
     content: '▶';
     font-size: 9px;
-    color: var(--ts-text-muted, #64748b);
+    color: var(--ts-text-muted, #94a3b8);
     flex-shrink: 0;
+    display: inline-block;
   }
-  details[open].tree-node > summary.tree-node-row::before { transform: rotate(90deg); display: inline-block; }
-  .tree-node-row:hover { background: var(--ts-bg-subtle, #f1f5f9); }
-  .tree-leaf .tree-node-row { padding-left: calc(8px + 13px); }
+  details[open].tree-node > summary.tree-node-row::before { transform: rotate(90deg); }
+  /* Leaf nodes get the same left padding as nodes with the arrow */
+  .tree-leaf > .tree-node-row { padding-left: 27px; }
+  /* Children group — indent + left branch line */
+  .tree-children {
+    margin-left: 20px;
+    padding-left: 16px;
+    padding-top: 2px;
+    padding-bottom: 2px;
+    border-left: 1.5px solid var(--ts-border, #cbd5e1);
+  }
   .tree-node-label { display: flex; flex-direction: column; flex: 1; min-width: 0; }
   .tree-node-name { font-size: 13px; color: var(--ts-text, #0f172a); }
   .tree-node-id { font-size: 11px; color: var(--ts-text-muted, #64748b); font-family: var(--vscode-editor-font-family, monospace); }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
## Problem

Tree tab rendered activities as plain unstyled text — no visible node boundaries, no branch connector lines between levels.

## Fix

- Each activity node is now a card: `border: 1px solid`, `background`, `border-radius: 6px`
- Children groups are wrapped in `.tree-children` with `border-left` — this gives the visual branch connector line
- Leaf nodes get compensating `padding-left` to align with expandable-node arrow spacing
- Removed inline `padding-left: depth * 20px` hack; nesting is now handled entirely by the `.tree-children` wrapper

## Test plan

- [ ] Open an `.activities.transitrix.yaml` — nodes show as cards with visible borders
- [ ] File with `parent` references — branch connector line (border-left) visible alongside children
- [ ] Flat file (no `parent`) — clean card list, no regressions on Network/Gantt tabs
🤖 Generated with [Claude Code](https://claude.com/claude-code)