### PR TITLE
ci: guard against packages/diagrams/src changes without a version bump

### DIFF
--- a/.github/workflows/diagrams-version-bump.yml
+++ b/.github/workflows/diagrams-version-bump.yml
@@ -1,0 +1,31 @@
+name: Diagrams version-bump guard
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  check-version-bump:
+    runs-on: ubuntu-latest
+    name: diagrams/src change requires version bump
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Check diagrams version bump
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: node scripts/check-diagrams-version-bump.mjs

--- a/scripts/check-diagrams-version-bump.mjs
+++ b/scripts/check-diagrams-version-bump.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+// CI guard: fail if packages/diagrams/src changes without a version bump.
+//
+// Runs on every PR targeting main. If any non-test file under
+// packages/diagrams/src/ is added or modified and the version field in
+// packages/diagrams/package.json is unchanged relative to the PR base, the
+// check fails. Test files (under __tests__/ or matching *.test.ts(x)) are
+// excluded from the trigger.
+
+import { execSync } from 'node:child_process';
+
+const baseSha = process.env.BASE_SHA;
+const headSha = process.env.HEAD_SHA;
+
+if (!baseSha || !headSha) {
+  console.error('[diagrams-version-bump] missing BASE_SHA / HEAD_SHA env vars (must be invoked from a pull_request workflow).');
+  process.exit(2);
+}
+
+try {
+  execSync(`git fetch --no-tags --depth=1 origin ${baseSha}`, { stdio: 'pipe' });
+} catch {
+  // Fallback: rely on existing fetch depth from the checkout step.
+}
+
+let changedFiles;
+try {
+  changedFiles = execSync(`git diff --name-only ${baseSha} ${headSha}`, {
+    encoding: 'utf8',
+    maxBuffer: 16 * 1024 * 1024,
+  })
+    .split('\n')
+    .map((s) => s.trim())
+    .filter(Boolean);
+} catch (err) {
+  console.error('[diagrams-version-bump] failed to compute diff:', err.message);
+  process.exit(2);
+}
+
+const srcChanges = changedFiles.filter((f) => {
+  if (!f.startsWith('packages/diagrams/src/')) return false;
+  if (f.includes('/__tests__/')) return false;
+  if (f.endsWith('.test.ts') || f.endsWith('.test.tsx')) return false;
+  return true;
+});
+
+if (srcChanges.length === 0) {
+  console.log('[diagrams-version-bump] no non-test src changes in packages/diagrams — check skipped.');
+  process.exit(0);
+}
+
+console.log(`[diagrams-version-bump] ${srcChanges.length} non-test src change(s) detected:`);
+for (const f of srcChanges) console.log(`  ${f}`);
+
+let baseVersion, headVersion;
+try {
+  const basePkg = JSON.parse(
+    execSync(`git show ${baseSha}:packages/diagrams/package.json`, { encoding: 'utf8' }),
+  );
+  baseVersion = basePkg.version;
+} catch (err) {
+  console.error('[diagrams-version-bump] failed to read packages/diagrams/package.json at base:', err.message);
+  process.exit(2);
+}
+
+try {
+  const headPkg = JSON.parse(
+    execSync(`git show ${headSha}:packages/diagrams/package.json`, { encoding: 'utf8' }),
+  );
+  headVersion = headPkg.version;
+} catch (err) {
+  console.error('[diagrams-version-bump] failed to read packages/diagrams/package.json at head:', err.message);
+  process.exit(2);
+}
+
+if (baseVersion === headVersion) {
+  console.error(`[diagrams-version-bump] FAIL: packages/diagrams/src changed but version is still ${headVersion}.`);
+  console.error('[diagrams-version-bump] Bump packages/diagrams/package.json version before merging.');
+  process.exit(1);
+}
+
+console.log(`[diagrams-version-bump] OK: version bumped ${baseVersion} → ${headVersion}.`);


### PR DESCRIPTION
## Summary

- Adds `scripts/check-diagrams-version-bump.mjs`: a PR-time check that fails if any non-test file under `packages/diagrams/src/` is modified without bumping the `version` field in `packages/diagrams/package.json` relative to the PR base.
- Adds `.github/workflows/diagrams-version-bump.yml`: wires the check into the CI pipeline for every PR targeting `main`.

## Behaviour

| Scenario | Result |
|---|---|
| PR touches only test files (`__tests__/`, `*.test.ts(x)`) | Skipped (pass) |
| PR touches only docs, other packages, or repo root | Skipped (pass) |
| PR bumps version only (no src change) | Skipped (pass) |
| PR changes `packages/diagrams/src/*.ts` **and** bumps version | Pass |
| PR changes `packages/diagrams/src/*.ts` without bumping version | **Fail** |

## Test plan

- [x] False-positive (acme_corp sync PR, no diagrams/src change): script exits 0
- [x] False-positive (version-bump-only PR, no src change): script exits 0
- [x] True-positive (CapabilityMapView addition, no version bump): script exits 1 with clear message
- [x] True-positive (compliance module addition, no version bump): script exits 1 with clear message

🤖 Generated with [Claude Code](https://claude.com/claude-code)