### PR TITLE
fix(diagrams): relabel descendant types and cap levels on reparent

### DIFF
--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",

--- a/packages/diagrams/src/goals/__tests__/mutations.test.ts
+++ b/packages/diagrams/src/goals/__tests__/mutations.test.ts
@@ -109,3 +109,45 @@ describe('restoreFromBacklog', () => {
     expect(r.result!.goals.find(g => g.id === 3)!.parent_id).toBe(1);
   });
 });
+
+describe('reparent — descendant type relabeling and level cap', () => {
+  const DEEP: GoalTree = {
+    goal_types: [
+      { name: 'Strategy', level: 0 },
+      { name: 'Business Goal', level: 1 },
+      { name: 'Project', level: 2 },
+      { name: 'Task', level: 3 },
+    ],
+    goals: [
+      { id: 1, name: 'Root', type: 'Strategy', level: 0, parent_id: 0 },
+      { id: 2, name: 'BG1', type: 'Business Goal', level: 1, parent_id: 1 },
+      { id: 3, name: 'Proj1', type: 'Project', level: 2, parent_id: 2 },
+      { id: 4, name: 'Task1', type: 'Task', level: 3, parent_id: 3 },
+    ],
+  };
+
+  it('relabels descendant types via getTypeForLevel when reparenting shifts levels', () => {
+    // Move Proj1 (id=3, level=2) directly under Root (id=1, level=0); delta = -1
+    // Task1 (child of Proj1, level=3): new level = 2, type should be 'Project'
+    const r = reparent(DEEP, 3, 1);
+    expect(r.ok).toBe(true);
+    const proj = r.result!.goals.find(g => g.id === 3)!;
+    const task = r.result!.goals.find(g => g.id === 4)!;
+    expect(proj.level).toBe(1);
+    expect(proj.type).toBe('Business Goal');
+    expect(task.level).toBe(2);
+    expect(task.type).toBe('Project');
+  });
+
+  it('caps descendant level at maxLevel and refuses when that violates GOALS-012', () => {
+    // Move Root (id=1, level=0) under Root2 (id=5, level=0); delta = +1
+    // BG1: 1→2, Proj1: 2→3 (maxLevel), Task1: 3→4, capped at 3
+    // Task1 (capped level=3) under Proj1 (level=3) violates GOALS-012 → refused
+    const tree: GoalTree = {
+      ...DEEP,
+      goals: [...DEEP.goals, { id: 5, name: 'Root2', type: 'Strategy', level: 0, parent_id: 0 }],
+    };
+    const r = reparent(tree, 1, 5);
+    expect(r.ok).toBe(false);
+  });
+});

--- a/packages/diagrams/src/goals/mutations.ts
+++ b/packages/diagrams/src/goals/mutations.ts
@@ -22,12 +22,12 @@ function getTypeForLevel(tree: GoalTree, level: number): string {
   return gt?.name ?? '';
 }
 
-function updateDescendantLevels(goals: Goal[], id: number, levelDelta: number): void {
-  for (const g of goals) {
+function updateDescendantLevels(clone: GoalTree, id: number, levelDelta: number, maxLevel: number): void {
+  for (const g of clone.goals) {
     if (g.parent_id === id) {
-      g.level += levelDelta;
-      g.type = '';
-      updateDescendantLevels(goals, g.id, levelDelta);
+      g.level = Math.min(g.level + levelDelta, maxLevel);
+      g.type = getTypeForLevel(clone, g.level);
+      updateDescendantLevels(clone, g.id, levelDelta, maxLevel);
     }
   }
 }
@@ -70,7 +70,7 @@ export function reparent(tree: GoalTree, sourceId: number, targetId: number): Mu
   source.parent_id = targetId;
   source.level = newLevel;
   source.type = getTypeForLevel(clone, newLevel);
-  if (levelDelta !== 0) updateDescendantLevels(clone.goals, sourceId, levelDelta);
+  if (levelDelta !== 0) updateDescendantLevels(clone, sourceId, levelDelta, maxLevel);
 
   const v = validateGoalTree(clone);
   if (!v.valid) return refusalError(v.errors[0]?.message ?? 'Validation failed after reparent');


### PR DESCRIPTION
## Summary

- `updateDescendantLevels` in `mutations.ts` was blanking the `type` field (`''`) instead of recomputing it via `getTypeForLevel` — cards that changed level via a deep drag rendered with an empty type badge until manually re-edited.
- The function applied `levelDelta` uncapped, so descendants could end up with `level > maxLevel` — an invalid state now caught cleanly by `validateGoalTree` rather than silently stored.
- Both are fixed: `type` is now recomputed from the goal-types schema, `level` is capped at `maxLevel` before validation runs.

## Test plan

- [ ] New unit test: 4-level tree, reparent `Proj1` (level 2) under `Root` (level 0), delta = −1 — assert `Task1` gets level 2 and type `'Project'` (not `''`).
- [ ] New unit test: move root under another root (delta = +1), deep descendant would exceed maxLevel → cap triggers GOALS-012 → `reparent()` returns `ok: false` (not silent corruption).
- [ ] All 1230 existing tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)