### PR TITLE
refactor(extension): drop deprecated file-extension support

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -56,13 +56,9 @@
     "workspaceContains:**/*.goals.transitrix.yaml",
     "workspaceContains:**/*.dgca.transitrix.yaml",
     "workspaceContains:**/*.dga.transitrix.yaml",
-    "workspaceContains:**/*.fgca.transitrix.yaml",
-    "workspaceContains:**/*.fga.transitrix.yaml",
-    "workspaceContains:**/*.activities.transitrix.yaml",
     "workspaceContains:**/*.action.transitrix.yaml",
     "workspaceContains:**/*.action-card.transitrix.yaml",
     "workspaceContains:**/*.actions-tree.transitrix.yaml",
-    "workspaceContains:**/*.activities-tree.transitrix.yaml",
     "workspaceContains:**/*.blocks.transitrix.yaml",
     "workspaceContains:**/*.applications.transitrix.yaml",
     "workspaceContains:**/*.products.transitrix.yaml",
@@ -70,7 +66,6 @@
     "workspaceContains:**/*.scenarios.transitrix.yaml",
     "workspaceContains:**/*.capability-map.transitrix.yaml",
     "workspaceContains:**/*.process-blueprint.transitrix.yaml",
-    "workspaceContains:**/*.activity-card.transitrix.yaml",
     "workspaceContains:**/*.compliance-impact.view.yaml",
     "workspaceContains:**/*.coverage-metric.transitrix.yaml",
     "workspaceContains:**/*.compliance-impact.transitrix.yaml",
@@ -455,17 +450,6 @@
         "configuration": "./language-configuration.json"
       },
       {
-        "id": "transitrix-fga",
-        "aliases": [
-          "Transitrix FGA",
-          "Factor-Goal-Activity"
-        ],
-        "extensions": [
-          ".fga.transitrix.yaml"
-        ],
-        "configuration": "./language-configuration.json"
-      },
-      {
         "id": "transitrix-products",
         "aliases": [
           "Transitrix Products",
@@ -532,17 +516,6 @@
         "configuration": "./language-configuration.json"
       },
       {
-        "id": "transitrix-activity-card",
-        "aliases": [
-          "Transitrix Activity Card",
-          "Activity Card"
-        ],
-        "extensions": [
-          ".activity-card.transitrix.yaml"
-        ],
-        "configuration": "./language-configuration.json"
-      },
-      {
         "id": "transitrix-action-card",
         "aliases": [
           "Transitrix Action Card",
@@ -550,17 +523,6 @@
         ],
         "extensions": [
           ".action-card.transitrix.yaml"
-        ],
-        "configuration": "./language-configuration.json"
-      },
-      {
-        "id": "transitrix-activities",
-        "aliases": [
-          "Transitrix Activities",
-          "Activity Network"
-        ],
-        "extensions": [
-          ".activities.transitrix.yaml"
         ],
         "configuration": "./language-configuration.json"
       },
@@ -582,8 +544,7 @@
           "Action Catalogue Tree"
         ],
         "extensions": [
-          ".actions-tree.transitrix.yaml",
-          ".activities-tree.transitrix.yaml"
+          ".actions-tree.transitrix.yaml"
         ],
         "configuration": "./language-configuration.json"
       },
@@ -648,18 +609,6 @@
         "icon": "$(type-hierarchy)"
       },
       {
-        "command": "transitrixStudio.previewFGCA",
-        "title": "Transitrix: Preview FGCA diagram (deprecated — use DGCA)",
-        "category": "Transitrix",
-        "icon": "$(type-hierarchy)"
-      },
-      {
-        "command": "transitrixStudio.previewFGA",
-        "title": "Transitrix: Preview FGA diagram (deprecated — use DGA)",
-        "category": "Transitrix",
-        "icon": "$(type-hierarchy)"
-      },
-      {
         "command": "transitrixStudio.previewActivities",
         "title": "Transitrix: Preview action network diagram (PSND + Gantt + Tree)",
         "category": "Transitrix",
@@ -698,18 +647,6 @@
       {
         "command": "transitrixStudio.saveDGAAsSvg",
         "title": "Transitrix: Save DGA diagram as SVG",
-        "category": "Transitrix",
-        "icon": "$(save)"
-      },
-      {
-        "command": "transitrixStudio.saveFGCAAsSvg",
-        "title": "Transitrix: Save FGCA diagram as SVG (deprecated)",
-        "category": "Transitrix",
-        "icon": "$(save)"
-      },
-      {
-        "command": "transitrixStudio.saveFGAAsSvg",
-        "title": "Transitrix: Save FGA diagram as SVG (deprecated)",
         "category": "Transitrix",
         "icon": "$(save)"
       },
@@ -821,26 +758,6 @@
       {
         "command": "transitrixStudio.copyDGAAsPng",
         "title": "Transitrix: Copy DGA diagram as PNG",
-        "category": "Transitrix"
-      },
-      {
-        "command": "transitrixStudio.saveFGCAAsPng",
-        "title": "Transitrix: Save FGCA diagram as PNG (deprecated)",
-        "category": "Transitrix"
-      },
-      {
-        "command": "transitrixStudio.copyFGCAAsPng",
-        "title": "Transitrix: Copy FGCA diagram as PNG (deprecated)",
-        "category": "Transitrix"
-      },
-      {
-        "command": "transitrixStudio.saveFGAAsPng",
-        "title": "Transitrix: Save FGA diagram as PNG (deprecated)",
-        "category": "Transitrix"
-      },
-      {
-        "command": "transitrixStudio.copyFGAAsPng",
-        "title": "Transitrix: Copy FGA diagram as PNG (deprecated)",
         "category": "Transitrix"
       },
       {
@@ -988,21 +905,6 @@
           "group": "navigation@-10"
         },
         {
-          "when": "resourceFilename =~ /\\.fgca\\.transitrix\\.yaml$/",
-          "command": "transitrixStudio.previewFGCA",
-          "group": "navigation@-10"
-        },
-        {
-          "when": "resourceFilename =~ /\\.fga\\.transitrix\\.yaml$/",
-          "command": "transitrixStudio.previewFGA",
-          "group": "navigation@-10"
-        },
-        {
-          "when": "resourceFilename =~ /\\.activities\\.transitrix\\.yaml$/",
-          "command": "transitrixStudio.previewActivities",
-          "group": "navigation@-10"
-        },
-        {
           "when": "resourceFilename =~ /\\.action\\.transitrix\\.yaml$/",
           "command": "transitrixStudio.previewActivities",
           "group": "navigation@-10"
@@ -1014,11 +916,6 @@
         },
         {
           "when": "resourceFilename =~ /\\.actions-tree\\.transitrix\\.yaml$/",
-          "command": "transitrixStudio.previewActionsTree",
-          "group": "navigation@-10"
-        },
-        {
-          "when": "resourceFilename =~ /\\.activities-tree\\.transitrix\\.yaml$/",
           "command": "transitrixStudio.previewActionsTree",
           "group": "navigation@-10"
         },
@@ -1058,28 +955,13 @@
           "group": "navigation@-9"
         },
         {
-          "when": "resourceFilename =~ /\\.fgca\\.transitrix\\.yaml$/",
-          "command": "transitrixStudio.saveFGCAAsSvg",
-          "group": "navigation@-9"
-        },
-        {
           "when": "activeWebviewPanelId == fgcaPreview",
-          "command": "transitrixStudio.saveFGCAAsSvg",
-          "group": "navigation@-9"
-        },
-        {
-          "when": "resourceFilename =~ /\\.fga\\.transitrix\\.yaml$/",
-          "command": "transitrixStudio.saveFGAAsSvg",
+          "command": "transitrixStudio.saveDGCAAsSvg",
           "group": "navigation@-9"
         },
         {
           "when": "activeWebviewPanelId == fgaPreview",
-          "command": "transitrixStudio.saveFGAAsSvg",
-          "group": "navigation@-9"
-        },
-        {
-          "when": "resourceFilename =~ /\\.activities\\.transitrix\\.yaml$/",
-          "command": "transitrixStudio.saveActivitiesAsSvg",
+          "command": "transitrixStudio.saveDGAAsSvg",
           "group": "navigation@-9"
         },
         {
@@ -1140,16 +1022,6 @@
         {
           "when": "activeWebviewPanelId == processBlueprintPreview",
           "command": "transitrixStudio.saveProcessBlueprintAsSvg",
-          "group": "navigation@-9"
-        },
-        {
-          "when": "resourceFilename =~ /\\.activity-card\\.transitrix\\.yaml$/",
-          "command": "transitrixStudio.previewActivityCard",
-          "group": "navigation@-10"
-        },
-        {
-          "when": "resourceFilename =~ /\\.activity-card\\.transitrix\\.yaml$/",
-          "command": "transitrixStudio.saveActivityCardAsSvg",
           "group": "navigation@-9"
         },
         {

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -55,17 +55,8 @@ function isDGAFile(doc: vscode.TextDocument): boolean {
   return doc.fileName.endsWith('.dga.transitrix.yaml');
 }
 
-function isFGCAFile(doc: vscode.TextDocument): boolean {
-  return doc.fileName.endsWith('.fgca.transitrix.yaml');
-}
-
-function isFGAFile(doc: vscode.TextDocument): boolean {
-  return doc.fileName.endsWith('.fga.transitrix.yaml');
-}
-
 function isActivitiesFile(doc: vscode.TextDocument): boolean {
-  return doc.fileName.endsWith('.activities.transitrix.yaml')
-    || doc.fileName.endsWith('.action.transitrix.yaml');
+  return doc.fileName.endsWith('.action.transitrix.yaml');
 }
 
 function isActionCardFile(doc: vscode.TextDocument): boolean {
@@ -101,8 +92,7 @@ function isProcessBlueprintFile(doc: vscode.TextDocument): boolean {
 }
 
 function isActivityCardFile(doc: vscode.TextDocument): boolean {
-  return doc.fileName.endsWith('.activity-card.transitrix.yaml')
-    || isActionCardFile(doc);
+  return isActionCardFile(doc);
 }
 
 function isCoverageMetricFile(doc: vscode.TextDocument): boolean {
@@ -322,7 +312,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     }),
     vscode.commands.registerCommand('transitrixStudio.previewDGCA', async () => {
       const doc = vscode.window.activeTextEditor?.document;
-      if (!doc || (!isDGCAFile(doc) && !isFGCAFile(doc))) {
+      if (!doc || !isDGCAFile(doc)) {
         vscode.window.showWarningMessage('Open a *.dgca.transitrix.yaml file first.');
         return;
       }
@@ -330,34 +320,18 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     }),
     vscode.commands.registerCommand('transitrixStudio.previewDGA', async () => {
       const doc = vscode.window.activeTextEditor?.document;
-      if (!doc || (!isDGAFile(doc) && !isFGAFile(doc))) {
+      if (!doc || !isDGAFile(doc)) {
         vscode.window.showWarningMessage('Open a *.dga.transitrix.yaml file first.');
-        return;
-      }
-      await fgaPreview.showOrReveal(doc);
-    }),
-    vscode.commands.registerCommand('transitrixStudio.previewFGCA', async () => {
-      const doc = vscode.window.activeTextEditor?.document;
-      if (!doc || (!isFGCAFile(doc) && !isDGCAFile(doc))) {
-        vscode.window.showWarningMessage('Open a *.fgca.transitrix.yaml (or *.dgca.transitrix.yaml) file first.');
-        return;
-      }
-      await fgcaPreview.showOrReveal(doc);
-    }),
-    vscode.commands.registerCommand('transitrixStudio.previewFGA', async () => {
-      const doc = vscode.window.activeTextEditor?.document;
-      if (!doc || (!isFGAFile(doc) && !isDGAFile(doc))) {
-        vscode.window.showWarningMessage('Open a *.fga.transitrix.yaml (or *.dga.transitrix.yaml) file first.');
         return;
       }
       await fgaPreview.showOrReveal(doc);
     }),
     vscode.commands.registerCommand('transitrixStudio.previewActivities', async () => {
       const doc = vscode.window.activeTextEditor?.document;
-      const notation = doc && (isDGCAFile(doc) ? probeDocNotation(doc) : undefined);
-      const isActivities = doc && (isActivitiesFile(doc) || notation === 'activities' || notation === 'action');
+      const notation = doc && isDGCAFile(doc) ? probeDocNotation(doc) : undefined;
+      const isActivities = doc && (isActivitiesFile(doc) || notation === 'action');
       if (!isActivities) {
-        vscode.window.showWarningMessage('Open a *.action.transitrix.yaml (or *.activities.transitrix.yaml) file first.');
+        vscode.window.showWarningMessage('Open a *.action.transitrix.yaml file first.');
         return;
       }
       await activitiesPreview.showOrReveal(doc);
@@ -393,12 +367,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     vscode.commands.registerCommand('transitrixStudio.saveDGAAsSvg', () =>
       fgaPreview.saveAsSvg(),
     ),
-    vscode.commands.registerCommand('transitrixStudio.saveFGCAAsSvg', () =>
-      fgcaPreview.saveAsSvg(),
-    ),
-    vscode.commands.registerCommand('transitrixStudio.saveFGAAsSvg', () =>
-      fgaPreview.saveAsSvg(),
-    ),
     vscode.commands.registerCommand('transitrixStudio.saveActivitiesAsSvg', () =>
       activitiesPreview.saveAsSvg(),
     ),
@@ -412,10 +380,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     vscode.commands.registerCommand('transitrixStudio.copyDGCAAsPng', () => fgcaPreview.copyAsPng()),
     vscode.commands.registerCommand('transitrixStudio.saveDGAAsPng', () => fgaPreview.saveAsPng()),
     vscode.commands.registerCommand('transitrixStudio.copyDGAAsPng', () => fgaPreview.copyAsPng()),
-    vscode.commands.registerCommand('transitrixStudio.saveFGCAAsPng', () => fgcaPreview.saveAsPng()),
-    vscode.commands.registerCommand('transitrixStudio.copyFGCAAsPng', () => fgcaPreview.copyAsPng()),
-    vscode.commands.registerCommand('transitrixStudio.saveFGAAsPng', () => fgaPreview.saveAsPng()),
-    vscode.commands.registerCommand('transitrixStudio.copyFGAAsPng', () => fgaPreview.copyAsPng()),
     vscode.commands.registerCommand('transitrixStudio.saveActivitiesAsPng', () => activitiesPreview.saveAsPng()),
     vscode.commands.registerCommand('transitrixStudio.copyActivitiesAsPng', () => activitiesPreview.copyAsPng()),
     vscode.commands.registerCommand('transitrixStudio.previewApplications', async () => {
@@ -474,7 +438,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     vscode.commands.registerCommand('transitrixStudio.previewActivityCard', async () => {
       const doc = vscode.window.activeTextEditor?.document;
       if (!doc || !isActivityCardFile(doc)) {
-        vscode.window.showWarningMessage('Open a *.activity-card.transitrix.yaml file first.');
+        vscode.window.showWarningMessage('Open a *.action-card.transitrix.yaml file first.');
         return;
       }
       await activityCardPreview.showOrReveal(doc);
@@ -607,13 +571,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         void gapDashboardPreview.refresh();
       }
       if (isGoalsFile(doc)) { void goalsPreview.refreshSaved(doc); return; }
-      if (isDGCAFile(doc) || isFGCAFile(doc)) {
-        const notation = isDGCAFile(doc) ? probeDocNotation(doc) : undefined;
+      if (isDGCAFile(doc)) {
+        const notation = probeDocNotation(doc);
         if (notation === 'goals') { void goalsPreview.refreshSaved(doc); return; }
-        if (notation === 'activities' || notation === 'action') { void activitiesPreview.refreshSaved(doc); return; }
+        if (notation === 'action') { void activitiesPreview.refreshSaved(doc); return; }
         void fgcaPreview.refreshSaved(doc); return;
       }
-      if (isDGAFile(doc) || isFGAFile(doc)) { void fgaPreview.refreshSaved(doc); return; }
+      if (isDGAFile(doc)) { void fgaPreview.refreshSaved(doc); return; }
       if (isActivitiesFile(doc)) { void activitiesPreview.refreshSaved(doc); return; }
       if (isActionsTreeFileName(doc.fileName)) { void actionsTreePreview.refreshSaved(doc); return; }
       if (isBlocksFile(doc)) { void blocksPreview.refreshSaved(doc); return; }
@@ -631,13 +595,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     }),
     vscode.workspace.onDidOpenTextDocument(async (doc) => {
       if (isGoalsFile(doc)) { await goalsPreview.showOrReveal(doc); return; }
-      if (isDGCAFile(doc) || isFGCAFile(doc)) {
-        const notation = isDGCAFile(doc) ? probeDocNotation(doc) : undefined;
+      if (isDGCAFile(doc)) {
+        const notation = probeDocNotation(doc);
         if (notation === 'goals') { await goalsPreview.showOrReveal(doc); return; }
-        if (notation === 'activities' || notation === 'action') { await activitiesPreview.showOrReveal(doc); return; }
+        if (notation === 'action') { await activitiesPreview.showOrReveal(doc); return; }
         await fgcaPreview.showOrReveal(doc); return;
       }
-      if (isDGAFile(doc) || isFGAFile(doc)) { await fgaPreview.showOrReveal(doc); return; }
+      if (isDGAFile(doc)) { await fgaPreview.showOrReveal(doc); return; }
       if (isActivitiesFile(doc)) { await activitiesPreview.showOrReveal(doc); return; }
       if (isActionsTreeFileName(doc.fileName)) { await actionsTreePreview.showOrReveal(doc); return; }
       if (isBlocksFile(doc)) { await blocksPreview.showOrReveal(doc); return; }


### PR DESCRIPTION
## Summary

Removes deprecated `*.fgca` / `*.fga` / `*.activities` / `*.activity-card` / `*.activities-tree` file-extension support from the VS Code extension surface — matching the validator-level removal already shipped in the prior alias cleanup. Canonical names: `dgca`, `dga`, `action`, `action-card`, `actions-tree`.

- `extension/package.json`: drop 5 deprecated `workspaceContains` activation events; drop 3 deprecated language entries (`transitrix-fga`, `transitrix-activities`, `transitrix-activity-card`); drop `.activities-tree.transitrix.yaml` from `transitrix-actions-tree`; drop 8 deprecated command declarations (`previewFGCA` / `previewFGA` and the `saveFGCA*` / `copyFGCA*` / `saveFGA*` / `copyFGA*` PNG+SVG variants); drop deprecated editor-title menu when-clauses; retarget the `activeWebviewPanelId == fgcaPreview` / `fgaPreview` panel-title menu entries onto the canonical `saveDGCAAsSvg` / `saveDGAAsSvg` commands.
- `extension/src/extension.ts`: remove `isFGCAFile` / `isFGAFile` helpers and their callers in `previewDGCA` / `previewDGA` and the save/open document handlers; drop the deprecated branch from `isActivitiesFile` / `isActivityCardFile`; drop the 8 deprecated command registrations; drop the now-dead `notation === 'activities'` runtime check (the validator errors on that value).

Out of scope for this PR (separate concerns, separate slices): the deprecated `transitrix.spacing.fgca.*` / `transitrix.curvature.fgca` etc. settings keys (and their type unions in `spacing-config.ts`); internal class / file / variable renames (`FGCAPreview`, `fgcaPreview`, `fgca-preview.ts`); test fixtures and organization canon files still using the deprecated extensions.

## Test plan

- [x] `npm run compile` — clean (root + diagrams)
- [x] `npm run compile:extension` — clean
- [x] `npm test` — 414 core + 1056 diagrams = 1470 passing locally
- [ ] Manual: open a `.dgca.transitrix.yaml` file in the extension host; confirm preview opens and the editor-title "Save DGCA as SVG" button still works; confirm the DGCA preview panel's tab "Save DGCA as SVG" button works (retargeted from the deprecated FGCA command).
- [ ] Manual: confirm `.fgca.transitrix.yaml` / `.fga.transitrix.yaml` / `.activities.transitrix.yaml` / `.activity-card.transitrix.yaml` files no longer get language colouring, activation, or editor-title preview buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)