### PR TITLE
docs(changelog): add BPMN routing-crossings fix to 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,12 @@
 
 ### Fixed
 
+- **BPMN — fewer routing crossings and redundant bends.** Collinear
+  intermediate waypoints (no direction change) are now stripped from routed
+  edges, and converging S-curve flows into the same join element are routed
+  via a shared approach column when their midpoints would otherwise
+  interleave, avoiding crossings. Adds the `parallel-tracks` corpus fixture.
+
 - **BPMN — equalize toggle now applies normalization.** The `ProcessPreview`
   lambda in the extension dropped the `opts` argument, so `uniformLaneHeight`
   never reached `layoutProcess` regardless of the equalize checkbox state.


### PR DESCRIPTION
## Summary
- #338 (routing-crossings/bends fix) merged after #339 (2.8.0 release notes) landed, so its CHANGELOG entry was missing from the `[2.8.0]` section.
- Adds a `### Fixed` entry under `[2.8.0]` for the collinear-waypoint removal and converging S-curve crossing fix. No version bump — `v2.8.0` hasn't been tagged yet, so this is still part of the same unreleased line.

## Test plan
- [x] Docs-only change, no code touched