### PR TITLE
feat(bpmn): add Title header to BPMN diagram views

### DIFF
--- a/extension/src/process-preview.ts
+++ b/extension/src/process-preview.ts
@@ -162,6 +162,10 @@ export class ProcessPreview {
       const nonce = genNonce();
       const { panel: controlsPanel, script: controlsScript } = buildBpmnControls(nonce, this.uniformLaneHeight);
 
+      // Title sourced from the process name — the same top-level name field
+      // that all other diagram types expose in their title header.
+      const processTitle = layout.process.name || undefined;
+
       this.panel.webview.html = buildDiagramFrame({
         filename,
         notation: 'BPMN Process',
@@ -169,6 +173,7 @@ export class ProcessPreview {
         errorMsg,
         warnings: warningMsgs,
         themeId,
+        title: processTitle,
         saveSvgCommand: SAVE_BPMN_PROCESS_SVG_COMMAND,
         spacingCommand: OPEN_BPMN_SETTINGS_COMMAND,
         themeCommand: OPEN_THEME_COMMAND,

--- a/tests/diagram-frame.test.ts
+++ b/tests/diagram-frame.test.ts
@@ -40,6 +40,48 @@ describe('buildDiagramFrame error strip', () => {
   });
 });
 
+// #420 — Title header: BPMN (and other diagram types) pass a `title` option so
+// the frame renders a .frame-header block matching the standard visual treatment.
+describe('buildDiagramFrame title header', () => {
+  it('renders frame-header when title is provided', () => {
+    const html = buildDiagramFrame({
+      ...base,
+      svgContent: '<svg/>',
+      title: 'Order Fulfilment Process',
+    });
+    expect(html).toContain('class="frame-header"');
+    expect(html).toContain('class="frame-title"');
+    expect(html).toContain('Order Fulfilment Process');
+  });
+
+  it('emits no frame-header when title is omitted', () => {
+    const html = buildDiagramFrame({ ...base, svgContent: '<svg/>' });
+    expect(html).not.toContain('class="frame-header"');
+    expect(html).not.toContain('class="frame-title"');
+  });
+
+  it('escapes special characters in the title', () => {
+    const html = buildDiagramFrame({
+      ...base,
+      svgContent: '<svg/>',
+      title: '<Process> & "Test"',
+    });
+    expect(html).toContain('&lt;Process&gt; &amp; &quot;Test&quot;');
+    expect(html).not.toContain('<Process>');
+  });
+
+  it('renders subtitle when provided alongside title', () => {
+    const html = buildDiagramFrame({
+      ...base,
+      svgContent: '<svg/>',
+      title: 'Main title',
+      subtitle: 'Sub description',
+    });
+    expect(html).toContain('class="frame-subtitle"');
+    expect(html).toContain('Sub description');
+  });
+});
+
 describe('buildDiagramFrame warnings strip', () => {
   it('renders warnings in a collapsible strip, collapsed by default', () => {
     const html = buildDiagramFrame({


### PR DESCRIPTION
## Summary

- BPMN diagrams had no title header while every other diagram type rendered one.
- The process name is already available on `layout.process.name` (parsed from `process.name` in the YAML).
- Now passed to `buildDiagramFrame` as `title`, which produces the `.frame-header` / `.frame-title` block at the same font, position, and style as all other notation types.
- Four new unit tests in `diagram-frame.test.ts` cover the title-header contract: renders when provided, absent when omitted, escapes special chars, subtitle alongside title.

No changes to BPMN content rendering or data model.

## Test plan

- [ ] Run `npx vitest run tests/diagram-frame.test.ts` — all 11 tests pass.
- [ ] Open a `.bpmn.transitrix.yaml` in VS Code with the custom renderer — the title bar should now show the process name above the pool diagram.
- [ ] A BPMN file with no `name` on the process block should render no title block (no empty header).

🤖 Generated with [Claude Code](https://claude.com/claude-code)