### PR TITLE
chore(diagrams): bump version to 1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7781,7 +7781,7 @@
     },
     "packages/diagrams": {
       "name": "@transitrix/diagrams",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Bumps `@transitrix/diagrams` from 1.5.0 to 1.6.0 in `packages/diagrams/package.json` (+ lockfile).
- `GoalTreeView` and `CapabilityMapView` were added as new exports without a corresponding package version bump, so the npm-publish workflow's idempotent skip-if-already-published check has silently no-op'd on every extension release since — the registry has been stuck on 1.5.0 while the workspace source moved on.
- Minor bump: additive, backward-compatible new component exports.

## Test plan

- [x] `npm run build --workspace packages/diagrams` — clean
- [x] `npm --workspace packages/diagrams test` — 73 files / 1228 tests passing
- [ ] After merge: publish via `workflow_dispatch` on the npm-publish workflow, confirm `@transitrix/diagrams@1.6.0` appears on the registry with both new components

🤖 Generated with [Claude Code](https://claude.com/claude-code)