### PR TITLE
ci(npm-publish): publish @transitrix/cli alongside diagrams, idempotently

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,16 +1,23 @@
-name: npm — publish @transitrix/diagrams
+name: npm — publish packages
 
-# Triggered on every GitHub Release to publish @transitrix/diagrams to npm.
+# Triggered on every GitHub Release to publish the npm packages:
+#   @transitrix/diagrams  (packages/diagrams — built via its workspace build)
+#   @transitrix/cli       (packages/cli — assembled by its prepack script)
+#
+# Each publish step is idempotent: it compares the workspace version with the
+# registry and skips when that version is already published, so releases that
+# bump only one package (or neither) stay green.
 #
 # Prerequisites (one-time maintainer setup):
-#   - NPM_TOKEN — Automation-type granular access token from npmjs.com with
-#     read-write permission on the @transitrix/diagrams package.
+#   - NPM_TOKEN — npm access token with read-write permission on BOTH
+#     @transitrix/diagrams and @transitrix/cli (classic Automation token, or a
+#     granular token that lists both packages — mind the granular-token expiry).
 #     Create at: https://www.npmjs.com/settings/<user>/tokens
 #     Save as a repo Actions secret named NPM_TOKEN.
 #
-# The package version comes from packages/diagrams/package.json and is
-# versioned independently from the VS Code extension. Bump it before cutting
-# a release that includes library changes.
+# Package versions come from each workspace's package.json and are versioned
+# independently from the VS Code extension. Bump them in the release PR when
+# the corresponding sources changed.
 
 on:
   release:
@@ -22,7 +29,7 @@ permissions:
 
 jobs:
   publish:
-    name: Publish @transitrix/diagrams to npm
+    name: Publish npm packages
     runs-on: ubuntu-latest
 
     steps:
@@ -42,7 +49,7 @@ jobs:
         run: |
           if [ -z "$NPM_TOKEN" ]; then
             echo "::error::NPM_TOKEN Actions secret is not set."
-            echo "::error::Create an Automation token on npmjs.com and save it as a repo Actions secret named NPM_TOKEN."
+            echo "::error::Create an npm token with read-write access to @transitrix/diagrams AND @transitrix/cli, and save it as a repo Actions secret named NPM_TOKEN."
             exit 1
           fi
 
@@ -52,7 +59,28 @@ jobs:
       - name: Build @transitrix/diagrams
         run: npm run build --workspace packages/diagrams
 
-      - name: Publish to npm
+      # Publish order matters: diagrams first, then cli (runbook convention).
+      - name: Publish @transitrix/diagrams (skips if version already published)
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --workspace packages/diagrams --access public
+        run: |
+          LOCAL=$(node -p "require('./packages/diagrams/package.json').version")
+          PUBLISHED=$(npm view "@transitrix/diagrams@$LOCAL" version 2>/dev/null || echo "")
+          if [ "$PUBLISHED" = "$LOCAL" ]; then
+            echo "@transitrix/diagrams@$LOCAL is already on the registry — skipping."
+          else
+            npm publish --workspace packages/diagrams --access public
+          fi
+
+      - name: Publish @transitrix/cli (skips if version already published)
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          LOCAL=$(node -p "require('./packages/cli/package.json').version")
+          PUBLISHED=$(npm view "@transitrix/cli@$LOCAL" version 2>/dev/null || echo "")
+          if [ "$PUBLISHED" = "$LOCAL" ]; then
+            echo "@transitrix/cli@$LOCAL is already on the registry — skipping."
+          else
+            # prepack (scripts/build-cli-package.mjs) assembles dist/ + schemas/.
+            npm publish --workspace packages/cli --access public
+          fi

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -1,25 +1,27 @@
 # Release runbook
 
-How a Transitrix Studio release ships. Since the CI publish workflows landed
-(2026-06), **publishing the GitHub Release is the trigger for everything
-except the CLI** — the manual npm procedure this runbook used to describe
-survives only for `@transitrix/cli`.
+How a Transitrix Studio release ships: **publishing the GitHub Release is
+the trigger for everything** — npm packages, both VS Code marketplaces, and
+the JetBrains plugin all publish from CI.
 
 ## What publishes where
 
 | Artifact | Pipeline | Trigger |
 |---|---|---|
-| `@transitrix/diagrams` → npm | `.github/workflows/npm-publish.yml` | GitHub Release **published** (or `workflow_dispatch`) |
+| `@transitrix/diagrams` + `@transitrix/cli` → npm | `.github/workflows/npm-publish.yml` | GitHub Release **published** (or `workflow_dispatch`) |
 | VS Code extension → VS Code Marketplace | `.github/workflows/vscode-marketplace-publish.yml` | same |
 | VS Code extension → Open VSX (Cursor / VSCodium / Windsurf) | `.github/workflows/openvsx-publish.yml` | same |
 | IntelliJ plugin → JetBrains Marketplace | `.github/workflows/jetbrains-publish.yml` | same (plugin version derived from the release tag, `v` prefix stripped) |
-| `@transitrix/cli` → npm | **manual** (see below) | maintainer runs `npm publish` |
 
 Secrets backing the automation (repo Actions secrets): `NPM_TOKEN`
-(granular, read-write on `@transitrix/diagrams` only — this is why the CLI
-is not automated), `VSCE_PAT`, `OVSX_PAT`, and the JetBrains signing set
-(`CERTIFICATE_CHAIN`, `PRIVATE_KEY`, `PRIVATE_KEY_PASSWORD`,
-`PUBLISH_TOKEN`).
+(read-write on **both** `@transitrix/diagrams` and `@transitrix/cli`;
+mind the expiry if it is a granular token), `VSCE_PAT`, `OVSX_PAT`, and
+the JetBrains signing set (`CERTIFICATE_CHAIN`, `PRIVATE_KEY`,
+`PRIVATE_KEY_PASSWORD`, `PUBLISH_TOKEN`).
+
+The npm publish steps are idempotent: each compares the workspace version
+with the registry and skips when that version is already published, so
+releases that bump only one package (or neither) stay green.
 
 ## Release procedure
 
@@ -37,7 +39,7 @@ notes PRs:
   - `packages/diagrams/package.json` — bump when the diagrams library
     changed since its last published version (independent semver line);
   - `packages/cli/package.json` — bump when the bundled compiler sources
-    (`src/`) changed (independent semver line; publish is manual, step 4).
+    (`src/`) changed (independent semver line).
 - Pre-flight, from a clean tree on the release branch:
   - [ ] `npm run build` green
   - [ ] `npm run compile` + `npm run compile:extension` green
@@ -58,8 +60,10 @@ notes PRs:
 Publishing the release starts all four workflows. Watch them under
 Actions → filter event `release`:
 
-- `npm — publish @transitrix/diagrams` — verify with
-  `npm view @transitrix/diagrams version`.
+- `npm — publish packages` — `@transitrix/diagrams` first, then
+  `@transitrix/cli` (versions that are already on the registry are
+  skipped). Verify with `npm view @transitrix/diagrams version` and
+  `npm view @transitrix/cli version`.
 - `VS Code Marketplace — multi-platform publish` — per-platform VSIX build
   (`extension:prep` installs the platform-correct `@resvg/resvg-js-*`
   binary) + `vsce publish`.
@@ -71,22 +75,13 @@ Actions → filter event `release`:
 Every workflow also supports `workflow_dispatch` for re-runs (e.g. a
 transient marketplace failure) without re-publishing the release.
 
-### 4. `@transitrix/cli` — manual npm publish
+### 4. Post-publish sanity check (optional)
 
-Not covered by automation (the `NPM_TOKEN` grant is scoped to
-`@transitrix/diagrams`). The slim package is assembled by
-`scripts/build-cli-package.mjs`, which runs automatically at `prepack`;
-it bundles `src/cli.ts` + handlers into `packages/cli/dist/` and copies
-`schemas/` next to it. The package does **not** depend on
-`@transitrix/diagrams` — the diagrams source it needs is bundled in.
-
-From a clean checkout of the release commit:
-
-```bash
-npm pack --dry-run --workspace packages/cli    # inspect: dist/, schemas/, README, LICENSE only
-npm publish --access public --workspace packages/cli   # prompts npm login / 2FA OTP
-npm view @transitrix/cli version
-```
+The `@transitrix/cli` slim package is assembled by
+`scripts/build-cli-package.mjs` at `prepack`; it bundles `src/cli.ts` +
+handlers into `packages/cli/dist/` and copies `schemas/` next to it. The
+package does **not** depend on `@transitrix/diagrams` — the diagrams
+source it needs is bundled in.
 
 Sanity check the published bin on a fresh machine/directory:
 
@@ -94,6 +89,14 @@ Sanity check the published bin on a fresh machine/directory:
 npm i -g @transitrix/cli
 transitrix --help
 transitrix compile <sample>.yaml out.bpmn
+```
+
+Manual publish fallback (e.g. the token expired mid-release) — from a
+clean checkout of the release commit:
+
+```bash
+npm pack --dry-run --workspace packages/cli    # inspect: dist/, schemas/, README, LICENSE only
+npm publish --access public --workspace packages/cli   # prompts npm login / 2FA OTP
 ```
 
 ## Unpublish / yank (npm)


### PR DESCRIPTION
Automates the last manual publish step. The release-triggered npm workflow now publishes **both** packages in runbook order (`@transitrix/diagrams`, then `@transitrix/cli`).

Key design point — **idempotent publish steps**: each step compares the workspace version against the registry (`npm view <pkg>@<local-version>`) and skips when that exact version is already published. Without this, any release that doesn't bump one of the packages would fail the job on `npm publish` over an existing version. This also makes `workflow_dispatch` re-runs safe.

The runbook is updated to match: the CLI moves out of the manual section; manual `npm publish` stays documented as a fallback (e.g. token expiry mid-release), and the post-publish sanity check is kept.

## Maintainer action required before the next release (Valerii)

Reissue the npm token so it covers **both** packages, and update the `NPM_TOKEN` repo secret:
- npmjs.com → Access Tokens → Generate New Token
- either a **classic Automation** token (no expiry, bypasses 2FA), or a **granular** token listing `@transitrix/diagrams` **and** `@transitrix/cli` with read-write — note granular tokens expire (max 1 year), which is exactly what bit the local publish today
- repo Settings → Secrets and variables → Actions → update `NPM_TOKEN`

Until the token is updated, the diagrams step keeps working as before and the CLI step will fail with the masked-403 `E404` — nothing worse.

## Verification

- YAML parses clean; step logic mirrors the existing verify/build steps
- Publish-skip logic exercised mentally against today's state: diagrams\@1.5.0 and cli\@1.1.0 are both on the registry → a re-run today would skip both steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)