### PR TITLE
feat(location): add LOCATION primitive types + unit_located_at relation validation

### DIFF
--- a/packages/diagrams/src/actor/__tests__/validate.test.ts
+++ b/packages/diagrams/src/actor/__tests__/validate.test.ts
@@ -103,4 +103,12 @@ describe('validateActor — ACTOR-003 (engagement fields forbidden inline)', () 
   it('flags inline owner', () => {
     expect(codes({ ...valid(), owner: 'ACTOR-OPS-1' })).toContain('ACTOR-003');
   });
+
+  it('flags inline located_at (location belongs in a REL file)', () => {
+    expect(codes({ ...valid(), located_at: 'LOCATION-TBILISI-1' })).toContain('ACTOR-003');
+  });
+
+  it('flags inline unit_located_at (location belongs in a REL file)', () => {
+    expect(codes({ ...valid(), unit_located_at: 'LOCATION-TBILISI-1' })).toContain('ACTOR-003');
+  });
 });

--- a/packages/diagrams/src/actor/types.ts
+++ b/packages/diagrams/src/actor/types.ts
@@ -18,6 +18,8 @@ export const ACTOR_FORBIDDEN_INLINE_FIELDS = [
   'community_membership',
   'contracting',
   'unit_parent',
+  'located_at',
+  'unit_located_at',
   'roles',
   'owner',
 ] as const;

--- a/packages/diagrams/src/index.ts
+++ b/packages/diagrams/src/index.ts
@@ -13,6 +13,7 @@ export * from "./confidence/index";
 export * from "./factor/index";
 export * from "./fgca/index";
 export * from "./goals/index";
+export * from "./location/index";
 export * from "./process-blueprint/index";
 export * from "./process-map/index";
 export * from "./products/index";

--- a/packages/diagrams/src/location/__tests__/validate.test.ts
+++ b/packages/diagrams/src/location/__tests__/validate.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { validateLocation } from '../validate.js';
+
+function valid(): Record<string, unknown> {
+  return {
+    notation: 'location',
+    id: 'LOCATION-TBILISI-1',
+    name: 'Tbilisi Office',
+    type: 'office',
+    address: '14 Rustaveli Ave, Tbilisi 0108, Georgia',
+    country_code: 'GE',
+    timezone: 'Asia/Tbilisi',
+    zone: 'canon',
+    admitted_at: '2026-06-28',
+    admitted_by: 'v.korobeinikov',
+    gate_checks: { uniqueness: 'pass', consistency: 'pass', completeness: 'pass' },
+    valid_from: '2024-01-01',
+    valid_to: null,
+  };
+}
+
+const codes = (input: unknown): string[] =>
+  validateLocation(input).errors.map(e => e.code);
+
+describe('validateLocation — positive', () => {
+  it('accepts a well-formed office location', () => {
+    const r = validateLocation(valid());
+    expect(r.valid, JSON.stringify(r.errors)).toBe(true);
+  });
+
+  it('accepts a country with no optional fields', () => {
+    const a = valid();
+    a.id = 'LOCATION-GE-1';
+    a.name = 'Georgia';
+    a.type = 'country';
+    delete a.address;
+    delete a.country_code;
+    delete a.timezone;
+    expect(validateLocation(a).valid).toBe(true);
+  });
+
+  it('accepts a virtual location', () => {
+    const a = valid();
+    a.id = 'LOCATION-VIRTUAL-1';
+    a.name = 'Remote';
+    a.type = 'virtual';
+    expect(validateLocation(a).valid).toBe(true);
+  });
+
+  it('accepts a location with a valid parent reference', () => {
+    expect(validateLocation({ ...valid(), parent: 'LOCATION-GE-1' }).valid).toBe(true);
+  });
+
+  it('accepts valid_to as a date string', () => {
+    expect(validateLocation({ ...valid(), valid_to: '2026-12-31' }).valid).toBe(true);
+  });
+});
+
+describe('validateLocation — LOC-001 (shape / id grammar)', () => {
+  it('flags a missing required envelope field (name)', () => {
+    const a = valid();
+    delete a.name;
+    expect(codes(a)).toContain('LOC-001');
+  });
+
+  it('flags an id that violates the grammar', () => {
+    expect(codes({ ...valid(), id: 'LOCATION-001' })).toContain('LOC-001');
+    expect(codes({ ...valid(), id: 'LOC-1' })).toContain('LOC-001');
+  });
+
+  it('flags a wrong notation tag', () => {
+    expect(codes({ ...valid(), notation: 'place' })).toContain('LOC-001');
+  });
+
+  it('flags a non-canon zone', () => {
+    expect(codes({ ...valid(), zone: 'sandbox' })).toContain('LOC-001');
+  });
+
+  it('flags a missing zone', () => {
+    const a = valid();
+    delete a.zone;
+    expect(codes(a)).toContain('LOC-001');
+  });
+
+  it('flags a missing type', () => {
+    const a = valid();
+    delete a.type;
+    expect(codes(a)).toContain('LOC-001');
+  });
+
+  it('flags a missing valid_to key', () => {
+    const a = valid();
+    delete a.valid_to;
+    expect(codes(a)).toContain('LOC-001');
+  });
+
+  it('flags missing gate_checks', () => {
+    const a = valid();
+    delete a.gate_checks;
+    expect(codes(a)).toContain('LOC-001');
+  });
+
+  it('rejects a non-object', () => {
+    expect(codes(null)).toEqual(['LOC-001']);
+  });
+});
+
+describe('validateLocation — LOC-002 (type enum)', () => {
+  it('flags a type outside the allowed enum', () => {
+    expect(codes({ ...valid(), type: 'building' })).toContain('LOC-002');
+    expect(codes({ ...valid(), type: 'facility' })).toContain('LOC-002');
+  });
+});
+
+describe('validateLocation — LOC-003 (parent grammar)', () => {
+  it('flags a parent that is not a LOCATION-… id', () => {
+    expect(codes({ ...valid(), parent: 'ACTOR-OPS-1' })).toContain('LOC-003');
+    expect(codes({ ...valid(), parent: 'not-an-id' })).toContain('LOC-003');
+  });
+
+  it('accepts a null or absent parent without error', () => {
+    expect(codes({ ...valid(), parent: undefined })).not.toContain('LOC-003');
+    const a = valid();
+    delete a.parent;
+    expect(codes(a)).not.toContain('LOC-003');
+  });
+});

--- a/packages/diagrams/src/location/index.ts
+++ b/packages/diagrams/src/location/index.ts
@@ -1,0 +1,2 @@
+export type { Location, LocationType } from './types.js';
+export { LOCATION_TYPES } from './types.js';

--- a/packages/diagrams/src/location/index.ts
+++ b/packages/diagrams/src/location/index.ts
@@ -1,2 +1,3 @@
 export type { Location, LocationType } from './types.js';
 export { LOCATION_TYPES } from './types.js';
+export { validateLocation } from './validate.js';

--- a/packages/diagrams/src/location/types.ts
+++ b/packages/diagrams/src/location/types.ts
@@ -1,0 +1,29 @@
+// LOCATION — physical and virtual place primitive (ArchiMate Location/Facility).
+// Schema: methodology notations/elements/21-locations.md
+
+import type { GateChecks } from '../requirement/types.js';
+
+export const LOCATION_TYPES = ['country', 'region', 'city', 'site', 'office', 'virtual'] as const;
+export type LocationType = typeof LOCATION_TYPES[number];
+
+export interface Location {
+  notation: 'location';
+  id: string;
+  name: string;
+  type: LocationType;
+  address?: string;
+  country_code?: string;
+  timezone?: string;
+  parent?: string;
+  description?: string;
+
+  // Admission record (CONTRACT.md §6).
+  zone: 'canon';
+  admitted_at: string;
+  admitted_by: string;
+  gate_checks: GateChecks;
+
+  // Primitive lifecycle (CONTRACT.md §7).
+  valid_from: string;
+  valid_to: string | null;
+}

--- a/packages/diagrams/src/location/validate.ts
+++ b/packages/diagrams/src/location/validate.ts
@@ -1,0 +1,70 @@
+// LOCATION validator — methodology notations/elements/21-locations.md §6.
+//
+// Implements LOC-001..003. The shared HDR-/LIFECYCLE- rules are
+// cross-cutting concerns (CONTRACT.md §8) and out of scope for the
+// single-artefact validator.
+
+import type { ValidationError, ValidationWarning, ValidationResult } from '../validation-types.js';
+import { isCanonicalIdOfType, typeOfId } from '../typed-id.js';
+import { LOCATION_TYPES } from './types.js';
+
+const REQUIRED_STRING_FIELDS = [
+  'name', 'admitted_at', 'admitted_by', 'valid_from',
+] as const;
+
+const TYPES: readonly string[] = LOCATION_TYPES;
+
+export function validateLocation(input: unknown): ValidationResult {
+  const errors: ValidationError[] = [];
+  const warnings: ValidationWarning[] = [];
+
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    errors.push({ code: 'LOC-001', message: 'Location must be a YAML mapping.' });
+    return { valid: false, errors, warnings };
+  }
+  const a = input as Record<string, unknown>;
+
+  // LOC-001 — id grammar + notation tag + envelope.
+  if (!isCanonicalIdOfType(a.id, 'LOCATION')) {
+    errors.push({ code: 'LOC-001', message: `id "${String(a.id)}" must match LOCATION-[<middle>-]<INTEGER>.`, path: 'id' });
+  }
+  if (a.notation !== 'location') {
+    errors.push({ code: 'LOC-001', message: 'notation must be the fixed value "location".', path: 'notation' });
+  }
+  if (a.zone !== undefined && a.zone !== 'canon') {
+    errors.push({ code: 'LOC-001', message: 'zone must be "canon" for a LOCATION.', path: 'zone' });
+  } else if (a.zone === undefined) {
+    errors.push({ code: 'LOC-001', message: 'zone is required.', path: 'zone' });
+  }
+  for (const field of REQUIRED_STRING_FIELDS) {
+    const v = a[field];
+    if (typeof v !== 'string' || v.trim() === '') {
+      errors.push({ code: 'LOC-001', message: `${field} is required.`, path: field });
+    }
+  }
+  if (a.gate_checks === null || typeof a.gate_checks !== 'object') {
+    errors.push({ code: 'LOC-001', message: 'gate_checks is required and must be a mapping.', path: 'gate_checks' });
+  }
+  if (!('valid_to' in a) || !(typeof a.valid_to === 'string' || a.valid_to === null)) {
+    errors.push({ code: 'LOC-001', message: 'valid_to is required (an ISO date string or null).', path: 'valid_to' });
+  }
+  if (typeof a.type !== 'string' || a.type.trim() === '') {
+    errors.push({ code: 'LOC-001', message: 'type is required.', path: 'type' });
+  } else if (!TYPES.includes(a.type)) {
+    // LOC-002 — type enum.
+    errors.push({ code: 'LOC-002', message: `type "${a.type}" must be one of ${TYPES.join(', ')}.`, path: 'type' });
+  }
+
+  // LOC-003 — parent must resolve to a LOCATION when present.
+  if ('parent' in a && a.parent !== undefined && a.parent !== null) {
+    if (typeof a.parent !== 'string' || !isCanonicalIdOfType(a.parent, 'LOCATION')) {
+      errors.push({
+        code: 'LOC-003',
+        message: `parent "${String(a.parent)}" must be a canonical LOCATION-… id.`,
+        path: 'parent',
+      });
+    }
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}

--- a/packages/diagrams/src/repo-validate/__tests__/validate-repo.test.ts
+++ b/packages/diagrams/src/repo-validate/__tests__/validate-repo.test.ts
@@ -147,3 +147,154 @@ describe('validateRepoModel — syntax', () => {
     expect(findings[0].message).toContain('broken.yaml');
   });
 });
+
+describe('validateRepoModel — layer-semantics (unit_located_at / located_at)', () => {
+  function locationModel() {
+    const model = cleanModel();
+    model.elements.push(
+      el('canon/elements/02_business/actors/ACTOR-OPS-1.yaml', {
+        notation: 'actor',
+        id: 'ACTOR-OPS-1',
+        type: 'business_unit',
+      }),
+      el('canon/elements/02_business/actors/ACTOR-JANE-1.yaml', {
+        notation: 'actor',
+        id: 'ACTOR-JANE-1',
+        type: 'person',
+      }),
+      el('canon/elements/02_business/locations/LOCATION-TBILISI-1.yaml', {
+        notation: 'location',
+        id: 'LOCATION-TBILISI-1',
+      }),
+    );
+    return model;
+  }
+
+  it('accepts a valid unit_located_at (business_unit → LOCATION)', () => {
+    const model = locationModel();
+    model.relations.push(
+      el('canon/relations/REL-LOC-1.yaml', {
+        notation: 'relation',
+        id: 'REL-LOC-1',
+        type: 'unit_located_at',
+        from: 'ACTOR-OPS-1',
+        to: 'LOCATION-TBILISI-1',
+      }),
+    );
+    expect(validateRepoModel(model)).toEqual([]);
+  });
+
+  it('accepts a valid located_at for a business_unit', () => {
+    const model = locationModel();
+    model.relations.push(
+      el('canon/relations/REL-LOC-2.yaml', {
+        notation: 'relation',
+        id: 'REL-LOC-2',
+        type: 'located_at',
+        from: 'ACTOR-OPS-1',
+        to: 'LOCATION-TBILISI-1',
+      }),
+    );
+    expect(validateRepoModel(model)).toEqual([]);
+  });
+
+  it('accepts a valid located_at for a person', () => {
+    const model = locationModel();
+    model.relations.push(
+      el('canon/relations/REL-LOC-3.yaml', {
+        notation: 'relation',
+        id: 'REL-LOC-3',
+        type: 'located_at',
+        from: 'ACTOR-JANE-1',
+        to: 'LOCATION-TBILISI-1',
+      }),
+    );
+    expect(validateRepoModel(model)).toEqual([]);
+  });
+
+  it('flags unit_located_at with a wrong from type (person instead of business_unit)', () => {
+    const model = locationModel();
+    model.relations.push(
+      el('canon/relations/REL-BAD-1.yaml', {
+        notation: 'relation',
+        id: 'REL-BAD-1',
+        type: 'unit_located_at',
+        from: 'ACTOR-JANE-1',
+        to: 'LOCATION-TBILISI-1',
+      }),
+    );
+    const findings = validateRepoModel(model);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ scope: 'repo', id: 'REL-BAD-1' });
+    expect(findings[0].message).toContain('unit_located_at');
+    expect(findings[0].message).toContain('business_unit');
+  });
+
+  it('flags unit_located_at with a non-ACTOR from element', () => {
+    const model = locationModel();
+    model.relations.push(
+      el('canon/relations/REL-BAD-2.yaml', {
+        notation: 'relation',
+        id: 'REL-BAD-2',
+        type: 'unit_located_at',
+        from: 'GOAL-OPS-1',
+        to: 'LOCATION-TBILISI-1',
+      }),
+    );
+    const findings = validateRepoModel(model);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ scope: 'repo', id: 'REL-BAD-2' });
+    expect(findings[0].message).toContain('unit_located_at');
+  });
+
+  it('flags unit_located_at with a non-LOCATION to element', () => {
+    const model = locationModel();
+    model.relations.push(
+      el('canon/relations/REL-BAD-3.yaml', {
+        notation: 'relation',
+        id: 'REL-BAD-3',
+        type: 'unit_located_at',
+        from: 'ACTOR-OPS-1',
+        to: 'GOAL-OPS-1',
+      }),
+    );
+    const findings = validateRepoModel(model);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ scope: 'repo', id: 'REL-BAD-3' });
+    expect(findings[0].message).toContain('LOCATION');
+  });
+
+  it('flags located_at with a non-actor from element', () => {
+    const model = locationModel();
+    model.relations.push(
+      el('canon/relations/REL-BAD-4.yaml', {
+        notation: 'relation',
+        id: 'REL-BAD-4',
+        type: 'located_at',
+        from: 'CAPABILITY-V1',
+        to: 'LOCATION-TBILISI-1',
+      }),
+    );
+    const findings = validateRepoModel(model);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ scope: 'repo', id: 'REL-BAD-4' });
+    expect(findings[0].message).toContain('located_at');
+  });
+
+  it('does not emit layer-semantic findings for unknown endpoints (ref-integrity handles those)', () => {
+    const model = locationModel();
+    model.relations.push(
+      el('canon/relations/REL-MISSING.yaml', {
+        notation: 'relation',
+        id: 'REL-MISSING',
+        type: 'unit_located_at',
+        from: 'ACTOR-UNKNOWN-99',
+        to: 'LOCATION-UNKNOWN-99',
+      }),
+    );
+    const findings = validateRepoModel(model);
+    // ref-integrity fires for missing endpoints; no duplicate layer-semantic finding
+    expect(findings.every((f) => !f.message.includes('Layer-semantics'))).toBe(true);
+    expect(findings.some((f) => f.message.includes('ACTOR-UNKNOWN-99'))).toBe(true);
+  });
+});

--- a/packages/diagrams/src/repo-validate/validate-repo.ts
+++ b/packages/diagrams/src/repo-validate/validate-repo.ts
@@ -143,15 +143,90 @@ function checkReferentialIntegrity(input: RepoModelInput, findings: RepoFinding[
 
 /** Phase 5 — ArchiMate layer-semantics on relations.
  *
- * lint.py ships `_check_semantic_rules` as a no-op stub (`pass`). It is ported
- * here faithfully as a no-op so repo-scope validation reaches parity with
- * lint.py on the reference fixture. Real layer-semantics rules are DEFERRED
- * until the methodology defines them; when it does, they land here (a relation
- * whose `type` is illegal between its endpoints' ArchiMate layers). Kept as a
- * named hook so the intent — and the gap — is explicit rather than missing. */
-function checkLayerSemantics(_input: RepoModelInput, _findings: RepoFinding[]): void {
-  // Intentionally empty — parity with lint.py's stubbed phase 5. Do not add
-  // rules here without coordinating the methodology semantics canon.
+ * Enforces endpoint-type constraints for relation kinds whose methodology
+ * semantics are formally defined. Rules added here must have a corresponding
+ * entry in methodology `notations/elements/17-relations.md`; do not add
+ * speculative rules.
+ *
+ * Implemented kinds:
+ *   unit_located_at — ACTOR(business_unit) → LOCATION  (21-locations.md)
+ *   located_at      — ACTOR(person|business_unit) → LOCATION (canonical form)
+ *
+ * lint.py ships this as a no-op stub; Studio is ahead of the Python tool here.
+ * These findings are non-blocking for cross-tool parity — they surface only in
+ * the TypeScript validator path (CLI `validate --scope=repo`). */
+function checkLayerSemantics(input: RepoModelInput, findings: RepoFinding[]): void {
+  const elementById = new Map<string, Record<string, unknown>>();
+  for (const doc of input.elements) {
+    const id = docId(doc);
+    if (id && doc.data) elementById.set(id, doc.data);
+  }
+
+  for (const doc of input.relations) {
+    if (!doc.data) continue;
+    const relId = docId(doc) ?? '';
+    const relType = doc.data['type'];
+    if (typeof relType !== 'string') continue;
+
+    const fromId = endpointId(doc.data['from']) ?? endpointId(doc.data['source']);
+    const toId = endpointId(doc.data['to']) ?? endpointId(doc.data['target']);
+
+    if (relType === 'unit_located_at') {
+      if (fromId) {
+        const from = elementById.get(fromId);
+        if (from && (from['notation'] !== 'actor' || from['type'] !== 'business_unit')) {
+          findings.push({
+            scope: PScope,
+            id: relId,
+            message:
+              `Layer-semantics: '${relId}' type 'unit_located_at' requires from to be ` +
+              `ACTOR(business_unit); got notation='${from['notation']}', type='${from['type']}'.`,
+          });
+        }
+      }
+      if (toId) {
+        const to = elementById.get(toId);
+        if (to && to['notation'] !== 'location') {
+          findings.push({
+            scope: PScope,
+            id: relId,
+            message:
+              `Layer-semantics: '${relId}' type 'unit_located_at' requires to to be a LOCATION; ` +
+              `got notation='${to['notation']}'.`,
+          });
+        }
+      }
+    } else if (relType === 'located_at') {
+      if (fromId) {
+        const from = elementById.get(fromId);
+        if (
+          from &&
+          (from['notation'] !== 'actor' ||
+            (from['type'] !== 'person' && from['type'] !== 'business_unit'))
+        ) {
+          findings.push({
+            scope: PScope,
+            id: relId,
+            message:
+              `Layer-semantics: '${relId}' type 'located_at' requires from to be ` +
+              `ACTOR(person|business_unit); got notation='${from['notation']}', type='${from['type']}'.`,
+          });
+        }
+      }
+      if (toId) {
+        const to = elementById.get(toId);
+        if (to && to['notation'] !== 'location') {
+          findings.push({
+            scope: PScope,
+            id: relId,
+            message:
+              `Layer-semantics: '${relId}' type 'located_at' requires to to be a LOCATION; ` +
+              `got notation='${to['notation']}'.`,
+          });
+        }
+      }
+    }
+  }
 }
 
 /** Phase 6 — an element that is Active/Production must declare an owner. */


### PR DESCRIPTION
## Summary

- Adds the `LOCATION` place primitive to `@transitrix/diagrams` (`packages/diagrams/src/location/`): `LocationType` enum (`country | region | city | site | office | virtual`) and `Location` interface matching the methodology YAML schema.
- Implements `checkLayerSemantics` in the repo-scope validator to enforce endpoint-type constraints for `unit_located_at` (ACTOR(business_unit) → LOCATION) and `located_at` (ACTOR(person|business_unit) → LOCATION). Previously this phase was a deferred no-op stub.
- Adds `located_at` and `unit_located_at` to `ACTOR_FORBIDDEN_INLINE_FIELDS` — the methodology spec requires these to be first-class time-aware REL files, never inline on the actor identity file.
- Exports the new location module from the diagrams package index.
- 9 new test cases covering valid relations and all rejection paths (wrong from-type, non-actor from, non-location to, missing endpoints).

## Test plan

- [x] `npm --workspace packages/diagrams run test` — 1011 tests, all pass
- [x] `npm test` (root vitest suite) — 414 tests, all pass
- [x] `npm run build` — no TypeScript errors
- [x] Pre-PR hygiene: no internal references in diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)