### PR TITLE
chore(release): 2.6.0 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2.6.0] — 2026-06-26
+
+### Added
+
+- **Capability Map — Tree view.** Add `view: tree` to a `.capability-map.transitrix.yaml` file to render a depth-banded SVG node tree (250×64 px rounded nodes, pink/yellow/blue level fills, maturity badges). Nodes are collapsible/expandable via +/− buttons; a colour-coded legend band shows depth proportions. The default `view: cards` layout is unchanged.
+
+- **ACTIVITY → ACTION notation — viewer support.** The extension now recognises `*.action.transitrix.yaml`, `*.action-card.transitrix.yaml`, `*.actions-tree.transitrix.yaml`, and `*.activities-tree.transitrix.yaml`. The validators and resolver accept the canonical `action` / `action-card` notation keys and the new root fields (`actions:`, `action_card:`, `action_type`, `action_goal`, `ACTION-*` IDs) alongside the deprecated `activities` / `activity-card` equivalents. Legacy files continue to open and now show a deprecation banner prompting migration.
+
+---
+
 ## [2.5.0] — 2026-06-25
 
 ### Changed

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Architecture-as-code for the modern enterprise. Author 17 notations — goals, processes, capabilities, BPMN, applications, more — as plain YAML, get live diagrams in VS Code. Diffable in git. AI-friendly. Open source. Built on ArchiMate 3.2 and BPMN 2.0.",
   "license": "MIT",
   "icon": "icon.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
Version bump `2.5.0 → 2.6.0` and CHANGELOG entry.

## What's in this release

### Added

- **Capability Map — Tree view** (`view: tree`): depth-banded SVG node tree with DSM-matching design, collapse/expand, colour legend. (#306)
- **ACTIVITY → ACTION notation — viewer support**: extension recognises `*.action.*`, `*.action-card.*`, `*.actions-tree.*`, `*.activities-tree.*`; validators and resolver accept canonical keys; legacy files show a deprecation banner. (#305)

## Checklist

- [x] `CHANGELOG.md` updated
- [x] `package.json` bumped to 2.6.0
- [x] `extension/package.json` bumped to 2.6.0
- [ ] Tests green on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)