### PR TITLE
feat(viewer): ACTIVITY → ACTION primitive rename — viewer update

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -59,6 +59,10 @@
     "workspaceContains:**/*.fgca.transitrix.yaml",
     "workspaceContains:**/*.fga.transitrix.yaml",
     "workspaceContains:**/*.activities.transitrix.yaml",
+    "workspaceContains:**/*.action.transitrix.yaml",
+    "workspaceContains:**/*.action-card.transitrix.yaml",
+    "workspaceContains:**/*.actions-tree.transitrix.yaml",
+    "workspaceContains:**/*.activities-tree.transitrix.yaml",
     "workspaceContains:**/*.blocks.transitrix.yaml",
     "workspaceContains:**/*.applications.transitrix.yaml",
     "workspaceContains:**/*.products.transitrix.yaml",
@@ -539,6 +543,17 @@
         "configuration": "./language-configuration.json"
       },
       {
+        "id": "transitrix-action-card",
+        "aliases": [
+          "Transitrix Action Card",
+          "Action Card"
+        ],
+        "extensions": [
+          ".action-card.transitrix.yaml"
+        ],
+        "configuration": "./language-configuration.json"
+      },
+      {
         "id": "transitrix-activities",
         "aliases": [
           "Transitrix Activities",
@@ -546,6 +561,29 @@
         ],
         "extensions": [
           ".activities.transitrix.yaml"
+        ],
+        "configuration": "./language-configuration.json"
+      },
+      {
+        "id": "transitrix-action",
+        "aliases": [
+          "Transitrix Action",
+          "Action Network"
+        ],
+        "extensions": [
+          ".action.transitrix.yaml"
+        ],
+        "configuration": "./language-configuration.json"
+      },
+      {
+        "id": "transitrix-actions-tree",
+        "aliases": [
+          "Transitrix Actions Tree",
+          "Action Catalogue Tree"
+        ],
+        "extensions": [
+          ".actions-tree.transitrix.yaml",
+          ".activities-tree.transitrix.yaml"
         ],
         "configuration": "./language-configuration.json"
       },
@@ -623,7 +661,13 @@
       },
       {
         "command": "transitrixStudio.previewActivities",
-        "title": "Transitrix: Preview activity network diagram",
+        "title": "Transitrix: Preview action network diagram (PSND + Gantt + Tree)",
+        "category": "Transitrix",
+        "icon": "$(type-hierarchy)"
+      },
+      {
+        "command": "transitrixStudio.previewActionsTree",
+        "title": "Transitrix: Preview action catalogue tree",
         "category": "Transitrix",
         "icon": "$(type-hierarchy)"
       },
@@ -959,6 +1003,26 @@
           "group": "navigation@-10"
         },
         {
+          "when": "resourceFilename =~ /\\.action\\.transitrix\\.yaml$/",
+          "command": "transitrixStudio.previewActivities",
+          "group": "navigation@-10"
+        },
+        {
+          "when": "resourceFilename =~ /\\.action-card\\.transitrix\\.yaml$/",
+          "command": "transitrixStudio.previewActivityCard",
+          "group": "navigation@-10"
+        },
+        {
+          "when": "resourceFilename =~ /\\.actions-tree\\.transitrix\\.yaml$/",
+          "command": "transitrixStudio.previewActionsTree",
+          "group": "navigation@-10"
+        },
+        {
+          "when": "resourceFilename =~ /\\.activities-tree\\.transitrix\\.yaml$/",
+          "command": "transitrixStudio.previewActionsTree",
+          "group": "navigation@-10"
+        },
+        {
           "when": "resourceFilename =~ /\\.blocks\\.transitrix\\.yaml$/",
           "command": "transitrixStudio.previewBlocks",
           "group": "navigation@-10"
@@ -1016,6 +1080,16 @@
         {
           "when": "resourceFilename =~ /\\.activities\\.transitrix\\.yaml$/",
           "command": "transitrixStudio.saveActivitiesAsSvg",
+          "group": "navigation@-9"
+        },
+        {
+          "when": "resourceFilename =~ /\\.action\\.transitrix\\.yaml$/",
+          "command": "transitrixStudio.saveActivitiesAsSvg",
+          "group": "navigation@-9"
+        },
+        {
+          "when": "resourceFilename =~ /\\.action-card\\.transitrix\\.yaml$/",
+          "command": "transitrixStudio.saveActivityCardAsSvg",
           "group": "navigation@-9"
         },
         {

--- a/extension/src/actions-tree-preview.ts
+++ b/extension/src/actions-tree-preview.ts
@@ -1,0 +1,334 @@
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+import yaml from 'js-yaml';
+import { escXml } from '@transitrix/diagrams/webview/render-util.js';
+import { buildDiagramFrame, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
+import { todayIso } from './svg-title-block.js';
+import { coerceDatesToIsoStrings } from '@transitrix/diagrams/yaml-normalize.js';
+import { StaticPreview } from './static-preview.js';
+import { findCanonRoot, isUnderCanon, readYamlDocsUnder } from './canon-loader.js';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface ActionEntry {
+  id: string;
+  name: string;
+  action_type?: string;
+  parent?: string;
+  owner?: string;
+  start_date?: string;
+  end_date?: string;
+}
+
+interface ActionsTreeScope {
+  root_action?: string;
+  action_type?: string;
+  goals?: string[];
+}
+
+// ── Tree rendering ────────────────────────────────────────────────────────────
+
+const ACTION_TYPE_LEVEL: Record<string, number> = {
+  initiative: 1, 'strategic initiative': 1,
+  programme: 2, program: 2,
+  project: 3,
+  task: 4,
+};
+
+function actionTypeLevel(type: string | undefined): number {
+  return type ? (ACTION_TYPE_LEVEL[type.toLowerCase()] ?? 99) : 99;
+}
+
+function actionTypeBadgeClass(type: string | undefined): string {
+  if (!type) return '';
+  return `tree-badge tree-badge-${type.toLowerCase().replace(/\s+/g, '-')}`;
+}
+
+function buildActionsTreeHtml(
+  actions: ActionEntry[],
+  filename: string,
+  date: string,
+  version?: string,
+): string {
+  if (actions.length === 0) {
+    return '<div class="section-notice">No action elements found.</div>';
+  }
+
+  const childrenOf = new Map<string | undefined, ActionEntry[]>();
+  for (const act of actions) {
+    const key = act.parent ?? undefined;
+    if (!childrenOf.has(key)) childrenOf.set(key, []);
+    childrenOf.get(key)!.push(act);
+  }
+
+  const sortFn = (a: ActionEntry, b: ActionEntry): number => {
+    const diff = actionTypeLevel(a.action_type) - actionTypeLevel(b.action_type);
+    return diff !== 0 ? diff : a.id.localeCompare(b.id);
+  };
+  for (const [, kids] of childrenOf) kids.sort(sortFn);
+
+  function renderNode(act: ActionEntry): string {
+    const kids = childrenOf.get(act.id) ?? [];
+    const badgeClass = actionTypeBadgeClass(act.action_type);
+    const badge = act.action_type
+      ? `<span class="${badgeClass}">${escXml(act.action_type)}</span>`
+      : '';
+    const metaParts: string[] = [];
+    if (act.owner) metaParts.push(escXml(act.owner));
+    if (act.start_date && act.end_date) metaParts.push(`${escXml(act.start_date)} → ${escXml(act.end_date)}`);
+    else if (act.start_date) metaParts.push(`from ${escXml(act.start_date)}`);
+    const meta = metaParts.length ? `<span class="tree-node-meta">${metaParts.join(' · ')}</span>` : '';
+    const label = `<div class="tree-node-label"><span class="tree-node-name">${escXml(act.name)}</span><span class="tree-node-id">${escXml(act.id)}</span></div>`;
+
+    if (kids.length === 0) {
+      return `<div class="tree-node tree-leaf"><div class="tree-node-row">${label}${badge}${meta}</div></div>`;
+    }
+    const openAttr = actionTypeLevel(act.action_type) <= 3 ? ' open' : '';
+    const kidsHtml = `<div class="tree-children">${kids.map((k) => renderNode(k)).join('')}</div>`;
+    return `<details class="tree-node"${openAttr}><summary class="tree-node-row">${label}${badge}${meta}</summary>${kidsHtml}</details>`;
+  }
+
+  const allIds = new Set(actions.map((a) => a.id));
+  const orphans = actions.filter((a) => a.parent && !allIds.has(a.parent));
+  const roots = [...(childrenOf.get(undefined) ?? []), ...orphans].sort(sortFn);
+
+  if (roots.length === 0) {
+    return '<div class="section-notice">No root actions found — check parent references.</div>';
+  }
+
+  const versionPart = version ? ` · v${escXml(version)}` : '';
+  const titleHtml = `<div class="diagram-title-block diagram-title-block-html">
+  <div class="text-header">Actions tree — Initiative → Programme → Project → Task</div>
+  <div class="text-secondary">${escXml(filename)}</div>
+  <div class="text-secondary">${escXml(date)}${versionPart}</div>
+</div>`;
+
+  return `${titleHtml}<div class="tree-view">${roots.map((r) => renderNode(r)).join('')}</div>`;
+}
+
+// ── Scope filtering ───────────────────────────────────────────────────────────
+
+function applyScope(
+  actions: ActionEntry[],
+  scope: ActionsTreeScope | undefined,
+  relations: unknown[],
+): ActionEntry[] {
+  if (!scope) return actions;
+  let result = actions;
+
+  if (scope.action_type) {
+    const targetType = scope.action_type.toLowerCase();
+    result = result.filter((a) => (a.action_type ?? '').toLowerCase() === targetType);
+  }
+
+  if (scope.goals && scope.goals.length > 0) {
+    const goalSet = new Set(scope.goals);
+    const connectedIds = new Set<string>();
+    for (const doc of relations) {
+      if (!doc || typeof doc !== 'object' || Array.isArray(doc)) continue;
+      const r = doc as Record<string, unknown>;
+      if (r['notation'] !== 'relation') continue;
+      const type = typeof r['type'] === 'string' ? r['type'] : '';
+      if (type !== 'action_goal' && type !== 'activity_goal') continue;
+      const to = typeof r['to'] === 'string' ? r['to'] : '';
+      if (!goalSet.has(to)) continue;
+      const from = typeof r['from'] === 'string' ? r['from'] : '';
+      if (from) connectedIds.add(from);
+    }
+    result = result.filter((a) => connectedIds.has(a.id));
+  }
+
+  if (scope.root_action) {
+    const rootId = scope.root_action;
+    const inScope = new Set<string>();
+    const queue = [rootId];
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      inScope.add(current);
+      for (const a of actions) {
+        if (a.parent === current && !inScope.has(a.id)) queue.push(a.id);
+      }
+    }
+    result = result.filter((a) => inScope.has(a.id));
+  }
+
+  return result;
+}
+
+// ── CSS ───────────────────────────────────────────────────────────────────────
+
+const ACTIONS_TREE_CSS = `
+  .tree-view { padding: 4px 8px 16px; }
+  .tree-node { margin: 3px 0; }
+  .tree-node-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 7px 10px;
+    border-radius: 6px;
+    border: 1px solid var(--ts-border, #e2e8f0);
+    background: var(--ts-bg-surface, #ffffff);
+    list-style: none;
+  }
+  .tree-node-row:hover { background: var(--ts-bg-subtle, #f8fafc); }
+  details.tree-node > summary.tree-node-row { cursor: pointer; }
+  details.tree-node > summary.tree-node-row::-webkit-details-marker { display: none; }
+  details.tree-node > summary.tree-node-row::before {
+    content: '▶';
+    font-size: 9px;
+    color: var(--ts-text-muted, #94a3b8);
+    flex-shrink: 0;
+    display: inline-block;
+  }
+  details[open].tree-node > summary.tree-node-row::before { transform: rotate(90deg); }
+  .tree-leaf > .tree-node-row { padding-left: 27px; }
+  .tree-children {
+    margin-left: 20px;
+    padding-left: 16px;
+    padding-top: 2px;
+    padding-bottom: 2px;
+    border-left: 1.5px solid var(--ts-border, #cbd5e1);
+  }
+  .tree-node-label { display: flex; flex-direction: column; flex: 1; min-width: 0; }
+  .tree-node-name { font-size: 13px; color: var(--ts-text, #0f172a); }
+  .tree-node-id { font-size: 11px; color: var(--ts-text-muted, #64748b); font-family: var(--vscode-editor-font-family, monospace); }
+  .tree-node-meta { font-size: 11px; color: var(--ts-text-muted, #64748b); white-space: nowrap; }
+  .tree-badge { font-size: 10px; font-weight: 600; padding: 2px 7px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; }
+  .tree-badge-initiative,
+  .tree-badge-strategic-initiative { background: #fff7ed; color: var(--ts-brand-orange, #ff4d00); border: 1px solid var(--ts-brand-orange, #ff4d00); }
+  .tree-badge-programme { background: #eff6ff; color: #2563eb; border: 1px solid #93c5fd; }
+  .tree-badge-project { background: var(--ts-layer-activity, #d4edda); color: #166534; border: 1px solid #86efac; }
+  .tree-badge-task { background: var(--ts-bg-subtle, #f1f5f9); color: var(--ts-text-muted, #64748b); border: 1px solid var(--ts-border, #cbd5e1); }
+  .section-notice { margin: 0 16px; padding: 10px 14px; border-left: 3px solid var(--ts-text-muted, #94a3b8); background: var(--ts-bg-subtle, #f8fafc); color: var(--ts-text-muted, #64748b); font-size: 12px; }
+`;
+
+// ── Preview class ─────────────────────────────────────────────────────────────
+
+export class ActionsTreePreview extends StaticPreview {
+  readonly panelTitle = 'Actions Tree Preview';
+  protected readonly viewType = 'actionsTreePreview';
+  protected readonly enableCommandUris = [OPEN_THEME_COMMAND];
+
+  async refreshIfSiblingSaved(doc: vscode.TextDocument): Promise<void> {
+    if (!this.panel || !this.trackedUri) return;
+    if (!doc.fileName.endsWith('.yaml')) return;
+    const treeUri = vscode.Uri.parse(this.trackedUri);
+    const canonRoot = findCanonRoot(treeUri);
+    if (!canonRoot) return;
+    if (!isUnderCanon(canonRoot, doc.uri)) return;
+    const treeDoc = await vscode.workspace.openTextDocument(treeUri);
+    await this.pushDocument(treeDoc);
+  }
+
+  protected override async pushDocument(doc: vscode.TextDocument): Promise<void> {
+    if (!this.panel) return;
+    const data = await this.loadCanonData(doc.uri);
+    this.panel.webview.html = this.buildHtml(doc.getText(), path.basename(doc.fileName), data);
+  }
+
+  private async loadCanonData(
+    fileUri: vscode.Uri,
+  ): Promise<{ actions: ActionEntry[]; relations: unknown[]; warnings: string[] }> {
+    const warnings: string[] = [];
+    const canonRoot = findCanonRoot(fileUri);
+    if (!canonRoot) {
+      warnings.push('Could not locate a canon/ root above this file — no action elements can be loaded.');
+      return { actions: [], relations: [], warnings };
+    }
+
+    const rawDocs: unknown[] = [];
+    const relations: unknown[] = [];
+    await readYamlDocsUnder(vscode.Uri.joinPath(canonRoot, 'elements'), rawDocs, warnings);
+    await readYamlDocsUnder(vscode.Uri.joinPath(canonRoot, 'relations'), relations, warnings);
+
+    const actions: ActionEntry[] = [];
+    for (const doc of rawDocs) {
+      if (!doc || typeof doc !== 'object' || Array.isArray(doc)) continue;
+      const d = doc as Record<string, unknown>;
+      const notation = typeof d['notation'] === 'string' ? d['notation'] : '';
+      if (notation !== 'action' && notation !== 'activity') continue;
+      const id = typeof d['id'] === 'string' ? d['id'].trim() : '';
+      if (!id) continue;
+      actions.push({
+        id,
+        name: typeof d['name'] === 'string' ? d['name'] : id,
+        action_type: typeof d['action_type'] === 'string'
+          ? d['action_type']
+          : (typeof d['activity_type'] === 'string' ? d['activity_type'] : undefined),
+        parent: typeof d['parent'] === 'string' ? d['parent'] : undefined,
+        owner: typeof d['owner'] === 'string' ? d['owner'] : undefined,
+        start_date: typeof d['start_date'] === 'string' ? d['start_date'] : undefined,
+        end_date: typeof d['end_date'] === 'string' ? d['end_date'] : undefined,
+      });
+    }
+
+    return { actions, relations, warnings };
+  }
+
+  private buildHtml(
+    yamlText: string,
+    filename: string,
+    data: { actions: ActionEntry[]; relations: unknown[]; warnings: string[] },
+  ): string {
+    let bodyContent = '';
+    let errorMsg = '';
+    const warnings = [...data.warnings];
+
+    try {
+      const parsed = coerceDatesToIsoStrings(yaml.load(yamlText) as unknown);
+      const raw = (parsed && typeof parsed === 'object' ? parsed : {}) as Record<string, unknown>;
+
+      const notation = typeof raw['notation'] === 'string' ? raw['notation'] : '';
+      if (!notation) {
+        errorMsg = 'notation field is required';
+      } else if (notation !== 'actions-tree' && notation !== 'activities-tree') {
+        errorMsg = `notation must be "actions-tree", got "${notation}"`;
+      } else {
+        if (notation === 'activities-tree') {
+          warnings.push('DEPRECATED_NOTATION: notation: "activities-tree" is deprecated — migrate to notation: "actions-tree"');
+        }
+
+        const docDate = typeof raw['date'] === 'string' ? raw['date'] : todayIso();
+        const docVersion = typeof raw['version'] === 'string' ? raw['version'] : undefined;
+
+        let scope: ActionsTreeScope | undefined;
+        const viewConfig = raw['view_config'];
+        if (viewConfig && typeof viewConfig === 'object' && !Array.isArray(viewConfig)) {
+          const vc = viewConfig as Record<string, unknown>;
+          const scopeRaw = vc['scope'];
+          if (scopeRaw && typeof scopeRaw === 'object' && !Array.isArray(scopeRaw)) {
+            const s = scopeRaw as Record<string, unknown>;
+            scope = {};
+            if (typeof s['root_action'] === 'string') scope.root_action = s['root_action'];
+            if (typeof s['action_type'] === 'string') scope.action_type = s['action_type'];
+            if (Array.isArray(s['goals'])) {
+              scope.goals = s['goals'].filter((g): g is string => typeof g === 'string');
+            }
+          }
+        }
+
+        const filtered = applyScope(data.actions, scope, data.relations);
+        bodyContent = buildActionsTreeHtml(filtered, filename, docDate, docVersion);
+      }
+    } catch (e) {
+      errorMsg = (e as Error).message ?? 'Parse error';
+    }
+
+    const themeId = vscode.workspace.getConfiguration('transitrix').get<ThemeId>('theme', 'transitrix');
+    return buildDiagramFrame({
+      filename,
+      notation: 'Actions Tree',
+      bodyContent,
+      errorMsg,
+      warnings,
+      themeId,
+      extraStyles: ACTIONS_TREE_CSS,
+      themeCommand: OPEN_THEME_COMMAND,
+    });
+  }
+}
+
+export function isActionsTreeFileName(fileName: string): boolean {
+  return fileName.endsWith('.actions-tree.transitrix.yaml')
+    || fileName.endsWith('.activities-tree.transitrix.yaml');
+}

--- a/extension/src/activity-card-preview.ts
+++ b/extension/src/activity-card-preview.ts
@@ -29,6 +29,7 @@ import {
 // the pure resolver in `@transitrix/diagrams` does the rest.
 
 const CARD_SUFFIX = '.activity-card.transitrix.yaml';
+const ACTION_CARD_SUFFIX = '.action-card.transitrix.yaml';
 
 // Single-line `<defs>` marker kept host-specific: the VS Code SVG places it
 // after the title block, while the host-neutral renderer emits a multi-line
@@ -69,8 +70,8 @@ export class ActivityCardPreview extends StaticSvgPreview {
     'transitrixStudio.copyActivityCardAsPng',
     'transitrixStudio.changeTheme',
   ];
-  protected readonly stripExt = /\.activity-card\.transitrix\.yaml$/;
-  protected readonly emptyMessage = 'No card rendered yet. Open a *.activity-card.transitrix.yaml file first.';
+  protected readonly stripExt = /\.(activity|action)-card\.transitrix\.yaml$/;
+  protected readonly emptyMessage = 'No card rendered yet. Open a *.action-card.transitrix.yaml (or *.activity-card.transitrix.yaml) file first.';
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   protected renderHtml(_yamlText: string, _filename: string): string { return ''; }

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -16,6 +16,7 @@ import { ScenariosPreview } from './scenarios-preview.js';
 import { CapabilityMapPreview } from './capability-map-preview.js';
 import { ProcessBlueprintPreview } from './process-blueprint-preview.js';
 import { ActivityCardPreview } from './activity-card-preview.js';
+import { ActionsTreePreview, isActionsTreeFileName } from './actions-tree-preview.js';
 import { ComplianceMatrixPreview } from './compliance-matrix-preview.js';
 import { ComplianceImpactPreview } from './compliance-impact-preview.js';
 import { SingleLawPreview } from './single-law-preview.js';
@@ -63,7 +64,12 @@ function isFGAFile(doc: vscode.TextDocument): boolean {
 }
 
 function isActivitiesFile(doc: vscode.TextDocument): boolean {
-  return doc.fileName.endsWith('.activities.transitrix.yaml');
+  return doc.fileName.endsWith('.activities.transitrix.yaml')
+    || doc.fileName.endsWith('.action.transitrix.yaml');
+}
+
+function isActionCardFile(doc: vscode.TextDocument): boolean {
+  return doc.fileName.endsWith('.action-card.transitrix.yaml');
 }
 
 function isBlocksFile(doc: vscode.TextDocument): boolean {
@@ -95,7 +101,8 @@ function isProcessBlueprintFile(doc: vscode.TextDocument): boolean {
 }
 
 function isActivityCardFile(doc: vscode.TextDocument): boolean {
-  return doc.fileName.endsWith('.activity-card.transitrix.yaml');
+  return doc.fileName.endsWith('.activity-card.transitrix.yaml')
+    || isActionCardFile(doc);
 }
 
 function isCoverageMetricFile(doc: vscode.TextDocument): boolean {
@@ -248,6 +255,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   const capabilityMapPreview = new CapabilityMapPreview();
   const processBlueprintPreview = new ProcessBlueprintPreview();
   const activityCardPreview = new ActivityCardPreview();
+  const actionsTreePreview = new ActionsTreePreview();
   const complianceMatrixPreview = new ComplianceMatrixPreview(context.extensionUri);
   const complianceImpactPreview = new ComplianceImpactPreview(context.extensionUri);
   const singleLawPreview = new SingleLawPreview(context.extensionUri);
@@ -346,12 +354,21 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     }),
     vscode.commands.registerCommand('transitrixStudio.previewActivities', async () => {
       const doc = vscode.window.activeTextEditor?.document;
-      const isActivities = doc && (isActivitiesFile(doc) || (isDGCAFile(doc) && probeDocNotation(doc) === 'activities'));
+      const notation = doc && (isDGCAFile(doc) ? probeDocNotation(doc) : undefined);
+      const isActivities = doc && (isActivitiesFile(doc) || notation === 'activities' || notation === 'action');
       if (!isActivities) {
-        vscode.window.showWarningMessage('Open a *.activities.transitrix.yaml or *.dgca.transitrix.yaml (with notation: activities) file first.');
+        vscode.window.showWarningMessage('Open a *.action.transitrix.yaml (or *.activities.transitrix.yaml) file first.');
         return;
       }
       await activitiesPreview.showOrReveal(doc);
+    }),
+    vscode.commands.registerCommand('transitrixStudio.previewActionsTree', async () => {
+      const doc = vscode.window.activeTextEditor?.document;
+      if (!doc || !isActionsTreeFileName(doc.fileName)) {
+        vscode.window.showWarningMessage('Open a *.actions-tree.transitrix.yaml file first.');
+        return;
+      }
+      await actionsTreePreview.showOrReveal(doc);
     }),
     vscode.commands.registerCommand('transitrixStudio.previewBlocks', async () => {
       const doc = vscode.window.activeTextEditor?.document;
@@ -578,6 +595,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       // a projection over canon/elements + canon/relations). Runs before the
       // per-type routing below (which early-returns on a match).
       void activityCardPreview.refreshIfSiblingSaved(doc);
+      void actionsTreePreview.refreshIfSiblingSaved(doc);
       void fgcaPreview.refreshIfSiblingSaved(doc);
       // Compliance views are repo-wide: re-scan the open ones whenever a canon
       // artefact (by filename convention) is saved. No-op when no panel is open.
@@ -592,11 +610,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       if (isDGCAFile(doc) || isFGCAFile(doc)) {
         const notation = isDGCAFile(doc) ? probeDocNotation(doc) : undefined;
         if (notation === 'goals') { void goalsPreview.refreshSaved(doc); return; }
-        if (notation === 'activities') { void activitiesPreview.refreshSaved(doc); return; }
+        if (notation === 'activities' || notation === 'action') { void activitiesPreview.refreshSaved(doc); return; }
         void fgcaPreview.refreshSaved(doc); return;
       }
       if (isDGAFile(doc) || isFGAFile(doc)) { void fgaPreview.refreshSaved(doc); return; }
       if (isActivitiesFile(doc)) { void activitiesPreview.refreshSaved(doc); return; }
+      if (isActionsTreeFileName(doc.fileName)) { void actionsTreePreview.refreshSaved(doc); return; }
       if (isBlocksFile(doc)) { void blocksPreview.refreshSaved(doc); return; }
       if (isApplicationsFile(doc)) { void applicationsPreview.refreshSaved(doc); return; }
       if (isProductsFile(doc)) { void productsPreview.refreshSaved(doc); return; }
@@ -615,11 +634,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       if (isDGCAFile(doc) || isFGCAFile(doc)) {
         const notation = isDGCAFile(doc) ? probeDocNotation(doc) : undefined;
         if (notation === 'goals') { await goalsPreview.showOrReveal(doc); return; }
-        if (notation === 'activities') { await activitiesPreview.showOrReveal(doc); return; }
+        if (notation === 'activities' || notation === 'action') { await activitiesPreview.showOrReveal(doc); return; }
         await fgcaPreview.showOrReveal(doc); return;
       }
       if (isDGAFile(doc) || isFGAFile(doc)) { await fgaPreview.showOrReveal(doc); return; }
       if (isActivitiesFile(doc)) { await activitiesPreview.showOrReveal(doc); return; }
+      if (isActionsTreeFileName(doc.fileName)) { await actionsTreePreview.showOrReveal(doc); return; }
       if (isBlocksFile(doc)) { await blocksPreview.showOrReveal(doc); return; }
       if (isApplicationsFile(doc)) { await applicationsPreview.showOrReveal(doc); return; }
       if (isProductsFile(doc)) { await productsPreview.showOrReveal(doc); return; }

--- a/packages/diagrams/src/activities/__tests__/validate.test.ts
+++ b/packages/diagrams/src/activities/__tests__/validate.test.ts
@@ -15,9 +15,43 @@ const minimalValid = {
 };
 
 describe('validateActivities', () => {
-  it('ACT-001 — accepts valid notation field', () => {
+  it('ACT-001 — accepts notation: activities (deprecated)', () => {
     const r = validateActivities(minimalValid);
     expect(r.valid).toBe(true);
+    // deprecated notation emits a warning, not an error
+    expect(r.warnings.some(w => w.code === 'DEPRECATED_NOTATION')).toBe(true);
+  });
+
+  it('ACT-001 — accepts notation: action (canonical)', () => {
+    const r = validateActivities({
+      notation: 'action',
+      actions: [
+        { id: 'ACTION-001', name: 'Start', duration: 3 },
+        { id: 'ACTION-002', name: 'End', duration: 2, predecessors: ['ACTION-001'] },
+      ],
+    });
+    expect(r.valid).toBe(true);
+    expect(r.warnings.some(w => w.code === 'DEPRECATED_NOTATION')).toBe(false);
+  });
+
+  it('ACT-001 — accepts notation: action with deprecated activities: key (emits field warning)', () => {
+    const r = validateActivities({
+      notation: 'action',
+      activities: [{ id: 'ACTION-001', name: 'Foo', duration: 1 }],
+    });
+    expect(r.valid).toBe(true);
+    expect(r.warnings.some(w => w.code === 'DEPRECATED_FIELD')).toBe(true);
+  });
+
+  it('ACT-001 — normalises action_type to activity_type for downstream layout', () => {
+    const input: Record<string, unknown> = {
+      notation: 'action',
+      actions: [{ id: 'ACTION-001', name: 'Foo', duration: 1, action_type: 'project' }],
+    };
+    const r = validateActivities(input);
+    expect(r.valid).toBe(true);
+    const entry = (input.actions as Array<Record<string, unknown>>)[0];
+    expect(entry['activity_type']).toBe('project');
   });
 
   it('ACT-001 — rejects missing notation', () => {

--- a/packages/diagrams/src/activities/validate.ts
+++ b/packages/diagrams/src/activities/validate.ts
@@ -19,20 +19,31 @@ export function validateActivities(input: unknown): ActivityValidationResult {
 
   const raw = input as Record<string, unknown>;
 
-  // ACT-001: notation must equal "activities"
+  // ACT-001: notation must be "action" (canonical) or "activities" (deprecated)
   if (raw.notation === undefined) {
     errors.push({ code: 'ACT-001', message: 'notation field is required' });
     return { valid: false, errors, warnings };
   }
-  if (raw.notation !== 'activities') {
-    errors.push({ code: 'ACT-001', message: `notation must be "activities", got "${String(raw.notation)}"` });
+  if (raw.notation !== 'action' && raw.notation !== 'activities') {
+    errors.push({ code: 'ACT-001', message: `notation must be "action", got "${String(raw.notation)}"` });
     return { valid: false, errors, warnings };
+  }
+  if (raw.notation === 'activities') {
+    warnings.push({ code: 'DEPRECATED_NOTATION', message: 'notation: "activities" is deprecated — migrate to notation: "action"' });
   }
 
-  if (!Array.isArray(raw.activities)) {
-    errors.push({ code: 'SCHEMA_INVALID', message: 'activities must be an array', path: 'activities' });
+  // Accept "actions:" (canonical) or "activities:" (deprecated)
+  const rawArray = Array.isArray(raw.actions) ? raw.actions : (Array.isArray(raw.activities) ? raw.activities : undefined);
+  if (Array.isArray(raw.activities) && !Array.isArray(raw.actions)) {
+    warnings.push({ code: 'DEPRECATED_FIELD', message: 'Root key "activities:" is deprecated — rename to "actions:"' });
+  }
+  if (!rawArray) {
+    const canonKey = raw.notation === 'action' ? 'actions' : 'activities';
+    errors.push({ code: 'SCHEMA_INVALID', message: `${canonKey} must be an array`, path: canonKey });
     return { valid: false, errors, warnings };
   }
+  // Normalise onto raw.activities for the rest of this function (avoids touching downstream code)
+  if (!Array.isArray(raw.activities)) raw.activities = raw.actions;
 
   // ACT-014 / ACT-015: project.calendar validation (run before per-activity loop;
   // surfaces clearly even when activities also have issues).
@@ -98,6 +109,11 @@ export function validateActivities(input: unknown): ActivityValidationResult {
       continue;
     }
     const act = a as Record<string, unknown>;
+
+    // Normalise action_type → activity_type (canonical rename; old name kept for compat)
+    if (act['action_type'] !== undefined && act['activity_type'] === undefined) {
+      act['activity_type'] = act['action_type'];
+    }
 
     // ACT-010: reject single-value forms
     if ('goal' in act) {

--- a/packages/diagrams/src/activity-card/__tests__/resolver.test.ts
+++ b/packages/diagrams/src/activity-card/__tests__/resolver.test.ts
@@ -241,7 +241,7 @@ describe('resolveActivityCard', () => {
     expect(pc001!.message).toContain('canon/elements/**');
     expect(pc001!.message).toContain('canon/views/activities/**');
     // Must include actionable hint with expected file pattern (§7 PC-001)
-    expect(pc001!.message).toContain('notation: activity');
+    expect(pc001!.message).toContain('notation: action');
     expect(pc001!.message).toContain(`id: "${CARD.activity_card.project}"`);
   });
 

--- a/packages/diagrams/src/activity-card/__tests__/validate.test.ts
+++ b/packages/diagrams/src/activity-card/__tests__/validate.test.ts
@@ -20,10 +20,34 @@ const VALID = {
 };
 
 describe('validateActivityCard', () => {
-  it('accepts a well-formed card', () => {
+  it('accepts a well-formed card (deprecated notation: activity-card)', () => {
     const r = validateActivityCard(VALID);
     expect(r.valid).toBe(true);
     expect(r.errors).toHaveLength(0);
+    expect(r.warnings.some(w => w.code === 'DEPRECATED_NOTATION')).toBe(true);
+  });
+
+  it('accepts notation: action-card with action_card block (canonical)', () => {
+    const r = validateActivityCard({
+      notation: 'action-card',
+      action_card: {
+        id: 'ACTION_CARD-EU-PROGRAMME-1',
+        project: 'ACTION-EU-PROGRAMME-1',
+      },
+    });
+    expect(r.valid).toBe(true);
+    expect(r.warnings.some(w => w.code === 'DEPRECATED_NOTATION')).toBe(false);
+  });
+
+  it('accepts action_card block with legacy ACTIVITY_CARD id prefix', () => {
+    const r = validateActivityCard({
+      notation: 'action-card',
+      action_card: {
+        id: 'ACTIVITY_CARD-EU-PROGRAMME-1',
+        project: 'ACTION-EU-PROGRAMME-1',
+      },
+    });
+    expect(r.valid).toBe(true);
   });
 
   it('rejects non-object input', () => {

--- a/packages/diagrams/src/activity-card/resolver.ts
+++ b/packages/diagrams/src/activity-card/resolver.ts
@@ -104,16 +104,17 @@ function collectByNotation(
 }
 
 /**
- * GOAL ids reached by an *active* `activity_goal` relation originating at
- * `fromId`. A relation with a non-null `valid_to` has ended (the activity was
- * re-aimed) and is excluded — the card shows the currently-served goals.
+ * GOAL ids reached by an *active* `action_goal` (or legacy `activity_goal`)
+ * relation originating at `fromId`. A relation with a non-null `valid_to` has
+ * ended (the activity was re-aimed) and is excluded.
  */
 function activeActivityGoals(relations: unknown[], fromId: string): string[] {
   const out: string[] = [];
   for (const doc of relations) {
     if (!isObject(doc)) continue;
     if (str(doc['notation']) !== 'relation') continue;
-    if (str(doc['type']) !== 'activity_goal') continue;
+    const type = str(doc['type']);
+    if (type !== 'action_goal' && type !== 'activity_goal') continue;
     if (str(doc['from']) !== fromId) continue;
     const to = str(doc['to']);
     if (!to) continue;
@@ -125,11 +126,8 @@ function activeActivityGoals(relations: unknown[], fromId: string): string[] {
 }
 
 /**
- * STAKEHOLDER ids + roles reached by an *active* `activity_stakeholder`
- * relation originating at `fromId`. A relation with a non-null `valid_to` has
- * ended and is excluded, so the card shows the project's currently-engaged
- * stakeholders. The optional `role` field on the relation carries the
- * project-role (initiator | owner | sponsor | project_manager).
+ * STAKEHOLDER ids + roles reached by an *active* `action_stakeholder` (or
+ * legacy `activity_stakeholder`) relation originating at `fromId`.
  */
 function activeActivityStakeholders(
   relations: unknown[],
@@ -139,7 +137,8 @@ function activeActivityStakeholders(
   for (const doc of relations) {
     if (!isObject(doc)) continue;
     if (str(doc['notation']) !== 'relation') continue;
-    if (str(doc['type']) !== 'activity_stakeholder') continue;
+    const type = str(doc['type']);
+    if (type !== 'action_stakeholder' && type !== 'activity_stakeholder') continue;
     if (str(doc['from']) !== fromId) continue;
     const to = str(doc['to']);
     if (!to) continue;
@@ -165,20 +164,22 @@ export function resolveActivityCard(
     return { valid: false, errors, warnings };
   }
 
-  const activities = collectByNotation(sources.elements, 'activity');
-  const projectRec = activities.get(projectId);
+  // Look up by canonical `notation: action` first, then legacy `notation: activity`.
+  const actionElements = collectByNotation(sources.elements, 'action');
+  const activityElements = collectByNotation(sources.elements, 'activity');
+  const allActionElements = new Map([...activityElements, ...actionElements]); // action wins on duplicate id
+  const projectRec = allActionElements.get(projectId);
 
-  // PC-001 — project must resolve to an admitted ACTIVITY element after
-  // exhausting the canonical resolution scope (§6.1): canon/elements/**
-  // recursively first, then canon/views/activities/** as secondary fallback.
+  // PC-001 — project must resolve to an admitted ACTION (or legacy ACTIVITY)
+  // element after exhausting the canonical resolution scope (§6.1).
   if (!projectRec) {
     errors.push({
       code: 'PC-001',
       message:
-        `activity_card.project "${projectId}" not found after searching ` +
+        `action_card.project "${projectId}" not found after searching ` +
         `canon/elements/** and canon/views/activities/** — ` +
-        `add a YAML file with notation: activity and id: "${projectId}" ` +
-        `(e.g. canon/elements/05_implementation/activities/${projectId}.yaml)`,
+        `add a YAML file with notation: action and id: "${projectId}" ` +
+        `(e.g. canon/elements/05_implementation/actions/${projectId}.yaml)`,
     });
     return { valid: false, errors, warnings };
   }
@@ -349,13 +350,14 @@ export function resolveActivityCard(
   });
 
   // ── Child activities — parent = project id ──────────────────────────────────
+  // Look in both `notation: action` and legacy `notation: activity` elements.
   const childActivities: ResolvedChildActivity[] = [];
-  for (const [id, rec] of activities) {
+  for (const [id, rec] of allActionElements) {
     if (str(rec['parent']) !== projectId) continue;
     childActivities.push({
       id,
       name: str(rec['name']) ?? id,
-      activity_type: str(rec['activity_type']),
+      activity_type: str(rec['action_type']) ?? str(rec['activity_type']),
       start_date: str(rec['start_date']),
       end_date: str(rec['end_date']),
       owner: str(rec['owner']),
@@ -401,7 +403,7 @@ export function resolveActivityCard(
     valid_to: validToOk ? (validToRaw as string) : undefined,
     start_date: str(projectRec['start_date']),
     end_date: str(projectRec['end_date']),
-    activity_type: str(projectRec['activity_type']),
+    activity_type: str(projectRec['action_type']) ?? str(projectRec['activity_type']),
     status: str(projectRec['status']),
   };
 

--- a/packages/diagrams/src/activity-card/validate.ts
+++ b/packages/diagrams/src/activity-card/validate.ts
@@ -26,8 +26,8 @@ import type { ValidationError, ValidationWarning, ValidationResult } from '../va
 
 export type { ValidationError, ValidationWarning, ValidationResult };
 
-const ACTIVITY_CARD_ID_RE = /^ACTIVITY_CARD(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
-const ACTIVITY_ID_RE = /^ACTIVITY(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
+const ACTIVITY_CARD_ID_RE = /^(ACTIVITY_CARD|ACTION_CARD)(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
+const ACTIVITY_ID_RE = /^(ACTIVITY|ACTION)(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
 const MILESTONE_ID_RE = /^MILESTONE(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
 const CHANGE_ID_RE = /^CHANGE(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
@@ -49,37 +49,46 @@ export function validateActivityCard(input: unknown): ValidationResult {
   // ── Header (CONTRACT.md §2) ────────────────────────────────────────────────
   if (!('notation' in raw)) {
     errors.push({ code: 'HDR-001', message: 'notation field is required' });
-  } else if (raw['notation'] !== 'activity-card') {
+  } else if (raw['notation'] !== 'action-card' && raw['notation'] !== 'activity-card') {
     errors.push({
       code: 'HDR-002',
-      message: `notation must be "activity-card", got "${String(raw['notation'])}"`,
+      message: `notation must be "action-card", got "${String(raw['notation'])}"`,
     });
+  } else if (raw['notation'] === 'activity-card') {
+    warnings.push({ code: 'DEPRECATED_NOTATION', message: 'notation: "activity-card" is deprecated — migrate to notation: "action-card"' });
   }
 
-  // ── activity_card block ─────────────────────────────────────────────────────
-  const block = raw['activity_card'];
+  // ── action_card / activity_card block ───────────────────────────────────────
+  // "action_card:" is canonical; "activity_card:" is accepted for compat.
+  const rawBlock = raw['action_card'] ?? raw['activity_card'];
+  if (raw['activity_card'] !== undefined && raw['action_card'] === undefined) {
+    warnings.push({ code: 'DEPRECATED_FIELD', message: 'Root key "activity_card:" is deprecated — rename to "action_card:"' });
+  }
+  const block = rawBlock;
   if (!block || typeof block !== 'object' || Array.isArray(block)) {
-    errors.push({ code: 'AC-001', message: 'Missing required root key: activity_card (object)' });
+    errors.push({ code: 'AC-001', message: 'Missing required root key: action_card (object)' });
     return { valid: false, errors, warnings };
   }
+  // Normalise onto activity_card for downstream (resolver reads doc.activity_card)
+  if (raw['activity_card'] === undefined) raw['activity_card'] = rawBlock;
   const card = block as Record<string, unknown>;
 
   if (!isNonEmptyString(card['id'])) {
-    errors.push({ code: 'AC-002', message: 'activity_card.id is required' });
+    errors.push({ code: 'AC-002', message: 'action_card.id is required' });
   } else if (!ACTIVITY_CARD_ID_RE.test(card['id'])) {
     errors.push({
       code: 'AC-002',
-      message: `activity_card.id "${card['id']}" must match ACTIVITY_CARD-[<middle>-]<INTEGER>`,
+      message: `action_card.id "${card['id']}" must match ACTION_CARD-[<middle>-]<INTEGER> (or legacy ACTIVITY_CARD-…)`,
     });
   }
 
   // PC-001 (document-local half): project present + well-formed.
   if (!isNonEmptyString(card['project'])) {
-    errors.push({ code: 'PC-001', message: 'activity_card.project is required (an ACTIVITY-… id)' });
+    errors.push({ code: 'PC-001', message: 'action_card.project is required (an ACTION-… id)' });
   } else if (!ACTIVITY_ID_RE.test(card['project'])) {
     errors.push({
       code: 'PC-001',
-      message: `activity_card.project "${card['project']}" is malformed; must match ACTIVITY-[<middle>-]<INTEGER>`,
+      message: `action_card.project "${card['project']}" is malformed; must match ACTION-[<middle>-]<INTEGER> (or legacy ACTIVITY-…)`,
     });
   }
 


### PR DESCRIPTION
## Summary

- **Extension routing**: `extension.ts` now recognises `.action.transitrix.yaml`, `.action-card.transitrix.yaml`, `.actions-tree.transitrix.yaml`, and `.activities-tree.transitrix.yaml`; routes each to the appropriate preview handler
- **New preview**: `actions-tree-preview.ts` renders the catalogue-level WBS tree from `canon/elements/`; emits a deprecation banner when `notation: activities-tree` is used
- **Validators updated**: `activities/validate.ts` and `activity-card/validate.ts` now accept the canonical new notation keys (`action`, `action-card`, `actions:`, `action_card:`) while keeping the deprecated old ones accepted with `DEPRECATED_NOTATION` / `DEPRECATED_FIELD` warnings
- **Resolver updated**: `activity-card/resolver.ts` resolves `action_goal`, `action_stakeholder`, `action_type`, and `notation: action` elements alongside their `activity_*` counterparts
- **`package.json`**: activationEvents, language registrations, command, and menu entries added for all new file suffixes

## Test plan

- [ ] All 59 test files in `packages/diagrams` pass (`npm test --workspace=packages/diagrams`)
- [ ] Opening a `*.action.transitrix.yaml` file triggers the activities network/Gantt/Tree preview
- [ ] Opening a `*.action-card.transitrix.yaml` file triggers the activity card preview
- [ ] Opening a `*.actions-tree.transitrix.yaml` file triggers the actions tree preview
- [ ] Legacy `*.activities.transitrix.yaml` and `*.activity-card.transitrix.yaml` files still open and show a deprecation banner
- [ ] Legacy `*.activities-tree.transitrix.yaml` files open via the new `previewActionsTree` command and show a deprecation banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)