### PR TITLE
feat(capability-map): SVG tree renderer — DSM-matching nodes, collapse/expand, legend

### DIFF
--- a/extension/src/capability-map-preview.ts
+++ b/extension/src/capability-map-preview.ts
@@ -1,12 +1,14 @@
+import * as path from 'node:path';
 import { escHtml } from '@transitrix/diagrams/webview/render-util.js';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, extractDiagramMeta, CATALOGUE_STYLES, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
 import { coerceDatesToIsoStrings } from '@transitrix/diagrams/yaml-normalize.js';
 import { validateCapabilityMap } from '@transitrix/diagrams/capability-map/validate.js';
-import { StaticPreview } from './static-preview.js';
+import { renderCapabilityTreeSvg } from '@transitrix/diagrams/capability-map/render-capability-tree.js';
+import { genNonce } from './preview-controls.js';
 
-// ── Types (used by render helpers) ───────────────────────────────────────────
+// ── Types (local, mirroring the shared package types) ─────────────────────────
 
 type CapabilityType = 'domain' | 'supporting';
 
@@ -32,7 +34,7 @@ interface CapabilityMapHeader {
   capabilities: CapabilityNode[];
 }
 
-// ── HTML render helpers ───────────────────────────────────────────────────────
+// ── HTML cards render helpers ─────────────────────────────────────────────────
 
 const MATURITY_LABEL: Record<number, string> = {
   1: 'Initial',
@@ -108,26 +110,114 @@ function buildCapabilityMapBody(map: CapabilityMapHeader): string {
   return vBlock + hBlock;
 }
 
+// ── Collapse script for tree view ─────────────────────────────────────────────
+
+function buildCollapseScript(nonce: string): string {
+  return `<script nonce="${nonce}">
+(function () {
+  var vscode = acquireVsCodeApi();
+  document.querySelectorAll('[data-node-id]').forEach(function (btn) {
+    btn.style.cursor = 'pointer';
+    btn.addEventListener('click', function () {
+      var nodeId = btn.getAttribute('data-node-id');
+      var collapsed = [];
+      document.querySelectorAll('[data-node-id]').forEach(function (b) {
+        if (b.getAttribute('data-collapsed') === 'true') {
+          collapsed.push(b.getAttribute('data-node-id'));
+        }
+      });
+      var idx = collapsed.indexOf(nodeId);
+      if (idx >= 0) {
+        collapsed.splice(idx, 1);
+      } else {
+        collapsed.push(nodeId);
+      }
+      vscode.postMessage({ type: 'transitrix:collapseToggle', collapsedIds: collapsed });
+    });
+  });
+}());
+</script>`;
+}
+
 // ── CapabilityMapPreview webview class ────────────────────────────────────────
 
-export class CapabilityMapPreview extends StaticPreview {
+export class CapabilityMapPreview {
   readonly panelTitle = 'Capability Map Preview';
-  protected readonly viewType = 'capabilityMapPreview';
-  protected readonly enableCommandUris = ['transitrixStudio.changeTheme'];
+  private panel: vscode.WebviewPanel | undefined;
+  private trackedUri: string | undefined;
+  /** Persisted within the preview session; reset when the document changes view mode. */
+  private collapsedIds = new Set<string>();
 
-  protected renderHtml(yamlText: string, filename: string): string {
+  isShowingDocument(uri: vscode.Uri): boolean {
+    return this.panel != null && this.trackedUri === uri.toString();
+  }
+
+  async showOrReveal(doc: vscode.TextDocument): Promise<void> {
+    this.trackedUri = doc.uri.toString();
+    if (this.panel) {
+      this.panel.title = `${this.panelTitle} — ${path.basename(doc.fileName)}`;
+      this.panel.reveal(vscode.ViewColumn.Beside, true);
+    } else {
+      this.panel = vscode.window.createWebviewPanel(
+        'capabilityMapPreview',
+        `${this.panelTitle} — ${path.basename(doc.fileName)}`,
+        { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
+        {
+          enableScripts: true,
+          retainContextWhenHidden: true,
+          enableCommandUris: ['transitrixStudio.changeTheme'],
+        },
+      );
+      this.panel.webview.onDidReceiveMessage((m) => {
+        if (m?.type === 'transitrix:collapseToggle' && Array.isArray(m.collapsedIds)) {
+          this.collapsedIds = new Set<string>(m.collapsedIds as string[]);
+          if (this.trackedUri) {
+            void vscode.workspace.openTextDocument(vscode.Uri.parse(this.trackedUri))
+              .then(d => this.pushDocument(d));
+          }
+        }
+      });
+      this.panel.onDidDispose(() => {
+        this.panel = undefined;
+        this.trackedUri = undefined;
+        this.collapsedIds = new Set();
+      });
+    }
+    await this.pushDocument(doc);
+  }
+
+  async refreshSaved(doc: vscode.TextDocument): Promise<void> {
+    if (!this.isShowingDocument(doc.uri)) return;
+    await this.pushDocument(doc);
+  }
+
+  async refreshConfig(): Promise<void> {
+    if (!this.panel || !this.trackedUri) return;
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.parse(this.trackedUri));
+    await this.pushDocument(doc);
+  }
+
+  private async pushDocument(doc: vscode.TextDocument): Promise<void> {
+    if (!this.panel) return;
+    this.panel.webview.html = this.buildHtml(doc.getText(), path.basename(doc.fileName));
+  }
+
+  private buildHtml(yamlText: string, filename: string): string {
     let bodyContent = '';
+    let svgContent = '';
     let errorMsg = '';
     let title: string | undefined;
     let subtitle: string | undefined;
     let version: string | undefined;
     let date: string | undefined;
+    let viewMode: 'cards' | 'tree' = 'cards';
 
     try {
       const parsed = coerceDatesToIsoStrings(yaml.load(yamlText) as unknown);
       if (parsed && typeof parsed === 'object') {
         const raw = parsed as Record<string, unknown>;
         ({ title, subtitle, date, version } = extractDiagramMeta(raw));
+        if (raw['view'] === 'tree') viewMode = 'tree';
       }
 
       const v = validateCapabilityMap(parsed);
@@ -136,10 +226,15 @@ export class CapabilityMapPreview extends StaticPreview {
       } else {
         const raw = parsed as Record<string, unknown>;
         const map = raw['capability_map'] as CapabilityMapHeader;
-        bodyContent = buildCapabilityMapBody(map);
         if (!title) title = map.name;
         if (!subtitle && map.description) subtitle = map.description;
         if (!date) date = map.assessment_date;
+
+        if (viewMode === 'tree') {
+          svgContent = renderCapabilityTreeSvg(map, { collapsedIds: this.collapsedIds });
+        } else {
+          bodyContent = buildCapabilityMapBody(map);
+        }
       }
     } catch (e) {
       errorMsg = (e as Error).message ?? 'Parse error';
@@ -148,6 +243,27 @@ export class CapabilityMapPreview extends StaticPreview {
     const themeId = vscode.workspace
       .getConfiguration('transitrix')
       .get<ThemeId>('theme', 'transitrix');
+
+    if (viewMode === 'tree' && !errorMsg) {
+      const nonce = genNonce();
+      return buildDiagramFrame({
+        filename,
+        notation: 'Capability Map',
+        svgContent,
+        errorMsg,
+        themeId,
+        title,
+        subtitle,
+        version,
+        date,
+        themeCommand: OPEN_THEME_COMMAND,
+        interactive: {
+          nonce,
+          controlsPanel: '',
+          controlsScript: buildCollapseScript(nonce),
+        },
+      });
+    }
 
     return buildDiagramFrame({
       filename,

--- a/packages/diagrams/src/capability-map/index.ts
+++ b/packages/diagrams/src/capability-map/index.ts
@@ -6,3 +6,14 @@ export type {
 } from './types.js';
 
 export { validateCapabilityMap } from './validate.js';
+
+export type {
+  CapabilityTreeNode,
+  CapabilityTreeEdge,
+  CapabilityTreeLevelCounts,
+  CapabilityTreeLayout,
+} from './layout-tree.js';
+export { layoutCapabilityTree, TREE_NODE_WIDTH, TREE_NODE_HEIGHT, TREE_RANK_SEP, TREE_NODE_SEP } from './layout-tree.js';
+
+export type { RenderCapabilityTreeOptions } from './render-capability-tree.js';
+export { renderCapabilityTreeSvg } from './render-capability-tree.js';

--- a/packages/diagrams/src/capability-map/layout-tree.ts
+++ b/packages/diagrams/src/capability-map/layout-tree.ts
@@ -1,0 +1,114 @@
+import type { CapabilityNode, CapabilityMapHeader } from './types.js';
+
+export const TREE_NODE_WIDTH = 250;
+export const TREE_NODE_HEIGHT = 64;
+/** Gap between sibling columns (node width + rank sep = 330px, matching DSM). */
+export const TREE_RANK_SEP = 80;
+/** Vertical gap between sibling nodes. */
+export const TREE_NODE_SEP = 24;
+
+export interface CapabilityTreeNode {
+  id: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  data: CapabilityNode;
+  depth: number;
+  hasChildren: boolean;
+  isCollapsed: boolean;
+}
+
+export interface CapabilityTreeEdge {
+  source: string;
+  target: string;
+}
+
+export interface CapabilityTreeLevelCounts {
+  /** Nodes at depth 0–2 (pink band). */
+  band0: number;
+  /** Nodes at depth 3–4 (yellow band). */
+  band1: number;
+  /** Nodes at depth 5+ (blue band). */
+  band2: number;
+}
+
+export interface CapabilityTreeLayout {
+  nodes: CapabilityTreeNode[];
+  edges: CapabilityTreeEdge[];
+  bounds: { x: number; y: number; width: number; height: number };
+  levelCounts: CapabilityTreeLevelCounts;
+}
+
+export function layoutCapabilityTree(
+  map: CapabilityMapHeader,
+  collapsedIds: Set<string> = new Set(),
+): CapabilityTreeLayout {
+  const nodes: CapabilityTreeNode[] = [];
+  const edges: CapabilityTreeEdge[] = [];
+
+  const colNextY = new Map<number, number>();
+  function getNextY(col: number): number {
+    return colNextY.get(col) ?? 0;
+  }
+  function advanceY(col: number, delta: number): void {
+    colNextY.set(col, (colNextY.get(col) ?? 0) + delta);
+  }
+
+  function placeNode(node: CapabilityNode, depth: number): { top: number; bottom: number } {
+    const isCollapsed = collapsedIds.has(node.id);
+    const hasChildren = Boolean(node.children?.length);
+    const visibleChildren = !isCollapsed && node.children?.length ? node.children : [];
+
+    const x = depth * (TREE_NODE_WIDTH + TREE_RANK_SEP);
+
+    if (visibleChildren.length === 0) {
+      const y = getNextY(depth);
+      advanceY(depth, TREE_NODE_HEIGHT + TREE_NODE_SEP);
+      nodes.push({ id: node.id, x, y, width: TREE_NODE_WIDTH, height: TREE_NODE_HEIGHT, data: node, depth, hasChildren, isCollapsed });
+      return { top: y, bottom: y + TREE_NODE_HEIGHT };
+    }
+
+    const childSpans: Array<{ top: number; bottom: number }> = [];
+    for (const child of visibleChildren) {
+      childSpans.push(placeNode(child, depth + 1));
+      edges.push({ source: node.id, target: child.id });
+    }
+
+    const spanTop = Math.min(...childSpans.map(s => s.top));
+    const spanBottom = Math.max(...childSpans.map(s => s.bottom));
+    const parentY = spanTop + (spanBottom - spanTop) / 2 - TREE_NODE_HEIGHT / 2;
+
+    const curColY = getNextY(depth);
+    const finalY = Math.max(parentY, curColY);
+    advanceY(depth, finalY - curColY + TREE_NODE_HEIGHT + TREE_NODE_SEP);
+
+    nodes.push({ id: node.id, x, y: finalY, width: TREE_NODE_WIDTH, height: TREE_NODE_HEIGHT, data: node, depth, hasChildren, isCollapsed });
+    return { top: Math.min(finalY, spanTop), bottom: Math.max(finalY + TREE_NODE_HEIGHT, spanBottom) };
+  }
+
+  for (const root of map.capabilities) {
+    placeNode(root, 0);
+    for (const [col, y] of colNextY) {
+      colNextY.set(col, y + TREE_NODE_SEP);
+    }
+  }
+
+  if (nodes.length === 0) {
+    return { nodes: [], edges: [], bounds: { x: 0, y: 0, width: 0, height: 0 }, levelCounts: { band0: 0, band1: 0, band2: 0 } };
+  }
+
+  const minX = Math.min(...nodes.map(n => n.x));
+  const minY = Math.min(...nodes.map(n => n.y));
+  const maxX = Math.max(...nodes.map(n => n.x + n.width));
+  const maxY = Math.max(...nodes.map(n => n.y + n.height));
+
+  const levelCounts: CapabilityTreeLevelCounts = { band0: 0, band1: 0, band2: 0 };
+  for (const n of nodes) {
+    if (n.depth <= 2) levelCounts.band0++;
+    else if (n.depth <= 4) levelCounts.band1++;
+    else levelCounts.band2++;
+  }
+
+  return { nodes, edges, bounds: { x: minX, y: minY, width: maxX - minX, height: maxY - minY }, levelCounts };
+}

--- a/packages/diagrams/src/capability-map/render-capability-tree.ts
+++ b/packages/diagrams/src/capability-map/render-capability-tree.ts
@@ -1,0 +1,131 @@
+import type { CapabilityMapHeader } from './types.js';
+import { layoutCapabilityTree, TREE_NODE_WIDTH, TREE_NODE_HEIGHT, TREE_NODE_SEP } from './layout-tree.js';
+import { horizontalCubicEdgePath, DEFAULT_EDGE_CURVATURE } from '../edge-path.js';
+import { escXml } from '../webview/render-util.js';
+
+const PAD = 24;
+const BTN_R = 8;
+const LEGEND_H = 40;
+const LABEL_MAX_CHARS = 28;
+const LABEL_TRIM_CHARS = 26;
+
+const BAND_LABELS = ['Levels 0–2', 'Levels 3–4', 'Levels 5+'] as const;
+
+function depthBand(depth: number): 0 | 1 | 2 {
+  if (depth <= 2) return 0;
+  if (depth <= 4) return 1;
+  return 2;
+}
+
+function truncate(s: string, max: number, trim: number): string {
+  return s.length > max ? s.slice(0, trim) + '…' : s;
+}
+
+export interface RenderCapabilityTreeOptions {
+  collapsedIds?: Set<string>;
+  curvature?: number;
+}
+
+/**
+ * Renders a capability-map as a left-to-right SVG node tree with DSM-matching
+ * visual design: depth-banded fills, maturity badges, and +/− collapse buttons.
+ *
+ * The SVG uses CSS classes (`tree-level-N`, `tree-maturity-N`, `tree-collapse-btn`)
+ * that must be resolved by the host's stylesheet (injected via `diagramClassCss()`
+ * in themes.ts). Collapse buttons carry `data-node-id` / `data-collapsed` attributes
+ * for the webview click handler.
+ */
+export function renderCapabilityTreeSvg(
+  map: CapabilityMapHeader,
+  opts: RenderCapabilityTreeOptions = {},
+): string {
+  const { collapsedIds = new Set(), curvature = DEFAULT_EDGE_CURVATURE } = opts;
+  const layout = layoutCapabilityTree(map, collapsedIds);
+
+  if (layout.nodes.length === 0) {
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="0" height="0" viewBox="0 0 0 0"></svg>`;
+  }
+
+  const ox = -layout.bounds.x + PAD;
+  const oy = -layout.bounds.y + PAD;
+  const svgW = layout.bounds.width + PAD * 2 + BTN_R;
+  const svgH = layout.bounds.height + PAD * 2 + LEGEND_H + TREE_NODE_SEP;
+
+  const nodeMap = new Map(layout.nodes.map(n => [n.id, n]));
+
+  const edgeSvg = layout.edges.map(e => {
+    const s = nodeMap.get(e.source);
+    const t = nodeMap.get(e.target);
+    if (!s || !t) return '';
+    const sx = s.x + ox + s.width;
+    const sy = s.y + oy + s.height / 2;
+    const tx = t.x + ox;
+    const ty = t.y + oy + t.height / 2;
+    return `<path d="${horizontalCubicEdgePath(sx, sy, tx, ty, curvature)}" class="diagram-edge"/>`;
+  }).filter(Boolean).join('\n');
+
+  const nodeSvg = layout.nodes.map(n => {
+    const x = n.x + ox;
+    const y = n.y + oy;
+    const band = depthBand(n.depth);
+    const mat = Math.max(1, Math.min(5, n.data.current_maturity | 0));
+
+    const nameText = truncate(n.data.name, LABEL_MAX_CHARS, LABEL_TRIM_CHARS);
+    const nameTitle = n.data.name.length > LABEL_MAX_CHARS ? escXml(n.data.name) : '';
+
+    // Maturity badge: left side of node
+    const badgeW = 28;
+    const badgeH = 18;
+    const badgeX = x + 10;
+    const badgeY = y + (TREE_NODE_HEIGHT - badgeH) / 2;
+
+    // Text area: right of badge
+    const textX = badgeX + badgeW + 8;
+    const nameY = y + TREE_NODE_HEIGHT / 2 - 8;
+    const idY = y + TREE_NODE_HEIGHT / 2 + 9;
+
+    // Collapse button: centered on right edge of node
+    const btnCx = x + TREE_NODE_WIDTH;
+    const btnCy = y + TREE_NODE_HEIGHT / 2;
+
+    const collapseBtn = n.hasChildren
+      ? `<circle class="tree-collapse-btn" cx="${btnCx}" cy="${btnCy}" r="${BTN_R}" data-node-id="${escXml(n.id)}" data-collapsed="${n.isCollapsed}"/>
+  <text class="tree-collapse-lbl" x="${btnCx}" y="${btnCy}" text-anchor="middle">${n.isCollapsed ? '+' : '−'}</text>`
+      : '';
+
+    return `<g${nameTitle ? ` title="${nameTitle}"` : ''}>
+  <rect class="tree-level-${band}" x="${x}" y="${y}" width="${TREE_NODE_WIDTH}" height="${TREE_NODE_HEIGHT}" rx="11" stroke="var(--ts-node-stroke,#94a3b8)" stroke-width="3"/>
+  <rect class="tree-maturity-${mat}" x="${badgeX}" y="${badgeY}" width="${badgeW}" height="${badgeH}" rx="4"/>
+  <text class="text-pill" x="${badgeX + badgeW / 2}" y="${badgeY + badgeH / 2}" text-anchor="middle" fill="white">L${mat}</text>
+  <text class="text-primary" x="${textX}" y="${nameY}" dominant-baseline="central">${escXml(nameText)}</text>
+  <text class="text-id" x="${textX}" y="${idY}" dominant-baseline="central">${escXml(n.id)}</text>
+  ${collapseBtn}
+</g>`;
+  }).join('\n');
+
+  // Legend band: proportional coloured blocks per level-count band
+  const legendY = layout.bounds.height + PAD * 2 + TREE_NODE_SEP / 2;
+  const legendW = svgW - PAD * 2;
+  const totalNodes = layout.nodes.length || 1;
+  const bandCounts = [layout.levelCounts.band0, layout.levelCounts.band1, layout.levelCounts.band2];
+  let legendX = PAD;
+  const legendSvg = bandCounts.map((count, i) => {
+    const bw = Math.max(1, Math.round(legendW * count / totalNodes));
+    const bx = legendX;
+    legendX += bw;
+    if (count === 0) return '';
+    return `<rect class="tree-level-${i}" x="${bx}" y="${legendY}" width="${bw}" height="24" rx="4" stroke="var(--ts-node-stroke,#94a3b8)" stroke-width="1"/>
+  <text class="text-id" x="${bx + bw / 2}" y="${legendY + 12}" text-anchor="middle" dominant-baseline="central">${escXml(BAND_LABELS[i])}</text>`;
+  }).filter(Boolean).join('\n');
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${svgW}" height="${svgH}" viewBox="0 0 ${svgW} ${svgH}">
+<defs>
+  <marker id="cap-tree-arrow" markerWidth="8" markerHeight="8" refX="8" refY="3" orient="auto">
+    <path d="M0,0 L0,6 L8,3 z" class="arrow-fill"/>
+  </marker>
+</defs>
+${edgeSvg}
+${nodeSvg}
+${legendSvg}
+</svg>`;
+}

--- a/packages/diagrams/src/capability-map/types.ts
+++ b/packages/diagrams/src/capability-map/types.ts
@@ -25,5 +25,7 @@ export interface CapabilityMapHeader {
 export interface CapabilityMapFile {
   notation: string;
   spec_version?: string;
+  /** Render mode for Studio previews. Defaults to 'cards'. */
+  view?: 'cards' | 'tree';
   capability_map: CapabilityMapHeader;
 }

--- a/packages/diagrams/src/theme/index.ts
+++ b/packages/diagrams/src/theme/index.ts
@@ -1,4 +1,4 @@
 export type { AdaptiveTokens } from './tokens.js';
-export { BRAND, FUNCTIONAL, LAYER_COLORS, LEVEL_COLORS, MATURITY_COLORS, STRUCTURAL, TYPOGRAPHY, CSS_VAR, getBaseResetCss } from './tokens.js';
+export { BRAND, FUNCTIONAL, LAYER_COLORS, LEVEL_COLORS, MATURITY_COLORS, TREE_LEVEL_COLORS, TREE_MATURITY_COLORS, STRUCTURAL, TYPOGRAPHY, CSS_VAR, getBaseResetCss } from './tokens.js';
 export type { ThemeId } from './themes.js';
 export { generateWebviewCss, generateSvgEmbedCss } from './themes.js';

--- a/packages/diagrams/src/theme/themes.ts
+++ b/packages/diagrams/src/theme/themes.ts
@@ -2,6 +2,8 @@ import {
   LAYER_COLORS,
   LEVEL_COLORS,
   MATURITY_COLORS,
+  TREE_LEVEL_COLORS,
+  TREE_MATURITY_COLORS,
   STRUCTURAL,
   TYPOGRAPHY,
   CSS_VAR,
@@ -75,7 +77,19 @@ function diagramVars(variant: 'light' | 'dark' | 'hc'): string {
   const sc = STRUCTURAL;
   const lv = LEVEL_COLORS[variant];
   const mat = MATURITY_COLORS[variant];
+  const treeLevel = TREE_LEVEL_COLORS;
+  const treeMat = TREE_MATURITY_COLORS[variant];
   const levelVars = lv.map((c, i) => `--ts-level-${i}:${c}`).join(';') + ';';
+  const treeVars = [
+    `${CSS_VAR.treeLevel0}:${treeLevel.band0[variant]}`,
+    `${CSS_VAR.treeLevel1}:${treeLevel.band1[variant]}`,
+    `${CSS_VAR.treeLevel2}:${treeLevel.band2[variant]}`,
+    `${CSS_VAR.treeMaturity1}:${treeMat[0]}`,
+    `${CSS_VAR.treeMaturity2}:${treeMat[1]}`,
+    `${CSS_VAR.treeMaturity3}:${treeMat[2]}`,
+    `${CSS_VAR.treeMaturity4}:${treeMat[3]}`,
+    `${CSS_VAR.treeMaturity5}:${treeMat[4]}`,
+  ].join(';') + ';';
   return [
     `${CSS_VAR.layerDriver}:${lc.driver[variant]}`,
     `${CSS_VAR.layerFactor}:${lc.factor[variant]}`,
@@ -92,7 +106,7 @@ function diagramVars(variant: 'light' | 'dark' | 'hc'): string {
     `${CSS_VAR.maturity3}:${mat[2]}`,
     `${CSS_VAR.maturity4}:${mat[3]}`,
     `${CSS_VAR.maturity5}:${mat[4]}`,
-  ].join(';') + ';' + levelVars;
+  ].join(';') + ';' + levelVars + treeVars;
 }
 
 /** CSS for the webview shell (toolbar, canvas). */
@@ -155,7 +169,18 @@ ${levelRules}
 .compliance-deadline{fill:var(${cv.statusErrorBg});stroke:var(${cv.statusErrorFg});}
 .compliance-deadline text{fill:var(${cv.statusErrorFg});}
 .compliance-badge{fill:var(${cv.statusErrorFg});}
-.compliance-badge-text{fill:var(${cv.textInverse});font-family:${t.fontFamily};font-size:8px;font-weight:700;}`;
+.compliance-badge-text{fill:var(${cv.textInverse});font-family:${t.fontFamily};font-size:8px;font-weight:700;}
+.tree-level-0{fill:var(${cv.treeLevel0});}
+.tree-level-1{fill:var(${cv.treeLevel1});}
+.tree-level-2{fill:var(${cv.treeLevel2});}
+.tree-maturity-1{fill:var(${cv.treeMaturity1});}
+.tree-maturity-2{fill:var(${cv.treeMaturity2});}
+.tree-maturity-3{fill:var(${cv.treeMaturity3});}
+.tree-maturity-4{fill:var(${cv.treeMaturity4});}
+.tree-maturity-5{fill:var(${cv.treeMaturity5});}
+.tree-collapse-btn{cursor:pointer;fill:white;stroke:var(${cv.nodeStroke});stroke-width:1.5;}
+.tree-collapse-btn:hover{fill:var(${cv.bgElevated});}
+.tree-collapse-lbl{fill:var(${cv.textSecondary});font-family:${t.fontFamily};font-size:12px;font-weight:700;dominant-baseline:central;pointer-events:none;}`;
 }
 
 /**

--- a/packages/diagrams/src/theme/tokens.ts
+++ b/packages/diagrams/src/theme/tokens.ts
@@ -49,6 +49,28 @@ export const MATURITY_COLORS = {
 } as const;
 
 /**
+ * DSM-matching capability tree node fill colors, grouped by depth band.
+ *   band0: depth 0–2 (pink)
+ *   band1: depth 3–4 (yellow)
+ *   band2: depth 5+  (blue)
+ */
+export const TREE_LEVEL_COLORS = {
+  band0: { light: '#fee0e0', dark: '#3d0f0f', hc: '#ff9999' },
+  band1: { light: '#ffffcb', dark: '#3a3500', hc: '#ffff88' },
+  band2: { light: '#c2f0ff', dark: '#003d4d', hc: '#66ccff' },
+} as const;
+
+/**
+ * DSM-matching maturity badge fills for the capability tree (L1–L5).
+ * Distinct from MATURITY_COLORS which drives the cards / compliance views.
+ */
+export const TREE_MATURITY_COLORS = {
+  light: ['#c1c1c1', '#ff3d67', '#ff9a59', '#fdef59', '#83cca3'],
+  dark:  ['#555555', '#cc1040', '#d06020', '#c8c000', '#4d9970'],
+  hc:    ['#cccccc', '#ff6699', '#ffbb77', '#ffff44', '#88ddaa'],
+} as const;
+
+/**
  * Typography hierarchy. All previews resolve text styling from these roles
  * — never from inline font-* attributes on individual <text> elements.
  *
@@ -128,6 +150,14 @@ export const CSS_VAR = {
   maturity3:        '--ts-maturity-3',
   maturity4:        '--ts-maturity-4',
   maturity5:        '--ts-maturity-5',
+  treeLevel0:       '--ts-tree-level-0',
+  treeLevel1:       '--ts-tree-level-1',
+  treeLevel2:       '--ts-tree-level-2',
+  treeMaturity1:    '--ts-tree-maturity-1',
+  treeMaturity2:    '--ts-tree-maturity-2',
+  treeMaturity3:    '--ts-tree-maturity-3',
+  treeMaturity4:    '--ts-tree-maturity-4',
+  treeMaturity5:    '--ts-tree-maturity-5',
 } as const;
 
 export function getBaseResetCss(): string {


### PR DESCRIPTION
## Summary

- Adds `view: tree` mode to the `capability-map` notation: depth-banded SVG node tree with DSM-matching visual design (250×64 px rounded nodes, pink/yellow/blue level fills, maturity badges)
- Collapse/expand subtrees via +/− buttons on node right edges; state persists within the preview session via a `transitrix:collapseToggle` postMessage round-trip
- Colour-coded legend band below the tree shows depth-band proportions
- Existing `view: cards` (default) is completely unchanged

## Files changed

| Area | Change |
|------|--------|
| `packages/diagrams/src/theme/tokens.ts` | `TREE_LEVEL_COLORS`, `TREE_MATURITY_COLORS`, new `CSS_VAR` entries |
| `packages/diagrams/src/theme/themes.ts` | Tree CSS variables injected into `diagramVars()`; `.tree-level-N`, `.tree-maturity-N`, `.tree-collapse-btn` classes in `diagramClassCss()` |
| `packages/diagrams/src/capability-map/layout-tree.ts` | New — depth-first layout engine (mirrors `goals/layout.ts`) |
| `packages/diagrams/src/capability-map/render-capability-tree.ts` | New — `renderCapabilityTreeSvg()` |
| `packages/diagrams/src/capability-map/index.ts` | Exports for layout and renderer |
| `packages/diagrams/src/capability-map/types.ts` | Optional `view?: 'cards' \| 'tree'` on `CapabilityMapFile` |
| `extension/src/capability-map-preview.ts` | Rewritten: standalone class with `enableScripts: true`, tree/cards branching, collapse handler |

## Test plan

- [ ] Add `view: tree` to a `.capability-map.transitrix.yaml` file → preview shows node tree
- [ ] Nodes are 250×64 px, rounded corners, pink/yellow/blue by depth
- [ ] Nodes with children show a +/− circle button on the right edge
- [ ] Clicking + collapses the subtree; clicking − expands it; state survives re-render
- [ ] Legend band appears below the tree with three colour blocks
- [ ] Remove `view: tree` (or set `view: cards`) → preview reverts to cards view
- [ ] All 995 diagrams-package tests pass (`npm test -w packages/diagrams`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)