### PR TITLE
refactor(extension): rename FGCAPreview/FGAPreview classes to DGCAPreview/DGAPreview

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -26,8 +26,6 @@
     "goal-tree",
     "dgca",
     "dga",
-    "fgca",
-    "fga",
     "activity-network",
     "psnd",
     "gantt",
@@ -955,12 +953,12 @@
           "group": "navigation@-9"
         },
         {
-          "when": "activeWebviewPanelId == fgcaPreview",
+          "when": "activeWebviewPanelId == dgcaPreview",
           "command": "transitrixStudio.saveDGCAAsSvg",
           "group": "navigation@-9"
         },
         {
-          "when": "activeWebviewPanelId == fgaPreview",
+          "when": "activeWebviewPanelId == dgaPreview",
           "command": "transitrixStudio.saveDGAAsSvg",
           "group": "navigation@-9"
         },

--- a/extension/src/dgca-preview.ts
+++ b/extension/src/dgca-preview.ts
@@ -253,9 +253,9 @@ ${body}
 </svg>`;
 }
 
-// ── FGCAPreview webview class ────────────────────────────────────────────────────────────────────────────
+// ── DGCAPreview webview class ────────────────────────────────────────────────────────────────────────────
 
-export class FGCAPreview {
+export class DGCAPreview {
   readonly panelTitle = 'DGCA Preview';
   private panel: vscode.WebviewPanel | undefined;
   private trackedUri: string | undefined;
@@ -274,7 +274,7 @@ export class FGCAPreview {
       this.panel.reveal(vscode.ViewColumn.Beside, true);
     } else {
       this.panel = vscode.window.createWebviewPanel(
-        'fgcaPreview',
+        'dgcaPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
         {
@@ -478,9 +478,9 @@ export class FGCAPreview {
   }
 }
 
-// ── FGAPreview webview class ──────────────────────────────────────────────────────────────────────────────
+// ── DGAPreview webview class ──────────────────────────────────────────────────────────────────────────────
 
-export class FGAPreview {
+export class DGAPreview {
   readonly panelTitle = 'DGA Preview';
   private panel: vscode.WebviewPanel | undefined;
   private trackedUri: string | undefined;
@@ -499,7 +499,7 @@ export class FGAPreview {
       this.panel.reveal(vscode.ViewColumn.Beside, true);
     } else {
       this.panel = vscode.window.createWebviewPanel(
-        'fgaPreview',
+        'dgaPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
         {

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -6,7 +6,7 @@ import type { CompileFn } from './preview.js';
 import { CervinPreview } from './preview.js';
 import { ProcessPreview, type ProcessLayoutFn, type BpmnDisplayOpts, SAVE_BPMN_PROCESS_SVG_COMMAND, OPEN_BPMN_SETTINGS_COMMAND } from './process-preview.js';
 import { GoalsPreview } from './goals-preview.js';
-import { FGCAPreview, FGAPreview } from './fgca-preview.js';
+import { DGCAPreview, DGAPreview } from './dgca-preview.js';
 import { ActivitiesPreview } from './activities-preview.js';
 import { BlocksPreview } from './blocks-preview.js';
 import { ApplicationsPreview } from './applications-preview.js';
@@ -234,8 +234,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   );
 
   const goalsPreview = new GoalsPreview(context.extensionUri);
-  const fgcaPreview = new FGCAPreview(context.extensionUri);
-  const fgaPreview = new FGAPreview(context.extensionUri);
+  const dgcaPreview = new DGCAPreview(context.extensionUri);
+  const dgaPreview = new DGAPreview(context.extensionUri);
   const activitiesPreview = new ActivitiesPreview(context.extensionUri);
   const blocksPreview = new BlocksPreview();
   const applicationsPreview = new ApplicationsPreview();
@@ -316,7 +316,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         vscode.window.showWarningMessage('Open a *.dgca.transitrix.yaml file first.');
         return;
       }
-      await fgcaPreview.showOrReveal(doc);
+      await dgcaPreview.showOrReveal(doc);
     }),
     vscode.commands.registerCommand('transitrixStudio.previewDGA', async () => {
       const doc = vscode.window.activeTextEditor?.document;
@@ -324,7 +324,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         vscode.window.showWarningMessage('Open a *.dga.transitrix.yaml file first.');
         return;
       }
-      await fgaPreview.showOrReveal(doc);
+      await dgaPreview.showOrReveal(doc);
     }),
     vscode.commands.registerCommand('transitrixStudio.previewActivities', async () => {
       const doc = vscode.window.activeTextEditor?.document;
@@ -362,10 +362,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       goalsPreview.saveAsSvg(),
     ),
     vscode.commands.registerCommand('transitrixStudio.saveDGCAAsSvg', () =>
-      fgcaPreview.saveAsSvg(),
+      dgcaPreview.saveAsSvg(),
     ),
     vscode.commands.registerCommand('transitrixStudio.saveDGAAsSvg', () =>
-      fgaPreview.saveAsSvg(),
+      dgaPreview.saveAsSvg(),
     ),
     vscode.commands.registerCommand('transitrixStudio.saveActivitiesAsSvg', () =>
       activitiesPreview.saveAsSvg(),
@@ -376,10 +376,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     vscode.commands.registerCommand('transitrixStudio.copyBlocksAsPng', () => blocksPreview.copyAsPng()),
     vscode.commands.registerCommand('transitrixStudio.saveGoalsAsPng', () => goalsPreview.saveAsPng()),
     vscode.commands.registerCommand('transitrixStudio.copyGoalsAsPng', () => goalsPreview.copyAsPng()),
-    vscode.commands.registerCommand('transitrixStudio.saveDGCAAsPng', () => fgcaPreview.saveAsPng()),
-    vscode.commands.registerCommand('transitrixStudio.copyDGCAAsPng', () => fgcaPreview.copyAsPng()),
-    vscode.commands.registerCommand('transitrixStudio.saveDGAAsPng', () => fgaPreview.saveAsPng()),
-    vscode.commands.registerCommand('transitrixStudio.copyDGAAsPng', () => fgaPreview.copyAsPng()),
+    vscode.commands.registerCommand('transitrixStudio.saveDGCAAsPng', () => dgcaPreview.saveAsPng()),
+    vscode.commands.registerCommand('transitrixStudio.copyDGCAAsPng', () => dgcaPreview.copyAsPng()),
+    vscode.commands.registerCommand('transitrixStudio.saveDGAAsPng', () => dgaPreview.saveAsPng()),
+    vscode.commands.registerCommand('transitrixStudio.copyDGAAsPng', () => dgaPreview.copyAsPng()),
     vscode.commands.registerCommand('transitrixStudio.saveActivitiesAsPng', () => activitiesPreview.saveAsPng()),
     vscode.commands.registerCommand('transitrixStudio.copyActivitiesAsPng', () => activitiesPreview.copyAsPng()),
     vscode.commands.registerCommand('transitrixStudio.previewApplications', async () => {
@@ -533,8 +533,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         !e.affectsConfiguration(VIEW_CONFIG_SECTION)
       ) return;
       void goalsPreview.refreshConfig();
-      void fgcaPreview.refreshConfig();
-      void fgaPreview.refreshConfig();
+      void dgcaPreview.refreshConfig();
+      void dgaPreview.refreshConfig();
       void activitiesPreview.refreshConfig();
       if (isThemeChange) {
         void blocksPreview.refreshConfig();
@@ -560,7 +560,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       // per-type routing below (which early-returns on a match).
       void activityCardPreview.refreshIfSiblingSaved(doc);
       void actionsTreePreview.refreshIfSiblingSaved(doc);
-      void fgcaPreview.refreshIfSiblingSaved(doc);
+      void dgcaPreview.refreshIfSiblingSaved(doc);
       // Compliance views are repo-wide: re-scan the open ones whenever a canon
       // artefact (by filename convention) is saved. No-op when no panel is open.
       if (/^(PRODUCT|REQUIREMENT|ASSERTION|LAW|REGULATION|POLICY|INTERNAL_STANDARD)-.*\.ya?ml$/.test(path.basename(doc.fileName))) {
@@ -575,9 +575,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         const notation = probeDocNotation(doc);
         if (notation === 'goals') { void goalsPreview.refreshSaved(doc); return; }
         if (notation === 'action') { void activitiesPreview.refreshSaved(doc); return; }
-        void fgcaPreview.refreshSaved(doc); return;
+        void dgcaPreview.refreshSaved(doc); return;
       }
-      if (isDGAFile(doc)) { void fgaPreview.refreshSaved(doc); return; }
+      if (isDGAFile(doc)) { void dgaPreview.refreshSaved(doc); return; }
       if (isActivitiesFile(doc)) { void activitiesPreview.refreshSaved(doc); return; }
       if (isActionsTreeFileName(doc.fileName)) { void actionsTreePreview.refreshSaved(doc); return; }
       if (isBlocksFile(doc)) { void blocksPreview.refreshSaved(doc); return; }
@@ -599,9 +599,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         const notation = probeDocNotation(doc);
         if (notation === 'goals') { await goalsPreview.showOrReveal(doc); return; }
         if (notation === 'action') { await activitiesPreview.showOrReveal(doc); return; }
-        await fgcaPreview.showOrReveal(doc); return;
+        await dgcaPreview.showOrReveal(doc); return;
       }
-      if (isDGAFile(doc)) { await fgaPreview.showOrReveal(doc); return; }
+      if (isDGAFile(doc)) { await dgaPreview.showOrReveal(doc); return; }
       if (isActivitiesFile(doc)) { await activitiesPreview.showOrReveal(doc); return; }
       if (isActionsTreeFileName(doc.fileName)) { await actionsTreePreview.showOrReveal(doc); return; }
       if (isBlocksFile(doc)) { await blocksPreview.showOrReveal(doc); return; }


### PR DESCRIPTION
## Summary

- Renames `extension/src/fgca-preview.ts` → `extension/src/dgca-preview.ts` (tracked as rename, 99% similarity)
- Renames exported classes: `FGCAPreview` → `DGCAPreview`, `FGAPreview` → `DGAPreview`
- Updates webview viewType IDs: `fgcaPreview` → `dgcaPreview`, `fgaPreview` → `dgaPreview`
- Updates corresponding `activeWebviewPanelId` when-clauses in `extension/package.json`
- Updates all usages in `extension/src/extension.ts` (import path, class names, variable names)
- Removes deprecated `fgca` and `fga` from the extension manifest `keywords` array

Imports from `@transitrix/diagrams/fgca/*` are intentionally unchanged — renaming that package directory is a separate, deeper concern.

## Test plan

- [ ] `tsc --noEmit` clean for both root and extension projects ✅
- [ ] 1135 unit tests pass ✅
- [ ] No private-hub references in diff ✅
- [ ] Open a `.dgca.transitrix.yaml` file in VS Code and confirm DGCA preview opens, Save as SVG/PNG buttons work
- [ ] Open a `.dga.transitrix.yaml` file and confirm DGA preview works similarly

🤖 Generated with [Claude Code](https://claude.com/claude-code)