### PR TITLE
chore(release): 2.9.1 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## [2.9.1] — 2026-07-03
+
+### Added
+
+- **Action preview — Tree view document root, export as Markdown.** The Tree
+  tab's hierarchy now nests under a single synthetic root node labelled with
+  the Action's own name (`doc.title`) instead of rendering a flat forest of
+  independent top-level activities — matching the "virtual root" convention
+  one level above Initiative (methodology `elements/24-action.md` §1), scaled
+  to one document. A new "Export tree as .md" toolbar button
+  (`transitrixStudio.exportActionTreeAsMarkdown`) saves the same hierarchy as
+  a nested Markdown list.
+
+### Fixed
+
+- **BPMN — skip-level same-lane flows no longer force a shared vertex or
+  detour the whole lane.** Four related routing fixes in
+  `src/layout-routing.ts`: (1) `buildGrid` now also adds a per-element "hug"
+  corridor row above/below each node, so a flow bypassing a single taller
+  neighbour finds a short local detour instead of the lane's outer margin;
+  that hug clearance is widened from the 6px minimum obstacle margin to a
+  visually comfortable 20px. (2) A gateway with both a direct
+  (adjacent-column) and a skip-level incoming flow no longer forces both onto
+  the same entry point — the skip-level one gets its own top/bottom face.
+  (3) The equivalent applies on the exit side: a gateway never crowds two or
+  more forward flows onto one vertex while another sits free. (4) A
+  gateway's own outgoing cross-lane flow no longer contends for a vertex an
+  incoming skip-level flow already claimed.
+
+- **Action preview — Gantt row labels no longer overlap.** The id/name pair
+  in the label column was laid out side by side with only a fixed offset,
+  which overflowed into the name text once the id got past a handful of
+  characters. Labels now stack (name above, id below, matching the entity
+  label convention used elsewhere) and the header reads "Actions" (Activity
+  is reserved for the process domain).
+
 ## [2.9.0] — 2026-07-03
 
 ### Changed

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "Architecture-as-code for the modern enterprise. Author 17 notations — goals, processes, capabilities, BPMN, applications, more — as plain YAML, get live diagrams in VS Code. Diffable in git. AI-friendly. Open source. Built on ArchiMate 3.2 and BPMN 2.0.",
   "license": "MIT",
   "icon": "icon.png",
@@ -557,6 +557,12 @@
         "title": "Transitrix: Save activity network as SVG",
         "category": "Transitrix",
         "icon": "$(save)"
+      },
+      {
+        "command": "transitrixStudio.exportActionTreeAsMarkdown",
+        "title": "Transitrix: Export action tree as Markdown",
+        "category": "Transitrix",
+        "icon": "$(export)"
       },
       {
         "command": "transitrixStudio.previewProducts",

--- a/extension/src/action-preview.ts
+++ b/extension/src/action-preview.ts
@@ -29,6 +29,8 @@ import { genNonce, buildControlsPanel, buildControlsScript } from './preview-con
 const ACTIVITIES_DEFAULT_H_GAP = 80;
 const ACTIVITIES_DEFAULT_V_GAP = 24;
 
+const EXPORT_TREE_MARKDOWN_COMMAND = 'transitrixStudio.exportActionTreeAsMarkdown';
+
 // ── Shared helpers ───────────────────────────────────────────────────────────
 
 function truncate(s: string, maxLen: number): string {
@@ -133,7 +135,7 @@ function ganttSvg(layout: GanttLayout, heading?: string, filename?: string, date
     `<rect class="diagram-node gantt-header" x="${ox}" y="${oy}" width="${G_LABEL_COL_W + timelineWidth}" height="${G_HEADER_H}"/>`,
   );
   headerParts.push(
-    `<text class="text-secondary" x="${ox + 12}" y="${oy + G_HEADER_H / 2}" dominant-baseline="central">Activity</text>`,
+    `<text class="text-secondary" x="${ox + 12}" y="${oy + G_HEADER_H / 2}" dominant-baseline="central">Actions</text>`,
   );
   // Month band: walk days, group by yyyy-mm.
   const months: Array<{ label: string; startCol: number; endCol: number }> = [];
@@ -174,12 +176,14 @@ function ganttSvg(layout: GanttLayout, heading?: string, filename?: string, date
         `<rect class="gantt-row-alt" x="${ox}" y="${rowY}" width="${G_LABEL_COL_W + timelineWidth}" height="${G_ROW_H}"/>`,
       );
     }
-    // Label column
+    // Label column — name on top (primary), id below in smaller grey text.
+    // Stacked rather than side-by-side: a single row width isn't enough to
+    // show both without overlap once the id gets past a handful of characters.
     rowParts.push(
-      `<text class="text-id" x="${ox + 8}" y="${rowY + G_ROW_H / 2}" dominant-baseline="central">${escXml(bar.id)}</text>`,
+      `<text class="text-primary" x="${ox + 8}" y="${rowY + 15}" dominant-baseline="central">${escXml(truncate(bar.name, 28))}</text>`,
     );
     rowParts.push(
-      `<text class="text-secondary" x="${ox + 56}" y="${rowY + G_ROW_H / 2}" dominant-baseline="central">${escXml(truncate(bar.name, 22))}</text>`,
+      `<text class="text-id" x="${ox + 8}" y="${rowY + 29}" dominant-baseline="central">${escXml(truncate(bar.id, 30))}</text>`,
     );
 
     // Bar geometry
@@ -397,6 +401,8 @@ interface ActivityViews {
   ganttSvg: string;
   /** HTML tree view body. Always non-empty when activities validated. */
   treeHtml: string;
+  /** Nested-list Markdown rendering of the same hierarchy as treeHtml. Used by "Export tree as .md". */
+  treeMarkdown: string;
 }
 
 // ── Tree view renderer ───────────────────────────────────────────────────────
@@ -418,11 +424,11 @@ function activityTypeBadgeClass(type: string | undefined): string {
 }
 
 function buildTreeHtml(doc: ActivityDoc, filename: string, date: string, version?: string, actionName?: string): string {
-  // Suppress project-type container nodes from the tree view — same convention
-  // as the Network view. The Action name in the header identifies the scope.
-  const activities = (doc.activities ?? []).filter(
-    (a) => a.activity_type?.toLowerCase() !== 'project',
-  );
+  // Unlike Network and Gantt, the Tree view keeps project-type container
+  // nodes visible — it's the WBS/hierarchy view, so the root of the tree is
+  // exactly where the project scope belongs (#337). Network/Gantt suppress it
+  // because those diagrams have no natural place for a durationless container.
+  const activities = doc.activities ?? [];
   if (activities.length === 0) {
     return '<div class="section-notice">No activities to display.</div>';
   }
@@ -481,21 +487,82 @@ function buildTreeHtml(doc: ActivityDoc, filename: string, date: string, version
   <div class="text-secondary">${escXml(date)}${versionPart}</div>
 </div>`;
 
-  return `${titleHtml}<div class="tree-view">${roots.map((r) => renderNode(r)).join('')}</div>`;
+  // The tree's actual root is the Action document itself (the Action name
+  // shown in the title block above) — not a forest of independent top-level
+  // activities. Wrapping `roots` under one synthetic node makes that
+  // structure visible: every activity nests under the plan it belongs to,
+  // matching the "virtual root" convention (elements/24-action.md §1) scaled
+  // down to this single document instead of the whole portfolio.
+  const docRootLabel = actionName ?? filename;
+  const docRootHtml = `<details class="tree-node tree-node-doc-root" open><summary class="tree-node-row tree-node-doc-root-row"><div class="tree-node-label"><span class="tree-node-name">${escXml(docRootLabel)}</span></div></summary><div class="tree-children">${roots.map((r) => renderNode(r)).join('')}</div></details>`;
+
+  return `${titleHtml}<div class="tree-view">${docRootHtml}</div>`;
+}
+
+/** Nested-list Markdown rendering of the same hierarchy as {@link buildTreeHtml}. */
+function buildTreeMarkdown(doc: ActivityDoc, actionName?: string): string {
+  const activities = doc.activities ?? [];
+  const heading = actionName ? `# ${actionName} — action decomposition` : '# Action decomposition';
+  if (activities.length === 0) {
+    return `${heading}\n\nNo activities to display.\n`;
+  }
+
+  const childrenOf = new Map<string | undefined, Activity[]>();
+  for (const act of activities) {
+    const key = act.parent ?? undefined;
+    if (!childrenOf.has(key)) childrenOf.set(key, []);
+    childrenOf.get(key)!.push(act);
+  }
+  const sortFn = (a: Activity, b: Activity): number => {
+    const diff = activityTypeLevel(a.activity_type) - activityTypeLevel(b.activity_type);
+    return diff !== 0 ? diff : a.id.localeCompare(b.id);
+  };
+  for (const [, kids] of childrenOf) kids.sort(sortFn);
+
+  const lines: string[] = [];
+  function renderNode(act: Activity, depth: number): void {
+    const metaParts: string[] = [];
+    if (act.activity_type) metaParts.push(act.activity_type);
+    if (act.owner) metaParts.push(act.owner);
+    if (act.start_date && act.end_date) metaParts.push(`${act.start_date} → ${act.end_date}`);
+    else if (act.start_date) metaParts.push(`from ${act.start_date}`);
+    const meta = metaParts.length ? ` — ${metaParts.join(' · ')}` : '';
+    lines.push(`${'  '.repeat(depth)}- ${act.name} (\`${act.id}\`)${meta}`);
+    for (const kid of childrenOf.get(act.id) ?? []) renderNode(kid, depth + 1);
+  }
+
+  const allIds = new Set(activities.map((a) => a.id));
+  const orphans = activities.filter((a) => a.parent && !allIds.has(a.parent));
+  const roots = [...(childrenOf.get(undefined) ?? []), ...orphans].sort(sortFn);
+
+  if (roots.length === 0) {
+    return `${heading}\n\nNo root activities found — check parent references.\n`;
+  }
+
+  // Mirror buildTreeHtml's synthetic doc-root: one top-level bullet for the
+  // Action document itself, with every parentless/orphan activity nested
+  // under it — not a flat list of independent top-level bullets.
+  const docRootLabel = actionName ?? 'Action';
+  lines.push(`- ${docRootLabel}`);
+  for (const root of roots) renderNode(root, 1);
+  return `${heading}\n\n${lines.join('\n')}\n`;
 }
 
 /**
- * Renderer/view convention (follow-up to #421):
+ * Renderer/view convention (follow-up to #421, corrected by #341's Tree
+ * regression):
  *
  * Project-type container nodes (activity_type === 'project') are suppressed
- * from ALL rendered views — Network, Gantt, and Tree. The diagram already
- * represents the project scope; rendering the container as a node or bar adds
- * visual noise. The doc.title (Action name) is shown in each view's header as
- * its own line so the reader can identify the action without the container node.
- * Canonical parent linkage is preserved in the raw doc; only the rendered node
- * lists are narrowed. doc.project.start_date (used by the Gantt for computed
- * mode) is on the project block, not on any activity — filtering activities
- * does not affect Gantt date computation.
+ * from the Network and Gantt views — those diagrams have no natural place for
+ * a durationless container, and rendering it as a node/bar adds visual noise.
+ * The Tree view is the WBS/hierarchy view and keeps the project node visible
+ * as the root — that's exactly where a reader expects to see the project
+ * scope. The doc.title (Action name) is additionally shown in each view's
+ * header as its own line. Canonical parent linkage is preserved in the raw
+ * doc; only the Network/Gantt rendered node lists are narrowed.
+ * doc.project.start_date (used by the Gantt for computed mode) is on the
+ * project block, not on any activity — filtering activities does not affect
+ * Gantt date computation.
  */
 function buildActivityViews(doc: ActivityDoc, gaps: ActivitiesLayoutOptions, curvature: number, entryCurvature: number | undefined, filename: string, date: string, version?: string): ActivityViews {
   // Suppress project-type container nodes from all views. A shallow copy is
@@ -510,6 +577,7 @@ function buildActivityViews(doc: ActivityDoc, gaps: ActivitiesLayoutOptions, cur
   const networkHeading = 'Network view — Project Schedule Network Diagram (PSND)';
   const networkSvgStr = networkSvg(filteredDoc, gaps, curvature, entryCurvature, networkHeading, filename, date, version, actionName);
   const gantt: GanttResult = computeGanttLayout(filteredDoc);
+  const treeMarkdownStr = buildTreeMarkdown(doc, actionName);
 
   const dateLine = date;
 
@@ -526,7 +594,7 @@ function buildActivityViews(doc: ActivityDoc, gaps: ActivitiesLayoutOptions, cur
 </div>
 <div class="section-notice">${escXml(gantt.reason)}</div>`;
     const treeHtmlStr = buildTreeHtml(doc, filename, date, version, actionName);
-    return { networkSvg: networkSvgStr, ganttBody, ganttSvg: '', treeHtml: treeHtmlStr };
+    return { networkSvg: networkSvgStr, ganttBody, ganttSvg: '', treeHtml: treeHtmlStr, treeMarkdown: treeMarkdownStr };
   }
 
   const modeLabel = gantt.mode === 'computed'
@@ -535,7 +603,7 @@ function buildActivityViews(doc: ActivityDoc, gaps: ActivitiesLayoutOptions, cur
   const ganttHeading = `Gantt view — ${modeLabel}`;
   const ganttSvgStr = ganttSvg(gantt, ganttHeading, filename, date, version, actionName);
   const treeHtmlStr = buildTreeHtml(doc, filename, date, version, actionName);
-  return { networkSvg: networkSvgStr, ganttBody: ganttSvgStr, ganttSvg: ganttSvgStr, treeHtml: treeHtmlStr };
+  return { networkSvg: networkSvgStr, ganttBody: ganttSvgStr, ganttSvg: ganttSvgStr, treeHtml: treeHtmlStr, treeMarkdown: treeMarkdownStr };
 }
 
 function buildCanvasContent(views: ActivityViews): string {
@@ -681,6 +749,10 @@ const ACTIVITIES_WEBVIEW_CSS = `
   .tree-badge-programme { background: #eff6ff; color: #2563eb; border: 1px solid #93c5fd; }
   .tree-badge-project { background: var(--ts-layer-activity, #d4edda); color: #166534; border: 1px solid #86efac; }
   .tree-badge-task { background: var(--ts-bg-subtle, #f1f5f9); color: var(--ts-text-muted, #64748b); border: 1px solid var(--ts-border, #cbd5e1); }
+  /* Doc-root row — the Action document itself, distinct from its activities. */
+  .tree-node-doc-root-row { border-color: var(--ts-brand-orange, #ff4d00); background: var(--ts-bg-subtle, #f8fafc); }
+  .tree-node-doc-root-row .tree-node-name { font-weight: 700; font-size: 14px; }
+  .tree-node-doc-root > .tree-children { margin-left: 8px; }
 `;
 
 const ACTIVITIES_STYLES = ACTIVITIES_WEBVIEW_CSS + ACTIVITIES_DIAGRAM_CSS;
@@ -697,6 +769,7 @@ export class ActionPreview {
   // to ask the user when both views are available.
   private lastNetworkSvg = '';
   private lastGanttSvg = '';
+  private lastTreeMarkdown = '';
 
   constructor(private readonly extensionUri: vscode.Uri) {}
 
@@ -722,7 +795,7 @@ export class ActionPreview {
           enableScripts: true,
           retainContextWhenHidden: true,
           localResourceRoots: [vscode.Uri.joinPath(this.extensionUri, 'media')],
-          enableCommandUris: ['transitrixStudio.saveActivitiesAsSvg', 'transitrixStudio.saveActivitiesAsPng', 'transitrixStudio.copyActivitiesAsPng', OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_THEME_COMMAND],
+          enableCommandUris: ['transitrixStudio.saveActivitiesAsSvg', 'transitrixStudio.saveActivitiesAsPng', 'transitrixStudio.copyActivitiesAsPng', EXPORT_TREE_MARKDOWN_COMMAND, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_THEME_COMMAND],
         },
       );
       this.panel.webview.onDidReceiveMessage((m) => { void applyControlMessage('action', m); });
@@ -778,6 +851,7 @@ export class ActionPreview {
         bodyContent = buildCanvasContent(views);
         this.lastNetworkSvg = views.networkSvg;
         this.lastGanttSvg = views.ganttSvg;
+        this.lastTreeMarkdown = views.treeMarkdown;
       }
     } catch (e) {
       errorMsg = (e as Error).message ?? 'Parse error';
@@ -786,6 +860,7 @@ export class ActionPreview {
     if (!bodyContent) {
       this.lastNetworkSvg = '';
       this.lastGanttSvg = '';
+      this.lastTreeMarkdown = '';
     }
 
     const themeId = vscode.workspace
@@ -802,7 +877,7 @@ export class ActionPreview {
 
     return buildDiagramFrame({
       filename,
-      notation: 'Activities (PSND + Gantt)',
+      notation: 'Actions (PSND + Gantt)',
       bodyContent,
       errorMsg,
       warnings,
@@ -814,8 +889,29 @@ export class ActionPreview {
       spacingCommand: OPEN_SPACING_SETTINGS_COMMAND,
       curvatureCommand: OPEN_CURVATURE_SETTINGS_COMMAND,
       themeCommand: OPEN_THEME_COMMAND,
+      extraButtons: [{ command: EXPORT_TREE_MARKDOWN_COMMAND, label: 'Export tree as .md', title: 'Save the Tree view decomposition as a nested Markdown list' }],
       interactive: { nonce, controlsPanel, controlsScript: buildControlsScript(nonce) },
     });
+  }
+
+  /** Save the Tree view's current hierarchy as a nested Markdown list. */
+  async exportTreeAsMarkdown(): Promise<void> {
+    if (!this.lastTreeMarkdown) {
+      vscode.window.showWarningMessage('No diagram rendered yet. Open a *.action.transitrix.yaml or *.dgca.transitrix.yaml (with notation: action) file first.');
+      return;
+    }
+    const sourceUri = this.trackedUri ? vscode.Uri.parse(this.trackedUri) : undefined;
+    const stem = sourceUri
+      ? path.basename(sourceUri.fsPath).replace(/\.(action|dgca)\.transitrix\.yaml$/, '')
+      : 'action-tree';
+    const suffixed = `${stem}-tree.md`;
+    const defaultUri = sourceUri
+      ? vscode.Uri.file(path.join(path.dirname(sourceUri.fsPath), suffixed))
+      : vscode.Uri.file(suffixed);
+    const target = await vscode.window.showSaveDialog({ defaultUri, filters: { 'Markdown': ['md'] } });
+    if (!target) return;
+    await vscode.workspace.fs.writeFile(target, Buffer.from(this.lastTreeMarkdown, 'utf-8'));
+    vscode.window.showInformationMessage(`Saved: ${path.basename(target.fsPath)}`);
   }
 
   /**

--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -107,6 +107,14 @@ export interface DiagramFrameOpts {
    */
   themeCommand?: string;
   /**
+   * Extra command-URI toolbar buttons beyond the fixed save/spacing/theme
+   * slots above — e.g. a notation-specific export action (Action preview's
+   * "Export tree as .md"). Rendered after the built-in buttons, in order.
+   * Same opt-in contract as `saveSvgCommand`: the preview's webview must
+   * include each `command` in `enableCommandUris`.
+   */
+  extraButtons?: Array<{ command: string; label: string; title: string }>;
+  /**
    * When true, adds a "Legend" toggle button to the toolbar (CSS-only, no scripts).
    * The SVG must wrap its legend elements in `<g class="diagram-legend-col">`.
    * Follows the same pattern as the title toggle (TX-R009).
@@ -413,6 +421,7 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
     themeId = 'transitrix', extraStyles = '', fixPrompt = '',
     title, subtitle, version, date,
     saveSvgCommand, savePngCommand, copyPngCommand, spacingCommand, curvatureCommand, scopeCommand, themeCommand,
+    extraButtons = [],
     interactive, legendToggle, snapshotUi,
   } = opts;
 
@@ -516,6 +525,11 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
   }
   if (showCopyPng) {
     actionParts.push(`<a href="command:${escXml(copyPngCommand!)}" class="toolbar-btn" title="Copy the current diagram to the clipboard as a PNG image">Copy image</a>`);
+  }
+  if (canvasContent) {
+    for (const b of extraButtons) {
+      actionParts.push(`<a href="command:${escXml(b.command)}" class="toolbar-btn" title="${escXml(b.title)}">${escXml(b.label)}</a>`);
+    }
   }
   if (showSpacing) {
     actionParts.push(`<a href="command:${escXml(spacingCommand!)}" class="toolbar-btn" title="Adjust the horizontal/vertical spacing for this notation in Settings">Spacing…</a>`);

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -382,6 +382,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     vscode.commands.registerCommand('transitrixStudio.copyDGAAsPng', () => dgaPreview.copyAsPng()),
     vscode.commands.registerCommand('transitrixStudio.saveActivitiesAsPng', () => actionPreview.saveAsPng()),
     vscode.commands.registerCommand('transitrixStudio.copyActivitiesAsPng', () => actionPreview.copyAsPng()),
+    vscode.commands.registerCommand('transitrixStudio.exportActionTreeAsMarkdown', () => actionPreview.exportTreeAsMarkdown()),
     vscode.commands.registerCommand('transitrixStudio.previewApplications', async () => {
       const doc = vscode.window.activeTextEditor?.document;
       if (!doc || !isApplicationsFile(doc)) {

--- a/organizations/acme_corp/canon/views/action/gdpr-remediation.dgca.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/action/gdpr-remediation.dgca.transitrix.yaml
@@ -14,6 +14,9 @@ version: "0.1"
 date: "2026-06-10"
 author: "Acme Compliance Office"
 
+project:
+  start_date: "2026-03-01"
+
 actions:
   - id: ACTION-GDPR-GAP-1
     name: "GDPR & NIS2 gap assessment"

--- a/organizations/acme_corp/canon/views/bpmn/data-subject-erasure.bpmn.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/bpmn/data-subject-erasure.bpmn.transitrix.yaml
@@ -49,6 +49,9 @@ process:
             - id: TASK-FLAG-GAP
               type: task
               name: "Flag archive exception for manual review"
+            - id: GW-CONFIRM-JOIN
+              type: exclusiveGateway
+              name: "Erasure path joined"
             - id: TASK-RECORD-CLOSURE
               type: task
               name: "Record completion within 30-day window"
@@ -89,9 +92,11 @@ process:
       to: TASK-FLAG-GAP
       condition: "data present in 7-year archive (known gap)"
     - from: GW-ARCHIVE
-      to: TASK-CONFIRM
+      to: GW-CONFIRM-JOIN
       default: true
     - from: TASK-FLAG-GAP
+      to: GW-CONFIRM-JOIN
+    - from: GW-CONFIRM-JOIN
       to: TASK-CONFIRM
     - from: TASK-CONFIRM
       to: TASK-RECORD-CLOSURE

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/cli",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "description": "Transitrix CLI — compile, validate, and report on Transitrix diagrams (BPMN, Goals, FGCA, …) from any shell or CI pipeline.",
   "license": "MIT",

--- a/src/layout-routing.ts
+++ b/src/layout-routing.ts
@@ -68,6 +68,16 @@ const TRACK_MAX_OFFSET_PX = 18;
 /** Minimum free strip height to qualify as a horizontal corridor. */
 const MIN_CORRIDOR_PX = 14;
 
+/**
+ * Clearance for the per-element "hug" rows a skip-level flow uses to bypass
+ * a single node (buildGrid, below) — comfortably larger than the minimum
+ * legal OBSTACLE_MARGIN_PX. A* minimises path length, so it always prefers
+ * the tightest legal candidate row; without a deliberately wider gap here,
+ * a bypass arc reads as skimming the node's edge even when the lane has
+ * plenty of headroom to spare.
+ */
+const HUG_CLEARANCE_PX = 20;
+
 type Dir = 0 | 1 | 2 | 3; // R, D, L, U
 const DX = [1, 0, -1, 0] as const;
 const DY = [0, 1, 0, -1] as const;
@@ -91,6 +101,16 @@ function portDir(port: Port): Dir {
     case 'bottom': return 1;
     case 'left':   return 2;
     case 'top':    return 3;
+  }
+}
+
+/** Direction of travel when ARRIVING at (moving into) the given face. */
+function entryDir(port: Port): Dir {
+  switch (port) {
+    case 'left':   return 0; // moving right, into the left face
+    case 'top':    return 1; // moving down, into the top face
+    case 'right':  return 2; // moving left, into the right face
+    case 'bottom': return 3; // moving up, into the bottom face
   }
 }
 
@@ -154,11 +174,15 @@ export function planPorts(ir: ProcessIr, p: Placement): Map<string, FlowPlan> {
   // Exit-port overrides (gateway vertex distribution + cross-lane verticals).
   const flowExitPort = new Map<string, Port>();
   const flowExitYOffset = new Map<string, number>();
+  // Entry-port overrides (join-side vertex distribution — see below).
+  const flowEntryPort = new Map<string, Port>();
 
   // Same-lane forward gateway flows grouped by source.
-  const fwdSameLaneByGw = new Map<string, Array<{ id: string; toB: Bounds }>>();
+  const fwdSameLaneByGw = new Map<string, Array<{ id: string; toB: Bounds; colSpan: number }>>();
   // Same-lane forward flows from non-gateway sources grouped by source.
   const fwdSameLaneByTask = new Map<string, Array<{ id: string; targetX: number }>>();
+  // Same-lane forward flows INTO a gateway, grouped by target (join side).
+  const fwdSameLaneIntoGw = new Map<string, Array<{ id: string; colSpan: number }>>();
 
   for (const f of ir.flows) {
     const fb = p.elements.get(f.from);
@@ -167,14 +191,40 @@ export function planPorts(ir: ProcessIr, p: Placement): Map<string, FlowPlan> {
     const sameLane = p.laneOf.get(f.from) === p.laneOf.get(f.to);
     if (!sameLane || isBackward(fb, tb)) continue;
     if (GATEWAY_TYPES.has(p.typeOf.get(f.from) ?? '')) {
+      const colSpan = Math.abs((p.columnOf.get(f.to) ?? 0) - (p.columnOf.get(f.from) ?? 0));
       const arr = fwdSameLaneByGw.get(f.from) ?? [];
-      arr.push({ id: f.id, toB: tb });
+      arr.push({ id: f.id, toB: tb, colSpan });
       fwdSameLaneByGw.set(f.from, arr);
     } else {
       const arr = fwdSameLaneByTask.get(f.from) ?? [];
       arr.push({ id: f.id, targetX: tb.x });
       fwdSameLaneByTask.set(f.from, arr);
     }
+    if (GATEWAY_TYPES.has(p.typeOf.get(f.to) ?? '')) {
+      const colSpan = Math.abs((p.columnOf.get(f.to) ?? 0) - (p.columnOf.get(f.from) ?? 0));
+      const arr = fwdSameLaneIntoGw.get(f.to) ?? [];
+      arr.push({ id: f.id, colSpan });
+      fwdSameLaneIntoGw.set(f.to, arr);
+    }
+  }
+
+  // Join-side vertex distribution: when a gateway receives both a "direct"
+  // same-lane predecessor (the immediately preceding column) and a
+  // "skip-level" one (bypassing an intervening node in the same row),
+  // forcing both onto the default LEFT face makes the skip-level flow
+  // converge on the exact same entry point as the direct one — it then has
+  // to detour around the intervening node just to reach that shared point.
+  // Routing the skip-level entry through TOP (falling back to BOTTOM for a
+  // second one) instead gives it a short, independent approach and keeps
+  // the direct flow's straight-through path uncluttered.
+  for (const [, flows] of fwdSameLaneIntoGw) {
+    if (flows.length <= 1) continue;
+    const direct = flows.some((f) => f.colSpan <= 1);
+    const skip = flows.filter((f) => f.colSpan > 1);
+    if (!direct || skip.length === 0) continue;
+    skip.forEach((f, i) => {
+      flowEntryPort.set(f.id, i % 2 === 0 ? 'top' : 'bottom');
+    });
   }
 
   // Non-gateway sources with several forward same-lane exits: spread the exit
@@ -188,9 +238,19 @@ export function planPorts(ir: ProcessIr, p: Placement): Map<string, FlowPlan> {
     });
   }
 
-  // Gateway same-lane forward flows: one diamond vertex per directional group.
-  //   most-above target → TOP vertex, most-below → BOTTOM vertex,
-  //   level targets and extras → RIGHT vertex with Y-offset spread.
+  // Gateway same-lane forward flows: one diamond vertex per directional
+  // group — most-above target → TOP, most-below → BOTTOM, everything else
+  // → RIGHT. A gateway has three usable forward vertices (left is reserved
+  // for backward loops); never let two or more flows double up on one of
+  // them while another sits completely unclaimed. Whichever flows don't win
+  // the top/bottom vertex outright are ranked by how much they'd benefit
+  // from a vertex of their own — a skip-level flow (colSpan > 1, bypassing
+  // an intervening node) has genuine travel budget for a wide arc from
+  // TOP/BOTTOM; a merely-further-above/below extra is next; a flow that's
+  // level with the gateway and adjacent (colSpan ≤ 1, nothing to detour
+  // around) benefits least and is the last to be moved off RIGHT. Only once
+  // every vertex is spoken for does a further flow double up on RIGHT,
+  // spread by Y-offset — an inherent limit of a 3-vertex shape.
   for (const [sourceId, flows] of fwdSameLaneByGw) {
     if (flows.length <= 1) continue;
     const gwB = p.elements.get(sourceId)!;
@@ -203,16 +263,29 @@ export function planPorts(ir: ProcessIr, p: Placement): Map<string, FlowPlan> {
       .filter((f) => f.toB.y + f.toB.height / 2 > gwCY + GATEWAY_VERTEX_THRESHOLD_PX)
       .sort((a, b) => (b.toB.y + b.toB.height / 2) - (a.toB.y + a.toB.height / 2));
 
-    if (above.length > 0) flowExitPort.set(above[0].id, 'top');
-    if (below.length > 0) flowExitPort.set(below[0].id, 'bottom');
+    let topTaken = false;
+    let bottomTaken = false;
+    if (above.length > 0) { flowExitPort.set(above[0].id, 'top'); topTaken = true; }
+    if (below.length > 0) { flowExitPort.set(below[0].id, 'bottom'); bottomTaken = true; }
 
-    const rightFlows = [
+    const overflow = [
       ...above.slice(1),
       ...flows.filter(
         (f) => Math.abs(f.toB.y + f.toB.height / 2 - gwCY) <= GATEWAY_VERTEX_THRESHOLD_PX,
       ),
       ...below.slice(1),
-    ].sort((a, b) => a.toB.y - b.toB.y);
+    ].sort((a, b) => b.colSpan - a.colSpan || a.toB.y - b.toB.y);
+
+    if (overflow.length > 1 && !topTaken) {
+      flowExitPort.set(overflow.shift()!.id, 'top');
+      topTaken = true;
+    }
+    if (overflow.length > 1 && !bottomTaken) {
+      flowExitPort.set(overflow.shift()!.id, 'bottom');
+      bottomTaken = true;
+    }
+
+    const rightFlows = overflow.sort((a, b) => a.toB.y - b.toB.y);
     if (rightFlows.length > 1) {
       const total = (rightFlows.length - 1) * MULTI_EXIT_OFFSET_STEP_PX;
       rightFlows.forEach((f, i) => {
@@ -221,9 +294,24 @@ export function planPorts(ir: ProcessIr, p: Placement): Map<string, FlowPlan> {
     }
   }
 
+  // Vertex ports already claimed at a node by the join-side entry
+  // distribution above (e.g. a skip-level flow entering via 'top') — consulted
+  // below so a gateway's own outgoing cross-lane flow doesn't converge on the
+  // same vertex an incoming flow is already using.
+  const usedEntryPort = new Map<string, Set<Port>>();
+  for (const f of ir.flows) {
+    const port = flowEntryPort.get(f.id);
+    if (!port) continue;
+    const set = usedEntryPort.get(f.to) ?? new Set<Port>();
+    set.add(port);
+    usedEntryPort.set(f.to, set);
+  }
+
   // Cross-lane gateway flows: bottom vertex when the target lane is below,
   // top vertex when above (unless the target is clearly to the left —
-  // those route as backward-style left U-turns).
+  // those route as backward-style left U-turns, or the vertex is already
+  // claimed by an incoming join-side flow at this same gateway — see above —
+  // in which case the default RIGHT exit is left in place instead).
   for (const f of ir.flows) {
     const fb = p.elements.get(f.from);
     const tb = p.elements.get(f.to);
@@ -235,8 +323,9 @@ export function planPorts(ir: ProcessIr, p: Placement): Map<string, FlowPlan> {
     if (targetClearlyLeft) continue;
     const targetBelow = tb.y >= fb.y + fb.height - EPSILON_PX;
     const targetAbove = tb.y + tb.height <= fb.y + EPSILON_PX;
-    if (targetBelow) flowExitPort.set(f.id, 'bottom');
-    else if (targetAbove) flowExitPort.set(f.id, 'top');
+    const claimed = usedEntryPort.get(f.from);
+    if (targetBelow && !claimed?.has('bottom')) flowExitPort.set(f.id, 'bottom');
+    else if (targetAbove && !claimed?.has('top')) flowExitPort.set(f.id, 'top');
   }
 
   const plans = new Map<string, FlowPlan>();
@@ -258,9 +347,12 @@ export function planPorts(ir: ProcessIr, p: Placement): Map<string, FlowPlan> {
     const yOffset = exitPort === 'right' ? (flowExitYOffset.get(f.id) ?? 0) : 0;
 
     const start = portPoint(fb, exitPort, yOffset);
-    // Entry is always the left face, approached moving right; the straight
-    // vertical fast path (top/bottom face) is handled before the search.
-    const end = portPoint(tb, 'left');
+    // Entry defaults to the left face, approached moving right; join-side
+    // vertex distribution (above) overrides this for a skip-level incoming
+    // flow sharing a gateway with a direct one. The straight vertical fast
+    // path (top/bottom face) is handled before the search.
+    const entryPort = backward || targetClearlyLeft ? 'left' : (flowEntryPort.get(f.id) ?? 'left');
+    const end = portPoint(tb, entryPort);
 
     const colSpan = Math.abs(
       (p.columnOf.get(f.to) ?? 0) - (p.columnOf.get(f.from) ?? 0),
@@ -272,7 +364,7 @@ export function planPorts(ir: ProcessIr, p: Placement): Map<string, FlowPlan> {
       start,
       startDir: portDir(exitPort),
       end,
-      endDir: 0, // moving right into the left face
+      endDir: entryDir(entryPort),
       backward,
       columnSpan: colSpan,
     });
@@ -349,6 +441,23 @@ export function buildGrid(
     }
     if (lb.y + lb.height - cursor >= MIN_CORRIDOR_PX) {
       ys.push((cursor + lb.y + lb.height) / 2);
+    }
+
+    // Per-element hug rows, in addition to the merge above. The lane-wide
+    // merge treats any two elements that overlap in Y as one obstacle block —
+    // right for elements genuinely stacked at the same X, but it also erases
+    // the local clearance around a *shorter* neighbour standing next to a
+    // taller one at a different column (same row-centre, common case: a
+    // gateway beside a task). A skip-level edge that only needs to hop over
+    // that one taller node then finds no row until the lane's outer margin,
+    // producing a detour spanning the whole lane instead of hugging the node.
+    // Adding each element's own top/bottom edge as a raw candidate fixes
+    // this without touching the merge: hBlocked/vBlocked already gate every
+    // grid segment per element, so a row that's genuinely blocked somewhere
+    // along its length simply goes unused there — safe to add unconditionally.
+    for (const [id, b] of p.elements) {
+      if (p.laneOf.get(id) !== laneId) continue;
+      ys.push(b.y - HUG_CLEARANCE_PX, b.y + b.height + HUG_CLEARANCE_PX);
     }
   }
   if (o.laneVerticalGap >= 8) {


### PR DESCRIPTION
## Summary

Patch release — same pattern as the 2.8.0 (#339) / 2.9.0 (#344) notes PRs.

- **fix(bpmn):** skip-level same-lane flows no longer force a shared vertex
  or detour the whole lane (`src/layout-routing.ts` — corridor hug rows +
  wider clearance, join/exit-side vertex distribution, cross-lane vertex
  contention check).
- **feat(action-preview):** Tree view renders a single document-root node
  instead of a flat forest of top-level activities; new "Export tree as .md"
  toolbar button; Gantt row labels no longer overlap; header reads "Actions".
- **chore(acme_corp):** demo-data tweaks so the Gantt view and the BPMN
  routing fixes above have something real to render against.
- **chore(release):** CHANGELOG entry + version bumps.

## Versions

- `package.json` + `extension/package.json`: 2.9.0 → 2.9.1 (patch, via
  `node scripts/bump-extension-version.mjs patch`).
- `packages/cli/package.json`: 1.1.0 → 1.1.1 — bundled compiler sources
  (`src/layout-routing.ts`) changed since the last published version.
- `packages/diagrams/package.json`: left at 1.5.0 — untouched this release.

## Pre-flight (all green)

- [x] `npm run build`
- [x] `npm run compile` + `npm run compile:extension`
- [x] `npm test` (root core + diagrams workspace — 1153 tests)
- [x] CHANGELOG heading matches the version fields

## Test plan

- [ ] Merge, verify `main` has the bump
- [ ] Draft release `v2.9.1` per `docs/release-runbook.md` §2 (Valerii gates)
- [ ] Publish → watch the four release workflows fire