### PR TITLE
feat(activity-card): drop Assessments section from layout

### DIFF
--- a/packages/diagrams/src/activity-card/__tests__/example.test.ts
+++ b/packages/diagrams/src/activity-card/__tests__/example.test.ts
@@ -71,13 +71,11 @@ describe('activity-card worked example (eu-programme)', () => {
     // Description row
     expect(layout.descriptionRow?.label).toBe('Description');
     // Chain sections
-    expect(layout.chainSections.map((s) => s.type)).toEqual(['drivers', 'assessments', 'goals', 'changes']);
+    expect(layout.chainSections.map((s) => s.type)).toEqual(['drivers', 'goals', 'changes']);
     const driversSection = layout.chainSections.find((s) => s.type === 'drivers')!;
     const goalsSection = layout.chainSections.find((s) => s.type === 'goals')!;
-    const assessmentsSection = layout.chainSections.find((s) => s.type === 'assessments')!;
     expect(driversSection.nodes.map((n) => n.id)).toContain('FACTOR-EU-MDR-1');
     expect(goalsSection.nodes.map((n) => n.id)).toContain('GOAL-EU-MARKET-1');
-    expect(assessmentsSection.isEmpty).toBe(true); // no assessment in this fixture
     // Chain edges
     expect(layout.chainEdges).toContainEqual({ sourceId: 'FACTOR-EU-MDR-1', targetId: 'GOAL-EU-MARKET-1' });
     expect(layout.chainEdges).toContainEqual({ sourceId: 'GOAL-EU-MARKET-1', targetId: 'CHANGE-EU-COMPLIANCE-1' });

--- a/packages/diagrams/src/activity-card/__tests__/layout.test.ts
+++ b/packages/diagrams/src/activity-card/__tests__/layout.test.ts
@@ -94,20 +94,17 @@ describe('layoutActivityCard', () => {
     expect(l.descriptionRow).toBeUndefined();
   });
 
-  it('four chain sections in order: drivers, assessments, goals, changes', () => {
+  it('three chain sections in order: drivers, goals, changes', () => {
     const l = layoutActivityCard(RESOLVED);
-    expect(l.chainSections.map((s) => s.type)).toEqual(['drivers', 'assessments', 'goals', 'changes']);
+    expect(l.chainSections.map((s) => s.type)).toEqual(['drivers', 'goals', 'changes']);
   });
 
   it('chain sections carry the resolved nodes', () => {
     const l = layoutActivityCard(RESOLVED);
     const drivers = l.chainSections.find((s) => s.type === 'drivers')!;
-    const assessments = l.chainSections.find((s) => s.type === 'assessments')!;
     const goals = l.chainSections.find((s) => s.type === 'goals')!;
     const changes = l.chainSections.find((s) => s.type === 'changes')!;
     expect(drivers.nodes.map((n) => n.id)).toEqual(['FACTOR-EU-MDR-1']);
-    expect(assessments.nodes.map((n) => n.id)).toEqual(['ASSESSMENT-MDR-1']);
-    expect(assessments.nodes[0].meta).toBe('2026-03-01');
     expect(goals.nodes.map((n) => n.id)).toEqual(['GOAL-EU-MARKET-1']);
     expect(changes.nodes.map((n) => n.id)).toEqual(['CHANGE-EU-COMPLIANCE-1']);
   });
@@ -127,10 +124,6 @@ describe('layoutActivityCard', () => {
     expect(l.chainEdges).toContainEqual({ sourceId: 'GOAL-EU-MARKET-1', targetId: 'CHANGE-EU-COMPLIANCE-1' });
   });
 
-  it('builds driver→assessment edge when assessment is linked', () => {
-    const l = layoutActivityCard(RESOLVED);
-    expect(l.chainEdges).toContainEqual({ sourceId: 'FACTOR-EU-MDR-1', targetId: 'ASSESSMENT-MDR-1' });
-  });
 
   it('milestone ArchiMate class is set', () => {
     const l = layoutActivityCard(RESOLVED);

--- a/packages/diagrams/src/activity-card/layout.ts
+++ b/packages/diagrams/src/activity-card/layout.ts
@@ -183,7 +183,7 @@ export function layoutActivityCard(
     cursorY += height + SECTION_GAP;
   }
 
-  // ── 5. Chain: Drivers → Assessments → Goals → Changes ────────────────────
+  // ── 5. Chain: Drivers → Goals → Changes ──────────────────────────────────
   // Each section is a full-width band with a header label and stacked node rows.
   // An empty section shows a gap indicator ("— not on file") so the author
   // sees which parts of the narrative are missing.
@@ -222,13 +222,9 @@ export function layoutActivityCard(
   }
 
   const { drivers, goals, changes } = card.motivation;
-  const assessments = card.assessments ?? [];
 
   pushChainSection('drivers', 'Drivers', 'What prompted this initiative?',
     drivers.map((d) => ({ id: d.id, name: d.name })));
-
-  pushChainSection('assessments', 'Assessments', 'What is the current gap?',
-    assessments.map((a) => ({ id: a.id, name: a.name, meta: a.observed_at })));
 
   pushChainSection('goals', 'Goals', 'What outcome do we target?',
     goals.map((g) => ({ id: g.id, name: g.name })));
@@ -242,9 +238,6 @@ export function layoutActivityCard(
   // Node-level chain edges.
   const driverIdSet = new Set(drivers.map((d) => d.id));
   const goalIdSet = new Set(goals.map((g) => g.id));
-  for (const a of assessments) {
-    if (driverIdSet.has(a.driverId)) chainEdges.push({ sourceId: a.driverId, targetId: a.id });
-  }
   for (const g of goals) {
     for (const did of g.driverIds) {
       if (driverIdSet.has(did)) chainEdges.push({ sourceId: did, targetId: g.id });

--- a/packages/diagrams/src/activity-card/types.ts
+++ b/packages/diagrams/src/activity-card/types.ts
@@ -285,7 +285,7 @@ export interface ChainEdge {
  * so the author sees the missing data.
  */
 export interface ChainSectionLayout {
-  type: 'drivers' | 'assessments' | 'goals' | 'changes';
+  type: 'drivers' | 'goals' | 'changes';
   /** Section header label. */
   label: string;
   /** Short question answered by this section, shown in grey after the label. */

--- a/packages/diagrams/src/webview/render-activity-card.ts
+++ b/packages/diagrams/src/webview/render-activity-card.ts
@@ -12,7 +12,7 @@
  * CROSS-DOCUMENT RESOLUTION CAVEAT
  * The Activity Card is the only MULTI-DOCUMENT Studio notation: the card YAML
  * names a project Activity, and the project's name, dates, motivation chain
- * (Drivers → Assessments → Goals → Changes) and child activities are pulled BY
+ * (Drivers → Goals → Changes) and child activities are pulled BY
  * REFERENCE from the canonical element + relation store (`canon/elements/**`,
  * `canon/relations/**`; see `../activity-card/resolver.ts`). That resolution
  * requires reading those files from disk, which is NOT available inside the
@@ -135,10 +135,9 @@ export function renderActivityCardBody(layout: ActivityCardLayout, ox: number, o
     });
   }
 
-  // Chain sections (Drivers → Assessments → Goals → Changes).
+  // Chain sections (Drivers → Goals → Changes).
   const SECTION_LEVEL: Record<string, number> = {
     drivers: 4,
-    assessments: 5,
     goals: 5,
     changes: 6,
   };


### PR DESCRIPTION
Removes the Assessments section from the Activity Card layout. The chain reads Drivers -> Goals -> Changes; Assessments were a structural mismatch at this level.