### PR TITLE
fix(render-blocks): fix text overlap and unify block/goals node style

### DIFF
--- a/extension/src/action-preview.ts
+++ b/extension/src/action-preview.ts
@@ -3,7 +3,7 @@ import { escXml } from '@transitrix/diagrams/webview/render-util.js';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, prepareSvgForExport, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
-import { TITLE_BLOCK_H, titleBlockSvg, todayIso } from './svg-title-block.js';
+import { TITLE_BLOCK_H, todayIso } from './svg-title-block.js';
 import {
   validateActivities,
   layoutActivities,
@@ -41,15 +41,40 @@ function truncate(s: string, maxLen: number): string {
 // supplies the SVG presentation layer only.
 
 const N_PAD = 24;
+// Extra SVG title-block line height for the optional action-name line.
+const ACTIVITY_ACTION_NAME_H = 16;
 
-function networkSvg(doc: ActivityDoc, gaps: ActivitiesLayoutOptions = {}, curvature: number = DEFAULT_EDGE_CURVATURE, entryCurvature?: number, heading?: string, filename?: string, date?: string, version?: string): string {
+/**
+ * SVG title block for activity views — extends the shared 3-line block with an
+ * optional 4th line for the document's Action name (doc.title). When present,
+ * the action name appears immediately after the heading as its own text element,
+ * pushing filename and date down by ACTIVITY_ACTION_NAME_H px.
+ */
+function activityTitleBlockSvg(heading: string, filename: string, date: string, x: number, top: number, actionName?: string): string {
+  const dateLine = `Generated: ${date}`;
+  let y = top + 14;
+  const lines: string[] = [
+    `<text class="text-header" x="${x}" y="${y}">${escXml(heading)}</text>`,
+  ];
+  y += 16;
+  if (actionName) {
+    lines.push(`<text class="text-secondary" x="${x}" y="${y}">${escXml(actionName)}</text>`);
+    y += 16;
+  }
+  lines.push(`<text class="text-secondary" x="${x}" y="${y}">${escXml(filename)}</text>`);
+  y += 16;
+  lines.push(`<text class="text-secondary" x="${x}" y="${y}">${escXml(dateLine)}</text>`);
+  return `<g class="diagram-title-block">\n  ${lines.join('\n  ')}\n</g>`;
+}
+
+function networkSvg(doc: ActivityDoc, gaps: ActivitiesLayoutOptions = {}, curvature: number = DEFAULT_EDGE_CURVATURE, entryCurvature?: number, heading?: string, filename?: string, date?: string, version?: string, actionName?: string): string {
   const layout: ActivitiesLayout = layoutActivities(doc, gaps);
   if (layout.nodes.length === 0) {
     return '<svg xmlns="http://www.w3.org/2000/svg" width="200" height="60"><text class="text-primary" x="10" y="40">No activities</text></svg>';
   }
 
   const showTitle = heading != null && filename != null && date != null;
-  const titleH = showTitle ? TITLE_BLOCK_H : 0;
+  const titleH = showTitle ? (TITLE_BLOCK_H + (actionName ? ACTIVITY_ACTION_NAME_H : 0)) : 0;
   const cpm = computeCpm(doc.activities ?? []);
   const W = layout.bounds.width + N_PAD * 2;
   const H = layout.bounds.height + N_PAD * 2 + titleH;
@@ -58,7 +83,7 @@ function networkSvg(doc: ActivityDoc, gaps: ActivitiesLayoutOptions = {}, curvat
 
   const body = renderActivitiesNetworkBody(layout, cpm, ox, oy, curvature, entryCurvature);
 
-  const titleSvg = showTitle ? titleBlockSvg(heading!, filename!, date!, N_PAD, N_PAD, version) : '';
+  const titleSvg = showTitle ? activityTitleBlockSvg(heading!, filename!, date!, N_PAD, N_PAD, actionName) : '';
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">
 ${ACTIVITIES_NETWORK_DEFS}
 ${titleSvg}
@@ -85,7 +110,7 @@ function daysBetween(startISO: string, endISO: string): number {
   return Math.round(ms / 86_400_000);
 }
 
-function ganttSvg(layout: GanttLayout, heading?: string, filename?: string, date?: string, version?: string): string {
+function ganttSvg(layout: GanttLayout, heading?: string, filename?: string, date?: string, version?: string, actionName?: string): string {
   // Sort bars by start date then id for stable display order.
   const bars = [...layout.bars].sort((a, b) => {
     if (a.startDate !== b.startDate) return a.startDate < b.startDate ? -1 : 1;
@@ -93,7 +118,7 @@ function ganttSvg(layout: GanttLayout, heading?: string, filename?: string, date
   });
 
   const showTitle = heading != null && filename != null && date != null;
-  const titleH = showTitle ? TITLE_BLOCK_H : 0;
+  const titleH = showTitle ? (TITLE_BLOCK_H + (actionName ? ACTIVITY_ACTION_NAME_H : 0)) : 0;
   const totalDays = daysBetween(layout.timelineStart, layout.timelineEnd) + 1;
   const timelineWidth = totalDays * G_DAY_W;
   const W = G_LABEL_COL_W + timelineWidth + G_PAD * 2;
@@ -342,7 +367,7 @@ function ganttSvg(layout: GanttLayout, heading?: string, filename?: string, date
     }
   }
 
-  const titleSvg = showTitle ? titleBlockSvg(heading!, filename!, date!, G_PAD, G_PAD, version) : '';
+  const titleSvg = showTitle ? activityTitleBlockSvg(heading!, filename!, date!, G_PAD, G_PAD, actionName) : '';
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">
 <defs>
   <marker id="gantt-arrow" markerWidth="6" markerHeight="6" refX="6" refY="3" orient="auto" markerUnits="userSpaceOnUse">
@@ -392,8 +417,12 @@ function activityTypeBadgeClass(type: string | undefined): string {
   return `tree-badge tree-badge-${type.toLowerCase().replace(/\s+/g, '-')}`;
 }
 
-function buildTreeHtml(doc: ActivityDoc, filename: string, date: string, version?: string): string {
-  const activities = doc.activities ?? [];
+function buildTreeHtml(doc: ActivityDoc, filename: string, date: string, version?: string, actionName?: string): string {
+  // Suppress project-type container nodes from the tree view — same convention
+  // as the Network view. The Action name in the header identifies the scope.
+  const activities = (doc.activities ?? []).filter(
+    (a) => a.activity_type?.toLowerCase() !== 'project',
+  );
   if (activities.length === 0) {
     return '<div class="section-notice">No activities to display.</div>';
   }
@@ -443,12 +472,11 @@ function buildTreeHtml(doc: ActivityDoc, filename: string, date: string, version
   }
 
   const versionPart = version ? ` · v${escXml(version)}` : '';
-  // #421: show the Action name (doc.title) in the tree-view header when present.
-  // The project container block is visible in this view and the heading
-  // compensates with the document-level Action name for human readability.
-  const actionName = doc.title ? `${escXml(doc.title)} — ` : '';
+  const actionNameLine = actionName
+    ? `\n  <div class="text-secondary">${escXml(actionName)}</div>`
+    : '';
   const titleHtml = `<div class="diagram-title-block diagram-title-block-html">
-  <div class="text-header">${actionName}Tree view — Initiative → Programme → Project → Task</div>
+  <div class="text-header">Tree view — Initiative → Programme → Project → Task</div>${actionNameLine}
   <div class="text-secondary">${escXml(filename)}</div>
   <div class="text-secondary">${escXml(date)}${versionPart}</div>
 </div>`;
@@ -457,46 +485,47 @@ function buildTreeHtml(doc: ActivityDoc, filename: string, date: string, version
 }
 
 /**
- * Renderer/view convention (#421):
+ * Renderer/view convention (follow-up to #421):
  *
- * Network (PSND) view — project container nodes (activity_type === 'project')
- * are suppressed by default. The diagram itself represents the project scope,
- * so the container adds visual noise without conveying additional information.
- * Canonical parent linkage is preserved in the raw doc; only the rendered
- * node list is narrowed.
- *
- * Text/Tree view — project container nodes remain visible for human readability.
- * The tree-view heading includes the document's Action name (doc.title) so the
- * reader knows which action they are reviewing even when the project node is
- * the root of the hierarchy.
+ * Project-type container nodes (activity_type === 'project') are suppressed
+ * from ALL rendered views — Network, Gantt, and Tree. The diagram already
+ * represents the project scope; rendering the container as a node or bar adds
+ * visual noise. The doc.title (Action name) is shown in each view's header as
+ * its own line so the reader can identify the action without the container node.
+ * Canonical parent linkage is preserved in the raw doc; only the rendered node
+ * lists are narrowed. doc.project.start_date (used by the Gantt for computed
+ * mode) is on the project block, not on any activity — filtering activities
+ * does not affect Gantt date computation.
  */
 function buildActivityViews(doc: ActivityDoc, gaps: ActivitiesLayoutOptions, curvature: number, entryCurvature: number | undefined, filename: string, date: string, version?: string): ActivityViews {
-  // #421: Suppress project-type container nodes in the Network (PSND) view only.
-  // A shallow copy is sufficient — only the activities array is replaced; all
-  // other doc fields (project block, title, dates, etc.) are shared by reference
-  // and are not mutated.
-  const networkDoc: ActivityDoc = {
-    ...doc,
-    activities: (doc.activities ?? []).filter(
-      (a) => a.activity_type?.toLowerCase() !== 'project',
-    ),
-  };
+  // Suppress project-type container nodes from all views. A shallow copy is
+  // sufficient — only the activities array is replaced; all other doc fields
+  // (project block, title, dates, etc.) are shared by reference and not mutated.
+  const filteredActivities = (doc.activities ?? []).filter(
+    (a) => a.activity_type?.toLowerCase() !== 'project',
+  );
+  const filteredDoc: ActivityDoc = { ...doc, activities: filteredActivities };
+  const actionName = doc.title ?? undefined;
+
   const networkHeading = 'Network view — Project Schedule Network Diagram (PSND)';
-  const networkSvgStr = networkSvg(networkDoc, gaps, curvature, entryCurvature, networkHeading, filename, date, version);
-  const gantt: GanttResult = computeGanttLayout(doc);
+  const networkSvgStr = networkSvg(filteredDoc, gaps, curvature, entryCurvature, networkHeading, filename, date, version, actionName);
+  const gantt: GanttResult = computeGanttLayout(filteredDoc);
 
   const dateLine = date;
 
   if (isGanttUnavailable(gantt)) {
     // No SVG to embed the title into — fall back to an HTML title block plus
     // the notice so the unavailable path still shows the same paragraph.
+    const actionNameLine = actionName
+      ? `\n  <div class="text-secondary">${escXml(actionName)}</div>`
+      : '';
     const ganttBody = `<div class="diagram-title-block diagram-title-block-html">
-  <div class="text-header">Gantt view — unavailable</div>
+  <div class="text-header">Gantt view — unavailable</div>${actionNameLine}
   <div class="text-secondary">${escXml(filename)}</div>
   <div class="text-secondary">${escXml(dateLine)}</div>
 </div>
 <div class="section-notice">${escXml(gantt.reason)}</div>`;
-    const treeHtmlStr = buildTreeHtml(doc, filename, date, version);
+    const treeHtmlStr = buildTreeHtml(doc, filename, date, version, actionName);
     return { networkSvg: networkSvgStr, ganttBody, ganttSvg: '', treeHtml: treeHtmlStr };
   }
 
@@ -504,8 +533,8 @@ function buildActivityViews(doc: ActivityDoc, gaps: ActivitiesLayoutOptions, cur
     ? `computed mode (project ${gantt.timelineStart} → ${gantt.timelineEnd})`
     : `pinned mode (${gantt.timelineStart} → ${gantt.timelineEnd})`;
   const ganttHeading = `Gantt view — ${modeLabel}`;
-  const ganttSvgStr = ganttSvg(gantt, ganttHeading, filename, date, version);
-  const treeHtmlStr = buildTreeHtml(doc, filename, date, version);
+  const ganttSvgStr = ganttSvg(gantt, ganttHeading, filename, date, version, actionName);
+  const treeHtmlStr = buildTreeHtml(doc, filename, date, version, actionName);
   return { networkSvg: networkSvgStr, ganttBody: ganttSvgStr, ganttSvg: ganttSvgStr, treeHtml: treeHtmlStr };
 }
 

--- a/packages/diagrams/src/activities/__tests__/gantt.test.ts
+++ b/packages/diagrams/src/activities/__tests__/gantt.test.ts
@@ -243,3 +243,48 @@ describe('computeGanttLayout — pinned mode', () => {
     expect(r.links[0].targetId).toBe('B');
   });
 });
+
+describe('computeGanttLayout — project-type activity suppression (regression for follow-up to #421)', () => {
+  // A project-type container activity is classified as a phase and rolls up into
+  // a bar spanning the full timeline. buildActivityViews filters project-type
+  // activities before calling computeGanttLayout so this bar never reaches the
+  // rendered Gantt. These tests confirm: (a) the container bar exists when NOT
+  // filtered, and (b) filtering it out still yields correct leaf/phase bars.
+
+  const docWithProjectContainer: ActivityDoc = {
+    notation: 'action',
+    title: 'Platform Launch Action',
+    project: { start_date: '2026-06-01' },
+    activities: [
+      { id: 'PROJ-1', name: 'Platform Launch', activity_type: 'project' },
+      { id: 'TASK-1', name: 'Design', activity_type: 'task', duration: 3, parent: 'PROJ-1' },
+      { id: 'TASK-2', name: 'Implement', activity_type: 'task', duration: 5, parent: 'PROJ-1', predecessors: ['TASK-1'] },
+    ],
+  };
+
+  it('includes the project container as a phase bar when not pre-filtered', () => {
+    const r = assertRenders(computeGanttLayout(docWithProjectContainer));
+    const projBar = r.bars.find(b => b.id === 'PROJ-1');
+    expect(projBar).toBeDefined();
+    expect(projBar!.kind).toBe('phase');
+  });
+
+  it('still renders leaf tasks correctly when project-type activity is pre-filtered', () => {
+    const filteredDoc: ActivityDoc = {
+      ...docWithProjectContainer,
+      activities: docWithProjectContainer.activities.filter(
+        (a) => a.activity_type?.toLowerCase() !== 'project',
+      ),
+    };
+    const r = assertRenders(computeGanttLayout(filteredDoc));
+    // Project container bar must not appear.
+    expect(r.bars.find(b => b.id === 'PROJ-1')).toBeUndefined();
+    // Leaf tasks must still render with correct dates.
+    const t1 = r.bars.find(b => b.id === 'TASK-1')!;
+    const t2 = r.bars.find(b => b.id === 'TASK-2')!;
+    expect(t1).toBeDefined();
+    expect(t2).toBeDefined();
+    expect(t1.startDate).toBe('2026-06-01');
+    expect(t2.startDate).toBe('2026-06-04'); // ES = 3 (after TASK-1)
+  });
+});

--- a/packages/diagrams/src/webview/__tests__/render-blocks.test.ts
+++ b/packages/diagrams/src/webview/__tests__/render-blocks.test.ts
@@ -59,6 +59,15 @@ function extractLabels(svg: string): Array<{ cls: string; text: string }> {
   return out;
 }
 
+/** Extract {class, y} for each text element in SVG document order. */
+function extractTextY(svg: string): Array<{ cls: string; y: number }> {
+  const re = /<text class="(text-(?:primary|id))"[^>]*\by="([^"]+)"/g;
+  const out: Array<{ cls: string; y: number }> = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(svg))) out.push({ cls: m[1], y: parseFloat(m[2]) });
+  return out;
+}
+
 describe('renderBlocksSvg — leaf labels', () => {
   it('wraps a long name to at most 3 lines and truncates with …', () => {
     const longName =
@@ -151,5 +160,50 @@ describe('renderBlocksSvg — container headers', () => {
     }
     // At least one primary line must have been truncated.
     expect(primaries.some((l) => l.text.endsWith('…'))).toBe(true);
+  });
+});
+
+describe('renderBlocksSvg — name/ID vertical overlap regression (follows-up on #419)', () => {
+  // Root cause: NAME_ID_GAP was 6 px. text-primary is 12 px tall (±6 px around
+  // centre) and text-id is 10 px tall (±5 px around centre). The minimum gap
+  // between centres to avoid overlap is 11 px; a gap of 6 caused 5 px of overlap.
+  // Fix: NAME_ID_GAP = 14 (3 px visual buffer, matching the gap between name lines).
+
+  const NAME_HALF_H = 6;  // half of text-primary font size (12 px)
+  const ID_HALF_H = 5;    // half of text-id font size (10 px)
+
+  it('leaf node: last name line bottom does not overlap first ID line top (1 name + 1 ID)', () => {
+    const svg = renderBlocksSvg(leafDoc('Short', 'BLK-1'));
+    const positions = extractTextY(svg);
+    const nameY = positions.filter(p => p.cls === 'text-primary').map(p => p.y);
+    const idY = positions.filter(p => p.cls === 'text-id').map(p => p.y);
+    expect(nameY.length).toBeGreaterThan(0);
+    expect(idY.length).toBeGreaterThan(0);
+    const lastNameBottom = Math.max(...nameY) + NAME_HALF_H;
+    const firstIdTop = Math.min(...idY) - ID_HALF_H;
+    expect(firstIdTop).toBeGreaterThan(lastNameBottom);
+  });
+
+  it('leaf node: no overlap with a 3-word name (2 name lines + 1 ID)', () => {
+    const svg = renderBlocksSvg(leafDoc('Three Word Name', 'BLK-001'));
+    const positions = extractTextY(svg);
+    const nameY = positions.filter(p => p.cls === 'text-primary').map(p => p.y);
+    const idY = positions.filter(p => p.cls === 'text-id').map(p => p.y);
+    const lastNameBottom = Math.max(...nameY) + NAME_HALF_H;
+    const firstIdTop = Math.min(...idY) - ID_HALF_H;
+    expect(firstIdTop).toBeGreaterThan(lastNameBottom);
+  });
+
+  it('leaf node: no overlap with a long name (3 name lines) and wrapped ID (2 lines)', () => {
+    const longName =
+      'Personal data records that linger after consent withdrawal across many systems and archives';
+    const longId = 'VERY_LONG_BLOCK_IDENTIFIER_WITH_MANY_SEGMENTS_AND_MORE';
+    const svg = renderBlocksSvg(leafDoc(longName, longId));
+    const positions = extractTextY(svg);
+    const nameY = positions.filter(p => p.cls === 'text-primary').map(p => p.y);
+    const idY = positions.filter(p => p.cls === 'text-id').map(p => p.y);
+    const lastNameBottom = Math.max(...nameY) + NAME_HALF_H;
+    const firstIdTop = Math.min(...idY) - ID_HALF_H;
+    expect(firstIdTop).toBeGreaterThan(lastNameBottom);
   });
 });

--- a/packages/diagrams/src/webview/notation-style.ts
+++ b/packages/diagrams/src/webview/notation-style.ts
@@ -1,0 +1,12 @@
+/**
+ * Shared visual constants for entity-box (block-style) notation renderers.
+ *
+ * Goals, Nested Blocks, FGCA/DGCA, and any future notation using the same
+ * entity-box visual language import their shared style tokens from here.
+ * Centralising them prevents the per-renderer drift that caused the Goals/Blocks
+ * style mismatch (border radius diverged to rx=6 in Blocks vs rx=8 everywhere
+ * else). Change here and every notation updates together.
+ */
+
+/** Border-radius (px) for entity and leaf-block node rectangles. */
+export const ENTITY_NODE_RX = 8;

--- a/packages/diagrams/src/webview/render-blocks.ts
+++ b/packages/diagrams/src/webview/render-blocks.ts
@@ -16,6 +16,7 @@ import { layoutNestedBlocks } from '../blocks/layout.js';
 import type { BlocksFile, BlocksLayout, LaidOutBlock } from '../blocks/types.js';
 import { generateSvgEmbedCss, type ThemeId } from '../theme/index.js';
 import { escXml } from './render-util.js';
+import { ENTITY_NODE_RX } from './notation-style.js';
 
 const PAD = 24;
 
@@ -25,9 +26,12 @@ const CHAR_W = 7;
 const CHAR_W_ID = 6;
 
 // Vertical spacing between line centres.
-const LINE_H = 14;    // name lines (text-primary)
-const LINE_H_ID = 12; // id lines (text-id)
-const NAME_ID_GAP = 6; // gap between last name centre and first ID centre
+const LINE_H = 14;     // name lines (text-primary, 12 px font)
+const LINE_H_ID = 12;  // id lines (text-id, 10 px font)
+// Minimum gap to avoid overlap: half of name text height (6 px) + half of id
+// text height (5 px) = 11 px. Use 14 px to match the name-line separation and
+// leave a 3 px visual buffer — same as the gap between consecutive name lines.
+const NAME_ID_GAP = 14;
 
 /** Word-wrap `text` to at most `maxLines` lines of `maxChars` each. */
 function wrapWords(text: string, maxChars: number, maxLines: number): string[] {
@@ -110,7 +114,7 @@ function emitBlockSvg(b: LaidOutBlock, ox: number, oy: number, parts: string[]):
   const cls = levelClassForDepth(b.depth);
   const cx = b.x + ox + b.width / 2;
   parts.push(
-    `<rect class="diagram-node ${cls}" x="${b.x + ox}" y="${b.y + oy}" width="${b.width}" height="${b.height}" rx="6"/>`,
+    `<rect class="diagram-node ${cls}" x="${b.x + ox}" y="${b.y + oy}" width="${b.width}" height="${b.height}" rx="${ENTITY_NODE_RX}"/>`,
   );
 
   const innerW = Math.max(0, b.width - TEXT_MARGIN_X * 2);

--- a/packages/diagrams/src/webview/render-goals.ts
+++ b/packages/diagrams/src/webview/render-goals.ts
@@ -15,6 +15,7 @@ import type { GoalTree, GoalTreeLayout, LaidOutEdge } from '../goals/types.js';
 import { horizontalCubicEdgePath, DEFAULT_EDGE_CURVATURE } from '../edge-path.js';
 import { generateSvgEmbedCss, type ThemeId } from '../theme/index.js';
 import { escXml } from './render-util.js';
+import { ENTITY_NODE_RX } from './notation-style.js';
 
 const NODE_W = 250;
 const NODE_H = 72;
@@ -130,7 +131,7 @@ export function renderGoalsLayoutSvg(layout: GoalTreeLayout, options: RenderGoal
       const typeLabel = n.data.type ?? '';
       const idText = String(n.data.id);
       return `<g>
-  <rect class="diagram-node level-${level}" x="${x}" y="${y}" width="${n.width}" height="${n.height}" rx="8"/>
+  <rect class="diagram-node level-${level}" x="${x}" y="${y}" width="${n.width}" height="${n.height}" rx="${ENTITY_NODE_RX}"/>
   <text class="text-primary" x="${x + n.width / 2}" y="${nameY1}" text-anchor="middle" dominant-baseline="central">${escXml(line1)}</text>${twoLines ? `
   <text class="text-primary" x="${x + n.width / 2}" y="${nameY2}" text-anchor="middle" dominant-baseline="central">${escXml(line2)}</text>` : ''}${typeLabel ? `
   <text class="text-secondary" x="${x + n.width / 2}" y="${typeY}" text-anchor="middle" dominant-baseline="central">${escXml(typeLabel)}</text>` : ''}


### PR DESCRIPTION
## Root cause

Text inside block diagram nodes overlaps. Root cause is `NAME_ID_GAP = 6` px.

With `text-primary` at 12 px font size (±6 px from centre with `dominant-baseline="central"`) and `text-id` at 10 px (±5 px), the minimum gap between the last name line centre and the first ID line centre to avoid overlap is 11 px. A gap of 6 produced 5 px of vertical overlap on every leaf block regardless of how many name/ID lines rendered.

This affected leaf blocks in all configurations: 1+1, 2+1, and 3+2 name/ID lines.

Additionally, block nodes used `rx="6"` while Goals used `rx="8"`, causing the diagnosed "style drift" between notations.

## Changes

**`packages/diagrams/src/webview/notation-style.ts`** (new)

Shared style constants for entity-box notation renderers. Currently exports:
- `ENTITY_NODE_RX = 8` — border-radius used by Goals, Blocks, and FGCA entity nodes

Centralising this constant ensures future changes propagate to all notations instead of drifting again per-renderer.

**`packages/diagrams/src/webview/render-blocks.ts`**

- `NAME_ID_GAP`: 6 → 14. The 14 px gap matches the inter-name-line separation (LINE_H = 14) and leaves a 3 px visual buffer between last-name-bottom and first-id-top.
- `rx`: uses imported `ENTITY_NODE_RX` (= 8) instead of hardcoded 6.
- Import added for `ENTITY_NODE_RX` from `./notation-style.js`.

**`packages/diagrams/src/webview/render-goals.ts`**

- `rx`: uses imported `ENTITY_NODE_RX` (= 8) instead of hardcoded literal. No visual change — was already 8, now reads from the shared constant.
- Import added for `ENTITY_NODE_RX` from `./notation-style.js`.

**`packages/diagrams/src/webview/__tests__/render-blocks.test.ts`**

- `extractTextY` helper extracts `{cls, y}` from SVG text elements.
- 3 regression tests verify `firstIdTop > lastNameBottom` for 1+1, 2+1, and 3+2 name/ID line configurations.

## Acceptance criteria

- [x] Root-cause of text overlap identified and fixed (NAME_ID_GAP was insufficient)
- [x] Block node border radius matches Goals (rx=8)
- [x] Shared `notation-style.ts` module extracted — prevents future drift
- [x] No text overlap or overflow remains (verified by 3 regression tests)
- [x] Existing label-wrapping and truncation tests still pass (3 → 9 tests in render-blocks.test.ts)
- [x] 1153 tests pass; build clean