### PR TITLE
chore(release): 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2.5.0] — 2026-06-25
+
+### Changed
+
+- **DGCA — fourth column renamed Activity → Action.** The column header, preview heading, and schema key are now `actions` / "Action". The old `activities:` key is still accepted and produces a `DEPRECATED_NOTATION` warning; rename to `actions:` at your convenience.
+
+### Fixed
+
+- **Activities preview — Tree tab visual polish.** Node cards now show a border and background; child nodes are connected by a vertical branch line.
+
 ## [2.4.0] — 2026-06-25
 
 ### Added

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Architecture-as-code for the modern enterprise. Author 17 notations — goals, processes, capabilities, BPMN, applications, more — as plain YAML, get live diagrams in VS Code. Diffable in git. AI-friendly. Open source. Built on ArchiMate 3.2 and BPMN 2.0.",
   "license": "MIT",
   "icon": "icon.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
## Summary

- Bump version `2.4.0` → `2.5.0` in `package.json` and `extension/package.json`
- Add `[2.5.0]` entry to `CHANGELOG.md`

## Changes since 2.4.0

- **feat(dgca)** (#303): DGCA fourth column renamed Activity → Action; `actions:` is now canonical, `activities:` accepted with deprecation warning
- **fix(activities)** (#302): Activities Tree tab — node card borders and branch connector lines

## Test plan

- [ ] CI green
- [ ] CHANGELOG entry looks correct