### PR TITLE
refactor(extension): drop fgca/fga from spacing-config types + settings

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -181,34 +181,6 @@
           "default": 20,
           "description": "DGA preview: vertical gap (px) between stacked nodes within a column."
         },
-        "transitrix.spacing.fgca.horizontalGap": {
-          "type": "number",
-          "minimum": 20,
-          "maximum": 300,
-          "default": 160,
-          "description": "FGCA preview: horizontal gap (px) between the Driver/Goal/Change/Activity columns."
-        },
-        "transitrix.spacing.fgca.verticalGap": {
-          "type": "number",
-          "minimum": 20,
-          "maximum": 300,
-          "default": 20,
-          "description": "FGCA preview: vertical gap (px) between stacked nodes within a column."
-        },
-        "transitrix.spacing.fga.horizontalGap": {
-          "type": "number",
-          "minimum": 20,
-          "maximum": 300,
-          "default": 160,
-          "description": "FGA preview: horizontal gap (px) between the Driver/Goal/Activity columns."
-        },
-        "transitrix.spacing.fga.verticalGap": {
-          "type": "number",
-          "minimum": 20,
-          "maximum": 300,
-          "default": 20,
-          "description": "FGA preview: vertical gap (px) between stacked nodes within a column."
-        },
         "transitrix.spacing.action.horizontalGap": {
           "type": "number",
           "minimum": 20,
@@ -244,20 +216,6 @@
           "default": 1,
           "description": "DGA preview: edge curvature. 0 = straight lines, 1 = default, higher = stronger arc."
         },
-        "transitrix.curvature.fgca": {
-          "type": "number",
-          "minimum": 0,
-          "maximum": 3,
-          "default": 1,
-          "description": "FGCA preview: edge curvature. 0 = straight lines, 1 = default, higher = stronger arc."
-        },
-        "transitrix.curvature.fga": {
-          "type": "number",
-          "minimum": 0,
-          "maximum": 3,
-          "default": 1,
-          "description": "FGA preview: edge curvature. 0 = straight lines, 1 = default, higher = stronger arc."
-        },
         "transitrix.curvature.action": {
           "type": "number",
           "minimum": 0,
@@ -285,20 +243,6 @@
           "maximum": 3,
           "default": 1,
           "description": "DGA preview: curvature of the arrow at the point it enters a node. Defaults to transitrix.curvature.dga when equal to 1."
-        },
-        "transitrix.entryCurvature.fgca": {
-          "type": "number",
-          "minimum": 0,
-          "maximum": 3,
-          "default": 1,
-          "description": "FGCA preview: curvature of the arrow at the point it enters a node. Defaults to transitrix.curvature.fgca when equal to 1."
-        },
-        "transitrix.entryCurvature.fga": {
-          "type": "number",
-          "minimum": 0,
-          "maximum": 3,
-          "default": 1,
-          "description": "FGA preview: curvature of the arrow at the point it enters a node. Defaults to transitrix.curvature.fga when equal to 1."
         },
         "transitrix.entryCurvature.action": {
           "type": "number",

--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -29,7 +29,7 @@ export function prepareSvgForExport(svg: string, themeId: ThemeId = 'transitrix'
 }
 
 export interface DiagramFrameOpts {
-  /** Short filename shown in toolbar (e.g. "strategy-2026.fgca.transitrix.yaml"). */
+  /** Short filename shown in toolbar (e.g. "strategy-2026.dgca.transitrix.yaml"). */
   filename: string;
   /** Human-readable notation name shown in toolbar (e.g. "FGCA", "Goal tree"). */
   notation: string;

--- a/extension/src/preview-controls.ts
+++ b/extension/src/preview-controls.ts
@@ -7,7 +7,7 @@ import { escXml } from '@transitrix/diagrams/webview/render-util.js';
 // PR1 shipped the same controls as VS Code settings + a "…" toolbar link that
 // opens Settings. PR2 adds live, in-preview controls. Per Valerii's joint
 // `enableScripts` posture call (2026-06-02), the four interactive previews
-// (goals / fgca / fga / activities) now run with scripts enabled under a strict
+// (goals / dgca / dga / action) now run with scripts enabled under a strict
 // nonce-based CSP. This module is the *pure* string-building half of that work
 // — it never imports `vscode`, so it is unit-testable:
 //

--- a/extension/src/spacing-config.ts
+++ b/extension/src/spacing-config.ts
@@ -7,7 +7,7 @@ import type { ControlMessage, PreviewView } from './preview-controls.js';
 // mirroring the existing `transitrix.theme` pattern, and re-renders previews
 // on change. In-preview live sliders are deferred to PR2.
 
-export type SpacingNotation = 'goals' | 'dgca' | 'dga' | 'fgca' | 'fga' | 'action';
+export type SpacingNotation = 'goals' | 'dgca' | 'dga' | 'action';
 
 export interface SpacingGaps {
   /** px gap between columns (horizontal). */
@@ -37,7 +37,7 @@ export const OPEN_SPACING_SETTINGS_COMMAND = 'transitrixStudio.openSpacingSettin
 // PR1 persistence pattern as spacing: settings-backed, re-rendered on change,
 // in-preview slider deferred to the joint enableScripts call.
 
-export type CurvatureNotation = 'goals' | 'dgca' | 'dga' | 'fgca' | 'fga' | 'action';
+export type CurvatureNotation = 'goals' | 'dgca' | 'dga' | 'action';
 
 // Must match DEFAULT_EDGE_CURVATURE in @transitrix/diagrams so an unconfigured
 // preview is visually unchanged.
@@ -71,7 +71,7 @@ export const ENTRY_CURVATURE_CONFIG_SECTION = 'transitrix.entryCurvature';
 // pattern as spacing: settings-backed, re-rendered on change. The in-preview
 // root-picker dropdown is deferred to the joint enableScripts PR2.
 
-export type ScopeNotation = 'goals' | 'dgca' | 'dga' | 'fgca' | 'fga';
+export type ScopeNotation = 'goals' | 'dgca' | 'dga';
 
 /**
  * Resolves the configured scope for a notation. A non-empty `rootId` wins over
@@ -93,14 +93,14 @@ export const SCOPE_CONFIG_SECTION = 'transitrix.scope';
 /** Command that opens Settings filtered to the scope controls. */
 export const OPEN_SCOPE_SETTINGS_COMMAND = 'transitrixStudio.openScopeSettings';
 
-// ── Tree ↔ table view (vkgeorgia/strategy#137) ──────────────────────────────
+// ── Tree ↔ table view ────────────────────────────────────────────────────────
 //
-// FGCA/FGA previews can render as the tree/chain diagram (default) or as a
+// DGCA/DGA previews can render as the tree/chain diagram (default) or as a
 // flattened chain table. Same settings-backed persistence as the controls
 // above: the in-preview toolbar toggle writes `transitrix.view.<notation>` and
 // the preview re-renders.
 
-export type ViewNotation = 'dgca' | 'dga' | 'fgca' | 'fga';
+export type ViewNotation = 'dgca' | 'dga';
 
 /** Reads the persisted view for a notation. Defaults to 'tree' (no change). */
 export function readView(notation: ViewNotation): PreviewView {
@@ -149,7 +149,7 @@ export async function applyControlMessage(notation: SpacingNotation, msg: Contro
     await cfg.update(`entryCurvature.${notation}`, clamp(Number(msg.value), 0, 3), target);
     return;
   }
-  if (msg.control === 'view' && (notation === 'dgca' || notation === 'dga' || notation === 'fgca' || notation === 'fga')) {
+  if (msg.control === 'view' && (notation === 'dgca' || notation === 'dga')) {
     await cfg.update(`view.${notation}`, msg.field === 'table' ? 'table' : 'tree', target);
     return;
   }


### PR DESCRIPTION
## Summary

Final cleanup slice — removes deprecated FGCA/FGA identifiers from the extension's type system and VS Code configuration surface. The FGCA/FGA previews themselves were removed in prior slices; this PR clears the dead type unions and settings keys that had no remaining callers.

**`extension/src/spacing-config.ts`**
- `SpacingNotation`, `CurvatureNotation`: remove `'fgca' | 'fga'`
- `ScopeNotation`: remove `'fgca' | 'fga'` (now `'goals' | 'dgca' | 'dga'`)
- `ViewNotation`: remove `'fgca' | 'fga'` (now `'dgca' | 'dga'`)
- `applyControlMessage` view-guard narrowed to match
- Stale section comment updated to canonical notation names

**`extension/package.json`** — removes six settings that appeared in the VS Code Settings UI but had no code reading them:
- `transitrix.spacing.fgca.horizontalGap` / `.verticalGap`
- `transitrix.spacing.fga.horizontalGap` / `.verticalGap`
- `transitrix.curvature.fgca` / `.fga`
- `transitrix.entryCurvature.fgca` / `.fga`

**`extension/src/preview-controls.ts`**, **`extension/src/diagram-frame.ts`** — stale comments updated to canonical names.

## Test plan

- [x] `tsc --noEmit` clean (root project)
- [x] `tsc --noEmit` clean (extension project)
- [x] 1135 tests pass
- [x] Pre-PR hygiene: no new hub references introduced in diff