### PR TITLE
refactor(extension): rename ActivitiesPreview to ActionPreview + action settings keys

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -209,19 +209,19 @@
           "default": 20,
           "description": "FGA preview: vertical gap (px) between stacked nodes within a column."
         },
-        "transitrix.spacing.activities.horizontalGap": {
+        "transitrix.spacing.action.horizontalGap": {
           "type": "number",
           "minimum": 20,
           "maximum": 300,
           "default": 80,
-          "description": "Activities preview: horizontal gap (px) between CPM columns."
+          "description": "Action preview: horizontal gap (px) between CPM columns."
         },
-        "transitrix.spacing.activities.verticalGap": {
+        "transitrix.spacing.action.verticalGap": {
           "type": "number",
           "minimum": 20,
           "maximum": 300,
           "default": 24,
-          "description": "Activities preview: vertical gap (px) between stacked activity nodes."
+          "description": "Action preview: vertical gap (px) between stacked action nodes."
         },
         "transitrix.curvature.goals": {
           "type": "number",
@@ -258,12 +258,12 @@
           "default": 1,
           "description": "FGA preview: edge curvature. 0 = straight lines, 1 = default, higher = stronger arc."
         },
-        "transitrix.curvature.activities": {
+        "transitrix.curvature.action": {
           "type": "number",
           "minimum": 0,
           "maximum": 3,
           "default": 1,
-          "description": "Activities preview: CPM dependency-arrow curvature. 0 = straight lines, 1 = default, higher = stronger arc."
+          "description": "Action preview: CPM dependency-arrow curvature. 0 = straight lines, 1 = default, higher = stronger arc."
         },
         "transitrix.entryCurvature.goals": {
           "type": "number",
@@ -300,12 +300,12 @@
           "default": 1,
           "description": "FGA preview: curvature of the arrow at the point it enters a node. Defaults to transitrix.curvature.fga when equal to 1."
         },
-        "transitrix.entryCurvature.activities": {
+        "transitrix.entryCurvature.action": {
           "type": "number",
           "minimum": 0,
           "maximum": 3,
           "default": 1,
-          "description": "Activities preview: curvature of the dependency arrow at the point it enters an activity node. Defaults to transitrix.curvature.activities when equal to 1."
+          "description": "Action preview: curvature of the dependency arrow at the point it enters an action node. Defaults to transitrix.curvature.action when equal to 1."
         },
         "transitrix.scope.goals.rootId": {
           "type": "string",
@@ -973,7 +973,7 @@
           "group": "navigation@-9"
         },
         {
-          "when": "activeWebviewPanelId == activitiesPreview",
+          "when": "activeWebviewPanelId == actionPreview",
           "command": "transitrixStudio.saveActivitiesAsSvg",
           "group": "navigation@-9"
         },

--- a/extension/src/action-preview.ts
+++ b/extension/src/action-preview.ts
@@ -628,10 +628,10 @@ const ACTIVITIES_WEBVIEW_CSS = `
 
 const ACTIVITIES_STYLES = ACTIVITIES_WEBVIEW_CSS + ACTIVITIES_DIAGRAM_CSS;
 
-// ── ActivitiesPreview webview class ───────────────────────────────────────────
+// ── ActionPreview webview class ───────────────────────────────────────────────
 
-export class ActivitiesPreview {
-  readonly panelTitle = 'Activities Preview';
+export class ActionPreview {
+  readonly panelTitle = 'Action Preview';
   private panel: vscode.WebviewPanel | undefined;
   private trackedUri: string | undefined;
   // Saved separately so Save .svg can offer whichever view the user wants —
@@ -654,7 +654,7 @@ export class ActivitiesPreview {
       this.panel.reveal(vscode.ViewColumn.Beside, true);
     } else {
       this.panel = vscode.window.createWebviewPanel(
-        'activitiesPreview',
+        'actionPreview',
         `${this.panelTitle} — ${path.basename(doc.fileName)}`,
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
         {
@@ -668,7 +668,7 @@ export class ActivitiesPreview {
           enableCommandUris: ['transitrixStudio.saveActivitiesAsSvg', 'transitrixStudio.saveActivitiesAsPng', 'transitrixStudio.copyActivitiesAsPng', OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_THEME_COMMAND],
         },
       );
-      this.panel.webview.onDidReceiveMessage((m) => { void applyControlMessage('activities', m); });
+      this.panel.webview.onDidReceiveMessage((m) => { void applyControlMessage('action', m); });
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
     }
     await this.pushDocument(doc);
@@ -697,9 +697,9 @@ export class ActivitiesPreview {
     let warnings: string[] = [];
 
     const spacingDefaults = { horizontalGap: ACTIVITIES_DEFAULT_H_GAP, verticalGap: ACTIVITIES_DEFAULT_V_GAP };
-    const spacing = readSpacing('activities', spacingDefaults);
-    const curvature = readCurvature('activities');
-    const entryCurvature = readEntryCurvature('activities');
+    const spacing = readSpacing('action', spacingDefaults);
+    const curvature = readCurvature('action');
+    const entryCurvature = readEntryCurvature('action');
 
     try {
       const parsed = coerceDatesToIsoStrings(yaml.load(yamlText) as unknown);

--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -17,7 +17,7 @@ export { extractDiagramMeta };
  * Injects a <style> block with all --ts-* CSS variable definitions into an SVG string,
  * making it self-contained for file export (no external stylesheet required).
  *
- * Pass `notationCss` for the per-notation class rules (e.g. activities-preview's
+ * Pass `notationCss` for the per-notation class rules (e.g. action-preview's
  * `.act-node`, `.critical-edge`, `.gantt-bar`) that live in the preview's
  * webview `extraStyles` but are not part of the shared theme. Without them the
  * exported SVG falls through to browser defaults — typically black fills on

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -7,7 +7,7 @@ import { CervinPreview } from './preview.js';
 import { ProcessPreview, type ProcessLayoutFn, type BpmnDisplayOpts, SAVE_BPMN_PROCESS_SVG_COMMAND, OPEN_BPMN_SETTINGS_COMMAND } from './process-preview.js';
 import { GoalsPreview } from './goals-preview.js';
 import { DGCAPreview, DGAPreview } from './dgca-preview.js';
-import { ActivitiesPreview } from './activities-preview.js';
+import { ActionPreview } from './action-preview.js';
 import { BlocksPreview } from './blocks-preview.js';
 import { ApplicationsPreview } from './applications-preview.js';
 import { ProductsPreview } from './products-preview.js';
@@ -236,7 +236,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   const goalsPreview = new GoalsPreview(context.extensionUri);
   const dgcaPreview = new DGCAPreview(context.extensionUri);
   const dgaPreview = new DGAPreview(context.extensionUri);
-  const activitiesPreview = new ActivitiesPreview(context.extensionUri);
+  const actionPreview = new ActionPreview(context.extensionUri);
   const blocksPreview = new BlocksPreview();
   const applicationsPreview = new ApplicationsPreview();
   const productsPreview = new ProductsPreview();
@@ -334,7 +334,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         vscode.window.showWarningMessage('Open a *.action.transitrix.yaml file first.');
         return;
       }
-      await activitiesPreview.showOrReveal(doc);
+      await actionPreview.showOrReveal(doc);
     }),
     vscode.commands.registerCommand('transitrixStudio.previewActionsTree', async () => {
       const doc = vscode.window.activeTextEditor?.document;
@@ -368,7 +368,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       dgaPreview.saveAsSvg(),
     ),
     vscode.commands.registerCommand('transitrixStudio.saveActivitiesAsSvg', () =>
-      activitiesPreview.saveAsSvg(),
+      actionPreview.saveAsSvg(),
     ),
     // PNG export — save-to-file + copy-to-clipboard per vector notation
     // (vkgeorgia/strategy#32). Rasterized in the Node host via resvg.
@@ -380,8 +380,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     vscode.commands.registerCommand('transitrixStudio.copyDGCAAsPng', () => dgcaPreview.copyAsPng()),
     vscode.commands.registerCommand('transitrixStudio.saveDGAAsPng', () => dgaPreview.saveAsPng()),
     vscode.commands.registerCommand('transitrixStudio.copyDGAAsPng', () => dgaPreview.copyAsPng()),
-    vscode.commands.registerCommand('transitrixStudio.saveActivitiesAsPng', () => activitiesPreview.saveAsPng()),
-    vscode.commands.registerCommand('transitrixStudio.copyActivitiesAsPng', () => activitiesPreview.copyAsPng()),
+    vscode.commands.registerCommand('transitrixStudio.saveActivitiesAsPng', () => actionPreview.saveAsPng()),
+    vscode.commands.registerCommand('transitrixStudio.copyActivitiesAsPng', () => actionPreview.copyAsPng()),
     vscode.commands.registerCommand('transitrixStudio.previewApplications', async () => {
       const doc = vscode.window.activeTextEditor?.document;
       if (!doc || !isApplicationsFile(doc)) {
@@ -535,7 +535,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       void goalsPreview.refreshConfig();
       void dgcaPreview.refreshConfig();
       void dgaPreview.refreshConfig();
-      void activitiesPreview.refreshConfig();
+      void actionPreview.refreshConfig();
       if (isThemeChange) {
         void blocksPreview.refreshConfig();
         void processBlueprintPreview.refreshConfig();
@@ -574,11 +574,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       if (isDGCAFile(doc)) {
         const notation = probeDocNotation(doc);
         if (notation === 'goals') { void goalsPreview.refreshSaved(doc); return; }
-        if (notation === 'action') { void activitiesPreview.refreshSaved(doc); return; }
+        if (notation === 'action') { void actionPreview.refreshSaved(doc); return; }
         void dgcaPreview.refreshSaved(doc); return;
       }
       if (isDGAFile(doc)) { void dgaPreview.refreshSaved(doc); return; }
-      if (isActivitiesFile(doc)) { void activitiesPreview.refreshSaved(doc); return; }
+      if (isActivitiesFile(doc)) { void actionPreview.refreshSaved(doc); return; }
       if (isActionsTreeFileName(doc.fileName)) { void actionsTreePreview.refreshSaved(doc); return; }
       if (isBlocksFile(doc)) { void blocksPreview.refreshSaved(doc); return; }
       if (isApplicationsFile(doc)) { void applicationsPreview.refreshSaved(doc); return; }
@@ -598,11 +598,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       if (isDGCAFile(doc)) {
         const notation = probeDocNotation(doc);
         if (notation === 'goals') { await goalsPreview.showOrReveal(doc); return; }
-        if (notation === 'action') { await activitiesPreview.showOrReveal(doc); return; }
+        if (notation === 'action') { await actionPreview.showOrReveal(doc); return; }
         await dgcaPreview.showOrReveal(doc); return;
       }
       if (isDGAFile(doc)) { await dgaPreview.showOrReveal(doc); return; }
-      if (isActivitiesFile(doc)) { await activitiesPreview.showOrReveal(doc); return; }
+      if (isActivitiesFile(doc)) { await actionPreview.showOrReveal(doc); return; }
       if (isActionsTreeFileName(doc.fileName)) { await actionsTreePreview.showOrReveal(doc); return; }
       if (isBlocksFile(doc)) { await blocksPreview.showOrReveal(doc); return; }
       if (isApplicationsFile(doc)) { await applicationsPreview.showOrReveal(doc); return; }

--- a/extension/src/spacing-config.ts
+++ b/extension/src/spacing-config.ts
@@ -7,7 +7,7 @@ import type { ControlMessage, PreviewView } from './preview-controls.js';
 // mirroring the existing `transitrix.theme` pattern, and re-renders previews
 // on change. In-preview live sliders are deferred to PR2.
 
-export type SpacingNotation = 'goals' | 'dgca' | 'dga' | 'fgca' | 'fga' | 'activities';
+export type SpacingNotation = 'goals' | 'dgca' | 'dga' | 'fgca' | 'fga' | 'action';
 
 export interface SpacingGaps {
   /** px gap between columns (horizontal). */
@@ -37,7 +37,7 @@ export const OPEN_SPACING_SETTINGS_COMMAND = 'transitrixStudio.openSpacingSettin
 // PR1 persistence pattern as spacing: settings-backed, re-rendered on change,
 // in-preview slider deferred to the joint enableScripts call.
 
-export type CurvatureNotation = 'goals' | 'dgca' | 'dga' | 'fgca' | 'fga' | 'activities';
+export type CurvatureNotation = 'goals' | 'dgca' | 'dga' | 'fgca' | 'fga' | 'action';
 
 // Must match DEFAULT_EDGE_CURVATURE in @transitrix/diagrams so an unconfigured
 // preview is visually unchanged.
@@ -127,8 +127,8 @@ function clamp(n: number, min: number, max: number): number {
 
 /**
  * Applies one in-preview control change to VS Code configuration for `notation`.
- * Spacing/curvature apply to all four notations; scope only to goals/fgca/fga
- * (the Activities panel never renders a scope row). Scope is mutually exclusive
+ * Spacing/curvature apply to all four notations; scope only to goals/dgca/dga
+ * (the Action panel never renders a scope row). Scope is mutually exclusive
  * — setting a root clears the level cap and vice-versa, matching `readScope`'s
  * "one mode at a time" precedence and #77's AC.
  */
@@ -153,7 +153,7 @@ export async function applyControlMessage(notation: SpacingNotation, msg: Contro
     await cfg.update(`view.${notation}`, msg.field === 'table' ? 'table' : 'tree', target);
     return;
   }
-  if (msg.control === 'scope' && notation !== 'activities') {
+  if (msg.control === 'scope' && notation !== 'action') {
     if (msg.field === 'reset') {
       await cfg.update(`scope.${notation}.rootId`, '', target);
       await cfg.update(`scope.${notation}.maxLevel`, -1, target);


### PR DESCRIPTION
## Summary

Fifth slice of the deprecated-notation cleanup. Renames the Activities preview
to the canonical Action name, matching the ACTION primitive rename that landed
in prior methodology work:

- `activities-preview.ts` → `action-preview.ts` (git mv, 98% similarity)
- `ActivitiesPreview` class → `ActionPreview`; panel title updated
- Webview panel ID: `activitiesPreview` → `actionPreview`
- Settings keys renamed:
  - `transitrix.spacing.activities.*` → `transitrix.spacing.action.*`
  - `transitrix.curvature.activities` → `transitrix.curvature.action`
  - `transitrix.entryCurvature.activities` → `transitrix.entryCurvature.action`
- `SpacingNotation` / `CurvatureNotation` types: `'activities'` → `'action'`
- Scope guard in `applyControlMessage`: `!== 'activities'` → `!== 'action'`
- `package.json` when-clause updated to `actionPreview`

## Test plan

- [x] `tsc --noEmit` clean (root + extension)
- [x] 1135 tests pass
- [ ] Manual: open a `*.action.transitrix.yaml` file — preview opens as "Action Preview"; save-as-SVG toolbar button visible; spacing/curvature controls work

## Remaining scope (separate PRs)

- Extension settings keys for `fgca` / `fga` (`transitrix.spacing.fgca.*` etc.) — depends on dropping dead FGCA/FGA code paths in `dgca-preview.ts`
- `SpacingNotation` / `CurvatureNotation` / `ScopeNotation` / `ViewNotation` types: remove `'fgca'` / `'fga'` — coupled to the above
- Docs sweep (CHANGELOG, RELEASING migration guide)

🤖 Generated with [Claude Code](https://claude.com/claude-code)