### PR TITLE
feat(validate): wire CODEX validator into CLI and repo-scope (#518 C2)

### DIFF
--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",

--- a/packages/diagrams/src/codex/__tests__/example.test.ts
+++ b/packages/diagrams/src/codex/__tests__/example.test.ts
@@ -1,0 +1,40 @@
+// Conformance test for CODEX worked examples under
+// `tests/fixtures/notation-corpus/codex/` — pins #518 Phase C2 corpus signal.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import yaml from 'js-yaml';
+import { validateCodex, folderJurisdictionFromPath } from '../validate.js';
+
+const corpusRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../../../tests/fixtures/notation-corpus/codex',
+);
+
+function codexFixturePaths(): Array<{ rel: string; folderJurisdiction?: string }> {
+  const out: Array<{ rel: string; folderJurisdiction?: string }> = [];
+  for (const zone of ['external/EU', 'internal']) {
+    const dir = path.join(corpusRoot, zone);
+    for (const f of readdirSync(dir).filter((x) => x.endsWith('.yaml'))) {
+      const rel = path.join('codex', zone, f).replace(/\\/g, '/');
+      out.push({
+        rel,
+        folderJurisdiction: folderJurisdictionFromPath(rel),
+      });
+    }
+  }
+  return out;
+}
+
+describe('codex worked examples (notation-corpus)', () => {
+  for (const { rel, folderJurisdiction } of codexFixturePaths()) {
+    it(`validates ${rel} without error`, () => {
+      const data = yaml.load(readFileSync(path.join(corpusRoot, rel.replace(/^codex\//, '')), 'utf-8'));
+      const v = validateCodex(data, { folderJurisdiction });
+      expect(v.valid, JSON.stringify(v.errors)).toBe(true);
+      expect(v.errors).toHaveLength(0);
+    });
+  }
+});

--- a/packages/diagrams/src/codex/__tests__/validate.test.ts
+++ b/packages/diagrams/src/codex/__tests__/validate.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateCodex,
+  isCodexDoc,
+  folderJurisdictionFromPath,
+} from '../validate.js';
+
+const VALID_EXTERNAL = {
+  zone: 'codex',
+  id: 'LAW-GDPR-1',
+  name: 'General Data Protection Regulation',
+  type: 'LAW',
+  jurisdiction: 'eu',
+  effective_date: '2018-05-25',
+  admitted_at: '2026-06-01',
+  admitted_by: 'legal.team',
+  gate_checks: { uniqueness: 'pass' },
+};
+
+const VALID_INTERNAL = {
+  zone: 'codex',
+  id: 'INTERNAL_STANDARD-coding-conventions-1',
+  name: 'Engineering Coding Conventions',
+  type: 'INTERNAL_STANDARD',
+  issuing_authority: 'VP Engineering',
+  effective_date: '2026-01-01',
+  admitted_at: '2026-05-27',
+  admitted_by: 'vp.engineering',
+  gate_checks: { source_authority: 'VP Engineering' },
+};
+
+describe('validateCodex', () => {
+  it('accepts a valid external artefact', () => {
+    const r = validateCodex(VALID_EXTERNAL, { folderJurisdiction: 'eu' });
+    expect(r.valid, JSON.stringify(r.errors)).toBe(true);
+  });
+
+  it('accepts a valid internal artefact', () => {
+    expect(validateCodex(VALID_INTERNAL).valid).toBe(true);
+  });
+
+  it('CODEX-001 rejects non-mapping input', () => {
+    expect(validateCodex(null).errors.some((e) => e.code === 'CODEX-001')).toBe(true);
+  });
+
+  it('CODEX-001 rejects wrong zone', () => {
+    const r = validateCodex({ ...VALID_EXTERNAL, zone: 'canon' });
+    expect(r.errors.some((e) => e.code === 'CODEX-001' && e.path === 'zone')).toBe(true);
+  });
+
+  it('CODEX-002 rejects type/id prefix mismatch', () => {
+    const r = validateCodex({ ...VALID_EXTERNAL, type: 'REGULATION' });
+    expect(r.errors.some((e) => e.code === 'CODEX-002')).toBe(true);
+  });
+
+  it('CODEX-003 requires jurisdiction on external artefacts', () => {
+    const r = validateCodex({ ...VALID_EXTERNAL, jurisdiction: '' });
+    expect(r.errors.some((e) => e.code === 'CODEX-003' && e.path === 'jurisdiction')).toBe(true);
+  });
+
+  it('CODEX-005 enforces folder jurisdiction match', () => {
+    const r = validateCodex(VALID_EXTERNAL, { folderJurisdiction: 'ge' });
+    expect(r.errors.some((e) => e.code === 'CODEX-005')).toBe(true);
+  });
+
+  it('CODEX-004 requires issuing_authority on internal artefacts', () => {
+    const r = validateCodex({ ...VALID_INTERNAL, issuing_authority: '' });
+    expect(r.errors.some((e) => e.code === 'CODEX-004')).toBe(true);
+  });
+});
+
+describe('isCodexDoc', () => {
+  it('detects zone: codex', () => {
+    expect(isCodexDoc({ zone: 'codex', id: 'LAW-1' })).toBe(true);
+    expect(isCodexDoc({ zone: 'canon' })).toBe(false);
+  });
+});
+
+describe('folderJurisdictionFromPath', () => {
+  it('parses codex/external/<jurisdiction>/ paths', () => {
+    expect(folderJurisdictionFromPath('codex/external/eu/LAW-GDPR-1.yaml')).toBe('eu');
+    expect(folderJurisdictionFromPath('codex/internal/POLICY-1.yaml')).toBeUndefined();
+  });
+});

--- a/packages/diagrams/src/codex/index.ts
+++ b/packages/diagrams/src/codex/index.ts
@@ -1,0 +1,4 @@
+export { CODEX_ARTEFACT_TYPES, EXTERNAL_CODEX_TYPES, INTERNAL_CODEX_TYPES } from './types.js';
+export type { CodexArtefactType } from './types.js';
+export { validateCodex, isCodexDoc, folderJurisdictionFromPath } from './validate.js';
+export type { CodexValidateOptions } from './validate.js';

--- a/packages/diagrams/src/codex/types.ts
+++ b/packages/diagrams/src/codex/types.ts
@@ -1,0 +1,13 @@
+// Codex artefact — external laws/regulations and internal policies/standards.
+// Schema: methodology notations/elements/14-codex.md §3–§4.
+
+/** TYPE prefixes admitted in the codex zone (REQ-003 / 14-codex.md). */
+export const CODEX_ARTEFACT_TYPES = ['LAW', 'REGULATION', 'POLICY', 'INTERNAL_STANDARD'] as const;
+
+export type CodexArtefactType = (typeof CODEX_ARTEFACT_TYPES)[number];
+
+/** External codex artefacts (codex/external/<jurisdiction>/). */
+export const EXTERNAL_CODEX_TYPES: readonly CodexArtefactType[] = ['LAW', 'REGULATION'];
+
+/** Internal codex artefacts (codex/internal/). */
+export const INTERNAL_CODEX_TYPES: readonly CodexArtefactType[] = ['POLICY', 'INTERNAL_STANDARD'];

--- a/packages/diagrams/src/codex/validate.ts
+++ b/packages/diagrams/src/codex/validate.ts
@@ -1,0 +1,125 @@
+// CODEX validator — methodology notations/elements/14-codex.md §4.
+//
+// CODEX-001 — shape, zone, id grammar, admission envelope.
+// CODEX-002 — `type` field matches the id TYPE prefix when present.
+// CODEX-003 — external artefact frontmatter (jurisdiction, effective_date).
+// CODEX-004 — internal artefact frontmatter (issuing_authority, effective_date).
+// CODEX-005 — jurisdiction must match the parent folder under codex/external/
+//             (when `folderJurisdiction` is supplied by the repo sweep).
+
+import type { ValidationError, ValidationWarning, ValidationResult } from '../validation-types.js';
+import { isCanonicalId, typeOfId } from '../typed-id.js';
+import {
+  CODEX_ARTEFACT_TYPES,
+  EXTERNAL_CODEX_TYPES,
+  INTERNAL_CODEX_TYPES,
+  type CodexArtefactType,
+} from './types.js';
+
+export interface CodexValidateOptions {
+  /** Lowercased jurisdiction folder segment from `codex/external/<jurisdiction>/`. */
+  folderJurisdiction?: string;
+}
+
+function isCodexType(type: string | null): type is CodexArtefactType {
+  return type !== null && (CODEX_ARTEFACT_TYPES as readonly string[]).includes(type);
+}
+
+function normalizeType(value: unknown): string | undefined {
+  if (typeof value !== 'string' || value.trim() === '') return undefined;
+  return value.trim().toUpperCase();
+}
+
+export function validateCodex(input: unknown, options: CodexValidateOptions = {}): ValidationResult {
+  const errors: ValidationError[] = [];
+  const warnings: ValidationWarning[] = [];
+
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    errors.push({ code: 'CODEX-001', message: 'Codex artefact must be a YAML mapping.' });
+    return { valid: false, errors, warnings };
+  }
+  const c = input as Record<string, unknown>;
+
+  if (c.zone !== 'codex') {
+    errors.push({ code: 'CODEX-001', message: 'zone must be the fixed value "codex".', path: 'zone' });
+  }
+
+  const idType = typeOfId(c.id);
+  if (!isCanonicalId(c.id) || !isCodexType(idType)) {
+    errors.push({
+      code: 'CODEX-001',
+      message: `id "${String(c.id)}" must be a typed codex id (LAW, REGULATION, POLICY, or INTERNAL_STANDARD).`,
+      path: 'id',
+    });
+  }
+
+  if (typeof c.name !== 'string' || c.name.trim() === '') {
+    errors.push({ code: 'CODEX-001', message: 'name is required.', path: 'name' });
+  }
+  for (const field of ['admitted_at', 'admitted_by'] as const) {
+    const v = c[field];
+    if (typeof v !== 'string' || v.trim() === '') {
+      errors.push({ code: 'CODEX-001', message: `${field} is required.`, path: field });
+    }
+  }
+  if (c.gate_checks === null || typeof c.gate_checks !== 'object' || Array.isArray(c.gate_checks)) {
+    errors.push({ code: 'CODEX-001', message: 'gate_checks is required and must be a mapping.', path: 'gate_checks' });
+  }
+
+  const declaredType = normalizeType(c.type);
+  if (declaredType !== undefined && idType && declaredType !== idType) {
+    errors.push({
+      code: 'CODEX-002',
+      message: `type "${String(c.type)}" does not match the id TYPE prefix "${idType}".`,
+      path: 'type',
+    });
+  }
+
+  const artefactType = (declaredType ?? idType) as CodexArtefactType | null;
+
+  if (artefactType && (EXTERNAL_CODEX_TYPES as readonly string[]).includes(artefactType)) {
+    const jurisdiction = typeof c.jurisdiction === 'string' ? c.jurisdiction.trim() : '';
+    if (!jurisdiction) {
+      errors.push({ code: 'CODEX-003', message: 'jurisdiction is required for external codex artefacts.', path: 'jurisdiction' });
+    } else if (options.folderJurisdiction && jurisdiction.toLowerCase() !== options.folderJurisdiction.toLowerCase()) {
+      errors.push({
+        code: 'CODEX-005',
+        message: `jurisdiction "${jurisdiction}" must match the parent folder "${options.folderJurisdiction}" (CODEX-001).`,
+        path: 'jurisdiction',
+      });
+    }
+    if (typeof c.effective_date !== 'string' || c.effective_date.trim() === '') {
+      errors.push({ code: 'CODEX-003', message: 'effective_date is required for external codex artefacts.', path: 'effective_date' });
+    }
+  }
+
+  if (artefactType && (INTERNAL_CODEX_TYPES as readonly string[]).includes(artefactType)) {
+    if (typeof c.issuing_authority !== 'string' || c.issuing_authority.trim() === '') {
+      errors.push({
+        code: 'CODEX-004',
+        message: 'issuing_authority is required for internal codex artefacts.',
+        path: 'issuing_authority',
+      });
+    }
+    if (typeof c.effective_date !== 'string' || c.effective_date.trim() === '') {
+      errors.push({ code: 'CODEX-004', message: 'effective_date is required for internal codex artefacts.', path: 'effective_date' });
+    }
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}
+
+/** True when a parsed document is a codex-zone artefact candidate. */
+export function isCodexDoc(data: unknown): boolean {
+  if (data === null || typeof data !== 'object' || Array.isArray(data)) return false;
+  return (data as Record<string, unknown>).zone === 'codex';
+}
+
+/** Infer codex folder jurisdiction from a repo-relative path such as
+ *  `codex/external/eu/LAW-GDPR-1.yaml` → `eu`. */
+export function folderJurisdictionFromPath(filePath: string): string | undefined {
+  const parts = filePath.replace(/\\/g, '/').toLowerCase().split('/');
+  const extIdx = parts.indexOf('external');
+  if (extIdx < 0 || extIdx + 1 >= parts.length) return undefined;
+  return parts[extIdx + 1] || undefined;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,6 +24,7 @@ import {
   validateNotationDoc,
   CANONICAL_NOTATION_FILE_EXTENSIONS,
   inferNotationFromFilename,
+  resolveValidatorKey,
 } from './validate-notation.js';
 import { handleExportComplianceCommand } from './export-compliance.js';
 
@@ -291,7 +292,7 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
     console.error('             (goals, dgca, dga, fgca, fga, activities, activity-card,');
     console.error('             process-blueprint, blocks, applications, capability-map,');
     console.error('             products, scenarios, process-map, requirement, assertion,');
-    console.error('             compliance-impact, coverage-metric) — same checks as the preview.');
+    console.error('             compliance-impact, coverage-metric, codex) — same checks as the preview.');
     console.error('             Canonical notation extensions are accepted without --ext.');
     console.error('repo scope — whole-canon checks (referential integrity, atomicity,');
     console.error('             id uniqueness, policy) over <root> (default: cwd).');
@@ -339,50 +340,41 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
     process.exit(1);
   }
 
-  // Diagram-notation routing (vkgeorgia/strategy#258): validate via the same
-  // per-notation validator the VS Code preview uses, so the CLI emits the same
-  // findings the preview shows in red. BPMN / no-notation files fall through to
-  // the IR path below.
-  const probedNotation = probeNotation(fileText);
-  if (probedNotation && probedNotation !== 'bpmn') {
-    if (isFileValidatableNotation(probedNotation)) {
-      let data: unknown;
-      try {
-        data = loadNotationYaml(fileText);
-      } catch (e) {
-        const err = e as Error;
-        if (useJson) {
-          console.log(
-            JSON.stringify(
-              { valid: false, notation: probedNotation, message: err.message },
-              null,
-              2,
-            ),
-          );
-        } else {
-          console.error(`✗ ${src}`);
-          console.error();
-          console.error(`Parse error: ${err.message}`);
-          console.error();
-        }
-        process.exit(1);
-      }
-      const report = validateNotationDoc(probedNotation, data);
-      emitFileReport(src, report, useJson, probedNotation);
+  // Diagram-notation / codex routing (#258, #518): validate via the shared
+  // per-notation validators before the BPMN/IR path.
+  let data: unknown;
+  try {
+    data = loadNotationYaml(fileText);
+  } catch (e) {
+    const err = e as Error;
+    if (useJson) {
+      console.log(JSON.stringify({ valid: false, message: err.message }, null, 2));
+    } else {
+      console.error(`✗ ${src}`);
+      console.error();
+      console.error(`Parse error: ${err.message}`);
+      console.error();
+    }
+    process.exit(1);
+  }
+
+  const validatorKey = resolveValidatorKey(data) ?? inferNotationFromFilename(src);
+  if (validatorKey && validatorKey !== 'bpmn') {
+    if (isFileValidatableNotation(validatorKey)) {
+      const report = validateNotationDoc(validatorKey, data, { filePath: src });
+      emitFileReport(src, report, useJson, validatorKey);
       if (!report.isValid) {
         process.exit(1);
       }
       return;
     }
-    // Recognised notation, but no file-scope CLI validator yet — e.g. a future view
-    // type not wired in validate-notation.ts. Be honest: don't claim valid and
-    // don't mis-run the BPMN path.
+    // Recognised notation, but no file-scope CLI validator yet.
     const notice =
-      `notation "${probedNotation}" is not yet validated by the CLI — check it in ` +
+      `notation "${validatorKey}" is not yet validated by the CLI — check it in ` +
       `the Transitrix Studio preview, or run whole-canon checks with --scope=repo.`;
     if (useJson) {
       console.log(
-        JSON.stringify({ valid: null, notation: probedNotation, covered: false, message: notice }, null, 2),
+        JSON.stringify({ valid: null, notation: validatorKey, covered: false, message: notice }, null, 2),
       );
     } else {
       console.error(`• ${src}: ${notice}`);
@@ -400,13 +392,14 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
   // notation: field is absent or wrong, give a targeted error rather than the
   // generic extension list.
   const extNotation = inferNotationFromFilename(src);
-  if (extNotation && !probedNotation) {
+  if (extNotation && !resolveValidatorKey(data)) {
+    const hint = extNotation === 'codex' ? 'zone: codex' : `notation: ${extNotation}`;
     if (useJson) {
       console.log(
         JSON.stringify(
           {
             valid: false,
-            message: `missing notation: field — add 'notation: ${extNotation}' to the file`,
+            message: `missing ${hint} — add it to the file`,
           },
           null,
           2,
@@ -415,7 +408,7 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
     } else {
       console.error(`✗ ${src}`);
       console.error();
-      console.error(`Missing notation: field — add 'notation: ${extNotation}' to the file.`);
+      console.error(`Missing ${hint} — add it to the file.`);
       console.error();
     }
     process.exit(1);

--- a/src/repo-validate.ts
+++ b/src/repo-validate.ts
@@ -23,6 +23,7 @@ import {
   validateNotationDoc,
   isFileValidatableNotation,
   notationOf,
+  resolveValidatorKey,
   loadNotationYaml,
 } from './validate-notation.js';
 import { parseYamlToIr } from './parser.js';
@@ -110,6 +111,8 @@ export interface ViewFinding {
 export interface RepoScopeResult {
   canon: RepoFinding[];
   views: ViewFinding[];
+  /** Per-file codex artefact findings from `codex/**` (#518 Phase C2). */
+  codex: ViewFinding[];
   skipped: Array<{ file: string; notation: string }>;
 }
 
@@ -207,27 +210,90 @@ export function runViewValidate(root: string): {
   return { findings, skipped };
 }
 
+/** Collect YAML paths under `<root>/codex/**`. */
+function loadCodexDocs(root: string): Array<{ path: string; text: string }> {
+  const docs: Array<{ path: string; text: string }> = [];
+  let entries: string[] = [];
+  try {
+    entries = readdirSync(path.join(root, 'codex'), { recursive: true }) as string[];
+  } catch {
+    return docs;
+  }
+  for (const rel of entries) {
+    if (typeof rel !== 'string' || !isYaml(rel) || shouldSkip(rel)) continue;
+    const fullRel = path.join('codex', rel);
+    let text: string;
+    try {
+      text = readFileSync(path.join(root, fullRel), 'utf-8');
+    } catch {
+      continue;
+    }
+    docs.push({ path: fullRel.replace(/\\/g, '/'), text });
+  }
+  return docs;
+}
+
+/** Validate every codex artefact under `codex/**` (#518 Phase C2). */
+export function runCodexValidate(root: string): ViewFinding[] {
+  const findings: ViewFinding[] = [];
+  for (const doc of loadCodexDocs(root)) {
+    let data: unknown;
+    try {
+      data = loadNotationYaml(doc.text);
+    } catch (e) {
+      findings.push({
+        file: doc.path,
+        notation: 'codex',
+        ruleId: 'YAML',
+        severity: 'error',
+        message: (e as Error).message,
+      });
+      continue;
+    }
+    const key = resolveValidatorKey(data);
+    if (key !== 'codex') continue;
+    for (const f of validateNotationDoc('codex', data, { filePath: doc.path }).findings) {
+      if (f.severity === 'info') continue;
+      findings.push({
+        file: doc.path,
+        notation: 'codex',
+        ruleId: f.ruleId,
+        severity: f.severity,
+        message: f.message,
+      });
+    }
+  }
+  return findings;
+}
+
 /** Load the canon model under `root` and run the repo-scope checks: canon
- *  cross-references plus a per-file notation sweep over canon/views/**. */
+ *  cross-references plus per-file notation sweep over canon/views/** and codex/**. */
 export function runRepoValidate(root: string): RepoScopeResult {
   const canon = validateRepoModel(loadRepoModel(root));
   const { findings: views, skipped } = runViewValidate(root);
-  return { canon, views, skipped };
+  const codex = runCodexValidate(root);
+  return { canon, views, codex, skipped };
 }
 
 /** True when the run has a blocking finding — a canon finding or a view error.
  *  View warnings and skipped files do not fail the run. */
 export function repoScopeHasErrors(result: RepoScopeResult): boolean {
-  return result.canon.length > 0 || result.views.some((v) => v.severity === 'error');
+  return (
+    result.canon.length > 0
+    || result.views.some((v) => v.severity === 'error')
+    || result.codex.some((c) => c.severity === 'error')
+  );
 }
 
 /** Print the repo-scope result (human or JSON). Returns nothing; the caller sets
  *  the exit code via repoScopeHasErrors(). */
 export function reportRepoFindings(root: string, result: RepoScopeResult, useJson: boolean): void {
-  const { canon, views, skipped } = result;
+  const { canon, views, codex, skipped } = result;
   const viewErrors = views.filter((v) => v.severity === 'error');
   const viewWarnings = views.filter((v) => v.severity === 'warning');
-  const valid = canon.length === 0 && viewErrors.length === 0;
+  const codexErrors = codex.filter((c) => c.severity === 'error');
+  const codexWarnings = codex.filter((c) => c.severity === 'warning');
+  const valid = canon.length === 0 && viewErrors.length === 0 && codexErrors.length === 0;
 
   if (useJson) {
     console.log(
@@ -236,11 +302,9 @@ export function reportRepoFindings(root: string, result: RepoScopeResult, useJso
           scope: 'repo',
           root,
           valid,
-          // Canon cross-reference findings — frozen {scope,id,message} shape.
           findings: canon,
-          // Per-file notation findings from the canon/views/** sweep.
           views: { valid: viewErrors.length === 0, findings: views },
-          // View files whose notation has no file-scope CLI validator yet.
+          codex: { valid: codexErrors.length === 0, findings: codex },
           skipped,
         },
         null,
@@ -284,6 +348,21 @@ export function reportRepoFindings(root: string, result: RepoScopeResult, useJso
     console.log();
   }
 
+  if (codex.length > 0) {
+    console.log('Codex (codex/):');
+    let currentFile = '';
+    for (const c of codex) {
+      if (c.file !== currentFile) {
+        console.log(`  ${c.file} [codex]`);
+        currentFile = c.file;
+      }
+      const mark =
+        c.severity === 'error' ? `\x1b[31m✗ ${c.ruleId}\x1b[0m` : `\x1b[33m⚠ ${c.ruleId}\x1b[0m`;
+      console.log(`    ${mark} ${c.message}`);
+    }
+    console.log();
+  }
+
   if (skipped.length > 0) {
     console.log(
       `Skipped — notation not yet validated by the CLI (check in the preview): ${skipped.length} file${skipped.length === 1 ? '' : 's'}`,
@@ -304,6 +383,14 @@ export function reportRepoFindings(root: string, result: RepoScopeResult, useJso
   if (viewWarnings.length > 0) {
     parts.push(
       `\x1b[33m${viewWarnings.length}\x1b[0m view warning${viewWarnings.length === 1 ? '' : 's'}`,
+    );
+  }
+  if (codexErrors.length > 0) {
+    parts.push(`\x1b[31m${codexErrors.length}\x1b[0m codex error${codexErrors.length === 1 ? '' : 's'}`);
+  }
+  if (codexWarnings.length > 0) {
+    parts.push(
+      `\x1b[33m${codexWarnings.length}\x1b[0m codex warning${codexWarnings.length === 1 ? '' : 's'}`,
     );
   }
   if (parts.length > 0) {

--- a/src/validate-notation.ts
+++ b/src/validate-notation.ts
@@ -1,5 +1,5 @@
 // File-scope validation for diagram notations (vkgeorgia/strategy#258).
-// Group C (compliance suite): #518 Phase C1.
+// Group C (compliance suite): #518 Phase C1–C2.
 //
 // The VS Code preview renders its red error block from per-notation validators
 // in @transitrix/diagrams. This module exposes those same validators to the CLI
@@ -43,6 +43,13 @@ import { validateRequirement } from '@transitrix/diagrams/requirement/validate.j
 import { validateAssertion } from '@transitrix/diagrams/assertion/validate.js';
 import { parseImpactViewConfig } from '@transitrix/diagrams/compliance/impact.js';
 import { parseCoverageMetricConfig } from '@transitrix/diagrams/compliance/coverage-metric.js';
+import {
+  validateCodex,
+  isCodexDoc,
+  folderJurisdictionFromPath,
+} from '@transitrix/diagrams/codex/validate.js';
+import { CODEX_ARTEFACT_TYPES } from '@transitrix/diagrams/codex/types.js';
+import { typeOfId } from '@transitrix/diagrams/typed-id.js';
 
 /** The shape every notation validator returns: code/message findings split into
  *  blocking errors and advisory warnings. The concrete result types carry extra
@@ -108,6 +115,10 @@ function validateCoverageMetricDoc(input: unknown): NotationValidationResult {
   return { valid: true, errors: [], warnings };
 }
 
+function validateCodexDoc(input: unknown): NotationValidationResult {
+  return mapPackageResult(validateCodex(input));
+}
+
 // Keyed by the document's `notation:` field value — see the corpus under
 // tests/fixtures/notation-corpus/<notation>/.
 const VALIDATORS: Record<string, NotationValidator> = {
@@ -130,6 +141,8 @@ const VALIDATORS: Record<string, NotationValidator> = {
   assertion: validateAssertionDoc,
   'compliance-impact': validateComplianceImpactDoc,
   'coverage-metric': validateCoverageMetricDoc,
+  // Group C — codex zone (#518 Phase C2); `zone: codex`, not a notation: tag.
+  codex: validateCodexDoc,
 };
 
 /** Notation field values the CLI can validate per file. */
@@ -170,6 +183,9 @@ export function inferNotationFromFilename(filePath: string): string | undefined 
   const base = lower.split('/').pop() ?? lower;
   if (base.startsWith('requirement-') && base.endsWith('.yaml')) return 'requirement';
   if (base.startsWith('assertion-') && base.endsWith('.yaml')) return 'assertion';
+  const rawBase = (filePath.replace(/\\/g, '/').split('/').pop() ?? '').replace(/\.ya?ml$/i, '');
+  const idType = typeOfId(rawBase);
+  if (idType && (CODEX_ARTEFACT_TYPES as readonly string[]).includes(idType)) return 'codex';
   return undefined;
 }
 
@@ -188,6 +204,20 @@ export function notationOf(data: unknown): string | undefined {
   return undefined;
 }
 
+/** Resolve the validator dispatch key: explicit `notation:` wins; codex artefacts
+ *  are keyed as `codex` when `zone: codex`. */
+export function resolveValidatorKey(data: unknown): string | undefined {
+  const notation = notationOf(data);
+  if (notation && isFileValidatableNotation(notation)) return notation;
+  if (isCodexDoc(data)) return 'codex';
+  return notation;
+}
+
+export interface ValidateNotationOptions {
+  /** Repo-relative or absolute path — used for codex folder-jurisdiction checks. */
+  filePath?: string;
+}
+
 /** Parse + date-coerce a YAML string exactly as the previews do, so validator
  *  input — and therefore findings — match the preview. Throws on a YAML syntax
  *  error (the caller maps that to a parse-error report). */
@@ -198,8 +228,21 @@ export function loadNotationYaml(text: string): unknown {
 /** Run the per-notation validator and shape its result as a ValidationReport, so
  *  the CLI prints/serialises notation findings through the same path as BPMN
  *  validation. `notation` must be one isFileValidatableNotation() accepts. */
-export function validateNotationDoc(notation: string, data: unknown): ValidationReport {
-  const result = VALIDATORS[notation](data);
+export function validateNotationDoc(
+  notation: string,
+  data: unknown,
+  options: ValidateNotationOptions = {},
+): ValidationReport {
+  const result =
+    notation === 'codex'
+      ? mapPackageResult(
+          validateCodex(data, {
+            folderJurisdiction: options.filePath
+              ? folderJurisdictionFromPath(options.filePath)
+              : undefined,
+          }),
+        )
+      : VALIDATORS[notation](data);
   const findings: ValidationFinding[] = [
     ...result.errors.map(
       (e): ValidationFinding => ({ ruleId: e.code, severity: 'error', message: e.message }),

--- a/tests/fixtures/notation-corpus/codex/external/EU/LAW-GDPR-1.yaml
+++ b/tests/fixtures/notation-corpus/codex/external/EU/LAW-GDPR-1.yaml
@@ -1,20 +1,19 @@
 # Worked example — CODEX (external law): EU General Data Protection Regulation.
-# Fictional scenario: NorthBay Retail — EU compliance demo.
-# All article text is abbreviated and illustrative; not a verbatim legal extract.
 
 zone: codex
 id: LAW-GDPR-1
 name: "General Data Protection Regulation (GDPR)"
-type: regulation
+type: LAW
 jurisdiction: EU
 authority: "European Parliament and Council"
 effective_date: "2018-05-25"
 description: >
   Regulation (EU) 2016/679 on the protection of natural persons with regard to the
-  processing of personal data and the free movement of such data. Applies to
-  organisations processing personal data of EU residents regardless of
-  where the organisation is established.
+  processing of personal data and the free movement of such data.
 
-# Admission record (CONTRACT.md §6)
 admitted_at: "2026-06-01"
 admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass

--- a/tests/fixtures/notation-corpus/codex/external/EU/LAW-NIS2-1.yaml
+++ b/tests/fixtures/notation-corpus/codex/external/EU/LAW-NIS2-1.yaml
@@ -1,21 +1,20 @@
 # Worked example — CODEX (external law): EU NIS2 Directive.
-# Fictional scenario: NorthBay Retail — EU compliance demo.
-# All article text is abbreviated and illustrative; not a verbatim legal extract.
 
 zone: codex
 id: LAW-NIS2-1
 name: "NIS2 Directive — Network and Information Security"
-type: directive
+type: LAW
 jurisdiction: EU
 authority: "European Parliament and Council"
 effective_date: "2023-01-16"
 transposition_deadline: "2024-10-17"
 description: >
   Directive (EU) 2022/2555 on measures for a high common level of cybersecurity
-  across the Union. Expands the scope of NIS to cover additional sectors (including
-  digital infrastructure and online marketplaces) and introduces stronger security
-  requirements, incident reporting, and supply-chain risk management obligations.
+  across the Union.
 
-# Admission record (CONTRACT.md §6)
 admitted_at: "2026-06-01"
 admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass

--- a/tests/fixtures/notation-corpus/codex/internal/INTERNAL_STANDARD-coding-conventions-1.yaml
+++ b/tests/fixtures/notation-corpus/codex/internal/INTERNAL_STANDARD-coding-conventions-1.yaml
@@ -1,0 +1,13 @@
+# Worked example — internal codex artefact.
+
+zone: codex
+id: INTERNAL_STANDARD-coding-conventions-1
+name: "Engineering Coding Conventions"
+type: INTERNAL_STANDARD
+description: "Internal coding standards for in-house development."
+issuing_authority: "VP Engineering"
+effective_date: "2026-01-01"
+admitted_at: "2026-05-27"
+admitted_by: "vp.engineering"
+gate_checks:
+  source_authority: "VP Engineering"

--- a/tests/repo-validate-codex.test.ts
+++ b/tests/repo-validate-codex.test.ts
@@ -1,0 +1,113 @@
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { afterAll, beforeAll, describe, it, expect } from 'vitest';
+
+import {
+  runCodexValidate,
+  runRepoValidate,
+  repoScopeHasErrors,
+} from '../src/repo-validate.js';
+
+// Phase C2 (#518): `validate --scope=repo` sweeps codex/** with folder jurisdiction.
+
+const corpus = join(
+  dirname(fileURLToPath(import.meta.url)),
+  'fixtures',
+  'notation-corpus',
+);
+
+function write(root: string, rel: string, body: string): void {
+  const p = join(root, rel);
+  mkdirSync(dirname(p), { recursive: true });
+  writeFileSync(p, body, 'utf8');
+}
+
+function copyCorpus(root: string, rel: string, corpusRel: string): void {
+  write(root, rel, readFileSync(join(corpus, corpusRel), 'utf8'));
+}
+
+describe('repo-scope codex sweep (#518 C2)', () => {
+  let root: string;
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), 'tx-codex-'));
+    copyCorpus(root, 'codex/external/EU/LAW-GDPR-1.yaml', 'codex/external/EU/LAW-GDPR-1.yaml');
+    copyCorpus(
+      root,
+      'codex/internal/INTERNAL_STANDARD-coding-conventions-1.yaml',
+      'codex/internal/INTERNAL_STANDARD-coding-conventions-1.yaml',
+    );
+    write(
+      root,
+      'codex/external/EU/LAW-BAD-1.yaml',
+      [
+        'zone: codex',
+        'id: LAW-BAD-1',
+        'name: Bad jurisdiction',
+        'type: LAW',
+        'jurisdiction: ge',
+        'effective_date: "2020-01-01"',
+        'admitted_at: "2026-06-01"',
+        'admitted_by: test',
+        'gate_checks:',
+        '  uniqueness: pass',
+        '',
+      ].join('\n'),
+    );
+  });
+
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('flags CODEX-005 when jurisdiction disagrees with folder', () => {
+    const findings = runCodexValidate(root);
+    const bad = findings.filter((f) => f.file.endsWith('LAW-BAD-1.yaml'));
+    expect(bad.some((f) => f.ruleId === 'CODEX-005' && f.severity === 'error')).toBe(true);
+  });
+
+  it('leaves clean corpus codex files error-free', () => {
+    const findings = runCodexValidate(root);
+    const clean = findings.filter(
+      (f) =>
+        f.severity === 'error'
+        && (f.file.endsWith('LAW-GDPR-1.yaml')
+          || f.file.endsWith('INTERNAL_STANDARD-coding-conventions-1.yaml')),
+    );
+    expect(clean).toEqual([]);
+  });
+
+  it('runRepoValidate includes codex findings in error gate', () => {
+    const result = runRepoValidate(root);
+    expect(result.codex.some((c) => c.ruleId === 'CODEX-005')).toBe(true);
+    expect(repoScopeHasErrors(result)).toBe(true);
+  });
+});
+
+describe('repo-scope codex sweep — clean tree passes (#518 C2)', () => {
+  let root: string;
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), 'tx-codex-clean-'));
+    copyCorpus(root, 'codex/external/EU/LAW-GDPR-1.yaml', 'codex/external/EU/LAW-GDPR-1.yaml');
+    copyCorpus(root, 'codex/external/EU/LAW-NIS2-1.yaml', 'codex/external/EU/LAW-NIS2-1.yaml');
+    copyCorpus(
+      root,
+      'codex/internal/INTERNAL_STANDARD-coding-conventions-1.yaml',
+      'codex/internal/INTERNAL_STANDARD-coding-conventions-1.yaml',
+    );
+  });
+
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('clean codex tree passes with no codex errors', () => {
+    const result = runRepoValidate(root);
+    expect(result.codex.filter((c) => c.severity === 'error')).toEqual([]);
+    expect(repoScopeHasErrors(result)).toBe(false);
+  });
+});

--- a/tests/validate-notation.test.ts
+++ b/tests/validate-notation.test.ts
@@ -26,6 +26,7 @@ import { validateRequirement } from '../packages/diagrams/src/requirement/valida
 import { validateAssertion } from '../packages/diagrams/src/assertion/validate.js';
 import { parseImpactViewConfig } from '../packages/diagrams/src/compliance/impact.js';
 import { parseCoverageMetricConfig } from '../packages/diagrams/src/compliance/coverage-metric.js';
+import { validateCodex } from '../packages/diagrams/src/codex/validate.js';
 
 const corpusRoot = join(dirname(fileURLToPath(import.meta.url)), 'fixtures', 'notation-corpus');
 
@@ -49,8 +50,8 @@ const GROUP_B = [
   'process-map',
 ];
 
-// Group C — compliance suite wired in #518 Phase C1.
-const GROUP_C = ['requirement', 'assertion', 'compliance-impact', 'coverage-metric'];
+// Group C — compliance suite wired in #518 Phase C1–C2.
+const GROUP_C = ['requirement', 'assertion', 'compliance-impact', 'coverage-metric', 'codex'];
 
 const ALL_NOTATIONS = [...GROUP_A, ...GROUP_B, ...GROUP_C];
 
@@ -90,6 +91,11 @@ describe('validate-notation — canonical extension helpers (#343)', () => {
   it('inferNotationFromFilename recognises element filenames by typed-id prefix', () => {
     expect(inferNotationFromFilename('canon/elements/REQUIREMENT-DATA-ERASURE-1.yaml')).toBe('requirement');
     expect(inferNotationFromFilename('canon/elements/ASSERTION-CRM-DATA-ERASURE-1.yaml')).toBe('assertion');
+  });
+
+  it('inferNotationFromFilename recognises codex typed-id filenames', () => {
+    expect(inferNotationFromFilename('codex/external/eu/LAW-GDPR-1.yaml')).toBe('codex');
+    expect(inferNotationFromFilename('codex/internal/INTERNAL_STANDARD-coding-conventions-1.yaml')).toBe('codex');
   });
 
   it('inferNotationFromFilename returns undefined for non-canonical names', () => {
@@ -159,6 +165,31 @@ describe('validate-notation — element notation corpus validates clean (#518 C1
         expect(report.isValid).toBe(true);
       });
     }
+  }
+});
+
+describe('validate-notation — codex corpus validates clean (#518 C2)', () => {
+  function codexFixtures(): string[] {
+    const root = join(corpusRoot, 'codex');
+    const out: string[] = [];
+    for (const zone of ['external/EU', 'internal']) {
+      const dir = join(root, zone);
+      for (const f of readdirSync(dir).filter((x) => x.endsWith('.yaml'))) {
+        out.push(join(dir, f));
+      }
+    }
+    return out;
+  }
+
+  for (const file of codexFixtures()) {
+    const name = file.slice(corpusRoot.length + 1).replace(/\\/g, '/');
+    it(`${name} → valid`, () => {
+      const data = loadNotationYaml(readFileSync(file, 'utf8'));
+      const report = validateNotationDoc('codex', data, { filePath: name });
+      const errors = report.findings.filter((f) => f.severity === 'error');
+      expect(errors, JSON.stringify(errors, null, 2)).toEqual([]);
+      expect(report.isValid).toBe(true);
+    });
   }
 });
 
@@ -268,5 +299,16 @@ describe('validate-notation — parity with the preview validator (#258, #518 C1
     const report = validateNotationDoc('coverage-metric', broken);
     expect(report.isValid).toBe(false);
     expect(report.findings.filter((f) => f.severity === 'error').length).toBe(raw.errors.length);
+  });
+
+  it('codex: CLI findings mirror validateCodex with folder jurisdiction', () => {
+    const broken = { zone: 'codex', id: 'LAW-X-1', name: 'X', jurisdiction: 'ge' };
+    const raw = validateCodex(broken, { folderJurisdiction: 'eu' });
+    const report = validateNotationDoc('codex', broken, {
+      filePath: 'codex/external/eu/LAW-X-1.yaml',
+    });
+    expect(report.isValid).toBe(raw.valid);
+    expect(report.findings.filter((f) => f.severity === 'error').map((f) => f.ruleId))
+      .toEqual(raw.errors.map((e) => e.code));
   });
 });


### PR DESCRIPTION
## Summary
- Add `@transitrix/diagrams` codex validator (CODEX-001..005): shape/zone/id, type↔id prefix, external/internal frontmatter, folder jurisdiction under `codex/external/<jurisdiction>/`.
- Wire `codex` into file-scope `transitrix validate` (via `zone: codex` or typed-id filename) and repo-scope sweep over `codex/**`.
- Bump `@transitrix/diagrams` to **1.7.3**; corpus fixtures + unit/integration tests.

Phase **C2** of epic **#518** (follows merged #360 / C1).

## Test plan
- [x] `npm run test:diagrams` — codex validate + example tests green
- [x] `npm run test:core` — `validate-notation` + `repo-validate-codex` green (3 unrelated `cli-migrate` failures on local methodology 2.0.0)
- [x] `node dist/cli.js validate --scope=repo --root <acme-corp>` — codex sweep runs; surfaces existing `CODEX-002` on `LAW-GDPR-1` / `LAW-NIS2-1` (data fix separate)
