### PR TITLE
chore(cli): bump @transitrix/cli to 1.1.0, drop unused elkjs dependency

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/cli",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "description": "Transitrix CLI — compile, validate, and report on Transitrix diagrams (BPMN, Goals, FGCA, …) from any shell or CI pipeline.",
   "license": "MIT",
@@ -41,7 +41,6 @@
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
     "bpmn-moddle": "^10.0.0",
-    "elkjs": "^0.9.3",
     "js-yaml": "^4.1.0",
     "xmlbuilder2": "^3.1.1"
   }


### PR DESCRIPTION
Prepares the npm update of `@transitrix/cli` so the published CLI ships the BPMN layout engine v2 (#343).

- version `1.0.0 → 1.1.0` (minor — new layout engine in the bundled compiler)
- `elkjs` removed from runtime dependencies: layout v2 no longer imports it; verified **zero** `elkjs` references in all four esbuild bundles. Lighter install for CLI users.

## Verification

- `npm run build:cli-package` green
- `npm pack --dry-run --workspace packages/cli`: 10 files (dist/, schemas/, README, LICENSE), 115.8 kB tarball — nothing extraneous
- smoke test: `node packages/cli/dist/cli.js compile` on the feature-release corpus fixture emits layout-v2 metrics

## After merge (Valerii — manual, npm CLI publish is not automated)

```bash
git checkout main && git pull
npm publish --access public --workspace packages/cli   # prompts npm login / 2FA OTP
npm view @transitrix/cli version                        # expect 1.1.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)