### PR TITLE
docs: fix RELEASING.md + add [Unreleased] CHANGELOG for notation alias removals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,61 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **LOCATION primitive — validator + `unit_located_at` relation.** `LOCATION`
+  is now a first-class business-layer element. `unit_located_at` validates the
+  business-unit → LOCATION relation with `BLOC-001..003` and `LOC-001..003`
+  rules; mismatched subject/target types produce a `layer_semantics` error.
+
+- **BUSINESS_SERVICE primitive — validator + relation layer-semantics.**
+  `BUSINESS_SERVICE` elements validate with `BSVC-001..003`; the `provides`
+  and `used_by` relations enforce source/target type constraints.
+
+- **INTEGRATION primitive — validator + `interface_semantics` enforcement.**
+  `INTEGRATION` elements validate with `INTG-001..003`; the new
+  `interface_semantics` relation kind enforces source/target constraints with
+  `INTG-004..005` rules.
+
+- **NODE + TECHNOLOGY_SERVICE primitives — validators + `hosts`/`uses` relations.**
+  `NODE` and `TECHNOLOGY_SERVICE` validate with `NODE-001..003` /
+  `TSVC-001..003`; the `hosts` and `uses` relations carry `TSVC-003`
+  layer-semantics enforcement.
+
+### Removed
+
+- **Deprecated notation aliases `fgca`, `fga`, `activities`, `activity-card`.**
+  The CLI validators now emit errors (not warnings) for these legacy notation
+  values. Canonical replacements: `dgca`, `dga`, `action`, `action-card`.
+  See [RELEASING.md](RELEASING.md) for migration steps.
+
+- **Deprecated VS Code file-extension support for `*.fgca`, `*.fga`,
+  `*.activities`, `*.activity-card`, `*.activities-tree`.** The extension no
+  longer activates for these file patterns; preview commands, language entries,
+  and activation events for the deprecated suffixes are removed. Use the
+  canonical equivalents: `*.dgca`, `*.dga`, `*.action`, `*.action-card`,
+  `*.actions-tree`.
+
+- **Deprecated org canon examples and IntelliJ plugin notation entries.**
+  `canon/views/fgca/` and `canon/views/fga/` removed; `canon/views/activities/`
+  and `canon/views/activity-card/` renamed to `action/` and `action-card/`.
+  IntelliJ plugin's deprecated suffix→kind mappings for `fgca`, `fga`,
+  `activities`, `activity-card` removed; canonical `action` / `action-card`
+  mappings added.
+
+### Internal
+
+- **`FGCAPreview` → `DGCAPreview`, `FGAPreview` → `DGAPreview`.** Internal
+  preview class names, webview panel IDs (`fgcaPreview` → `dgcaPreview`,
+  `fgaPreview` → `dgaPreview`), and `when`-clause guards updated to canonical
+  names.
+
+- **IntelliJ `until-build` widened to 262** for JetBrains 2026.2
+  compatibility.
+
+---
+
 ## [2.7.0] — 2026-06-26
 
 ### Added

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,19 +4,20 @@ Migration notes for adopters upgrading across major changes.
 
 ---
 
-## 1.x → 2.0 (planned)
+## 2.x — deprecated notation aliases removed (2.7.x, 2026-06)
 
-### FGCA/FGA → DGCA/DGA notation rename (breaking at 2.0)
+The deprecated notation shims that had been carried for backwards compatibility
+since the methodology renames are fully removed in the 2.7.x release line.
 
-The `fgca` and `fga` notation keys, file extensions, and UI strings have been
-renamed to `dgca` and `dga` to reflect the "Driver" terminology that replaced
-"Factor" across the methodology.
+### FGCA/FGA → DGCA/DGA
 
-**1.x behaviour (current):** both old and new names are accepted. A deprecation
-warning is emitted when the legacy `notation: fgca` or `notation: fga` key is
-encountered.
+The `fgca` and `fga` notation keys and file extensions have been renamed to
+`dgca` and `dga` (Driver-Goal-Change-Activity / Driver-Goal-Activity), reflecting
+the "Driver" terminology that replaced "Factor" across the methodology.
 
-**2.0:** legacy keys will be dropped. Migrate before upgrading.
+**Current state (2.7.x+):** the legacy names are removed. The CLI validators
+reject `notation: fgca` / `notation: fga` with errors. The VS Code extension no
+longer activates for `*.fgca.transitrix.yaml` / `*.fga.transitrix.yaml` files.
 
 #### Migration steps
 
@@ -39,7 +40,8 @@ encountered.
    convention — rename to `DGCA-*` / `DGA-*`. (Not required; the validator
    accepts any string `id`.)
 
-4. Update VS Code settings keys if you have workspace-level overrides:
+4. Update VS Code settings keys if you have workspace-level overrides.
+   The old keys are deprecated and will be removed in a future 2.x patch:
    - `transitrix.spacing.fgca.*` → `transitrix.spacing.dgca.*`
    - `transitrix.spacing.fga.*` → `transitrix.spacing.dga.*`
    - `transitrix.curvature.fgca` → `transitrix.curvature.dgca`
@@ -50,4 +52,77 @@ encountered.
    - `transitrix.view.fga` → `transitrix.view.dga`
 
 5. Update any scripts or CI commands that reference `fgca`/`fga` notation
-   names in `cervin validate` / `transitrix validate` invocations.
+   names in `transitrix validate` invocations.
+
+---
+
+### activities/activity-card → action/action-card
+
+The `activities` and `activity-card` notation keys and file extensions have been
+renamed to `action` and `action-card`. The `activities-tree` extension is now
+`actions-tree`.
+
+**Current state (2.7.x+):** the legacy names are removed. The CLI validators
+reject `notation: activities` / `notation: activity-card` with errors. The VS
+Code extension no longer activates for `*.activities.transitrix.yaml`,
+`*.activity-card.transitrix.yaml`, or `*.activities-tree.transitrix.yaml` files.
+
+#### Migration steps
+
+1. Rename files:
+   - `*.activities.transitrix.yaml` → `*.action.transitrix.yaml`
+   - `*.activity-card.transitrix.yaml` → `*.action-card.transitrix.yaml`
+   - `*.activities-tree.transitrix.yaml` → `*.actions-tree.transitrix.yaml`
+
+2. Update the `notation:` header inside each file:
+
+   ```yaml
+   # before
+   notation: activities      # or: activity-card
+
+   # after
+   notation: action          # or: action-card
+   ```
+
+3. Update the root key in YAML files that used the old key:
+
+   ```yaml
+   # before
+   activities:
+     - id: ACT-001
+       ...
+
+   # after
+   actions:
+     - id: ACTION-001
+       ...
+   ```
+
+   Same for `activity_card:` → `action_card:`.
+
+4. Update VS Code settings keys if you have workspace-level overrides.
+   The old keys are deprecated and will be removed in a future 2.x patch:
+   - `transitrix.spacing.activities.*` → `transitrix.spacing.action.*`
+   - `transitrix.curvature.activities` → `transitrix.curvature.action`
+   - `transitrix.entryCurvature.activities` → `transitrix.entryCurvature.action`
+
+5. Update any scripts or CI commands that reference `activities` /
+   `activity-card` notation names in `transitrix validate` invocations.
+
+---
+
+## 1.x → 2.0
+
+### Cervin → Transitrix rename (breaking at 2.0.0)
+
+All `cervin` compatibility shims introduced in 1.x are removed in 2.0.0.
+See [CHANGELOG.md](CHANGELOG.md) — 2.0.0 section — for the full list of removed
+items and drop-in replacements.
+
+Summary of what changed:
+
+- `cervin` CLI binary → `transitrix`
+- `cervin.*` VS Code settings → `transitrix.*`
+- `cervin.*` VS Code commands → `transitrix.*`
+- `.cervinrc` project config → `.transitrixrc` (identical JSON schema)
+- `"[cervin-yaml]"` in settings.json → `"[transitrix-yaml]"`


### PR DESCRIPTION
## Summary

- **RELEASING.md** was stale: the FGCA/FGA migration section described deprecated aliases as still accepted in 1.x and "planned for 2.0 removal" — both wrong. The aliases were removed in the 2.7.x release line. Rewrites the section to reflect actual current state; adds the activities/activity-card → action/action-card migration section (also removed in 2.7.x); tightens the 1.x → 2.0 Cervin section.
- **CHANGELOG.md** adds an `[Unreleased]` section for the post-2.7.0 work not yet under a version tag: new LOCATION / BUSINESS_SERVICE / INTEGRATION / NODE / TECHNOLOGY_SERVICE primitive validators; removal of all deprecated notation aliases, VS Code activationEvents, org canon examples, IntelliJ entries, and internal preview class renames.

## Test plan

- [x] `tsc --noEmit` clean (docs-only change — no code modified)
- [x] Pre-PR hygiene check: no internal references in diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)