### PR TITLE
chore(intellij): widen until-build to 262 for JetBrains 2026.2

### DIFF
--- a/intellij/gradle.properties
+++ b/intellij/gradle.properties
@@ -7,10 +7,10 @@ pluginVersion = 2.2.0
 # IntelliJ IDEA Community 2024.2 — JCEF-bearing baseline (JCEF requires 2020.2+).
 platformVersion = 2024.2
 pluginSinceBuild = 242
-# Upper bound covers IDEA 2026.1 (build 261). The plugin builds against the
+# Upper bound covers IDEA 2026.2 (build 262). The plugin builds against the
 # 2024.2 baseline but uses only stable platform + JCEF APIs, so it loads on
 # later IDEs; widen this as new IDEA majors are validated.
-pluginUntilBuild = 261.*
+pluginUntilBuild = 262.*
 
 gradleVersion = 8.10.2
 


### PR DESCRIPTION
## Summary

- Raises `pluginUntilBuild` from `261.*` to `262.*` in `intellij/gradle.properties`
- Keeps the plugin available after JetBrains releases IDE version 262 (2026.2)
- No API changes — compatibility ceiling only

## Test plan

- [ ] CI build passes for the IntelliJ module
- [ ] Plugin XML `until-build` reflects `262` in the built artifact