### PR TITLE
fix(fgca): preserve canonical string IDs in diagram nodes

### DIFF
--- a/packages/diagrams/src/fgca/__tests__/parse-canonical.test.ts
+++ b/packages/diagrams/src/fgca/__tests__/parse-canonical.test.ts
@@ -159,8 +159,22 @@ describe('parseCanonicalFGCA — edge-driving fields populated', () => {
     expect(parsed.goals[0].factor).toHaveLength(1);
     // goal → change edge
     expect(parsed.changes[0].goal_id).not.toBe(0);
+    expect(parsed.changes[0].goal_id).not.toBe('');
     // change → activity edge
     expect(parsed.changes[0].activity_ids).toHaveLength(1);
+  });
+
+  it('preserves canonical string IDs — not converted to sequential numbers', () => {
+    const r = parseCanonicalFGCA(VALID);
+    expect(r.valid).toBe(true);
+    const parsed = r.parsed!;
+    expect(parsed.factors[0].id).toBe('FACTOR-1');
+    expect(parsed.goals[0].id).toBe('GOAL-1');
+    expect(parsed.goals[0].factor![0].id).toBe('FACTOR-1');
+    expect(parsed.changes[0].id).toBe('CHANGE-1');
+    expect(parsed.changes[0].goal_id).toBe('GOAL-1');
+    expect(parsed.changes[0].activity_ids[0]).toBe('ACTIVITY-1');
+    expect(parsed.activities[0].id).toBe('ACTIVITY-1');
   });
 });
 
@@ -242,7 +256,7 @@ describe('parseCanonicalFGA — example file regression', () => {
       expect(r.errors).toEqual([]);
       expect(r.valid).toBe(true);
       // Every activity must carry a goal_id, or the FGA preview draws no edges.
-      expect(r.parsed!.activities.every((a) => a.goal_id != null && a.goal_id !== 0)).toBe(true);
+      expect(r.parsed!.activities.every((a) => a.goal_id != null && a.goal_id !== 0 && a.goal_id !== '')).toBe(true);
     });
   }
 });

--- a/packages/diagrams/src/fgca/parse-canonical.ts
+++ b/packages/diagrams/src/fgca/parse-canonical.ts
@@ -63,10 +63,6 @@ function asObjectArray(v: unknown): Array<Record<string, unknown>> | null {
   return v.map((el) => (el && typeof el === 'object' ? (el as Record<string, unknown>) : null) as Record<string, unknown>);
 }
 
-interface InternalIdMap {
-  /** Canonical typed-string ID → internal numeric ID for layout consumption. */
-  toInternal: Map<string, number>;
-}
 
 /**
  * Validate canonical FGCA YAML and, on success, return an internal-form
@@ -223,32 +219,20 @@ export function parseCanonicalFGCA(input: unknown): CanonicalFGCAResult {
     return out;
   }
 
-  // Build internal id-maps (canonical string ID → internal sequential number).
-  const idMap: InternalIdMap = { toInternal: new Map() };
-  const allCanonicalIds = [...factorIds, ...goalIds, ...changeIds, ...activityIds];
-  allCanonicalIds.forEach((id, i) => idMap.toInternal.set(id, i + 1));
-
-  function intId(canonical: string): number {
-    const n = idMap.toInternal.get(canonical);
-    if (n === undefined) {
-      // Shouldn't happen — we built the map from the same sets.
-      throw new Error(`internal: canonical id "${canonical}" not mapped`);
-    }
-    return n;
-  }
-
-  // Layer entries (internal form).
+  // Layer entries (internal form). Canonical string IDs are passed through
+  // directly — no conversion to sequential numbers. The layout and renderer
+  // treat IDs as opaque keys and also display them verbatim to the user.
   const internalFactors: DriverItem[] = factors.map((el) => ({
-    id: intId(String(el!['id'])),
+    id: String(el!['id']),
     name: String(el!['name'] ?? ''),
   }));
 
   const internalGoals: GoalItem[] = goals.map((el, i) => {
     const refIds = checkRefArray(el!, 'factors', factorIds, FACTOR_OR_DRIVER_ID_RE, 'FGCA-008', `goals[${i}]`);
     return {
-      id: intId(String(el!['id'])),
+      id: String(el!['id']),
       name: String(el!['name'] ?? ''),
-      factor: refIds.map((r) => ({ id: intId(r) })),
+      factor: refIds.map((r) => ({ id: r })),
     };
   });
 
@@ -284,10 +268,10 @@ export function parseCanonicalFGCA(input: unknown): CanonicalFGCAResult {
     const canonicalChangeId = String(el!['id']);
     const linkedActivityIds = activitiesForChange.get(canonicalChangeId) ?? [];
     return {
-      id: intId(canonicalChangeId),
+      id: canonicalChangeId,
       name: String(el!['name'] ?? ''),
-      goal_id: goalRefs.length > 0 ? intId(goalRefs[0]) : 0,
-      activity_ids: linkedActivityIds.map((aid) => intId(aid)),
+      goal_id: goalRefs.length > 0 ? goalRefs[0] : '',
+      activity_ids: linkedActivityIds,
     };
   });
 
@@ -295,9 +279,9 @@ export function parseCanonicalFGCA(input: unknown): CanonicalFGCAResult {
     const goalRefs = checkRefArray(el!, 'goals', goalIds, GOAL_ID_RE, 'FGCA-011', `actions[${i}]`);
     const typeVal = typeof el!['type'] === 'string' ? el!['type'] : undefined;
     return {
-      id: intId(String(el!['id'])),
+      id: String(el!['id']),
       name: String(el!['name'] ?? ''),
-      goal_id: goalRefs.length > 0 ? intId(goalRefs[0]) : null,
+      goal_id: goalRefs.length > 0 ? goalRefs[0] : null,
       ...(typeVal !== undefined ? { type: typeVal } : {}),
     };
   });


### PR DESCRIPTION
FGCA node IDs were being coerced from the canonical string form during parse-canonical. This preserves the string IDs throughout so downstream diagram renderers see the correct ID values.