### PR TITLE
refactor(extension): drop dead fgca/fga code paths + compliance-scan deprecated notation names

### DIFF
--- a/extension/src/compliance-scan.ts
+++ b/extension/src/compliance-scan.ts
@@ -70,8 +70,8 @@ const SILENT_NOTATIONS = new Set([
   'driver', 'equipment', 'factor', 'goal', 'registry', 'relation', 'role', 'rule',
   'stakeholder', 'target-state',
   // View / diagram notations
-  'activities', 'activity-card', 'applications', 'blocks', 'bpmn',
-  'capability-map', 'compliance-impact', 'coverage-metric', 'dga', 'dgca', 'fga', 'fgca',
+  'action', 'action-card', 'applications', 'blocks', 'bpmn',
+  'capability-map', 'compliance-impact', 'coverage-metric', 'dga', 'dgca',
   'goals', 'issues', 'process-blueprint', 'process-map', 'products', 'scenarios',
 ]);
 

--- a/extension/src/dgca-preview.ts
+++ b/extension/src/dgca-preview.ts
@@ -100,8 +100,8 @@ function chainTableHtml(table: ChainTable): string {
   return `<div class="chain-table-wrap"><table class="chain-table"><thead>${head}</thead><tbody>${body}</tbody></table></div>`;
 }
 
-/** Assembles the interactive control-panel model shared by FGCA and FGA. */
-function fgcaControlsModel(
+/** Assembles the interactive control-panel model shared by DGCA and DGA. */
+function chainControlsModel(
   gaps: { horizontalGap: number; verticalGap: number },
   defaults: { horizontalGap: number; verticalGap: number },
   curvature: number,
@@ -123,9 +123,9 @@ function fgcaControlsModel(
 
 interface ChainPreviewParams {
   /** Toolbar / frame notation label. */
-  notation: 'DGCA' | 'DGA' | 'FGCA' | 'FGA';
+  notation: 'DGCA' | 'DGA';
   /** Settings namespace + view key (`transitrix.{spacing,curvature,scope,view}.<this>`). */
-  viewNotation: 'dgca' | 'dga' | 'fgca' | 'fga';
+  viewNotation: 'dgca' | 'dga';
   /** FGA hides the Change column. */
   hideChanges: boolean;
   /** SVG title-block heading (tree view). */
@@ -198,7 +198,7 @@ function renderChainPreview(
     if (scopeWarning) warnings.push(`${scopeWarning.code}: ${scopeWarning.message}`);
     svg = buildSvg(parsedDoc, p.hideChanges, { colGap: gaps.horizontalGap, rowGap: gaps.verticalGap, curvature, entryCurvature, scope }, p.heading, filename, docDate, docVersion);
   }
-  const model = fgcaControlsModel(gaps, spacingDefaults, curvature, scope, goalOptions, maxLevelPresent);
+  const model = chainControlsModel(gaps, spacingDefaults, curvature, scope, goalOptions, maxLevelPresent);
   const html = buildDiagramFrame({
     filename, notation: p.notation, svgContent: svg, errorMsg, warnings, themeId,
     saveSvgCommand: p.saveSvgCommand,
@@ -311,12 +311,12 @@ export class DGCAPreview {
   async refreshIfSiblingSaved(doc: vscode.TextDocument): Promise<void> {
     if (!this.panel || !this.trackedUri) return;
     if (!doc.fileName.endsWith('.yaml')) return;
-    const fgcaUri = vscode.Uri.parse(this.trackedUri);
-    const canonRoot = findCanonRoot(fgcaUri);
+    const viewUri = vscode.Uri.parse(this.trackedUri);
+    const canonRoot = findCanonRoot(viewUri);
     if (!canonRoot) return;
     if (!isUnderCanon(canonRoot, doc.uri)) return;
-    const fgcaDoc = await vscode.workspace.openTextDocument(fgcaUri);
-    await this.pushDocument(fgcaDoc);
+    const viewDoc = await vscode.workspace.openTextDocument(viewUri);
+    await this.pushDocument(viewDoc);
   }
 
   private async loadSnapshotMarkers(): Promise<SnapshotMarker[]> {
@@ -450,7 +450,7 @@ export class DGCAPreview {
 
   saveAsPng(): Promise<void> {
     const sourceUri = this.trackedUri ? vscode.Uri.parse(this.trackedUri) : undefined;
-    return savePngFromSvg({ ...this.pngTarget(), sourceUri, stripExt: /\.(dgca|fgca)\.transitrix\.yaml$/ });
+    return savePngFromSvg({ ...this.pngTarget(), sourceUri, stripExt: /\.dgca\.transitrix\.yaml$/ });
   }
 
   copyAsPng(): Promise<void> {
@@ -464,7 +464,7 @@ export class DGCAPreview {
     }
     const sourceUri = this.trackedUri ? vscode.Uri.parse(this.trackedUri) : undefined;
     const stem = sourceUri
-      ? path.basename(sourceUri.fsPath).replace(/\.(dgca|fgca)\.transitrix\.yaml$/, '')
+      ? path.basename(sourceUri.fsPath).replace(/\.dgca\.transitrix\.yaml$/, '')
       : 'diagram';
     const defaultUri = sourceUri
       ? vscode.Uri.file(path.join(path.dirname(sourceUri.fsPath), `${stem}.svg`))
@@ -659,7 +659,7 @@ export class DGAPreview {
 
   saveAsPng(): Promise<void> {
     const sourceUri = this.trackedUri ? vscode.Uri.parse(this.trackedUri) : undefined;
-    return savePngFromSvg({ ...this.pngTarget(), sourceUri, stripExt: /\.(dga|fga)\.transitrix\.yaml$/ });
+    return savePngFromSvg({ ...this.pngTarget(), sourceUri, stripExt: /\.dga\.transitrix\.yaml$/ });
   }
 
   copyAsPng(): Promise<void> {
@@ -673,7 +673,7 @@ export class DGAPreview {
     }
     const sourceUri = this.trackedUri ? vscode.Uri.parse(this.trackedUri) : undefined;
     const stem = sourceUri
-      ? path.basename(sourceUri.fsPath).replace(/\.(dga|fga)\.transitrix\.yaml$/, '')
+      ? path.basename(sourceUri.fsPath).replace(/\.dga\.transitrix\.yaml$/, '')
       : 'diagram';
     const defaultUri = sourceUri
       ? vscode.Uri.file(path.join(path.dirname(sourceUri.fsPath), `${stem}.svg`))


### PR DESCRIPTION
## Summary

Sixth slice of the deprecated-notation cleanup. Removes the last fgca/fga
dead code that remained after the deprecated file-extension activationEvents
were dropped in the second slice:

- `ChainPreviewParams.notation`: `'DGCA' | 'DGA' | 'FGCA' | 'FGA'` → `'DGCA' | 'DGA'`
- `ChainPreviewParams.viewNotation`: `'dgca' | 'dga' | 'fgca' | 'fga'` → `'dgca' | 'dga'`
- `fgcaControlsModel` → `chainControlsModel` (internal function rename)
- Local variables `fgcaUri`/`fgcaDoc` → `viewUri`/`viewDoc` in `refreshIfSiblingSaved`
- `DGCAPreview.saveAsPng/saveAsSvg`: regex simplified from `/(dgca|fgca)/` to `/dgca/`
- `DGAPreview.saveAsPng/saveAsSvg`: regex simplified from `/(dga|fga)/` to `/dga/`
- `SILENT_NOTATIONS` in `compliance-scan.ts`: deprecated entries `activities`,
  `activity-card`, `fga`, `fgca` replaced with canonical `action`, `action-card`

## Test plan

- [x] `tsc --noEmit` clean (root + extension)
- [x] 1135 tests pass

## Remaining scope (separate PRs)

- `SpacingNotation` / `CurvatureNotation` / `ScopeNotation` / `ViewNotation` types:
  remove `'fgca'` / `'fga'` from `spacing-config.ts` — depends on PR #329 merging
  (both touch the same file)
- `extension/package.json` configuration section: remove `transitrix.spacing.fgca.*`,
  `transitrix.spacing.fga.*`, `transitrix.curvature.fgca/fga`, etc.
- Docs sweep (CHANGELOG, RELEASING migration guide)

🤖 Generated with [Claude Code](https://claude.com/claude-code)