### PR TITLE
fix(dgca): accept ACTION-* ids and DGA mode without changes array

### DIFF
--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",

--- a/packages/diagrams/src/fgca/__tests__/parse-canonical.test.ts
+++ b/packages/diagrams/src/fgca/__tests__/parse-canonical.test.ts
@@ -35,6 +35,31 @@ describe('parseCanonicalFGCA', () => {
     expect(r.parsed?.activities).toHaveLength(1);
   });
 
+  it('accepts ACTION-* ids (methodology 1.0) alongside legacy ACTIVITY-*', () => {
+    const r = parseCanonicalFGCA({
+      ...VALID,
+      actions: [
+        { id: 'ACTION-CRM-EU-1', name: 'CRM rollout', changes: ['CHANGE-1'] },
+        { id: 'ACTIVITY-2', name: 'Legacy workstream', changes: ['CHANGE-1'] },
+      ],
+    });
+    expect(r.valid, JSON.stringify(r.errors)).toBe(true);
+    expect(r.parsed?.activities.map((a) => a.id)).toEqual(['ACTION-CRM-EU-1', 'ACTIVITY-2']);
+  });
+
+  it('defaults changes to [] when view_config.layers.changes is off (DGA-in-dgca)', () => {
+    const r = parseCanonicalFGCA({
+      ...VALID,
+      changes: undefined,
+      view_config: { layers: { changes: 'off' } },
+      actions: [
+        { id: 'ACTION-DISCOVERY-1', name: 'Gap assessment', goals: ['GOAL-1'] },
+      ],
+    });
+    expect(r.valid, JSON.stringify(r.errors)).toBe(true);
+    expect(r.parsed?.changes).toEqual([]);
+  });
+
   it('FGCA-001: rejects non-object input', () => {
     expect(parseCanonicalFGCA(null).errors[0].code).toBe('FGCA-001');
     expect(parseCanonicalFGCA('string').errors[0].code).toBe('FGCA-001');
@@ -196,6 +221,15 @@ describe('parseCanonicalFGA', () => {
     expect(r.parsed?.factors).toHaveLength(1);
     expect(r.parsed?.goals).toHaveLength(1);
     expect(r.parsed?.activities).toHaveLength(1);
+  });
+
+  it('accepts ACTION-* ids in FGA mode', () => {
+    const r = parseCanonicalFGA({
+      ...VALID_FGA,
+      actions: [{ id: 'ACTION-GDPR-DSR-WORKFLOW-1', name: 'DSR workflow', goals: ['GOAL-1'] }],
+    });
+    expect(r.valid, JSON.stringify(r.errors)).toBe(true);
+    expect(r.parsed?.activities[0].id).toBe('ACTION-GDPR-DSR-WORKFLOW-1');
   });
 
   it('populates activity.goal_id from activity.goals[] (the FGA edge-driving field)', () => {

--- a/packages/diagrams/src/fgca/parse-canonical.ts
+++ b/packages/diagrams/src/fgca/parse-canonical.ts
@@ -6,7 +6,7 @@
  *
  * - Flat top-level arrays, no `fgca:` wrapper.
  * - Typed string IDs per `IDS_AND_REFERENCES.md` (`FACTOR-1`,
- *   `GOAL-RET-1`, `CHANGE-1`, `ACTIVITY-ONBOARD-1`).
+ *   `GOAL-RET-1`, `CHANGE-1`, `ACTION-ONBOARD-1` (legacy `ACTIVITY-*` accepted).
  * - Plural canonical-direction cross-references: `goal.factors`,
  *   `change.goals`, `activity.changes`, `activity.goals`.
  * - Per-notation validation codes `FGCA-001 … FGCA-015`.
@@ -50,7 +50,8 @@ const DRIVER_ID_RE = /^DRIVER(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
 const FACTOR_OR_DRIVER_ID_RE = /^(FACTOR|DRIVER)(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
 const GOAL_ID_RE = /^GOAL(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
 const CHANGE_ID_RE = /^CHANGE(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
-const ACTIVITY_ID_RE = /^ACTIVITY(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
+// ACTION is canonical since methodology 1.0; ACTIVITY accepted for legacy docs.
+const ACTION_OR_ACTIVITY_ID_RE = /^(ACTION|ACTIVITY)(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
 const FGCA_DOC_ID_RE = /^(FGCA|DGCA)(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
 const CONSTRAINT_ID_RE = /^CONSTRAINT(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
 
@@ -61,6 +62,15 @@ function isNonEmptyString(v: unknown): v is string {
 function asObjectArray(v: unknown): Array<Record<string, unknown>> | null {
   if (!Array.isArray(v)) return null;
   return v.map((el) => (el && typeof el === 'object' ? (el as Record<string, unknown>) : null) as Record<string, unknown>);
+}
+
+/** DGA mode (`view_config.layers.changes: off`) may omit the changes layer. */
+function isChangesLayerOff(raw: Record<string, unknown>): boolean {
+  const vc = raw['view_config'];
+  if (!vc || typeof vc !== 'object') return false;
+  const layers = (vc as Record<string, unknown>)['layers'];
+  if (!layers || typeof layers !== 'object') return false;
+  return (layers as Record<string, unknown>)['changes'] === 'off';
 }
 
 
@@ -114,7 +124,10 @@ export function parseCanonicalFGCA(input: unknown): CanonicalFGCAResult {
 
   const factorsRaw = asObjectArray(raw['factors']);
   const goalsRaw = asObjectArray(raw['goals']);
-  const changesRaw = asObjectArray(raw['changes']);
+  let changesRaw = asObjectArray(raw['changes']);
+  if (changesRaw === null && raw['changes'] === undefined && isChangesLayerOff(raw)) {
+    changesRaw = [];
+  }
   const activitiesRaw = asObjectArray(raw['actions']);
   if (activitiesRaw === null && 'activities' in raw) {
     errors.push({ code: 'FGCA-004', message: '"activities" key is not accepted — rename to "actions"', path: 'actions' });
@@ -177,7 +190,7 @@ export function parseCanonicalFGCA(input: unknown): CanonicalFGCAResult {
   factors.forEach((el, i) => checkLayerElement(el, `factors[${i}]`, FACTOR_OR_DRIVER_ID_RE, factorIds));
   goals.forEach((el, i) => checkLayerElement(el, `goals[${i}]`, GOAL_ID_RE, goalIds));
   changes.forEach((el, i) => checkLayerElement(el, `changes[${i}]`, CHANGE_ID_RE, changeIds));
-  activities.forEach((el, i) => checkLayerElement(el, `activities[${i}]`, ACTIVITY_ID_RE, activityIds));
+  activities.forEach((el, i) => checkLayerElement(el, `activities[${i}]`, ACTION_OR_ACTIVITY_ID_RE, activityIds));
 
   if (errors.length > 0) return { valid: false, errors, warnings };
 


### PR DESCRIPTION
## Summary

- DGCA/DGA canonical parser now accepts **`ACTION-*`** work-package IDs (methodology 1.0) alongside legacy **`ACTIVITY-*`**.
- When `view_config.layers.changes: off` (DGA mode inside a `notation: dgca` file), a missing `changes` key defaults to `[]` instead of FGCA-004.

Fixes preview/CLI validation errors on acme-corp `canon/views/dgca/*.dgca.transitrix.yaml`.

## Test plan

- [x] `npx vitest run src/fgca/__tests__/parse-canonical.test.ts` — 27 green
- [x] `transitrix validate acme-corp/canon/views/dgca/eu-expansion.dgca.transitrix.yaml` — valid
- [x] `transitrix validate acme-corp/canon/views/dgca/eu-compliance-dga.dgca.transitrix.yaml` — valid
- [ ] Extension dev host: open both DGCA views — no red error panel
