### PR TITLE
docs(release-runbook): describe the automated publish pipeline

### DIFF
--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -1,157 +1,106 @@
-# Release runbook — npm
+# Release runbook
 
-How to publish Transitrix's npm packages by hand. This is the manual procedure
-agreed in strategy hub issue `vkgeorgia/strategy#199`; CI publish-on-tag
-automation is a deferred follow-up.
+How a Transitrix Studio release ships. Since the CI publish workflows landed
+(2026-06), **publishing the GitHub Release is the trigger for everything
+except the CLI** — the manual npm procedure this runbook used to describe
+survives only for `@transitrix/cli`.
 
-The VS Code extension `.vsix` flow is a separate pipeline — see
-[`docs/packaging.md`](packaging.md) for the per-platform build,
-[`docs/vscode-marketplace-publish-runbook.md`](vscode-marketplace-publish-runbook.md)
-for the VS Code Marketplace publish, and
-[`docs/openvsx-publish-runbook.md`](openvsx-publish-runbook.md) for the
-Open VSX (Cursor / VSCodium / Windsurf) publish hop.
+## What publishes where
 
-## Packages
+| Artifact | Pipeline | Trigger |
+|---|---|---|
+| `@transitrix/diagrams` → npm | `.github/workflows/npm-publish.yml` | GitHub Release **published** (or `workflow_dispatch`) |
+| VS Code extension → VS Code Marketplace | `.github/workflows/vscode-marketplace-publish.yml` | same |
+| VS Code extension → Open VSX (Cursor / VSCodium / Windsurf) | `.github/workflows/openvsx-publish.yml` | same |
+| IntelliJ plugin → JetBrains Marketplace | `.github/workflows/jetbrains-publish.yml` | same (plugin version derived from the release tag, `v` prefix stripped) |
+| `@transitrix/cli` → npm | **manual** (see below) | maintainer runs `npm publish` |
 
-Two scoped packages live on the `@transitrix/*` namespace:
+Secrets backing the automation (repo Actions secrets): `NPM_TOKEN`
+(granular, read-write on `@transitrix/diagrams` only — this is why the CLI
+is not automated), `VSCE_PAT`, `OVSX_PAT`, and the JetBrains signing set
+(`CERTIFICATE_CHAIN`, `PRIVATE_KEY`, `PRIVATE_KEY_PASSWORD`,
+`PUBLISH_TOKEN`).
 
-| Package | Source | Bin | Notes |
-|---|---|---|---|
-| `@transitrix/diagrams` | `packages/diagrams/` | — | Shared rendering / validation / pure-mutation library. Consumed by the CLI, the VS Code extension, and downstream tools. |
-| `@transitrix/cli` | slim package — own `package.json` with `bin` + `files` allowlist, `dist/cli.js` + runtime deps only (not the whole repo) | `transitrix` only (no `cervin` alias — the new package is born in the 2.0 era, see `#191`) | First release `1.0.0`, independent of the extension version line. |
+## Release procedure
 
-**Publish order matters: `@transitrix/diagrams` first, then `@transitrix/cli`** —
-the CLI depends on diagrams; npm has to be able to resolve it.
+### 1. Release PR (agent-preparable)
 
-## Prerequisites (one-time, Valerii action)
+One PR against `main` — the pattern of the 2.8.0 (#339) and 2.9.0 (#344)
+notes PRs:
 
-These steps are outside the agent scope and must be done before the first
-publish session:
+- `CHANGELOG.md`: retitle `[Unreleased]` to `[X.Y.Z] — <date>`; make sure
+  every PR merged since the previous notes PR has an entry (fixes merged
+  after the notes PR are the usual gap).
+- Versions:
+  - root `package.json` + `extension/package.json` — bump together via
+    `node scripts/bump-extension-version.mjs minor|patch|major`;
+  - `packages/diagrams/package.json` — bump when the diagrams library
+    changed since its last published version (independent semver line);
+  - `packages/cli/package.json` — bump when the bundled compiler sources
+    (`src/`) changed (independent semver line; publish is manual, step 4).
+- Pre-flight, from a clean tree on the release branch:
+  - [ ] `npm run build` green
+  - [ ] `npm run compile` + `npm run compile:extension` green
+  - [ ] `npm test` green (root core + diagrams workspace)
+  - [ ] CHANGELOG heading matches the version fields
 
-1. **Create the `transitrix` npm organisation** at <https://www.npmjs.com/org/create>.
-2. **Enable 2FA for `@transitrix/*` writes** (org settings → "Require 2FA for write actions").
-3. Confirm `npm whoami` shows the publishing account is a member of the org with
-   publish permission on the scope.
-4. (Optional, recommended) Reserve the unscoped `transitrix` name on npm so a
-   future squatter can't grab it — even if we ship under `@transitrix/cli`.
+### 2. Merge + draft release (Valerii gates)
 
-A registry token is **not** needed for manual publishes; `npm publish` uses the
-interactive 2FA OTP. A token is only required when CI publish-on-tag is wired
-up later.
+- Merge the release PR; verify `main` actually has the bump.
+- Create a **draft** GitHub Release: tag `vX.Y.Z`, target `main`, title
+  `Transitrix Studio X.Y.Z`, body = the CHANGELOG section under a
+  `## What's changed` heading. (A draft creates no tag; the tag is created
+  on the then-current target when the draft is published — so always merge
+  the release PR **before** publishing.)
 
-## Pre-flight checklist (run for every release)
+### 3. Publish the release → automation fires
 
-Run from a clean checkout of the tag/commit being released:
+Publishing the release starts all four workflows. Watch them under
+Actions → filter event `release`:
 
-- [ ] `git status` clean; on the exact commit being shipped (no local edits).
-- [ ] `npm ci` (not `npm install`) — reproducible install from `package-lock.json`.
-- [ ] `npm run build` succeeds for the root package, emitting `dist/`.
-- [ ] `npm --workspace packages/diagrams run build` succeeds, emitting
-      `packages/diagrams/dist/`.
-- [ ] `npm test` is green (root core tests + diagrams workspace tests).
-- [ ] `npm run compile && npm run compile:extension` are green
-      (catches type regressions the test suite doesn't exercise).
-- [ ] `CHANGELOG.md` has an entry for the version being shipped (move
-      `[Unreleased]` items to a dated heading; bump the version header).
-- [ ] The version field in the package being published matches the CHANGELOG
-      heading.
-- [ ] `npm whoami` returns the expected publishing account and is a member of
-      the `transitrix` org with publish permission on the scope.
+- `npm — publish @transitrix/diagrams` — verify with
+  `npm view @transitrix/diagrams version`.
+- `VS Code Marketplace — multi-platform publish` — per-platform VSIX build
+  (`extension:prep` installs the platform-correct `@resvg/resvg-js-*`
+  binary) + `vsce publish`.
+- `Open VSX — multi-platform publish` — same build matrix, `ovsx publish`.
+- `JetBrains Marketplace — publish` — sets `pluginVersion` in
+  `intellij/gradle.properties` from the release tag, builds, signs,
+  publishes.
 
-## Publishing `@transitrix/diagrams`
+Every workflow also supports `workflow_dispatch` for re-runs (e.g. a
+transient marketplace failure) without re-publishing the release.
 
-1. **Flip the publish flag.** In `packages/diagrams/package.json` ensure
-   `"private": false` (or the field is absent). Add `homepage`, `repository`,
-   and `bugs` fields pointing at the monorepo if missing — npm shows these on
-   the package page.
-2. **Set the version.** First release: `1.0.0` per the published-package
-   versioning decision. Subsequent releases follow semver from there
-   (independent of the extension version line).
-3. **Dry-run the pack** to inspect the tarball contents:
-   ```bash
-   npm --workspace packages/diagrams pack --dry-run
-   ```
-   Verify the listed files match the `"files"` allowlist
-   (`dist/`, `src/`) — nothing extraneous, no secrets, no `node_modules`.
-4. **Publish:**
-   ```bash
-   npm --workspace packages/diagrams publish --access public
-   ```
-   - `--access public` is required for the first publish of a scoped package;
-     the default is `restricted`.
-   - npm prompts for the 2FA OTP interactively.
-5. **Verify** the package appeared on the registry:
-   ```bash
-   npm view @transitrix/diagrams version
-   ```
+### 4. `@transitrix/cli` — manual npm publish
 
-## Publishing `@transitrix/cli`
+Not covered by automation (the `NPM_TOKEN` grant is scoped to
+`@transitrix/diagrams`). The slim package is assembled by
+`scripts/build-cli-package.mjs`, which runs automatically at `prepack`;
+it bundles `src/cli.ts` + handlers into `packages/cli/dist/` and copies
+`schemas/` next to it. The package does **not** depend on
+`@transitrix/diagrams` — the diagrams source it needs is bundled in.
 
-The slim CLI package is *assembled* — it owns its `package.json`, `bin`, and
-`files` allowlist, ships bundled `dist/` + `schemas/` only, and does **not**
-include the rest of the monorepo. The assembly script is
-`scripts/build-cli-package.mjs`; the workspace's `prepack` runs it
-automatically for `npm pack` and `npm publish`.
+From a clean checkout of the release commit:
 
-1. **Prepare the publishable directory.** From the repo root, run
-   `npm run build:cli-package` (or rely on the workspace's `prepack` to do
-   it). The script esbuild-bundles `src/cli.ts`, `src/repo-validate.ts`, and
-   `src/export-compliance.ts` into `packages/cli/dist/`, externalising the
-   runtime npm deps (`ajv`, `ajv-formats`, `bpmn-moddle`, `elkjs`, `js-yaml`,
-   `xmlbuilder2`) and copying the JSON Schemas next to `dist/` (the runtime
-   resolves `dist/../schemas/bpmn-dsl.schema.json`, see
-   `src/schema-path.ts`). The slim `package.json` declares
-   `bin: { transitrix: "./dist/cli.js" }`, the runtime `dependencies` only
-   (no `devDependencies`), and `engines.node >= 20`. No `cervin` bin alias —
-   see the per-package table above.
-2. **Confirm the dependency on `@transitrix/diagrams`** in the slim
-   `package.json` points at a version range that includes the version just
-   published in the previous step (e.g. `"^1.0.0"`).
-3. **Dry-run:**
-   ```bash
-   npm pack --dry-run --workspace packages/cli
-   ```
-   Confirm the tarball contains `dist/cli.js`, `dist/repo-validate.js`,
-   `dist/export-compliance.js`, `schemas/*.json`, the slim `package.json`,
-   `README.md`, `LICENSE` — and nothing else. The packed tarball is
-   ~40 kB / 9 files at `1.0.0`.
-4. **Publish:**
-   ```bash
-   npm publish --access public --workspace packages/cli
-   ```
-   npm prompts for the 2FA OTP.
-5. **Verify on a clean machine / fresh directory:**
-   ```bash
-   npm i -g @transitrix/cli
-   transitrix --help                  # canonical
-   transitrix compile <sample>.yaml out.bpmn
-   ```
-   On Windows: `where.exe transitrix`. On macOS / Linux: `which transitrix`.
+```bash
+npm pack --dry-run --workspace packages/cli    # inspect: dist/, schemas/, README, LICENSE only
+npm publish --access public --workspace packages/cli   # prompts npm login / 2FA OTP
+npm view @transitrix/cli version
+```
 
-## Post-publish
+Sanity check the published bin on a fresh machine/directory:
 
-- **Tag the git commit** for traceability (matches the version published):
-  ```bash
-  git tag -s diagrams-v1.0.0 -m "Release @transitrix/diagrams 1.0.0"
-  git tag -s cli-v1.0.0      -m "Release @transitrix/cli 1.0.0"
-  git push --tags
-  ```
-- **Update consumer docs.** [`docs/cli.md`](cli.md) currently states "the CLI
-  is not yet published to npm" — promote `npm i -g @transitrix/cli` to the
-  primary install path and demote the `npm link`-from-a-clone instructions to
-  a "from source" subsection.
-- **Update strategy hub issue `#199`** with the published versions and a link
-  to the npm pages; close when the acceptance criteria are met.
-- **Notify downstream consumers** (e.g. the maintainer's compliance
-  renderer) that they can switch from the clone+`npm link` recipe to
-  `npm i -g @transitrix/cli`.
+```bash
+npm i -g @transitrix/cli
+transitrix --help
+transitrix compile <sample>.yaml out.bpmn
+```
 
-## Unpublish / yank
+## Unpublish / yank (npm)
 
-npm only permits unpublish within 72 hours of publish for non-trivial
-packages, and even within that window it's disruptive (cached installs break
-for downstream consumers). Prefer a **patch release with a fix** over an
-unpublish. If a published version is genuinely broken, mark it deprecated:
+npm only permits unpublish within 72 hours, and it breaks cached installs
+downstream. Prefer a patch release; if a version is genuinely broken, mark
+it deprecated instead:
 
 ```bash
 npm deprecate @transitrix/diagrams@1.0.0 "Broken — use 1.0.1+"
@@ -159,7 +108,9 @@ npm deprecate @transitrix/diagrams@1.0.0 "Broken — use 1.0.1+"
 
 ## Relates
 
-- Strategy hub: [`vkgeorgia/strategy#199`](https://github.com/vkgeorgia/strategy/issues/199) — the npm-publish task, including the decisions this runbook codifies.
-- [`docs/cli.md`](cli.md) — current install-from-clone instructions (to be updated post-publish).
-- [`docs/packaging.md`](packaging.md) — VS Code extension `.vsix` packaging (separate pipeline).
-- `CLAUDE.md` §Cervin naming — explains why `@transitrix/cli` ships with no `cervin` bin alias.
+- [`docs/packaging.md`](packaging.md) — VSIX packaging details.
+- [`docs/vscode-marketplace-publish-runbook.md`](vscode-marketplace-publish-runbook.md),
+  [`docs/openvsx-publish-runbook.md`](openvsx-publish-runbook.md) — the
+  marketplace-specific notes the workflows codify.
+- [`docs/cli.md`](cli.md) — CLI install docs.
+- Strategy hub `vkgeorgia/strategy#199` — the original npm-publish decisions.

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -113,4 +113,3 @@ npm deprecate @transitrix/diagrams@1.0.0 "Broken — use 1.0.1+"
   [`docs/openvsx-publish-runbook.md`](openvsx-publish-runbook.md) — the
   marketplace-specific notes the workflows codify.
 - [`docs/cli.md`](cli.md) — CLI install docs.
-- Strategy hub `vkgeorgia/strategy#199` — the original npm-publish decisions.


### PR DESCRIPTION
The runbook predated the publish automation: it described a fully manual npm procedure and called CI publish-on-tag "a deferred follow-up", while in reality publishing a GitHub Release now fires four workflows (npm `@transitrix/diagrams`, VS Code Marketplace, Open VSX, JetBrains). Verified live on the 2.9.0 release — all four green.

Rewritten around the actual flow:

1. **Release PR** — changelog retitle + version bumps + pre-flight checklist (pattern of #339 / #344).
2. **Merge, then draft release** — with the explicit warning that the tag is created at *publish* time on the then-current target, so the draft must be published only after the merge.
3. **Publish → automation fires** — what each workflow does, how to verify, `workflow_dispatch` for re-runs.
4. **`@transitrix/cli` — the only remaining manual npm publish** (NPM_TOKEN is granular to diagrams), with pack-inspection and post-publish sanity steps.

Also fixes two stale claims: the CLI does **not** depend on `@transitrix/diagrams` (its sources are bundled by `build-cli-package.mjs`), and the prerequisites/2FA-OTP framing now applies to the CLI section only.

Docs-only, no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)