### PR TITLE
feat(compliance): requirement traceability + hierarchy view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **Requirement traceability + hierarchy view.** A new
+  `transitrixStudio.previewRequirementTrace` command opens a script-less
+  webview for any `REQUIREMENT-*.yaml` or `CONSTRAINT-*.yaml` file. The view
+  shows two halves, both origin-agnostic (`legislative` / `process-product` /
+  `project-product`):
+  - **Trace chain** — `derived_from` codex sources → the element itself → any
+    `ASSERTION` targeting it (`about`) → the asserted `subject` +
+    `realised_via` elements. Every id is click-to-open. `REQ-COVERAGE-001` is
+    surfaced inline when no assertion targets the requirement.
+  - **Hierarchy** — the `parent` chain (immediate parent to root, per the new
+    `parent` field on REQUIREMENT / CONSTRAINT) plus direct children of the
+    element.
+
+  Assertion coverage is REQUIREMENT-only per `16-assertion.md` §1; a
+  CONSTRAINT-side trace shows sources + hierarchy only and notes the v1 scope
+  boundary inline. The extension activates on `REQUIREMENT-*.yaml`,
+  `CONSTRAINT-*.yaml`, or `ASSERTION-*.yaml` in the workspace, and the
+  editor-title bar surfaces a "Preview requirement trace + hierarchy" action
+  when a REQUIREMENT or CONSTRAINT file is open. Under the hood,
+  `@transitrix/diagrams` gains a pure `buildRequirementTrace` builder over
+  the existing compliance reverse-index (extended with `requirementsByParent`).
+
 ## [2.9.1] — 2026-07-03
 
 ### Added

--- a/extension/package.json
+++ b/extension/package.json
@@ -68,7 +68,8 @@
     "workspaceContains:**/*.coverage-metric.transitrix.yaml",
     "workspaceContains:**/*.compliance-impact.transitrix.yaml",
     "workspaceContains:**/ASSERTION-*.yaml",
-    "workspaceContains:**/REQUIREMENT-*.yaml"
+    "workspaceContains:**/REQUIREMENT-*.yaml",
+    "workspaceContains:**/CONSTRAINT-*.yaml"
   ],
   "contributes": {
     "configuration": {
@@ -742,6 +743,18 @@
         "icon": "$(refresh)"
       },
       {
+        "command": "transitrixStudio.previewRequirementTrace",
+        "title": "Transitrix: Preview requirement trace + hierarchy",
+        "category": "Transitrix",
+        "icon": "$(references)"
+      },
+      {
+        "command": "transitrixStudio.refreshRequirementTrace",
+        "title": "Transitrix: Refresh requirement-trace view",
+        "category": "Transitrix",
+        "icon": "$(refresh)"
+      },
+      {
         "command": "transitrixStudio.previewGapDashboard",
         "title": "Transitrix: Preview compliance gap dashboard",
         "category": "Transitrix",
@@ -945,6 +958,11 @@
         {
           "when": "resourceFilename =~ /^PRODUCT-.*\\.yaml$/",
           "command": "transitrixStudio.previewSingleProduct",
+          "group": "navigation@-10"
+        },
+        {
+          "when": "resourceFilename =~ /^(REQUIREMENT|CONSTRAINT)-.*\\.yaml$/",
+          "command": "transitrixStudio.previewRequirementTrace",
           "group": "navigation@-10"
         },
         {

--- a/extension/src/compliance-scan.ts
+++ b/extension/src/compliance-scan.ts
@@ -65,8 +65,9 @@ export async function scanComplianceCanon(): Promise<ScannedCanon> {
 // no warning is emitted. The warning is reserved for truly unrecognised values
 // (e.g. a typo like "asssertion") that might indicate a miscategorised file.
 const SILENT_NOTATIONS = new Set([
-  // Element notations
-  'activity', 'actor', 'assessment', 'business_object', 'change', 'constraint',
+  // Element notations (constraint is now handled by ingestComplianceDoc — kept
+  // out of this silent-skip list so a typo like 'constrain' still warns).
+  'activity', 'actor', 'assessment', 'business_object', 'change',
   'driver', 'equipment', 'factor', 'goal', 'registry', 'relation', 'role', 'rule',
   'stakeholder', 'target-state',
   // View / diagram notations

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -21,6 +21,7 @@ import { ComplianceMatrixPreview } from './compliance-matrix-preview.js';
 import { ComplianceImpactPreview } from './compliance-impact-preview.js';
 import { SingleLawPreview } from './single-law-preview.js';
 import { SingleProductPreview } from './single-product-preview.js';
+import { RequirementTracePreview } from './requirement-trace-preview.js';
 import { GapDashboardPreview } from './gap-dashboard-preview.js';
 import { CoverageMetricPreview } from './coverage-metric-preview.js';
 import { openComplianceFile } from './compliance-scan.js';
@@ -110,6 +111,10 @@ function isSingleLawFile(doc: vscode.TextDocument): boolean {
 
 function isSingleProductFile(doc: vscode.TextDocument): boolean {
   return /^PRODUCT-.*\.ya?ml$/i.test(path.basename(doc.fileName));
+}
+
+function isRequirementTraceFile(doc: vscode.TextDocument): boolean {
+  return /^(REQUIREMENT|CONSTRAINT)-.*\.ya?ml$/i.test(path.basename(doc.fileName));
 }
 
 function probeDocNotation(doc: vscode.TextDocument): string | undefined {
@@ -250,6 +255,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   const complianceImpactPreview = new ComplianceImpactPreview(context.extensionUri);
   const singleLawPreview = new SingleLawPreview(context.extensionUri);
   const singleProductPreview = new SingleProductPreview(context.extensionUri);
+  const requirementTracePreview = new RequirementTracePreview(context.extensionUri);
   const gapDashboardPreview = new GapDashboardPreview(context.extensionUri);
   const coverageMetricPreview = new CoverageMetricPreview(context.extensionUri);
 
@@ -472,6 +478,17 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       await singleProductPreview.showOrReveal(doc);
     }),
     vscode.commands.registerCommand('transitrixStudio.refreshSingleProduct', () => singleProductPreview.refresh()),
+    // Requirement traceability + hierarchy view —
+    // triggered from a REQUIREMENT-*.yaml or CONSTRAINT-*.yaml file's
+    // editor-title bar. Shows the trace chain (derived_from → element →
+    // ASSERTION → subject + realised_via) and the hierarchy (parent chain +
+    // direct children); origin-agnostic per 15-requirement.md §2.1.
+    vscode.commands.registerCommand('transitrixStudio.previewRequirementTrace', async () => {
+      const doc = vscode.window.activeTextEditor?.document;
+      if (!doc) { vscode.window.showWarningMessage('Open a REQUIREMENT or CONSTRAINT file first.'); return; }
+      await requirementTracePreview.showOrReveal(doc);
+    }),
+    vscode.commands.registerCommand('transitrixStudio.refreshRequirementTrace', () => requirementTracePreview.refresh()),
     // Gap dashboard (vkgeorgia/strategy#84 Phase 4) — repo-wide, palette-invoked.
     vscode.commands.registerCommand('transitrixStudio.previewGapDashboard', () => gapDashboardPreview.showOrReveal()),
     vscode.commands.registerCommand('transitrixStudio.refreshGapDashboard', () => gapDashboardPreview.refresh()),
@@ -550,6 +567,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         void complianceImpactPreview.refresh();
         void singleLawPreview.refresh();
         void singleProductPreview.refresh();
+        void requirementTracePreview.refresh();
         void gapDashboardPreview.refresh();
         void coverageMetricPreview.refreshConfig();
       }
@@ -564,11 +582,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       void dgcaPreview.refreshIfSiblingSaved(doc);
       // Compliance views are repo-wide: re-scan the open ones whenever a canon
       // artefact (by filename convention) is saved. No-op when no panel is open.
-      if (/^(PRODUCT|REQUIREMENT|ASSERTION|LAW|REGULATION|POLICY|INTERNAL_STANDARD)-.*\.ya?ml$/.test(path.basename(doc.fileName))) {
+      if (/^(PRODUCT|REQUIREMENT|CONSTRAINT|ASSERTION|LAW|REGULATION|POLICY|INTERNAL_STANDARD)-.*\.ya?ml$/.test(path.basename(doc.fileName))) {
         void complianceMatrixPreview.refresh();
         void complianceImpactPreview.refresh();
         void singleLawPreview.refresh();
         void singleProductPreview.refresh();
+        void requirementTracePreview.refresh();
         void gapDashboardPreview.refresh();
       }
       if (isGoalsFile(doc)) { void goalsPreview.refreshSaved(doc); return; }
@@ -617,6 +636,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       if (isComplianceImpactFile(doc)) { await complianceImpactPreview.showOrReveal(); return; }
       if (isSingleLawFile(doc)) { await singleLawPreview.showOrReveal(doc); return; }
       if (isSingleProductFile(doc)) { await singleProductPreview.showOrReveal(doc); return; }
+      if (isRequirementTraceFile(doc)) { await requirementTracePreview.showOrReveal(doc); return; }
       if (documentMatchesCervinSource(doc)) { await openBpmnPreviewForDocument(doc); return; }
     }),
   );

--- a/extension/src/requirement-trace-preview.ts
+++ b/extension/src/requirement-trace-preview.ts
@@ -1,0 +1,267 @@
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+import yaml from 'js-yaml';
+import { type ThemeId } from '@transitrix/diagrams/theme';
+import {
+  buildComplianceIndex,
+  buildRequirementTrace,
+  buildTraceElementCatalog,
+  scoreComplianceView,
+  type RequirementTrace,
+} from '@transitrix/diagrams/compliance';
+import { scanComplianceCanon } from './compliance-scan.js';
+import { complianceShell, escXml, openLink, statusBadge } from './compliance-render.js';
+
+// Requirement traceability + hierarchy view. Triggered
+// from a REQUIREMENT-*.yaml or CONSTRAINT-*.yaml file in the editor-title bar.
+// Shows the trace chain (derived_from → element → ASSERTION → subject +
+// realised_via) and the hierarchy (parent chain + direct children). Read-only,
+// script-less; click-to-open via command URIs.
+//
+// Assertion coverage applies to REQUIREMENT only (16-assertion.md §1) — a
+// CONSTRAINT-side trace shows sources + hierarchy but no assertion block.
+
+const OPEN_FILE_COMMAND = 'transitrixStudio.openComplianceFile';
+const REFRESH_COMMAND = 'transitrixStudio.refreshRequirementTrace';
+
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export class RequirementTracePreview {
+  readonly panelTitle = 'Requirement Trace Preview';
+  private panel: vscode.WebviewPanel | undefined;
+  private trackedUri: string | undefined;
+
+  constructor(private readonly extensionUri: vscode.Uri) {}
+
+  isShowingDocument(uri: vscode.Uri): boolean {
+    return this.panel != null && this.trackedUri === uri.toString();
+  }
+
+  async showOrReveal(doc: vscode.TextDocument): Promise<void> {
+    this.trackedUri = doc.uri.toString();
+    if (!this.panel) {
+      this.panel = vscode.window.createWebviewPanel(
+        'requirementTracePreview',
+        `${this.panelTitle} — ${path.basename(doc.fileName)}`,
+        { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
+        {
+          enableScripts: false,
+          retainContextWhenHidden: true,
+          enableCommandUris: [OPEN_FILE_COMMAND, REFRESH_COMMAND, 'transitrixStudio.changeTheme'],
+        },
+      );
+      this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
+    } else {
+      this.panel.title = `${this.panelTitle} — ${path.basename(doc.fileName)}`;
+      this.panel.reveal(vscode.ViewColumn.Beside, true);
+    }
+    await this.push(doc);
+  }
+
+  async refreshSaved(doc: vscode.TextDocument): Promise<void> {
+    if (this.isShowingDocument(doc.uri)) await this.push(doc);
+  }
+
+  async refresh(): Promise<void> {
+    if (!this.panel || !this.trackedUri) return;
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.parse(this.trackedUri));
+    await this.push(doc);
+  }
+
+  private async push(doc: vscode.TextDocument): Promise<void> {
+    if (!this.panel) return;
+    const themeId = vscode.workspace.getConfiguration('transitrix').get<ThemeId>('theme', 'transitrix');
+
+    let elementId = '';
+    let elementKind: 'requirement' | 'constraint' | undefined;
+    try {
+      const parsed = yaml.load(doc.getText());
+      if (parsed && typeof parsed === 'object') {
+        const r = parsed as Record<string, unknown>;
+        elementId = typeof r.id === 'string' ? r.id : '';
+        if (r.notation === 'requirement' || r.notation === 'constraint') elementKind = r.notation;
+      }
+    } catch { /* fall through */ }
+
+    if (!elementId) {
+      this.panel.webview.html = complianceShell({
+        title: 'Requirement trace',
+        themeId, refreshCommand: REFRESH_COMMAND, themeCommand: 'transitrixStudio.changeTheme',
+        bodyHtml: `<div class="cmp-empty">This file has no <code>id</code> — open a REQUIREMENT or CONSTRAINT file.</div>`,
+      });
+      return;
+    }
+
+    const scan = await scanComplianceCanon();
+    const index = buildComplianceIndex({ requirements: scan.requirements, assertions: scan.assertions });
+    const catalog = buildTraceElementCatalog(scan.products, scan.subjects);
+    const trace = buildRequirementTrace(elementId, index, catalog, scan.codex);
+
+    // Confidence over the element + assertion set targeting it (CONTRACT §11.6).
+    // Hierarchy siblings are structural context — not scored.
+    const confidence = scoreComplianceView(
+      [trace.requirement],
+      trace.assertions.map(a => a.assertion),
+      todayIso(),
+    );
+
+    const kind = elementKind ?? trace.requirement.element_kind ?? 'requirement';
+    const subtitleBits = [
+      elementId,
+      trace.requirement.origin ? `origin: ${trace.requirement.origin}` : null,
+      kind === 'constraint' ? 'CONSTRAINT' : null,
+    ].filter(Boolean).join(' · ');
+
+    this.panel.webview.html = complianceShell({
+      title: trace.requirement.name,
+      subtitle: subtitleBits,
+      filename: path.basename(doc.fileName),
+      date: todayIso(),
+      themeId,
+      refreshCommand: REFRESH_COMMAND,
+      themeCommand: 'transitrixStudio.changeTheme',
+      bodyHtml: this.traceHtml(trace, kind, scan.pathById),
+      confidence,
+    });
+  }
+
+  private traceHtml(
+    trace: RequirementTrace,
+    kind: 'requirement' | 'constraint',
+    pathById: Map<string, string>,
+  ): string {
+    const { requirement, sources, assertions, ancestors, children } = trace;
+
+    const description = requirement.description
+      ? `<p class="rt-desc">${escXml(requirement.description)}</p>`
+      : '';
+
+    // Hierarchy — parent chain. Renders root first (visual: root … → parent → self).
+    let hierarchyHtml = '';
+    if (ancestors.length > 0) {
+      const chain = [...ancestors].reverse();
+      const links = chain.map(a => {
+        const link = openLink(OPEN_FILE_COMMAND, pathById.get(a.id), escXml(a.name), `Open ${a.id}`);
+        return `<li>${link} <span class="cmp-req-id">${escXml(a.id)}</span></li>`;
+      }).join('');
+      const self = `<li class="rt-self">${escXml(requirement.name)} <span class="cmp-req-id">${escXml(requirement.id)}</span></li>`;
+      hierarchyHtml = `<section class="rt-section">
+        <h2>Parent chain <span class="cmp-count">(${ancestors.length})</span></h2>
+        <ol class="rt-parent-chain">${links}${self}</ol>
+      </section>`;
+    }
+
+    // Direct children — leaves of the hierarchy tree from this node.
+    let childrenHtml = '';
+    if (children.length > 0) {
+      const rows = children.map(c => {
+        const link = openLink(OPEN_FILE_COMMAND, pathById.get(c.id), escXml(c.name), `Open ${c.id}`);
+        const sev = c.severity ? `<span class="cmp-sev cmp-sev-${escXml(c.severity)}">${escXml(c.severity)}</span>` : '';
+        const originBadge = c.origin ? `<span class="rt-origin">${escXml(c.origin)}</span>` : '';
+        return `<li>${sev}${link} <span class="cmp-req-id">${escXml(c.id)}</span>${originBadge}</li>`;
+      }).join('');
+      childrenHtml = `<section class="rt-section">
+        <h2>Children <span class="cmp-count">(${children.length})</span></h2>
+        <ul class="rt-list">${rows}</ul>
+      </section>`;
+    }
+
+    // Backward trace — the derived_from codex artefacts. Origin-agnostic
+    // (15-requirement.md §2.1): a process-product / project-product requirement
+    // may legitimately have no sources.
+    let sourcesHtml = '';
+    if (sources.length > 0) {
+      const rows = sources.map(s => {
+        const label = s.codex?.name ? escXml(s.codex.name) : escXml(s.id);
+        const link = openLink(OPEN_FILE_COMMAND, pathById.get(s.id), label, `Open ${s.id}`);
+        const jur = s.codex?.jurisdiction
+          ? ` <span class="rt-jur">${escXml(s.codex.jurisdiction)}</span>`
+          : s.codex ? '' : ` <span class="rt-dangling">unresolved</span>`;
+        return `<li>${link} <span class="cmp-req-id">${escXml(s.id)}</span>${jur}</li>`;
+      }).join('');
+      sourcesHtml = `<section class="rt-section">
+        <h2>Sources <span class="cmp-count">(${sources.length})</span></h2>
+        <ul class="rt-list">${rows}</ul>
+      </section>`;
+    }
+
+    // Forward trace via ASSERTION — REQUIREMENT only (16-assertion.md §1).
+    let assertionsHtml = '';
+    if (kind === 'constraint') {
+      assertionsHtml = `<section class="rt-section">
+        <h2>Realisation</h2>
+        <p class="rt-note">CONSTRAINT-side ASSERTION mechanism is out of scope for v1 (16-assertion.md §1).
+          Compliance for this element is tracked via its <code>status</code> or downstream tooling.</p>
+      </section>`;
+    } else if (assertions.length === 0) {
+      assertionsHtml = `<section class="rt-section">
+        <h2>Realisation</h2>
+        <p class="rt-note">No ASSERTION targets this requirement — compliance gap
+          (<code>REQ-COVERAGE-001</code>).</p>
+      </section>`;
+    } else {
+      const rows = assertions.map(row => {
+        const a = row.assertion;
+        const aLink = openLink(OPEN_FILE_COMMAND, pathById.get(a.id), escXml(a.id), `Open ${a.id}`);
+        const subjLink = openLink(
+          OPEN_FILE_COMMAND, pathById.get(row.subject.id),
+          escXml(row.subject.name ?? row.subject.id), `Open ${row.subject.id}`,
+        );
+        const realised = row.realisedVia.length === 0
+          ? ''
+          : `<div class="rt-realised"><span class="rt-realised-label">realised via:</span> ${row.realisedVia.map(rv => {
+              const rvLink = openLink(OPEN_FILE_COMMAND, pathById.get(rv.id), escXml(rv.name ?? rv.id), `Open ${rv.id}`);
+              return `${rvLink} <span class="cmp-req-id">${escXml(rv.id)}</span>`;
+            }).join(' · ')}</div>`;
+        const meta = [
+          a.assessed_at ? `assessed ${a.assessed_at}` : null,
+          a.next_review_at ? `review by ${a.next_review_at}` : null,
+        ].filter(Boolean).join(' · ');
+        return `<li class="rt-assertion">
+          <div class="rt-assertion-head">
+            ${statusBadge(a.status)}
+            <span class="rt-subj">${subjLink} <span class="cmp-req-id">${escXml(row.subject.id)}</span></span>
+            <span class="rt-assertion-id">${aLink}</span>
+          </div>
+          ${realised}
+          ${meta ? `<div class="cmp-meta">${escXml(meta)}</div>` : ''}
+        </li>`;
+      }).join('');
+      assertionsHtml = `<section class="rt-section">
+        <h2>Realisation <span class="cmp-count">(${assertions.length} assertion${assertions.length === 1 ? '' : 's'})</span></h2>
+        <ul class="rt-assertions">${rows}</ul>
+      </section>`;
+    }
+
+    return `<style>${RT_CSS}</style>${description}${hierarchyHtml}${sourcesHtml}${assertionsHtml}${childrenHtml}`;
+  }
+}
+
+const RT_CSS = `
+.rt-desc { color: var(--ts-text-secondary, #475569); margin: 0 0 18px; max-width: 720px; line-height: 1.4; }
+.rt-section { margin: 0 0 22px; max-width: 860px; }
+.rt-section h2 { font-size: 13px; margin: 0 0 8px; color: var(--ts-text, #0f172a); }
+.rt-section h2 .cmp-count { color: var(--ts-text-muted, #64748b); font-weight: 400; }
+.rt-list { list-style: none; margin: 0; padding: 0; }
+.rt-list li { display: flex; align-items: center; gap: 8px; padding: 5px 2px; border-bottom: 1px solid var(--ts-border, #e2e8f0); font-size: 12px; }
+.rt-parent-chain { list-style: none; margin: 0; padding: 0; }
+.rt-parent-chain li { padding: 5px 2px 5px 20px; border-left: 2px solid var(--ts-border, #cbd5e1); margin-left: 6px; font-size: 12px; position: relative; }
+.rt-parent-chain li::before { content: '↳ '; color: var(--ts-text-muted, #64748b); position: absolute; left: 4px; }
+.rt-parent-chain li:first-child { padding-left: 4px; border-left: none; }
+.rt-parent-chain li:first-child::before { content: ''; }
+.rt-parent-chain li.rt-self { font-weight: 600; color: var(--ts-text, #0f172a); }
+.rt-note { color: var(--ts-text-muted, #64748b); font-size: 12px; margin: 0; }
+.rt-note code { font-family: var(--vscode-editor-font-family, monospace); }
+.rt-jur { display: inline-block; padding: 0 6px; margin-left: 4px; border-radius: 3px; font-size: 10px; background: var(--ts-bg-subtle, #f1f5f9); color: var(--ts-text-muted, #64748b); text-transform: uppercase; letter-spacing: 0.04em; }
+.rt-dangling { color: #b45309; font-size: 11px; font-style: normal; }
+.rt-origin { display: inline-block; padding: 0 6px; margin-left: 6px; border-radius: 3px; font-size: 10px; background: var(--ts-bg-subtle, #f1f5f9); color: var(--ts-text-muted, #64748b); text-transform: uppercase; letter-spacing: 0.04em; }
+.rt-assertions { list-style: none; margin: 0; padding: 0; }
+.rt-assertion { border: 1px solid var(--ts-border, #cbd5e1); border-radius: 6px; padding: 8px 12px; margin: 0 0 8px; }
+.rt-assertion-head { display: flex; align-items: center; gap: 8px; }
+.rt-subj { font-weight: 600; color: var(--ts-text, #0f172a); font-size: 12px; }
+.rt-assertion-id { margin-left: auto; font-size: 11px; }
+.rt-realised { margin-top: 4px; font-size: 12px; color: var(--ts-text-secondary, #475569); }
+.rt-realised-label { color: var(--ts-text-muted, #64748b); font-size: 11px; }
+`;

--- a/packages/diagrams/src/compliance/__tests__/trace.test.ts
+++ b/packages/diagrams/src/compliance/__tests__/trace.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest';
+import { buildComplianceIndex } from '../reverse-index.js';
+import { buildRequirementTrace, buildTraceElementCatalog } from '../trace.js';
+import type { ComplianceIndexInput } from '../types.js';
+import type { ComplianceCodexDoc } from '../classify.js';
+
+// Requirement traceability + hierarchy view.
+//
+// The two halves the view exposes:
+//   1. Trace chain — derived_from → REQUIREMENT → ASSERTION → subject +
+//      realised_via.
+//   2. Hierarchy — parent chain + children via the `parent` field
+//      (15-requirement.md §2.4 / ELEMENT_PRIMITIVES.md §7.13).
+
+const input: ComplianceIndexInput = {
+  requirements: [
+    // A broad legislative parent decomposed into two child requirements.
+    { id: 'REQUIREMENT-DATA-PROTECTION-1', name: 'Personal-data protection', origin: 'legislative', derived_from: ['REGULATION-GDPR-2016-1'], element_kind: 'requirement' },
+    { id: 'REQUIREMENT-DATA-ERASURE-1',    name: 'Erase on request within 30 days', origin: 'legislative', parent: 'REQUIREMENT-DATA-PROTECTION-1', derived_from: ['REGULATION-GDPR-2016-1'], element_kind: 'requirement' },
+    { id: 'REQUIREMENT-DATA-CONSENT-1',    name: 'Obtain consent before processing', origin: 'legislative', parent: 'REQUIREMENT-DATA-PROTECTION-1', element_kind: 'requirement' },
+    // A process-product sub-requirement below the erasure duty (cross-origin).
+    { id: 'REQUIREMENT-ERASURE-SLA-1',     name: 'Erasure SOP — 30d target', origin: 'process-product', parent: 'REQUIREMENT-DATA-ERASURE-1', element_kind: 'requirement' },
+    // Constraint hierarchy (mirror pattern).
+    { id: 'CONSTRAINT-EEA-TRANSFER-1',     name: 'No transfer outside EEA without safeguards', element_kind: 'constraint' },
+    { id: 'CONSTRAINT-EEA-ANALYTICS-1',    name: 'No PII in analytics logs', parent: 'CONSTRAINT-EEA-TRANSFER-1', element_kind: 'constraint' },
+    // Internal-only requirement — no source, no parent — for the empty-case sanity check.
+    { id: 'REQUIREMENT-INTERNAL-1',        name: 'Internal-only', element_kind: 'requirement' },
+  ],
+  assertions: [
+    { id: 'ASSERTION-1', about: 'REQUIREMENT-DATA-ERASURE-1', subject: 'PRODUCT-MOBILE-1', realised_via: ['CAPABILITY-V1', 'PROCESS-PURGE-1'], status: 'compliant' },
+    { id: 'ASSERTION-2', about: 'REQUIREMENT-DATA-ERASURE-1', subject: 'PRODUCT-WEB-1',    status: 'partial' },
+    { id: 'ASSERTION-3', about: 'REQUIREMENT-DATA-CONSENT-1', subject: 'PRODUCT-WEB-1',    status: 'compliant' },
+  ],
+};
+
+const codex: ComplianceCodexDoc[] = [
+  { id: 'REGULATION-GDPR-2016-1', name: 'GDPR', type: 'REGULATION', jurisdiction: 'EU' },
+];
+
+const catalog = buildTraceElementCatalog(
+  [{ id: 'PRODUCT-MOBILE-1', name: 'Mobile app' }, { id: 'PRODUCT-WEB-1', name: 'Web app' }],
+  [{ id: 'CAPABILITY-V1', name: 'Erasure capability v1' }, { id: 'PROCESS-PURGE-1', name: 'Purge process' }],
+);
+
+describe('buildComplianceIndex — requirementsByParent', () => {
+  const idx = buildComplianceIndex(input);
+  it('groups children of the same parent', () => {
+    const children = idx.requirementsByParent.get('REQUIREMENT-DATA-PROTECTION-1');
+    expect(children?.map(r => r.id).sort()).toEqual(['REQUIREMENT-DATA-CONSENT-1', 'REQUIREMENT-DATA-ERASURE-1']);
+  });
+  it('groups CONSTRAINT children the same way (element_kind-agnostic)', () => {
+    const children = idx.requirementsByParent.get('CONSTRAINT-EEA-TRANSFER-1');
+    expect(children?.map(r => r.id)).toEqual(['CONSTRAINT-EEA-ANALYTICS-1']);
+  });
+  it('returns undefined for a leaf with no children', () => {
+    expect(idx.requirementsByParent.has('REQUIREMENT-INTERNAL-1')).toBe(false);
+  });
+});
+
+describe('buildRequirementTrace — trace chain', () => {
+  const idx = buildComplianceIndex(input);
+  it('resolves derived_from codex artefacts on the sources block', () => {
+    const trace = buildRequirementTrace('REQUIREMENT-DATA-ERASURE-1', idx, catalog, codex);
+    expect(trace.sources).toHaveLength(1);
+    expect(trace.sources[0].id).toBe('REGULATION-GDPR-2016-1');
+    expect(trace.sources[0].codex?.jurisdiction).toBe('EU');
+  });
+  it('keeps a dangling derived_from ref with no codex when the artefact is missing', () => {
+    const local: ComplianceIndexInput = {
+      requirements: [{ id: 'REQUIREMENT-X-1', name: 'X', derived_from: ['LAW-MISSING-1'] }],
+      assertions: [],
+    };
+    const trace = buildRequirementTrace('REQUIREMENT-X-1', buildComplianceIndex(local), catalog);
+    expect(trace.sources).toEqual([{ id: 'LAW-MISSING-1' }]);
+  });
+  it('lists ASSERTIONs id-sorted, each with resolved subject + realised_via names', () => {
+    const trace = buildRequirementTrace('REQUIREMENT-DATA-ERASURE-1', idx, catalog, codex);
+    expect(trace.assertions.map(a => a.assertion.id)).toEqual(['ASSERTION-1', 'ASSERTION-2']);
+    expect(trace.assertions[0].subject).toEqual({ id: 'PRODUCT-MOBILE-1', name: 'Mobile app' });
+    expect(trace.assertions[0].realisedVia.map(r => r.name)).toEqual(['Erasure capability v1', 'Purge process']);
+  });
+  it('returns an empty assertions list for a REQUIREMENT with no filed claim', () => {
+    const trace = buildRequirementTrace('REQUIREMENT-DATA-PROTECTION-1', idx, catalog);
+    expect(trace.assertions).toEqual([]);
+  });
+  it('returns an empty assertions list for a CONSTRAINT (16-assertion.md §1 — CONSTRAINT-side out of v1)', () => {
+    const trace = buildRequirementTrace('CONSTRAINT-EEA-TRANSFER-1', idx, catalog);
+    expect(trace.assertions).toEqual([]);
+  });
+  it('falls back to id when the subject / realised_via element is not in the catalog (dangling ref)', () => {
+    const local: ComplianceIndexInput = {
+      requirements: [{ id: 'REQUIREMENT-Y-1', name: 'Y' }],
+      assertions: [{ id: 'ASSERTION-9', about: 'REQUIREMENT-Y-1', subject: 'PRODUCT-GONE-1', realised_via: ['CAPABILITY-GONE-1'], status: 'n_a' }],
+    };
+    const trace = buildRequirementTrace('REQUIREMENT-Y-1', buildComplianceIndex(local), catalog);
+    expect(trace.assertions[0].subject).toEqual({ id: 'PRODUCT-GONE-1' });
+    expect(trace.assertions[0].realisedVia).toEqual([{ id: 'CAPABILITY-GONE-1' }]);
+  });
+});
+
+describe('buildRequirementTrace — hierarchy', () => {
+  const idx = buildComplianceIndex(input);
+  it('walks ancestors: immediate parent first, root last', () => {
+    const trace = buildRequirementTrace('REQUIREMENT-ERASURE-SLA-1', idx, catalog);
+    expect(trace.ancestors.map(r => r.id)).toEqual([
+      'REQUIREMENT-DATA-ERASURE-1',
+      'REQUIREMENT-DATA-PROTECTION-1',
+    ]);
+  });
+  it('lists direct children id-sorted', () => {
+    const trace = buildRequirementTrace('REQUIREMENT-DATA-PROTECTION-1', idx, catalog);
+    expect(trace.children.map(r => r.id)).toEqual([
+      'REQUIREMENT-DATA-CONSENT-1',
+      'REQUIREMENT-DATA-ERASURE-1',
+    ]);
+  });
+  it('handles a top-level requirement (no ancestors) with no children', () => {
+    const trace = buildRequirementTrace('REQUIREMENT-INTERNAL-1', idx, catalog);
+    expect(trace.ancestors).toEqual([]);
+    expect(trace.children).toEqual([]);
+  });
+  it('supports CONSTRAINT hierarchy the same way', () => {
+    const trace = buildRequirementTrace('CONSTRAINT-EEA-ANALYTICS-1', idx, catalog);
+    expect(trace.ancestors.map(r => r.id)).toEqual(['CONSTRAINT-EEA-TRANSFER-1']);
+  });
+  it('terminates at a missing parent without throwing (broken model)', () => {
+    const local: ComplianceIndexInput = {
+      requirements: [{ id: 'REQUIREMENT-ORPHAN-1', name: 'Orphan', parent: 'REQUIREMENT-GONE-1' }],
+      assertions: [],
+    };
+    const trace = buildRequirementTrace('REQUIREMENT-ORPHAN-1', buildComplianceIndex(local), catalog);
+    expect(trace.ancestors).toEqual([]);
+  });
+  it('breaks a parent cycle rather than looping', () => {
+    // A → B → A (misauthored).
+    const local: ComplianceIndexInput = {
+      requirements: [
+        { id: 'REQUIREMENT-A-1', name: 'A', parent: 'REQUIREMENT-B-1' },
+        { id: 'REQUIREMENT-B-1', name: 'B', parent: 'REQUIREMENT-A-1' },
+      ],
+      assertions: [],
+    };
+    const trace = buildRequirementTrace('REQUIREMENT-A-1', buildComplianceIndex(local), catalog);
+    expect(trace.ancestors.map(r => r.id)).toEqual(['REQUIREMENT-B-1']);
+  });
+});
+
+describe('buildRequirementTrace — dangling target', () => {
+  it('returns a stub carrying the id as name when the requirement is not scanned', () => {
+    const trace = buildRequirementTrace('REQUIREMENT-UNKNOWN-1', buildComplianceIndex({ requirements: [], assertions: [] }), catalog);
+    expect(trace.requirement).toEqual({ id: 'REQUIREMENT-UNKNOWN-1', name: 'REQUIREMENT-UNKNOWN-1' });
+    expect(trace.sources).toEqual([]);
+    expect(trace.assertions).toEqual([]);
+    expect(trace.ancestors).toEqual([]);
+    expect(trace.children).toEqual([]);
+  });
+});

--- a/packages/diagrams/src/compliance/classify.ts
+++ b/packages/diagrams/src/compliance/classify.ts
@@ -65,7 +65,8 @@ export function ingestComplianceDoc(canon: ComplianceCanon, doc: unknown): strin
     canon.subjects.push({ id, name: str(d.name) ?? id });
     return id;
   }
-  if (d.notation === 'requirement') {
+  if (d.notation === 'requirement' || d.notation === 'constraint') {
+    const origin = str(d.origin);
     canon.requirements.push({
       id,
       name: str(d.name) ?? id,
@@ -73,6 +74,11 @@ export function ingestComplianceDoc(canon: ComplianceCanon, doc: unknown): strin
       derived_from: strArray(d.derived_from),
       admitted_at: str(d.admitted_at),
       deadline: str(d.deadline),
+      origin: origin === 'legislative' || origin === 'process-product' || origin === 'project-product' ? origin : undefined,
+      parent: str(d.parent),
+      element_kind: d.notation,
+      description: str(d.description),
+      next_review_at: str(d.next_review_at),
     });
     return id;
   }

--- a/packages/diagrams/src/compliance/index.ts
+++ b/packages/diagrams/src/compliance/index.ts
@@ -1,5 +1,6 @@
 export { buildComplianceIndex } from './reverse-index.js';
 export { buildLawTree, buildProductView } from './views.js';
+export { buildRequirementTrace, buildTraceElementCatalog } from './trace.js';
 export { buildGapReport } from './gap-report.js';
 export type { GapReport, GapReportOptions } from './gap-report.js';
 export { emptyCanon, ingestComplianceDoc } from './classify.js';
@@ -54,4 +55,9 @@ export type {
   ProductRequirementStatus,
   ObjectDetailDef,
   ObjectDetailInput,
+  RequirementTrace,
+  TraceAssertionRow,
+  TraceElementCatalog,
+  TraceElementRef,
+  TraceSourceRef,
 } from './types.js';

--- a/packages/diagrams/src/compliance/reverse-index.ts
+++ b/packages/diagrams/src/compliance/reverse-index.ts
@@ -19,15 +19,17 @@ export function buildComplianceIndex(input: ComplianceIndexInput): ComplianceInd
   const requirementsByLaw = new Map<string, IndexRequirement[]>();
   const assertionsByRequirement = new Map<string, IndexAssertion[]>();
   const assertionsBySubject = new Map<string, IndexAssertion[]>();
+  const requirementsByParent = new Map<string, IndexRequirement[]>();
 
   for (const r of input.requirements) {
     requirementById.set(r.id, r);
     for (const law of r.derived_from ?? []) push(requirementsByLaw, law, r);
+    if (r.parent) push(requirementsByParent, r.parent, r);
   }
   for (const a of input.assertions) {
     push(assertionsByRequirement, a.about, a);
     push(assertionsBySubject, a.subject, a);
   }
 
-  return { requirementById, requirementsByLaw, assertionsByRequirement, assertionsBySubject };
+  return { requirementById, requirementsByLaw, assertionsByRequirement, assertionsBySubject, requirementsByParent };
 }

--- a/packages/diagrams/src/compliance/trace.ts
+++ b/packages/diagrams/src/compliance/trace.ts
@@ -1,0 +1,118 @@
+// Requirement traceability + hierarchy builder.
+//
+// Two halves, both origin-agnostic per 15-requirement.md §2.1:
+//
+//   1. Trace chain — `derived_from` sources → the REQUIREMENT / CONSTRAINT
+//      itself → any ASSERTION targeting it (`about`) → the asserted `subject`
+//      + `realised_via` elements. Assertion coverage applies to REQUIREMENT
+//      only (16-assertion.md §1); CONSTRAINT trace shows sources + hierarchy
+//      only.
+//
+//   2. Hierarchy — the `parent` chain (ancestors, root last) plus the direct
+//      children (elements whose `parent` names this one). Same-TYPE only per
+//      15-requirement.md §2.4; the chain terminates at the first missing or
+//      cyclic parent so a broken model still renders something useful.
+//
+// Pure: takes the reverse index + a name-resolution map + optional codex list;
+// no IO. `ComplianceCodexDoc` comes from the scanner so we get jurisdiction
+// alongside the codex id in the sources block.
+
+import type {
+  ComplianceIndex,
+  IndexRequirement,
+  RequirementTrace,
+  TraceAssertionRow,
+  TraceElementCatalog,
+  TraceElementRef,
+  TraceSourceRef,
+} from './types.js';
+import type { ComplianceCodexDoc } from './classify.js';
+
+function byId<T extends { id: string }>(a: T, b: T): number {
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+}
+
+function resolveElement(id: string, catalog: TraceElementCatalog): TraceElementRef {
+  const name = catalog.nameById.get(id);
+  return name ? { id, name } : { id };
+}
+
+/**
+ * Walk the `parent` chain upward from `requirement`, stopping at the first
+ * missing or already-seen parent (cycle guard). Returns immediate parent first,
+ * root last. Empty array when the element has no `parent`.
+ */
+function collectAncestors(
+  requirement: IndexRequirement,
+  index: ComplianceIndex,
+): IndexRequirement[] {
+  const out: IndexRequirement[] = [];
+  const seen = new Set<string>([requirement.id]);
+  let current: IndexRequirement | undefined = requirement;
+  while (current?.parent && !seen.has(current.parent)) {
+    seen.add(current.parent);
+    const next = index.requirementById.get(current.parent);
+    if (!next) break;
+    out.push(next);
+    current = next;
+  }
+  return out;
+}
+
+/**
+ * Builds the REQUIREMENT / CONSTRAINT traceability view.
+ *
+ * @param requirementId typed id of the element to trace
+ * @param index         reverse index built by `buildComplianceIndex`
+ * @param catalog       name-resolution map for subject / realised_via refs
+ * @param codex         optional codex artefact list (from the scanner); when
+ *                      supplied, `sources[].codex` is populated with the
+ *                      resolved codex artefact for jurisdiction display
+ */
+export function buildRequirementTrace(
+  requirementId: string,
+  index: ComplianceIndex,
+  catalog: TraceElementCatalog,
+  codex: ComplianceCodexDoc[] = [],
+): RequirementTrace {
+  const requirement: IndexRequirement =
+    index.requirementById.get(requirementId) ?? { id: requirementId, name: requirementId };
+
+  const codexById = new Map<string, ComplianceCodexDoc>();
+  for (const c of codex) codexById.set(c.id, c);
+
+  const sources: TraceSourceRef[] = (requirement.derived_from ?? []).map(sid => {
+    const c = codexById.get(sid);
+    return c ? { id: sid, codex: c } : { id: sid };
+  });
+
+  const rawAssertions = index.assertionsByRequirement.get(requirementId) ?? [];
+  const assertions: TraceAssertionRow[] = [...rawAssertions]
+    .sort(byId)
+    .map(assertion => ({
+      assertion,
+      subject: resolveElement(assertion.subject, catalog),
+      realisedVia: (assertion.realised_via ?? []).map(rid => resolveElement(rid, catalog)),
+    }));
+
+  const ancestors = collectAncestors(requirement, index);
+  const children = [...(index.requirementsByParent.get(requirementId) ?? [])].sort(byId);
+
+  return { requirement, sources, assertions, ancestors, children };
+}
+
+/**
+ * Convenience: build a `TraceElementCatalog` from the scanned canon's product
+ * and subject buckets. Requirements/assertions are excluded — they are indexed
+ * separately by `buildComplianceIndex`; the catalog is only for resolving the
+ * elements a trace references (subjects + realised_via).
+ */
+export function buildTraceElementCatalog(
+  products: Array<{ id: string; name: string }>,
+  subjects: Array<{ id: string; name: string }>,
+): TraceElementCatalog {
+  const nameById = new Map<string, string>();
+  for (const p of products) nameById.set(p.id, p.name);
+  for (const s of subjects) nameById.set(s.id, s.name);
+  return { nameById };
+}

--- a/packages/diagrams/src/compliance/types.ts
+++ b/packages/diagrams/src/compliance/types.ts
@@ -4,8 +4,9 @@
 // single-product view here, and the gap dashboard in Phase 4.
 
 import type { AssertionStatus } from '../assertion/types.js';
+import type { ComplianceCodexDoc } from './classify.js';
 
-/** Projection of a REQUIREMENT the compliance views need. */
+/** Projection of a REQUIREMENT (or CONSTRAINT) the compliance views need. */
 export interface IndexRequirement {
   id: string;
   name: string;
@@ -20,6 +21,38 @@ export interface IndexRequirement {
    * past or imminent, CV-3 renders an urgent decoration on the cell.
    */
   deadline?: string;
+  /**
+   * Origin taxonomy (15-requirement.md §2.1): `legislative`, `process-product`,
+   * or `project-product`. Distinguishes the context from which the obligation
+   * was derived. Undefined for existing pre-taxonomy admissions (treated as
+   * `legislative` by tooling that supports origin-based filtering).
+   */
+  origin?: 'legislative' | 'process-product' | 'project-product';
+  /**
+   * Same-TYPE `parent` reference: the higher-scale obligation this one
+   * decomposes from (15-requirement.md §2.4; ELEMENT_PRIMITIVES.md §7.13 for
+   * CONSTRAINT). Origin-agnostic, structure-only. Enables the hierarchy half
+   * of the requirement traceability view.
+   */
+  parent?: string;
+  /**
+   * Motivation-layer element kind. `requirement` = positive obligation
+   * (15-requirement.md); `constraint` = restriction / prohibition
+   * (ELEMENT_PRIMITIVES.md §7.13). ASSERTION coverage applies to `requirement`
+   * only (16-assertion.md §1); the hierarchy half applies to both.
+   */
+  element_kind?: 'requirement' | 'constraint';
+  /**
+   * Longer-form description of the obligation (15-requirement.md §2). Optional;
+   * used by the requirement traceability view to show the requirement body
+   * inline. Not used by matrix / list views.
+   */
+  description?: string;
+  /**
+   * `next_review_at` review-checkpoint date (15-requirement.md §2.3; ISO 8601).
+   * Present when the author has scheduled a review; drives `REQ-STALE-001`.
+   */
+  next_review_at?: string;
 }
 
 // ── Temporal status (CV-3) ──────────────────────────────────────────────────
@@ -106,6 +139,11 @@ export interface ComplianceIndex {
   assertionsByRequirement: Map<string, IndexAssertion[]>;
   /** Subject id (product / process / capability) → assertions about it. */
   assertionsBySubject: Map<string, IndexAssertion[]>;
+  /**
+   * Parent id → the requirements/constraints that name it in `parent`
+   * (15-requirement.md §2.4). Enables the requirement-hierarchy view.
+   */
+  requirementsByParent: Map<string, IndexRequirement[]>;
 }
 
 // ── Single-law tree ─────────────────────────────────────────────────────────
@@ -133,4 +171,66 @@ export interface ProductView {
   productId: string;
   /** Requirements bound to the product via an assertion, requirement-id-sorted. */
   requirements: ProductRequirementStatus[];
+}
+
+// ── Requirement traceability + hierarchy view ───────────────────────────────
+
+/** A codex artefact resolved from a requirement's `derived_from` reference. */
+export interface TraceSourceRef {
+  /** Verbatim id from `derived_from`. Always present. */
+  id: string;
+  /** The codex artefact, when resolved by the scan. Absent for dangling refs. */
+  codex?: ComplianceCodexDoc;
+}
+
+/** A named element (subject or realising element) resolved by the trace. */
+export interface TraceElementRef {
+  id: string;
+  /** Element name when resolved by the scan; absent for dangling refs. */
+  name?: string;
+}
+
+/** One ASSERTION targeting the traced requirement, with subject + realising elements. */
+export interface TraceAssertionRow {
+  assertion: IndexAssertion;
+  subject: TraceElementRef;
+  /** Elements named in the assertion's `realised_via` list (may be empty). */
+  realisedVia: TraceElementRef[];
+}
+
+/**
+ * Requirement traceability + hierarchy view.
+ *
+ * Two halves, both origin-agnostic (15-requirement.md §2.1):
+ *  1. Trace chain — `derived_from` source(s) → the element itself → any
+ *     ASSERTION targeting it (`about`) → the asserted `subject` + `realised_via`
+ *     elements. Origin-agnostic per 15-requirement.md §2.1; assertion coverage
+ *     applies to REQUIREMENT only (16-assertion.md §1) — CONSTRAINT trace shows
+ *     only the source chain + hierarchy.
+ *  2. Hierarchy — `parent` chain (ancestors, root last of the array) + children
+ *     (any element whose `parent` names this one), sorted by id.
+ */
+export interface RequirementTrace {
+  /** The element being traced (REQUIREMENT or CONSTRAINT). Falls back to a
+   *  stub carrying the id as its name when the element is missing from the
+   *  scan (a dangling `parent` or a repository being edited). */
+  requirement: IndexRequirement;
+  /** Backward-trace: `derived_from` codex artefacts, verbatim order. */
+  sources: TraceSourceRef[];
+  /** Forward-trace via ASSERTION. Empty for CONSTRAINT elements (16-assertion.md §1) or for a REQUIREMENT with no filed assertion. */
+  assertions: TraceAssertionRow[];
+  /** Parent chain: immediate parent first, root last. Empty when the element has no `parent`. */
+  ancestors: IndexRequirement[];
+  /** Direct children: elements naming this one as their `parent`, id-sorted. */
+  children: IndexRequirement[];
+}
+
+/**
+ * The complementary data the trace builder needs to name subjects and realising
+ * elements. Names are resolved by looking up the id in this map; unresolved ids
+ * surface as the id alone (a dangling reference).
+ */
+export interface TraceElementCatalog {
+  /** id → human-readable name (or the id itself when unnamed). */
+  nameById: Map<string, string>;
 }


### PR DESCRIPTION
## Summary

- Adds a "Preview requirement trace + hierarchy" webview for any `REQUIREMENT-*.yaml` or `CONSTRAINT-*.yaml` file, working across all three requirement origins (legislative / process-product / project-product).
- **Trace chain**: `derived_from` codex sources -> the element itself -> any `ASSERTION` targeting it (`about`) -> the asserted `subject` + `realised_via` elements. Every id is click-to-open; `REQ-COVERAGE-001` is surfaced inline when no assertion targets the requirement.
- **Hierarchy**: the `parent` chain (immediate parent to root) plus direct children, via the `parent` field on REQUIREMENT / CONSTRAINT.
- Assertion coverage stays REQUIREMENT-only per the compliance model's v1 scope; a CONSTRAINT-side trace shows sources + hierarchy only and notes the boundary inline.
- `@transitrix/diagrams` gains a pure `buildRequirementTrace` builder over the existing compliance reverse-index (extended with `requirementsByParent`).

## Test plan

- [x] `npm run compile` (root + `packages/diagrams`) — clean
- [x] `npm run compile:extension` — clean
- [x] `npm test` — 73 files / 1228 tests passing, including 16 new trace-builder tests
- [ ] Manual: open a `REQUIREMENT-*.yaml` file, run "Preview requirement trace + hierarchy" from the editor title bar, confirm the webview renders both halves

🤖 Generated with [Claude Code](https://claude.com/claude-code)