### PR TITLE
chore(release): 2.9.0 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [2.9.0] — 2026-07-03
 
 ### Changed
 
@@ -19,6 +19,23 @@
   entry, gateway vertex distribution, top/bottom cross-lane gateway exits,
   left-face U-turn loops) are unchanged. `elkjs` is no longer used by the
   BPMN layout path.
+
+### Fixed
+
+- **Action preview — project node suppressed in Gantt and Tree views, Action
+  name on its own header line.** The project-container suppression added for
+  the Network view in 2.8.0 now also applies to the Gantt view (no more
+  full-width phase rollup bar for the project container) and the Tree view
+  (the project node no longer renders as the root tree block). The Action
+  name renders as its own line immediately below the view heading instead of
+  being merged into the heading text; SVG/PNG exports reserve 16 px for the
+  extra line. (#341)
+
+- **Blocks — name/ID text overlap fixed, entity-node style unified with
+  Goals.** Leaf block nodes rendered the grey ID line 5 px into the last name
+  line (`NAME_ID_GAP` 6 → 14). Block and Goals entity boxes now share the
+  same corner radius via the new `notation-style.ts` constant
+  `ENTITY_NODE_RX = 8`, removing the per-renderer style drift. (#342)
 
 ## [2.8.0] — 2026-07-01
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "Architecture-as-code for the modern enterprise. Author 17 notations — goals, processes, capabilities, BPMN, applications, more — as plain YAML, get live diagrams in VS Code. Diffable in git. AI-friendly. Open source. Built on ArchiMate 3.2 and BPMN 2.0.",
   "license": "MIT",
   "icon": "icon.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",


### PR DESCRIPTION
Release prep for **2.9.0** (pattern of the 2.8.0 notes PR #339).

## Changes

- **CHANGELOG**: `[Unreleased]` → `[2.9.0] — 2026-07-03` (BPMN layout engine v2, #343), plus the two entries that were missing for fixes merged after the 2.8.0 notes: action-preview Gantt/Tree project-node suppression + Action name header line (#341) and blocks name/ID overlap + entity corner-radius unification (#342).
- **Versions**: root + extension `2.8.0 → 2.9.0`, `@transitrix/diagrams` `1.4.0 → 1.5.0`.

## Pre-flight (docs/release-runbook.md)

- [x] working tree clean, branch cut from current `main` (9945bcb)
- [x] `npm run build` green
- [x] `npm run compile` + `npm run compile:extension` green
- [x] `npm test` green — 426 core + 1153 diagrams
- [x] CHANGELOG heading matches the version fields

## After merge (Valerii)

1. `git tag v2.9.0` on the merge commit + push tag.
2. VSIX build/publish on request (not built here per repo policy).
3. npm publish of `@transitrix/diagrams` 1.5.0 is optional/manual (2FA OTP, runbook order: diagrams → cli).

🤖 Generated with [Claude Code](https://claude.com/claude-code)