### PR TITLE
feat(diagrams): add optional onFactorClick callback to GoalNode/GoalTreeView

### DIFF
--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.6.1",
+  "version": "1.7.1",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",

--- a/packages/diagrams/src/goals/GoalNode.tsx
+++ b/packages/diagrams/src/goals/GoalNode.tsx
@@ -23,6 +23,7 @@ export interface GoalNodeData {
   onAddChild: (parentId: number, parentLevel: number) => void;
   onDelete: (id: number) => void;
   onToggleCollapse: (id: number) => void;
+  onFactorClick?: (factor: Factor) => void;
 }
 
 const GoalNode = memo(({ data }: { data: GoalNodeData }) => {
@@ -130,6 +131,10 @@ const GoalNode = memo(({ data }: { data: GoalNodeData }) => {
           {(openPanel === 'positive' ? positive : negative).map((f) => (
             <div
               key={f.id}
+              onClick={(e) => {
+                e.stopPropagation();
+                data.onFactorClick?.(f);
+              }}
               style={{
                 background: openPanel === 'positive' ? '#f0fdf4' : '#fef2f2',
                 border: `1px solid ${openPanel === 'positive' ? '#bbf7d0' : '#fecaca'}`,
@@ -138,6 +143,7 @@ const GoalNode = memo(({ data }: { data: GoalNodeData }) => {
                 padding: '4px 6px',
                 fontSize: 10,
                 textAlign: 'left',
+                cursor: data.onFactorClick ? 'pointer' : 'default',
               }}
             >
               <div style={{ fontWeight: 700 }}>{f.name}</div>

--- a/packages/diagrams/src/goals/GoalTreeView.tsx
+++ b/packages/diagrams/src/goals/GoalTreeView.tsx
@@ -12,7 +12,7 @@ import ReactFlow, {
   type NodeDragHandler,
 } from 'reactflow';
 import 'reactflow/dist/style.css';
-import type { Goal, GoalTree, GoalTreeLayout, LayoutOptions } from './types.js';
+import type { Factor, Goal, GoalTree, GoalTreeLayout, LayoutOptions } from './types.js';
 import { layoutGoalTree } from './layout.js';
 import { reparent, addChild, deleteWithDescendants, moveToBacklog, restoreFromBacklog } from './mutations.js';
 import type { ThemeTokens } from './theme.js';
@@ -31,6 +31,7 @@ export interface GoalTreeViewProps {
   showMiniMap?: boolean;
   onChange?: (event: GoalTreeChange) => void;
   onEditRequest?: (goal: Goal) => void;
+  onFactorClick?: (factor: Factor) => void;
 }
 
 export type GoalTreeChange =
@@ -102,6 +103,7 @@ function GoalTreeViewInner({
   showMiniMap = false,
   onChange,
   onEditRequest,
+  onFactorClick,
 }: GoalTreeViewProps): React.ReactElement {
   const theme = useMemo(() => resolveTheme(themeProp), [themeProp]);
   const [collapsedIds, setCollapsedIds] = useState<Set<number>>(new Set());
@@ -179,9 +181,10 @@ function GoalTreeViewInner({
         onAddChild,
         onDelete: onDeleteNode,
         onToggleCollapse,
+        onFactorClick,
       },
     }));
-  }, [layout.nodes, theme, readOnly, hoveredId, collapsedIds, onAddChild, onDeleteNode, onToggleCollapse]);
+  }, [layout.nodes, theme, readOnly, hoveredId, collapsedIds, onAddChild, onDeleteNode, onToggleCollapse, onFactorClick]);
 
   const buildEdges = useCallback((): Edge[] => {
     return layout.edges.map((e) => ({

--- a/packages/diagrams/src/goals/__tests__/GoalTreeView.test.tsx
+++ b/packages/diagrams/src/goals/__tests__/GoalTreeView.test.tsx
@@ -297,6 +297,25 @@ describe('GoalTreeView', () => {
     });
   });
 
+  it('fires onFactorClick with the clicked factor when a popover item is clicked', async () => {
+    const onFactorClick = vi.fn();
+    render(<GoalTreeView tree={makeTree()} onFactorClick={onFactorClick} />);
+    await waitFor(() => {
+      expect(screen.getByText('Cut churn')).toBeTruthy();
+    });
+
+    // Open the negative-factor panel on "Cut churn" (id=3, has risk factor "Support backlog")
+    const negativeBadge = screen.getByLabelText('1 negative factor');
+    negativeBadge.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    // The popover item for the risk factor should now be in the DOM
+    const factorItem = await waitFor(() => screen.getByText('Support backlog'));
+    factorItem.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    await waitFor(() => expect(onFactorClick).toHaveBeenCalledTimes(1));
+    expect(onFactorClick.mock.calls[0][0]).toMatchObject({ id: 10, name: 'Support backlog', impact_type: 'risk' });
+  });
+
   it('fires onEditRequest on double-click', async () => {
     const onEditRequest = vi.fn();
     render(<GoalTreeView tree={makeTree()} onEditRequest={onEditRequest} />);


### PR DESCRIPTION
## Summary

- DSM's old `GoalNode.jsx` called `navigate('/drivers')` when a factor badge or panel item was clicked. During M4 extraction (transitrix-dsm#57), this was correctly dropped since the library can't hardcode a route — but no extension point was provided to restore it.
- Adds `onFactorClick?: (factor: Factor) => void` to both `GoalNodeData` and `GoalTreeViewProps`.
- Each popover item's `onClick` calls the callback when present; no-op when absent — zero behavior change for hosts that don't pass it.
- `GoalTreeView` threads it down to `GoalNode` via node data.

**Follow-up note** (mentioned in issue): once DSM bumps `@transitrix/diagrams`, a one-liner in `GoalsVisualEditor.tsx` restores the original click-through — `onFactorClick={(f) => navigate('/drivers')}` using the existing `useNavigate` hook.

## Test plan

- [ ] New test: render with `onFactorClick` spy, click negative-factor badge to open panel, click the `Support backlog` item → callback fires once with `{ id: 10, name: 'Support backlog', impact_type: 'risk' }`.
- [ ] All 1229 existing tests continue to pass (no behavior change when `onFactorClick` is absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)