### PR TITLE
chore: bump @transitrix/diagrams 1.1.0 → 1.2.0 for v2.6.0 release

### DIFF
--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",


### PR DESCRIPTION
Fix the failed npm publish in the v2.6.0 release.

**Root cause:** The CI workflow reads the version from `packages/diagrams/package.json` (independent from the extension version). It was still at `1.1.0`, which is already published on npm → E403.

**Fix:** Bump to `1.2.0`.

After this merges, run the npm publish workflow manually:
`Actions → npm — publish @transitrix/diagrams → Run workflow → main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)