### PR TITLE
feat(validate): wire compliance notations to CLI (#518 C1)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -290,7 +290,8 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
     console.error('             BPMN, or any diagram notation routed by its notation: field');
     console.error('             (goals, dgca, dga, fgca, fga, activities, activity-card,');
     console.error('             process-blueprint, blocks, applications, capability-map,');
-    console.error('             products, scenarios, process-map) — same checks as the preview.');
+    console.error('             products, scenarios, process-map, requirement, assertion,');
+    console.error('             compliance-impact, coverage-metric) — same checks as the preview.');
     console.error('             Canonical notation extensions are accepted without --ext.');
     console.error('repo scope — whole-canon checks (referential integrity, atomicity,');
     console.error('             id uniqueness, policy) over <root> (default: cwd).');
@@ -373,11 +374,9 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
       }
       return;
     }
-    // Recognised notation, but no file-scope CLI validator yet — aggregate views
-    // like compliance-impact / coverage-metric that derive from other docs rather
-    // than validating standalone. Be honest: don't claim valid and don't mis-run
-    // the BPMN path — say so and exit 0 (the file itself isn't in error), so an
-    // agent loop isn't blocked on it.
+    // Recognised notation, but no file-scope CLI validator yet — e.g. a future view
+    // type not wired in validate-notation.ts. Be honest: don't claim valid and
+    // don't mis-run the BPMN path.
     const notice =
       `notation "${probedNotation}" is not yet validated by the CLI — check it in ` +
       `the Transitrix Studio preview, or run whole-canon checks with --scope=repo.`;

--- a/src/validate-notation.ts
+++ b/src/validate-notation.ts
@@ -1,5 +1,5 @@
 // File-scope validation for diagram notations (vkgeorgia/strategy#258).
-// Group C (compliance suite): strategy#518 Phase C1.
+// Group C (compliance suite): #518 Phase C1.
 //
 // The VS Code preview renders its red error block from per-notation validators
 // in @transitrix/diagrams. This module exposes those same validators to the CLI
@@ -125,7 +125,7 @@ const VALIDATORS: Record<string, NotationValidator> = {
   products: validateProductsCatalogue,
   scenarios: validateScenario,
   'process-map': validateProcessMap,
-  // Group C — compliance suite (strategy#518 Phase C1).
+  // Group C — compliance suite (#518 Phase C1).
   requirement: validateRequirementDoc,
   assertion: validateAssertionDoc,
   'compliance-impact': validateComplianceImpactDoc,

--- a/src/validate-notation.ts
+++ b/src/validate-notation.ts
@@ -1,4 +1,5 @@
 // File-scope validation for diagram notations (vkgeorgia/strategy#258).
+// Group C (compliance suite): vkgeorgia/strategy#518 Phase C1.
 //
 // The VS Code preview renders its red error block from per-notation validators
 // in @transitrix/diagrams. This module exposes those same validators to the CLI
@@ -38,6 +39,10 @@ import { validateCapabilityMap } from '@transitrix/diagrams/capability-map/valid
 import { validateProductsCatalogue } from '@transitrix/diagrams/products/validate.js';
 import { validateScenario } from '@transitrix/diagrams/scenarios/validate.js';
 import { validateProcessMap } from '@transitrix/diagrams/process-map/validate.js';
+import { validateRequirement } from '@transitrix/diagrams/requirement/validate.js';
+import { validateAssertion } from '@transitrix/diagrams/assertion/validate.js';
+import { parseImpactViewConfig } from '@transitrix/diagrams/compliance/impact.js';
+import { parseCoverageMetricConfig } from '@transitrix/diagrams/compliance/coverage-metric.js';
 
 /** The shape every notation validator returns: code/message findings split into
  *  blocking errors and advisory warnings. The concrete result types carry extra
@@ -49,6 +54,59 @@ interface NotationValidationResult {
 }
 
 type NotationValidator = (input: unknown) => NotationValidationResult;
+
+function mapPackageResult(result: {
+  valid: boolean;
+  errors: Array<{ code: string; message: string }>;
+  warnings: Array<{ code: string; message: string }>;
+}): NotationValidationResult {
+  return {
+    valid: result.valid,
+    errors: result.errors.map((e) => ({ code: e.code, message: e.message })),
+    warnings: result.warnings.map((w) => ({ code: w.code, message: w.message })),
+  };
+}
+
+function validateRequirementDoc(input: unknown): NotationValidationResult {
+  // Structural / TYPE rules only — REQ-002 catalog resolution is Phase C3 (#518).
+  return mapPackageResult(validateRequirement(input));
+}
+
+function validateAssertionDoc(input: unknown): NotationValidationResult {
+  const today = new Date().toISOString().slice(0, 10);
+  return mapPackageResult(validateAssertion(input, { today }));
+}
+
+function validateComplianceImpactDoc(input: unknown): NotationValidationResult {
+  const r = parseImpactViewConfig(input);
+  if (r.ok) return { valid: true, errors: [], warnings: [] };
+  return {
+    valid: false,
+    errors: r.errors.map((message) => ({ code: 'COMPIMP-001', message })),
+    warnings: [],
+  };
+}
+
+function splitComplianceCode(message: string, fallback: string): { code: string; message: string } {
+  const m = message.match(/^([A-Z][A-Z0-9_-]+):\s*(.*)$/s);
+  if (m) return { code: m[1], message: m[2].length > 0 ? m[2] : message };
+  return { code: fallback, message };
+}
+
+function validateCoverageMetricDoc(input: unknown): NotationValidationResult {
+  const r = parseCoverageMetricConfig(input);
+  if (!r.ok) {
+    return {
+      valid: false,
+      errors: r.errors.map((message) => splitComplianceCode(message, 'COVMET-001')),
+      warnings: [],
+    };
+  }
+  const warnings = (r.config.warnings ?? []).map((message) =>
+    splitComplianceCode(message, 'COVMET-WARN'),
+  );
+  return { valid: true, errors: [], warnings };
+}
 
 // Keyed by the document's `notation:` field value — see the corpus under
 // tests/fixtures/notation-corpus/<notation>/.
@@ -67,15 +125,38 @@ const VALIDATORS: Record<string, NotationValidator> = {
   products: validateProductsCatalogue,
   scenarios: validateScenario,
   'process-map': validateProcessMap,
+  // Group C — compliance suite (vkgeorgia/strategy#518 Phase C1).
+  requirement: validateRequirementDoc,
+  assertion: validateAssertionDoc,
+  'compliance-impact': validateComplianceImpactDoc,
+  'coverage-metric': validateCoverageMetricDoc,
 };
 
 /** Notation field values the CLI can validate per file. */
 export const FILE_VALIDATABLE_NOTATIONS = Object.keys(VALIDATORS);
 
-/** Canonical file extensions the validate command accepts without `--ext`, one
- *  per notation key: `.goals.transitrix.yaml`, `.dgca.transitrix.yaml`, etc. */
+/** View notations whose on-disk suffix is `.<notation>.transitrix.yaml`.
+ *  Element notations (requirement, assertion) use typed-id filenames instead. */
+export const NOTATIONS_WITH_CANONICAL_VIEW_EXTENSION: readonly string[] = [
+  'goals',
+  'dgca',
+  'dga',
+  'action',
+  'action-card',
+  'process-blueprint',
+  'blocks',
+  'applications',
+  'capability-map',
+  'products',
+  'scenarios',
+  'process-map',
+  'compliance-impact',
+  'coverage-metric',
+];
+
+/** Canonical file extensions the validate command accepts without `--ext`. */
 export const CANONICAL_NOTATION_FILE_EXTENSIONS: readonly string[] =
-  FILE_VALIDATABLE_NOTATIONS.map((n) => `.${n}.transitrix.yaml`);
+  NOTATIONS_WITH_CANONICAL_VIEW_EXTENSION.map((n) => `.${n}.transitrix.yaml`);
 
 /** Return the notation inferred from the file's canonical extension (e.g.
  *  `foo.dgca.transitrix.yaml` → `"dgca"`), or `undefined` for non-canonical
@@ -83,9 +164,12 @@ export const CANONICAL_NOTATION_FILE_EXTENSIONS: readonly string[] =
  *  extension file is missing its `notation:` field. */
 export function inferNotationFromFilename(filePath: string): string | undefined {
   const lower = filePath.replace(/\\/g, '/').toLowerCase();
-  for (const notation of FILE_VALIDATABLE_NOTATIONS) {
+  for (const notation of NOTATIONS_WITH_CANONICAL_VIEW_EXTENSION) {
     if (lower.endsWith(`.${notation}.transitrix.yaml`)) return notation;
   }
+  const base = lower.split('/').pop() ?? lower;
+  if (base.startsWith('requirement-') && base.endsWith('.yaml')) return 'requirement';
+  if (base.startsWith('assertion-') && base.endsWith('.yaml')) return 'assertion';
   return undefined;
 }
 

--- a/src/validate-notation.ts
+++ b/src/validate-notation.ts
@@ -1,5 +1,5 @@
 // File-scope validation for diagram notations (vkgeorgia/strategy#258).
-// Group C (compliance suite): vkgeorgia/strategy#518 Phase C1.
+// Group C (compliance suite): strategy#518 Phase C1.
 //
 // The VS Code preview renders its red error block from per-notation validators
 // in @transitrix/diagrams. This module exposes those same validators to the CLI
@@ -125,7 +125,7 @@ const VALIDATORS: Record<string, NotationValidator> = {
   products: validateProductsCatalogue,
   scenarios: validateScenario,
   'process-map': validateProcessMap,
-  // Group C — compliance suite (vkgeorgia/strategy#518 Phase C1).
+  // Group C — compliance suite (strategy#518 Phase C1).
   requirement: validateRequirementDoc,
   assertion: validateAssertionDoc,
   'compliance-impact': validateComplianceImpactDoc,

--- a/tests/repo-validate-views.test.ts
+++ b/tests/repo-validate-views.test.ts
@@ -36,13 +36,14 @@ describe('repo-scope views sweep (#258)', () => {
   beforeAll(() => {
     root = mkdtempSync(join(tmpdir(), 'tx-views-'));
     // A clean Group A file, a deliberately broken one, a BPMN file (validated via
-    // the IR pipeline), a Group B file (now covered too, since #179), and an
-    // aggregate view (coverage-metric) that has no single-file validator → skipped.
+    // the IR pipeline), a Group B file, and Group C compliance views (covered
+    // since #518 C1).
     copyCorpus(root, 'canon/views/goals/good.goals.transitrix.yaml', 'goals/strategy-2026.goals.transitrix.yaml');
     write(root, 'canon/views/goals/bad.goals.transitrix.yaml', 'notation: goals\nid: x\nname: Bad\ngoals: []\n');
     copyCorpus(root, 'canon/views/bpmn/ok.bpmn.transitrix.yaml', 'bpmn/simple-approval.bpmn.transitrix.yaml');
     copyCorpus(root, 'canon/views/applications/p.applications.transitrix.yaml', 'applications/portfolio-2026.applications.transitrix.yaml');
     copyCorpus(root, 'canon/views/coverage-metric/c.coverage-metric.transitrix.yaml', 'coverage-metric/eu-coverage.coverage-metric.transitrix.yaml');
+    copyCorpus(root, 'canon/views/compliance-impact/ci.compliance-impact.view.yaml', 'compliance-impact/gdpr-nis2.compliance-impact.view.yaml');
   });
 
   afterAll(() => {
@@ -79,10 +80,12 @@ describe('repo-scope views sweep (#258)', () => {
     expect(findings.filter((f) => f.notation === 'applications' && f.severity === 'error')).toEqual([]);
   });
 
-  it('reports notations with no file-scope validator as skipped, not silently passed', () => {
+  it('validates Group C compliance views (#518 C1), not skipped', () => {
     const { skipped, findings } = runViewValidate(root);
-    expect(skipped.some((s) => s.notation === 'coverage-metric')).toBe(true);
-    expect(findings.some((f) => f.notation === 'coverage-metric')).toBe(false);
+    expect(skipped.some((s) => s.notation === 'coverage-metric')).toBe(false);
+    expect(skipped.some((s) => s.notation === 'compliance-impact')).toBe(false);
+    expect(findings.filter((f) => f.notation === 'coverage-metric' && f.severity === 'error')).toEqual([]);
+    expect(findings.filter((f) => f.notation === 'compliance-impact' && f.severity === 'error')).toEqual([]);
   });
 
   it('runRepoValidate combines canon + views and fails on a view error', () => {
@@ -101,17 +104,19 @@ describe('repo-scope views sweep — clean tree passes (#258)', () => {
     copyCorpus(root, 'canon/views/goals/good.goals.transitrix.yaml', 'goals/strategy-2026.goals.transitrix.yaml');
     copyCorpus(root, 'canon/views/applications/p.applications.transitrix.yaml', 'applications/portfolio-2026.applications.transitrix.yaml');
     copyCorpus(root, 'canon/views/coverage-metric/c.coverage-metric.transitrix.yaml', 'coverage-metric/eu-coverage.coverage-metric.transitrix.yaml');
+    copyCorpus(root, 'canon/views/compliance-impact/ci.compliance-impact.view.yaml', 'compliance-impact/gdpr-nis2.compliance-impact.view.yaml');
   });
 
   afterAll(() => {
     rmSync(root, { recursive: true, force: true });
   });
 
-  it('clean Group A + Group B files pass; only uncovered views are skipped', () => {
+  it('clean Group A + Group B + Group C files pass with no skipped views', () => {
     const result = runRepoValidate(root);
     expect(result.views.filter((f) => f.severity === 'error')).toEqual([]);
     expect(repoScopeHasErrors(result)).toBe(false);
     expect(result.skipped.some((s) => s.notation === 'applications')).toBe(false);
-    expect(result.skipped.some((s) => s.notation === 'coverage-metric')).toBe(true);
+    expect(result.skipped.some((s) => s.notation === 'coverage-metric')).toBe(false);
+    expect(result.skipped.some((s) => s.notation === 'compliance-impact')).toBe(false);
   });
 });

--- a/tests/validate-notation.test.ts
+++ b/tests/validate-notation.test.ts
@@ -11,6 +11,7 @@ import {
   notationOf,
   FILE_VALIDATABLE_NOTATIONS,
   CANONICAL_NOTATION_FILE_EXTENSIONS,
+  NOTATIONS_WITH_CANONICAL_VIEW_EXTENSION,
   inferNotationFromFilename,
 } from '../src/validate-notation.js';
 // Imported directly to prove the CLI dispatch mirrors the validator the VS Code
@@ -21,6 +22,10 @@ import { validateCapabilityMap } from '../packages/diagrams/src/capability-map/v
 import { validateProductsCatalogue } from '../packages/diagrams/src/products/validate.js';
 import { validateScenario } from '../packages/diagrams/src/scenarios/validate.js';
 import { validateProcessMap } from '../packages/diagrams/src/process-map/validate.js';
+import { validateRequirement } from '../packages/diagrams/src/requirement/validate.js';
+import { validateAssertion } from '../packages/diagrams/src/assertion/validate.js';
+import { parseImpactViewConfig } from '../packages/diagrams/src/compliance/impact.js';
+import { parseCoverageMetricConfig } from '../packages/diagrams/src/compliance/coverage-metric.js';
 
 const corpusRoot = join(dirname(fileURLToPath(import.meta.url)), 'fixtures', 'notation-corpus');
 
@@ -44,47 +49,65 @@ const GROUP_B = [
   'process-map',
 ];
 
-const ALL_NOTATIONS = [...GROUP_A, ...GROUP_B];
+// Group C — compliance suite wired in #518 Phase C1.
+const GROUP_C = ['requirement', 'assertion', 'compliance-impact', 'coverage-metric'];
 
-function fixtures(notation: string): string[] {
+const ALL_NOTATIONS = [...GROUP_A, ...GROUP_B, ...GROUP_C];
+
+function viewFixtures(notation: string): string[] {
   return readdirSync(join(corpusRoot, notation))
-    .filter((f) => f.endsWith('.transitrix.yaml'))
+    .filter((f) => f.endsWith('.transitrix.yaml') || f.endsWith('.view.yaml'))
+    .map((f) => join(corpusRoot, notation, f));
+}
+
+function elementFixtures(notation: string): string[] {
+  return readdirSync(join(corpusRoot, notation))
+    .filter((f) => f.endsWith('.yaml') && !f.endsWith('.view.yaml'))
     .map((f) => join(corpusRoot, notation, f));
 }
 
 describe('validate-notation — canonical extension helpers (#343)', () => {
-  it('CANONICAL_NOTATION_FILE_EXTENSIONS has one entry per validatable notation', () => {
-    expect(CANONICAL_NOTATION_FILE_EXTENSIONS).toHaveLength(FILE_VALIDATABLE_NOTATIONS.length);
-    for (const notation of FILE_VALIDATABLE_NOTATIONS) {
+  it('CANONICAL_NOTATION_FILE_EXTENSIONS covers view notations only', () => {
+    expect(CANONICAL_NOTATION_FILE_EXTENSIONS).toHaveLength(
+      NOTATIONS_WITH_CANONICAL_VIEW_EXTENSION.length,
+    );
+    for (const notation of NOTATIONS_WITH_CANONICAL_VIEW_EXTENSION) {
       expect(CANONICAL_NOTATION_FILE_EXTENSIONS).toContain(`.${notation}.transitrix.yaml`);
     }
+    expect(CANONICAL_NOTATION_FILE_EXTENSIONS).not.toContain('.requirement.transitrix.yaml');
+    expect(CANONICAL_NOTATION_FILE_EXTENSIONS).not.toContain('.assertion.transitrix.yaml');
   });
 
-  it('inferNotationFromFilename matches canonical extensions', () => {
+  it('inferNotationFromFilename matches canonical view extensions', () => {
     expect(inferNotationFromFilename('foo/bar.dgca.transitrix.yaml')).toBe('dgca');
     expect(inferNotationFromFilename('foo/bar.goals.transitrix.yaml')).toBe('goals');
     expect(inferNotationFromFilename('foo/bar.capability-map.transitrix.yaml')).toBe('capability-map');
     expect(inferNotationFromFilename('foo/bar.action-card.transitrix.yaml')).toBe('action-card');
-    // Windows backslash paths
+    expect(inferNotationFromFilename('foo/bar.compliance-impact.transitrix.yaml')).toBe('compliance-impact');
     expect(inferNotationFromFilename('foo\\bar.dgca.transitrix.yaml')).toBe('dgca');
+  });
+
+  it('inferNotationFromFilename recognises element filenames by typed-id prefix', () => {
+    expect(inferNotationFromFilename('canon/elements/REQUIREMENT-DATA-ERASURE-1.yaml')).toBe('requirement');
+    expect(inferNotationFromFilename('canon/elements/ASSERTION-CRM-DATA-ERASURE-1.yaml')).toBe('assertion');
   });
 
   it('inferNotationFromFilename returns undefined for non-canonical names', () => {
     expect(inferNotationFromFilename('foo.bpmn.transitrix.yaml')).toBeUndefined();
     expect(inferNotationFromFilename('foo.yaml')).toBeUndefined();
     expect(inferNotationFromFilename('foo.unknown.transitrix.yaml')).toBeUndefined();
-    expect(inferNotationFromFilename('foo.dgca.yaml')).toBeUndefined(); // missing .transitrix
+    expect(inferNotationFromFilename('foo.dgca.yaml')).toBeUndefined();
   });
 });
 
-describe('validate-notation — dispatch (#258)', () => {
-  it('recognises all Group A and Group B notations', () => {
+describe('validate-notation — dispatch (#258, #518 C1)', () => {
+  it('recognises all Group A, B, and C notations', () => {
     for (const n of ALL_NOTATIONS) expect(isFileValidatableNotation(n)).toBe(true);
     expect([...FILE_VALIDATABLE_NOTATIONS].sort()).toEqual([...ALL_NOTATIONS].sort());
   });
 
-  it('does not claim BPMN, non-diagram views, or unknown notations', () => {
-    for (const n of ['bpmn', 'compliance-impact', 'coverage-metric', 'nonsense']) {
+  it('does not claim BPMN or unknown notations', () => {
+    for (const n of ['bpmn', 'nonsense']) {
       expect(isFileValidatableNotation(n)).toBe(false);
     }
   });
@@ -98,27 +121,49 @@ describe('validate-notation — dispatch (#258)', () => {
   });
 });
 
-describe('validate-notation — the notation corpus validates clean (#258)', () => {
-  for (const notation of ALL_NOTATIONS) {
-    for (const file of fixtures(notation)) {
+describe('validate-notation — the view notation corpus validates clean (#258)', () => {
+  for (const notation of [...GROUP_A, ...GROUP_B, 'coverage-metric']) {
+    for (const file of viewFixtures(notation)) {
       const name = file.slice(corpusRoot.length + 1).replace(/\\/g, '/');
       it(`${name} → valid`, () => {
         const data = loadNotationYaml(readFileSync(file, 'utf8'));
         const report = validateNotationDoc(notation, data);
         const errors = report.findings.filter((f) => f.severity === 'error');
-        // Surface the offending findings in the failure message if this regresses.
         expect(errors, JSON.stringify(errors, null, 2)).toEqual([]);
         expect(report.isValid).toBe(true);
-        expect(report.summary.errorCount).toBe(0);
+      });
+    }
+  }
+
+  for (const file of viewFixtures('compliance-impact')) {
+    const name = file.slice(corpusRoot.length + 1).replace(/\\/g, '/');
+    it(`${name} → valid`, () => {
+      const data = loadNotationYaml(readFileSync(file, 'utf8'));
+      const report = validateNotationDoc('compliance-impact', data);
+      const errors = report.findings.filter((f) => f.severity === 'error');
+      expect(errors, JSON.stringify(errors, null, 2)).toEqual([]);
+      expect(report.isValid).toBe(true);
+    });
+  }
+});
+
+describe('validate-notation — element notation corpus validates clean (#518 C1)', () => {
+  for (const notation of ['requirement', 'assertion'] as const) {
+    for (const file of elementFixtures(notation)) {
+      const name = file.slice(corpusRoot.length + 1).replace(/\\/g, '/');
+      it(`${name} → valid`, () => {
+        const data = loadNotationYaml(readFileSync(file, 'utf8'));
+        const report = validateNotationDoc(notation, data);
+        const errors = report.findings.filter((f) => f.severity === 'error');
+        expect(errors, JSON.stringify(errors, null, 2)).toEqual([]);
+        expect(report.isValid).toBe(true);
       });
     }
   }
 });
 
-describe('validate-notation — parity with the preview validator (#258)', () => {
+describe('validate-notation — parity with the preview validator (#258, #518 C1)', () => {
   it('goals findings mirror parseCanonicalGoals exactly', () => {
-    // A deliberately malformed goals doc — the CLI must surface the same codes
-    // the preview shows in its red block.
     const broken = { notation: 'goals', id: 'x', name: 'Broken', goals: [] };
     const raw = parseCanonicalGoals(broken);
     const report = validateNotationDoc('goals', broken);
@@ -133,7 +178,7 @@ describe('validate-notation — parity with the preview validator (#258)', () =>
   });
 
   it('maps validator warnings to advisory findings, not errors', () => {
-    const data = loadNotationYaml(readFileSync(fixtures('goals')[0], 'utf8'));
+    const data = loadNotationYaml(readFileSync(viewFixtures('goals')[0], 'utf8'));
     const raw = parseCanonicalGoals(data);
     const report = validateNotationDoc('goals', data);
     const warningCodes = report.findings
@@ -142,13 +187,11 @@ describe('validate-notation — parity with the preview validator (#258)', () =>
     expect(warningCodes).toEqual(raw.warnings.map((w) => w.code));
   });
 
-  // Group B parity — CLI dispatch calls the same package function the extension now imports.
   it('applications: CLI findings mirror validateApplicationsCatalogue exactly', () => {
     const broken = { notation: 'applications' };
     const raw = validateApplicationsCatalogue(broken);
     const report = validateNotationDoc('applications', broken);
     expect(report.isValid).toBe(raw.valid);
-    expect(report.isValid).toBe(false);
     expect(report.findings.filter((f) => f.severity === 'error').map((f) => f.ruleId))
       .toEqual(raw.errors.map((e) => e.code));
   });
@@ -158,7 +201,6 @@ describe('validate-notation — parity with the preview validator (#258)', () =>
     const raw = validateCapabilityMap(broken);
     const report = validateNotationDoc('capability-map', broken);
     expect(report.isValid).toBe(raw.valid);
-    expect(report.isValid).toBe(false);
     expect(report.findings.filter((f) => f.severity === 'error').map((f) => f.ruleId))
       .toEqual(raw.errors.map((e) => e.code));
   });
@@ -168,7 +210,6 @@ describe('validate-notation — parity with the preview validator (#258)', () =>
     const raw = validateProductsCatalogue(broken);
     const report = validateNotationDoc('products', broken);
     expect(report.isValid).toBe(raw.valid);
-    expect(report.isValid).toBe(false);
     expect(report.findings.filter((f) => f.severity === 'error').map((f) => f.ruleId))
       .toEqual(raw.errors.map((e) => e.code));
   });
@@ -178,7 +219,6 @@ describe('validate-notation — parity with the preview validator (#258)', () =>
     const raw = validateScenario(broken);
     const report = validateNotationDoc('scenarios', broken);
     expect(report.isValid).toBe(raw.valid);
-    expect(report.isValid).toBe(false);
     expect(report.findings.filter((f) => f.severity === 'error').map((f) => f.ruleId))
       .toEqual(raw.errors.map((e) => e.code));
   });
@@ -188,8 +228,45 @@ describe('validate-notation — parity with the preview validator (#258)', () =>
     const raw = validateProcessMap(broken);
     const report = validateNotationDoc('process-map', broken);
     expect(report.isValid).toBe(raw.valid);
-    expect(report.isValid).toBe(false);
     expect(report.findings.filter((f) => f.severity === 'error').map((f) => f.ruleId))
       .toEqual(raw.errors.map((e) => e.code));
+  });
+
+  it('requirement: CLI findings mirror validateRequirement exactly', () => {
+    const broken = { notation: 'requirement' };
+    const raw = validateRequirement(broken);
+    const report = validateNotationDoc('requirement', broken);
+    expect(report.isValid).toBe(raw.valid);
+    expect(report.findings.filter((f) => f.severity === 'error').map((f) => f.ruleId))
+      .toEqual(raw.errors.map((e) => e.code));
+  });
+
+  it('assertion: CLI findings mirror validateAssertion exactly', () => {
+    const broken = { notation: 'assertion' };
+    const today = new Date().toISOString().slice(0, 10);
+    const raw = validateAssertion(broken, { today });
+    const report = validateNotationDoc('assertion', broken);
+    expect(report.isValid).toBe(raw.valid);
+    expect(report.findings.filter((f) => f.severity === 'error').map((f) => f.ruleId))
+      .toEqual(raw.errors.map((e) => e.code));
+  });
+
+  it('compliance-impact: structural errors map to COMPIMP-001', () => {
+    const broken = { notation: 'compliance-impact', view: { name: 'X' } };
+    const raw = parseImpactViewConfig(broken);
+    expect(raw.ok).toBe(false);
+    const report = validateNotationDoc('compliance-impact', broken);
+    expect(report.isValid).toBe(false);
+    expect(report.findings.every((f) => f.ruleId === 'COMPIMP-001')).toBe(true);
+    expect(report.findings.length).toBe(raw.ok ? 0 : raw.errors.length);
+  });
+
+  it('coverage-metric: CLI mirrors parseCoverageMetricConfig on a broken doc', () => {
+    const broken = { notation: 'coverage-metric', view: { name: 'X' } };
+    const raw = parseCoverageMetricConfig(broken);
+    expect(raw.ok).toBe(false);
+    const report = validateNotationDoc('coverage-metric', broken);
+    expect(report.isValid).toBe(false);
+    expect(report.findings.filter((f) => f.severity === 'error').length).toBe(raw.errors.length);
   });
 });


### PR DESCRIPTION
## Summary

- Register **Group C** notations in `src/validate-notation.ts`: `requirement`, `assertion`, `compliance-impact`, `coverage-metric`.
- Element files validate via `notation:` frontmatter or `REQUIREMENT-*.yaml` / `ASSERTION-*.yaml` filename inference.
- `validate --scope=repo` no longer skips compliance-impact / coverage-metric views under `canon/views/**`.

Implements #518 Phase C1 (C2–C4 remain open).

## Test plan

- [x] `npx vitest run tests/validate-notation.test.ts tests/repo-validate-views.test.ts` — 49 green
- [x] `transitrix validate` on acme-corp compliance-impact, coverage-metric, REQUIREMENT YAML — valid
- [x] `transitrix validate --scope=repo --root <acme-corp> --json` — skipped: []