### PR TITLE
feat(business-service): add BUSINESS_SERVICE primitive validator + relation layer-semantics

### DIFF
--- a/packages/diagrams/src/business-service/__tests__/validate.test.ts
+++ b/packages/diagrams/src/business-service/__tests__/validate.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest';
+import { validateBusinessService } from '../validate.js';
+
+function valid(): Record<string, unknown> {
+  return {
+    notation: 'business-service',
+    id: 'BUSINESS_SERVICE-CRM-1',
+    name: 'CRM Service',
+    type: 'internal',
+    description: 'Customer relationship management service offering contact management and deal tracking.',
+    offering_unit: 'ACTOR-SALES-OPS-1',
+    capability: 'CAPABILITY-V2.1',
+    zone: 'canon',
+    admitted_at: '2026-06-28',
+    admitted_by: 'v.korobeinikov',
+    gate_checks: { uniqueness: 'pass', consistency: 'pass', completeness: 'pass' },
+    valid_from: '2024-01-01',
+    valid_to: null,
+  };
+}
+
+const codes = (input: unknown): string[] =>
+  validateBusinessService(input).errors.map(e => e.code);
+
+describe('validateBusinessService — positive', () => {
+  it('accepts a well-formed internal service with all optional fields', () => {
+    const r = validateBusinessService(valid());
+    expect(r.valid, JSON.stringify(r.errors)).toBe(true);
+  });
+
+  it('accepts an external service with no optional fields', () => {
+    const a = valid();
+    a.id = 'BUSINESS_SERVICE-ONBOARDING-1';
+    a.name = 'Onboarding Service';
+    a.type = 'external';
+    delete a.description;
+    delete a.offering_unit;
+    delete a.capability;
+    expect(validateBusinessService(a).valid).toBe(true);
+  });
+
+  it('accepts a shared service offered by a ROLE', () => {
+    expect(validateBusinessService({ ...valid(), type: 'shared', offering_unit: 'ROLE-PLATFORM-OWNER-1' }).valid).toBe(true);
+  });
+
+  it('accepts valid_to as a date string', () => {
+    expect(validateBusinessService({ ...valid(), valid_to: '2026-12-31' }).valid).toBe(true);
+  });
+
+  it('accepts a service with no offering_unit or capability', () => {
+    const a = valid();
+    delete a.offering_unit;
+    delete a.capability;
+    expect(validateBusinessService(a).valid).toBe(true);
+  });
+});
+
+describe('validateBusinessService — BSV-001 (shape / id grammar)', () => {
+  it('flags a missing required envelope field (name)', () => {
+    const a = valid();
+    delete a.name;
+    expect(codes(a)).toContain('BSV-001');
+  });
+
+  it('flags an id that violates the grammar', () => {
+    expect(codes({ ...valid(), id: 'BUSINESS_SERVICE-001' })).toContain('BSV-001');
+    expect(codes({ ...valid(), id: 'BSV-1' })).toContain('BSV-001');
+    expect(codes({ ...valid(), id: 'business-service-1' })).toContain('BSV-001');
+  });
+
+  it('flags a wrong notation tag', () => {
+    expect(codes({ ...valid(), notation: 'service' })).toContain('BSV-001');
+    expect(codes({ ...valid(), notation: 'business_service' })).toContain('BSV-001');
+  });
+
+  it('flags a non-canon zone', () => {
+    expect(codes({ ...valid(), zone: 'sandbox' })).toContain('BSV-001');
+  });
+
+  it('flags a missing zone', () => {
+    const a = valid();
+    delete a.zone;
+    expect(codes(a)).toContain('BSV-001');
+  });
+
+  it('flags a missing type', () => {
+    const a = valid();
+    delete a.type;
+    expect(codes(a)).toContain('BSV-001');
+  });
+
+  it('flags a missing valid_to key', () => {
+    const a = valid();
+    delete a.valid_to;
+    expect(codes(a)).toContain('BSV-001');
+  });
+
+  it('flags missing gate_checks', () => {
+    const a = valid();
+    delete a.gate_checks;
+    expect(codes(a)).toContain('BSV-001');
+  });
+
+  it('rejects a non-object', () => {
+    expect(codes(null)).toEqual(['BSV-001']);
+    expect(codes('string')).toEqual(['BSV-001']);
+  });
+});
+
+describe('validateBusinessService — BSV-002 (type enum)', () => {
+  it('flags a type outside the allowed enum', () => {
+    expect(codes({ ...valid(), type: 'public' })).toContain('BSV-002');
+    expect(codes({ ...valid(), type: 'platform' })).toContain('BSV-002');
+  });
+
+  it('accepts all valid type values', () => {
+    for (const t of ['internal', 'external', 'shared']) {
+      expect(codes({ ...valid(), type: t })).not.toContain('BSV-002');
+    }
+  });
+});
+
+describe('validateBusinessService — BSV-003 (offering_unit grammar)', () => {
+  it('flags an offering_unit that is not an ACTOR-… or ROLE-… id', () => {
+    expect(codes({ ...valid(), offering_unit: 'PRODUCT-PLATFORM-1' })).toContain('BSV-003');
+    expect(codes({ ...valid(), offering_unit: 'not-an-id' })).toContain('BSV-003');
+    expect(codes({ ...valid(), offering_unit: 'BUSINESS_SERVICE-CRM-1' })).toContain('BSV-003');
+  });
+
+  it('accepts a null or absent offering_unit without error', () => {
+    expect(codes({ ...valid(), offering_unit: undefined })).not.toContain('BSV-003');
+    const a = valid();
+    delete a.offering_unit;
+    expect(codes(a)).not.toContain('BSV-003');
+  });
+
+  it('accepts ACTOR-… and ROLE-… ids', () => {
+    expect(codes({ ...valid(), offering_unit: 'ACTOR-OPS-1' })).not.toContain('BSV-003');
+    expect(codes({ ...valid(), offering_unit: 'ROLE-SERVICE-OWNER-1' })).not.toContain('BSV-003');
+  });
+});
+
+describe('validateBusinessService — BSV-004 (capability grammar)', () => {
+  it('flags a capability that is not a CAPABILITY-… id', () => {
+    expect(codes({ ...valid(), capability: 'PRODUCT-MOBILE-1' })).toContain('BSV-004');
+    expect(codes({ ...valid(), capability: 'not-a-capability' })).toContain('BSV-004');
+  });
+
+  it('accepts a null or absent capability without error', () => {
+    expect(codes({ ...valid(), capability: undefined })).not.toContain('BSV-004');
+    const a = valid();
+    delete a.capability;
+    expect(codes(a)).not.toContain('BSV-004');
+  });
+
+  it('accepts a CAPABILITY-… id', () => {
+    expect(codes({ ...valid(), capability: 'CAPABILITY-V2.1' })).not.toContain('BSV-004');
+    expect(codes({ ...valid(), capability: 'CAPABILITY-H3.1' })).not.toContain('BSV-004');
+  });
+});

--- a/packages/diagrams/src/business-service/index.ts
+++ b/packages/diagrams/src/business-service/index.ts
@@ -1,0 +1,3 @@
+export type { BusinessService, BusinessServiceType } from './types.js';
+export { BUSINESS_SERVICE_TYPES } from './types.js';
+export { validateBusinessService } from './validate.js';

--- a/packages/diagrams/src/business-service/types.ts
+++ b/packages/diagrams/src/business-service/types.ts
@@ -1,0 +1,29 @@
+// BUSINESS_SERVICE — externally visible behaviour primitive (ArchiMate Business Service).
+// Schema: methodology notations/elements/25-business-services.md
+
+import type { GateChecks } from '../requirement/types.js';
+
+export const BUSINESS_SERVICE_TYPES = ['internal', 'external', 'shared'] as const;
+export type BusinessServiceType = typeof BUSINESS_SERVICE_TYPES[number];
+
+export interface BusinessService {
+  notation: 'business-service';
+  id: string;
+  name: string;
+  type: BusinessServiceType;
+  description?: string;
+  offering_unit?: string;
+  capability?: string;
+  owner_role?: string;
+  status?: string;
+
+  // Admission record (CONTRACT.md §6).
+  zone: 'canon';
+  admitted_at: string;
+  admitted_by: string;
+  gate_checks: GateChecks;
+
+  // Primitive lifecycle (CONTRACT.md §7).
+  valid_from: string;
+  valid_to: string | null;
+}

--- a/packages/diagrams/src/business-service/validate.ts
+++ b/packages/diagrams/src/business-service/validate.ts
@@ -1,0 +1,82 @@
+// BUSINESS_SERVICE validator — methodology notations/elements/25-business-services.md §5.
+//
+// Implements BSV-001..004. The shared HDR-/LIFECYCLE- rules are
+// cross-cutting concerns (CONTRACT.md §8) and out of scope for the
+// single-artefact validator.
+
+import type { ValidationError, ValidationWarning, ValidationResult } from '../validation-types.js';
+import { isCanonicalIdOfType, typeOfId } from '../typed-id.js';
+import { BUSINESS_SERVICE_TYPES } from './types.js';
+
+const REQUIRED_STRING_FIELDS = [
+  'name', 'admitted_at', 'admitted_by', 'valid_from',
+] as const;
+
+const TYPES: readonly string[] = BUSINESS_SERVICE_TYPES;
+
+export function validateBusinessService(input: unknown): ValidationResult {
+  const errors: ValidationError[] = [];
+  const warnings: ValidationWarning[] = [];
+
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    errors.push({ code: 'BSV-001', message: 'Business service must be a YAML mapping.' });
+    return { valid: false, errors, warnings };
+  }
+  const a = input as Record<string, unknown>;
+
+  // BSV-001 — id grammar + notation tag + envelope.
+  if (!isCanonicalIdOfType(a.id, 'BUSINESS_SERVICE')) {
+    errors.push({ code: 'BSV-001', message: `id "${String(a.id)}" must match BUSINESS_SERVICE-[<middle>-]<INTEGER>.`, path: 'id' });
+  }
+  if (a.notation !== 'business-service') {
+    errors.push({ code: 'BSV-001', message: 'notation must be the fixed value "business-service".', path: 'notation' });
+  }
+  if (a.zone !== undefined && a.zone !== 'canon') {
+    errors.push({ code: 'BSV-001', message: 'zone must be "canon" for a BUSINESS_SERVICE.', path: 'zone' });
+  } else if (a.zone === undefined) {
+    errors.push({ code: 'BSV-001', message: 'zone is required.', path: 'zone' });
+  }
+  for (const field of REQUIRED_STRING_FIELDS) {
+    const v = a[field];
+    if (typeof v !== 'string' || v.trim() === '') {
+      errors.push({ code: 'BSV-001', message: `${field} is required.`, path: field });
+    }
+  }
+  if (a.gate_checks === null || typeof a.gate_checks !== 'object') {
+    errors.push({ code: 'BSV-001', message: 'gate_checks is required and must be a mapping.', path: 'gate_checks' });
+  }
+  if (!('valid_to' in a) || !(typeof a.valid_to === 'string' || a.valid_to === null)) {
+    errors.push({ code: 'BSV-001', message: 'valid_to is required (an ISO date string or null).', path: 'valid_to' });
+  }
+  if (typeof a.type !== 'string' || a.type.trim() === '') {
+    errors.push({ code: 'BSV-001', message: 'type is required.', path: 'type' });
+  } else if (!TYPES.includes(a.type)) {
+    // BSV-002 — type enum.
+    errors.push({ code: 'BSV-002', message: `type "${a.type}" must be one of ${TYPES.join(', ')}.`, path: 'type' });
+  }
+
+  // BSV-003 — offering_unit must resolve to ACTOR(business_unit) or ROLE when present.
+  if ('offering_unit' in a && a.offering_unit !== undefined && a.offering_unit !== null) {
+    const t = typeOfId(a.offering_unit);
+    if (t !== 'ACTOR' && t !== 'ROLE') {
+      errors.push({
+        code: 'BSV-003',
+        message: `offering_unit "${String(a.offering_unit)}" must be an ACTOR-… or ROLE-… canonical id.`,
+        path: 'offering_unit',
+      });
+    }
+  }
+
+  // BSV-004 — capability must resolve to CAPABILITY when present.
+  if ('capability' in a && a.capability !== undefined && a.capability !== null) {
+    if (typeOfId(a.capability) !== 'CAPABILITY') {
+      errors.push({
+        code: 'BSV-004',
+        message: `capability "${String(a.capability)}" must be a CAPABILITY-… canonical id.`,
+        path: 'capability',
+      });
+    }
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}

--- a/packages/diagrams/src/index.ts
+++ b/packages/diagrams/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./activities/index";
 export * from "./activity-card/index";
 export * from "./actor/index";
+export * from "./business-service/index";
 export * from "./geometry";
 export * from "./applications/index";
 export * from "./assertion/index";

--- a/packages/diagrams/src/repo-validate/__tests__/validate-repo.test.ts
+++ b/packages/diagrams/src/repo-validate/__tests__/validate-repo.test.ts
@@ -298,3 +298,124 @@ describe('validateRepoModel — layer-semantics (unit_located_at / located_at)',
     expect(findings.some((f) => f.message.includes('ACTOR-UNKNOWN-99'))).toBe(true);
   });
 });
+
+describe('validateRepoModel — layer-semantics (offers / realizes)', () => {
+  function serviceModel() {
+    const model = cleanModel();
+    model.elements.push(
+      el('canon/elements/02_business/actors/ACTOR-OPS-1.yaml', {
+        notation: 'actor',
+        id: 'ACTOR-OPS-1',
+        type: 'business_unit',
+      }),
+      el('canon/elements/02_business/roles/ROLE-OWNER-1.yaml', {
+        notation: 'role',
+        id: 'ROLE-OWNER-1',
+      }),
+      el('canon/elements/02_business/business-services/BUSINESS_SERVICE-CRM-1.yaml', {
+        notation: 'business-service',
+        id: 'BUSINESS_SERVICE-CRM-1',
+      }),
+      el('canon/elements/02_business/capabilities/CAPABILITY-V2.yaml', {
+        notation: 'capability',
+        id: 'CAPABILITY-V2',
+      }),
+    );
+    return model;
+  }
+
+  it('accepts a valid offers (ACTOR(business_unit) → BUSINESS_SERVICE)', () => {
+    const model = serviceModel();
+    model.relations.push(
+      el('canon/relations/REL-SVC-1.yaml', {
+        notation: 'relation',
+        id: 'REL-SVC-1',
+        type: 'offers',
+        from: 'ACTOR-OPS-1',
+        to: 'BUSINESS_SERVICE-CRM-1',
+      }),
+    );
+    expect(validateRepoModel(model)).toEqual([]);
+  });
+
+  it('accepts a valid offers (ROLE → BUSINESS_SERVICE)', () => {
+    const model = serviceModel();
+    model.relations.push(
+      el('canon/relations/REL-SVC-2.yaml', {
+        notation: 'relation',
+        id: 'REL-SVC-2',
+        type: 'offers',
+        from: 'ROLE-OWNER-1',
+        to: 'BUSINESS_SERVICE-CRM-1',
+      }),
+    );
+    expect(validateRepoModel(model)).toEqual([]);
+  });
+
+  it('accepts a valid realizes (BUSINESS_SERVICE → CAPABILITY)', () => {
+    const model = serviceModel();
+    model.relations.push(
+      el('canon/relations/REL-SVC-3.yaml', {
+        notation: 'relation',
+        id: 'REL-SVC-3',
+        type: 'realizes',
+        from: 'BUSINESS_SERVICE-CRM-1',
+        to: 'CAPABILITY-V2',
+      }),
+    );
+    expect(validateRepoModel(model)).toEqual([]);
+  });
+
+  it('flags offers with a non-ACTOR/non-ROLE from element', () => {
+    const model = serviceModel();
+    model.relations.push(
+      el('canon/relations/REL-SVC-BAD-1.yaml', {
+        notation: 'relation',
+        id: 'REL-SVC-BAD-1',
+        type: 'offers',
+        from: 'CAPABILITY-V2',
+        to: 'BUSINESS_SERVICE-CRM-1',
+      }),
+    );
+    const findings = validateRepoModel(model);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ scope: 'repo', id: 'REL-SVC-BAD-1' });
+    expect(findings[0].message).toContain('offers');
+    expect(findings[0].message).toContain('ACTOR');
+  });
+
+  it('flags offers with a non-BUSINESS_SERVICE to element', () => {
+    const model = serviceModel();
+    model.relations.push(
+      el('canon/relations/REL-SVC-BAD-2.yaml', {
+        notation: 'relation',
+        id: 'REL-SVC-BAD-2',
+        type: 'offers',
+        from: 'ACTOR-OPS-1',
+        to: 'CAPABILITY-V2',
+      }),
+    );
+    const findings = validateRepoModel(model);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ scope: 'repo', id: 'REL-SVC-BAD-2' });
+    expect(findings[0].message).toContain('BUSINESS_SERVICE');
+  });
+
+  it('flags realizes with a non-BUSINESS_SERVICE from element', () => {
+    const model = serviceModel();
+    model.relations.push(
+      el('canon/relations/REL-SVC-BAD-3.yaml', {
+        notation: 'relation',
+        id: 'REL-SVC-BAD-3',
+        type: 'realizes',
+        from: 'ACTOR-OPS-1',
+        to: 'CAPABILITY-V2',
+      }),
+    );
+    const findings = validateRepoModel(model);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ scope: 'repo', id: 'REL-SVC-BAD-3' });
+    expect(findings[0].message).toContain('realizes');
+    expect(findings[0].message).toContain('BUSINESS_SERVICE');
+  });
+});

--- a/packages/diagrams/src/repo-validate/validate-repo.ts
+++ b/packages/diagrams/src/repo-validate/validate-repo.ts
@@ -149,8 +149,10 @@ function checkReferentialIntegrity(input: RepoModelInput, findings: RepoFinding[
  * speculative rules.
  *
  * Implemented kinds:
- *   unit_located_at — ACTOR(business_unit) → LOCATION  (21-locations.md)
+ *   unit_located_at — ACTOR(business_unit) → LOCATION        (21-locations.md)
  *   located_at      — ACTOR(person|business_unit) → LOCATION (canonical form)
+ *   offers          — ACTOR(business_unit)|ROLE → BUSINESS_SERVICE (25-business-services.md)
+ *   realizes        — BUSINESS_SERVICE → CAPABILITY           (25-business-services.md)
  *
  * lint.py ships this as a no-op stub; Studio is ahead of the Python tool here.
  * These findings are non-blocking for cross-tool parity — they surface only in
@@ -222,6 +224,48 @@ function checkLayerSemantics(input: RepoModelInput, findings: RepoFinding[]): vo
             message:
               `Layer-semantics: '${relId}' type 'located_at' requires to to be a LOCATION; ` +
               `got notation='${to['notation']}'.`,
+          });
+        }
+      }
+    } else if (relType === 'offers') {
+      if (fromId) {
+        const from = elementById.get(fromId);
+        if (
+          from &&
+          from['notation'] !== 'actor' &&
+          from['notation'] !== 'role'
+        ) {
+          findings.push({
+            scope: PScope,
+            id: relId,
+            message:
+              `Layer-semantics: '${relId}' type 'offers' requires from to be ` +
+              `ACTOR(business_unit) or ROLE; got notation='${from['notation']}'.`,
+          });
+        }
+      }
+      if (toId) {
+        const to = elementById.get(toId);
+        if (to && to['notation'] !== 'business-service') {
+          findings.push({
+            scope: PScope,
+            id: relId,
+            message:
+              `Layer-semantics: '${relId}' type 'offers' requires to to be a BUSINESS_SERVICE; ` +
+              `got notation='${to['notation']}'.`,
+          });
+        }
+      }
+    } else if (relType === 'realizes') {
+      if (fromId) {
+        const from = elementById.get(fromId);
+        if (from && from['notation'] !== 'business-service') {
+          findings.push({
+            scope: PScope,
+            id: relId,
+            message:
+              `Layer-semantics: '${relId}' type 'realizes' requires from to be ` +
+              `BUSINESS_SERVICE; got notation='${from['notation']}'.`,
           });
         }
       }


### PR DESCRIPTION
## Summary

- Adds `@transitrix/diagrams` validator for the `BUSINESS_SERVICE` zone primitive (ArchiMate Business Service — externally visible behaviour a unit or role offers to its consumers).
- Implements rules BSV-001..004 per the methodology spec: envelope/id grammar, type enum (`internal`/`external`/`shared`), `offering_unit` ACTOR|ROLE reference check, `capability` CAPABILITY reference check.
- Adds layer-semantics enforcement in `validate-repo.ts` for the `offers` (ACTOR|ROLE → BUSINESS_SERVICE) and `realizes` (BUSINESS_SERVICE → CAPABILITY) relation kinds per `17-relations.md §3`.
- Exports new module from `packages/diagrams/src/index.ts`.
- 22 validator unit tests + 7 repo-validate relation tests; all 1056 tests green.

## Test plan

- [x] `cd packages/diagrams && npx vitest run src/business-service` — 22 tests pass
- [x] Full `npm test` suite — 1056 tests pass, no regressions