### PR TITLE
feat(validate): repo-scope compliance catalogue and cross-doc checks (#518 C3)

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -40,6 +40,27 @@ passes with zero findings):
 - **Policy** — an element marked `Active`/`Production` (`metadata.status`) with no `metadata.owner`.
 - **ArchiMate layer-semantics** — *deferred* (lint.py ships this as a no-op stub; ported faithfully as a no-op until the methodology defines the rules).
 
+### Compliance suite (`--scope=repo`, #518)
+
+Repo-scope validation also sweeps the compliance notation surface with the same
+validators the VS Code preview uses:
+
+| Path | File-scope | Repo-scope cross-document |
+|------|------------|---------------------------|
+| `canon/elements/**/REQUIREMENT-*.yaml` | `REQ-*` shape | `REQ-002`/`003` with scanned `CanonCatalog` |
+| `canon/assertions/ASSERTION-*.yaml` | `ASSERT-*` shape | `ASSERT-002`..`005` + `ASSERT-007`/`008` warnings |
+| `codex/**` | `CODEX-*` | folder jurisdiction (`CODEX-005`) |
+| `canon/views/**.compliance-impact.*` | `COMPIMP-001` parse | `COMPIMP-REF`, `COMPIMP-009`..`011`, `buildImpactMatrix` |
+| `canon/views/**.coverage-metric.*` | `COVMET-*` parse | `COVMET-REF`, `buildCoverageMatrix` |
+
+**Derived views** (no YAML config file) — `compliance-matrix`, `gap-dashboard`,
+`single-law`, `single-product`, `requirement-trace` — are built interactively in
+the preview / `export-compliance`; they are not separate file validators.
+
+File-scope `transitrix validate <requirement.yaml>` runs shape rules only unless
+you pass a catalogue (repo-scope builds one automatically from `canon/**` +
+`codex/**`).
+
 ```
 $ transitrix validate --scope=repo --root organizations/acme_corp
 ✓ organizations/acme_corp — repo-scope validation passed

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",

--- a/packages/diagrams/src/compliance/__tests__/canon-catalog.test.ts
+++ b/packages/diagrams/src/compliance/__tests__/canon-catalog.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  admitDocumentToCatalog,
+  buildComplianceScan,
+  catalogFromMap,
+} from '../canon-catalog.js';
+
+describe('buildComplianceScan', () => {
+  it('admits codex, requirement, and assertion ids into the catalogue', () => {
+    const docs = [
+      {
+        path: 'codex/external/ge/LAW-PERSONAL-DATA-2017-1.yaml',
+        data: {
+          zone: 'codex',
+          id: 'LAW-PERSONAL-DATA-2017-1',
+          name: 'Law',
+          type: 'LAW',
+        },
+      },
+      {
+        path: 'canon/elements/01_motivation/requirements/REQUIREMENT-DATA-ERASURE-1.yaml',
+        data: {
+          notation: 'requirement',
+          id: 'REQUIREMENT-DATA-ERASURE-1',
+          name: 'Erasure',
+          derived_from: ['LAW-PERSONAL-DATA-2017-1'],
+        },
+      },
+      {
+        path: 'canon/elements/02_business/products/PRODUCT-MOBILE-1.yaml',
+        data: { notation: 'product', id: 'PRODUCT-MOBILE-1', name: 'Mobile' },
+      },
+      {
+        path: 'canon/assertions/ASSERTION-MOBILE-DATA-ERASURE-1.yaml',
+        data: {
+          notation: 'assertion',
+          id: 'ASSERTION-MOBILE-DATA-ERASURE-1',
+          about: 'REQUIREMENT-DATA-ERASURE-1',
+          subject: 'PRODUCT-MOBILE-1',
+          status: 'compliant',
+        },
+      },
+    ];
+
+    const { catalog, complianceCanon, pathById } = buildComplianceScan(docs);
+    expect(catalog.typeOf('LAW-PERSONAL-DATA-2017-1')).toBe('LAW');
+    expect(catalog.typeOf('REQUIREMENT-DATA-ERASURE-1')).toBe('REQUIREMENT');
+    expect(catalog.typeOf('PRODUCT-MOBILE-1')).toBe('PRODUCT');
+    expect(complianceCanon.requirements).toHaveLength(1);
+    expect(complianceCanon.assertions).toHaveLength(1);
+    expect(complianceCanon.codex).toHaveLength(1);
+    expect(pathById.get('REQUIREMENT-DATA-ERASURE-1')).toContain('requirements/');
+  });
+});
+
+describe('admitDocumentToCatalog', () => {
+  it('uses explicit codex type when the id prefix is ambiguous', () => {
+    const map = new Map<string, string>();
+    admitDocumentToCatalog(map, {
+      zone: 'codex',
+      id: 'INTERNAL_STANDARD-coding-conventions-1',
+      type: 'INTERNAL_STANDARD',
+    });
+    const catalog = catalogFromMap(map);
+    expect(catalog.typeOf('INTERNAL_STANDARD-coding-conventions-1')).toBe('INTERNAL_STANDARD');
+  });
+});

--- a/packages/diagrams/src/compliance/__tests__/view-resolution.test.ts
+++ b/packages/diagrams/src/compliance/__tests__/view-resolution.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+
+import { emptyCanon } from '../classify.js';
+import { catalogFromMap } from '../canon-catalog.js';
+import { collectImpactViewResolutionFindings } from '../impact.js';
+import { collectCoverageViewResolutionFindings } from '../coverage-metric.js';
+import type { ImpactViewConfig } from '../impact.js';
+import type { CoverageMetricConfig } from '../coverage-metric.js';
+
+const catalog = catalogFromMap(
+  new Map([
+    ['PRODUCT-ECOMM-1', 'PRODUCT'],
+    ['REQUIREMENT-GDPR-1', 'REQUIREMENT'],
+    ['LAW-GDPR-1', 'LAW'],
+  ]),
+);
+
+const complianceCanon = emptyCanon();
+complianceCanon.products.push({ id: 'PRODUCT-ECOMM-1', name: 'E-Commerce' });
+complianceCanon.requirements.push({ id: 'REQUIREMENT-GDPR-1', name: 'GDPR req' });
+complianceCanon.codex.push({ id: 'LAW-GDPR-1', name: 'GDPR' });
+
+describe('collectImpactViewResolutionFindings', () => {
+  const base: ImpactViewConfig = {
+    id: 'test-impact',
+    name: 'Test',
+    subjects: { products: ['PRODUCT-ECOMM-1'], processes: [], capabilities: [] },
+    obligations: { filter: { derived_from_codex: ['LAW-GDPR-1'] } },
+    status_display: { show: ['compliant'] },
+    empty_cells: {},
+    order_rows_by: 'id',
+  };
+
+  it('passes when subjects and regimes resolve', () => {
+    expect(collectImpactViewResolutionFindings(base, catalog, complianceCanon)).toEqual([]);
+  });
+
+  it('flags unresolved subjects and regimes', () => {
+    const findings = collectImpactViewResolutionFindings(
+      {
+        ...base,
+        subjects: { products: ['PRODUCT-MISSING-1'], processes: [], capabilities: [] },
+        obligations: { include: ['REQUIREMENT-MISSING-1'], filter: { derived_from_codex: ['LAW-MISSING-1'] } },
+      },
+      catalog,
+      complianceCanon,
+    );
+    expect(findings.some((f) => f.code === 'COMPIMP-REF' && f.message.includes('PRODUCT-MISSING-1'))).toBe(true);
+    expect(findings.some((f) => f.message.includes('REQUIREMENT-MISSING-1'))).toBe(true);
+    expect(findings.some((f) => f.message.includes('LAW-MISSING-1'))).toBe(true);
+  });
+});
+
+describe('collectCoverageViewResolutionFindings', () => {
+  const base: CoverageMetricConfig = {
+    id: 'test-coverage',
+    name: 'Test',
+    thresholds: { green: 0.9, amber: 0.7 },
+    subjects: { products: ['PRODUCT-ECOMM-1'] },
+    regimes: { include: ['LAW-GDPR-1'] },
+  };
+
+  it('passes when products and regimes resolve', () => {
+    expect(collectCoverageViewResolutionFindings(base, catalog, complianceCanon)).toEqual([]);
+  });
+
+  it('flags unresolved product and regime refs', () => {
+    const findings = collectCoverageViewResolutionFindings(
+      {
+        ...base,
+        subjects: { products: ['PRODUCT-MISSING-1'] },
+        regimes: { include: ['LAW-MISSING-1'] },
+      },
+      catalog,
+      complianceCanon,
+    );
+    expect(findings.some((f) => f.code === 'COVMET-REF')).toBe(true);
+    expect(findings).toHaveLength(2);
+  });
+});

--- a/packages/diagrams/src/compliance/canon-catalog.ts
+++ b/packages/diagrams/src/compliance/canon-catalog.ts
@@ -1,0 +1,76 @@
+// CanonCatalog builder — repo-scope cross-reference resolution (#518 Phase C3).
+//
+// Scans admitted YAML documents and builds the `{ typeOf }` catalogue that
+// `validateRequirement` / `validateAssertion` accept for REQ-002 and
+// ASSERT-002..005 resolution.
+
+import { typeOfId, type CanonCatalog } from '../typed-id.js';
+import { emptyCanon, ingestComplianceDoc, type ComplianceCanon } from './classify.js';
+
+export interface ScannedYamlDoc {
+  path: string;
+  data: unknown;
+}
+
+export interface ComplianceScanResult {
+  complianceCanon: ComplianceCanon;
+  catalog: CanonCatalog;
+  /** First path where each admitted id was seen (for gap-dashboard warnings). */
+  pathById: Map<string, string>;
+}
+
+function strId(doc: unknown): string | undefined {
+  if (doc === null || typeof doc !== 'object' || Array.isArray(doc)) return undefined;
+  const id = (doc as Record<string, unknown>).id;
+  return typeof id === 'string' && id.trim() !== '' ? id.trim() : undefined;
+}
+
+/** Admit one parsed document into the id → TYPE map. */
+export function admitDocumentToCatalog(map: Map<string, string>, doc: unknown): string | undefined {
+  const id = strId(doc);
+  if (!id) return undefined;
+
+  const fromPrefix = typeOfId(id);
+  if (fromPrefix) {
+    map.set(id, fromPrefix);
+    return id;
+  }
+
+  if (doc !== null && typeof doc === 'object' && !Array.isArray(doc)) {
+    const d = doc as Record<string, unknown>;
+    if (d.zone === 'codex') {
+      const explicit = typeof d.type === 'string' ? d.type.trim().toUpperCase() : undefined;
+      if (explicit) {
+        map.set(id, explicit);
+        return id;
+      }
+    }
+  }
+  return undefined;
+}
+
+/** Build a read-only `CanonCatalog` from a populated id → TYPE map. */
+export function catalogFromMap(map: Map<string, string>): CanonCatalog {
+  return { typeOf: (id: string) => map.get(id) };
+}
+
+/** Ingest compliance projections and admit cross-reference targets from a batch
+ *  of already-parsed YAML documents (no IO). */
+export function buildComplianceScan(docs: ScannedYamlDoc[]): ComplianceScanResult {
+  const complianceCanon = emptyCanon();
+  const catalogMap = new Map<string, string>();
+  const pathById = new Map<string, string>();
+
+  for (const { path, data } of docs) {
+    const ingested = ingestComplianceDoc(complianceCanon, data);
+    if (ingested) pathById.set(ingested, path);
+    const admitted = admitDocumentToCatalog(catalogMap, data);
+    if (admitted && !pathById.has(admitted)) pathById.set(admitted, path);
+  }
+
+  return {
+    complianceCanon,
+    catalog: catalogFromMap(catalogMap),
+    pathById,
+  };
+}

--- a/packages/diagrams/src/compliance/coverage-metric.ts
+++ b/packages/diagrams/src/compliance/coverage-metric.ts
@@ -8,6 +8,7 @@
 import type { AssertionStatus } from '../assertion/types.js';
 import type { ComplianceCanon } from './classify.js';
 import { buildComplianceIndex } from './reverse-index.js';
+import type { CanonCatalog } from '../typed-id.js';
 import type { IndexAssertion } from './types.js';
 
 // ── Config types ─────────────────────────────────────────────────────────────
@@ -91,6 +92,55 @@ export interface CoverageMatrix {
   version?: string;
   rows: CoverageRow[];
   thresholds: CoverageMetricThresholds;
+}
+
+/** Repo-scope cross-reference finding for a coverage-metric view (#518 C3). */
+export interface CoverageViewFinding {
+  code: string;
+  severity: 'error' | 'warning';
+  message: string;
+}
+
+/**
+ * Repo-scope cross-reference checks for a parsed coverage-metric view config.
+ * Surfaces unresolved product and regime ids before `buildCoverageMatrix` runs.
+ */
+export function collectCoverageViewResolutionFindings(
+  config: CoverageMetricConfig,
+  catalog: CanonCatalog,
+  complianceCanon: ComplianceCanon,
+): CoverageViewFinding[] {
+  const findings: CoverageViewFinding[] = [];
+  const codexIds = new Set(complianceCanon.codex.map((c) => c.id));
+
+  for (const id of config.subjects?.products ?? []) {
+    const t = catalog.typeOf(id);
+    if (t === undefined) {
+      findings.push({
+        code: 'COVMET-REF',
+        severity: 'error',
+        message: `subjects.products: "${id}" does not resolve to an admitted artefact.`,
+      });
+    } else if (t !== 'PRODUCT') {
+      findings.push({
+        code: 'COVMET-REF',
+        severity: 'error',
+        message: `subjects.products: "${id}" resolves to ${t}, not PRODUCT.`,
+      });
+    }
+  }
+
+  for (const id of config.regimes?.include ?? []) {
+    if (!codexIds.has(id)) {
+      findings.push({
+        code: 'COVMET-REF',
+        severity: 'error',
+        message: `regimes.include: "${id}" does not resolve to an admitted codex artefact.`,
+      });
+    }
+  }
+
+  return findings;
 }
 
 // ── Parser ───────────────────────────────────────────────────────────────────

--- a/packages/diagrams/src/compliance/impact.ts
+++ b/packages/diagrams/src/compliance/impact.ts
@@ -10,6 +10,7 @@
 import type { AssertionStatus } from '../assertion/types.js';
 import type { ComplianceCanon } from './classify.js';
 import { buildComplianceIndex } from './reverse-index.js';
+import type { CanonCatalog } from '../typed-id.js';
 import type { ComplianceIndex, IndexAssertion, IndexRequirement, ObjectDetailInput, ObjectDetailDef, DeadlineStatus } from './types.js';
 
 /** Filter selecting REQUIREMENTs by codex source (jurisdiction / regime keys
@@ -75,11 +76,76 @@ export interface ImpactColumn {
   subjectType: 'product' | 'process' | 'capability';
 }
 
-/** A structural validation finding emitted by the matrix builder. */
 export interface ImpactFinding {
   code: string;
   severity: 'error' | 'warning';
   message: string;
+}
+
+/**
+ * Repo-scope cross-reference checks for a parsed compliance-impact view config
+ * (#518 Phase C3). Surfaces unresolved subject, obligation, and regime ids before
+ * `buildImpactMatrix` runs.
+ */
+export function collectImpactViewResolutionFindings(
+  config: ImpactViewConfig,
+  catalog: CanonCatalog,
+  complianceCanon: ComplianceCanon,
+): ImpactFinding[] {
+  const findings: ImpactFinding[] = [];
+  const codexIds = new Set(complianceCanon.codex.map((c) => c.id));
+
+  const subjectChecks: Array<{
+    ids: string[] | undefined;
+    expectedType: string;
+    path: string;
+  }> = [
+    { ids: config.subjects.products, expectedType: 'PRODUCT', path: 'subjects.products' },
+    { ids: config.subjects.processes, expectedType: 'PROCESS', path: 'subjects.processes' },
+    { ids: config.subjects.capabilities, expectedType: 'CAPABILITY', path: 'subjects.capabilities' },
+  ];
+
+  for (const { ids, expectedType, path } of subjectChecks) {
+    for (const id of ids ?? []) {
+      const t = catalog.typeOf(id);
+      if (t === undefined) {
+        findings.push({
+          code: 'COMPIMP-REF',
+          severity: 'error',
+          message: `${path}: "${id}" does not resolve to an admitted artefact.`,
+        });
+      } else if (t !== expectedType) {
+        findings.push({
+          code: 'COMPIMP-REF',
+          severity: 'error',
+          message: `${path}: "${id}" resolves to ${t}, not ${expectedType}.`,
+        });
+      }
+    }
+  }
+
+  for (const id of config.obligations.include ?? []) {
+    const t = catalog.typeOf(id);
+    if (t === undefined || t !== 'REQUIREMENT') {
+      findings.push({
+        code: 'COMPIMP-REF',
+        severity: 'error',
+        message: `obligations.include: "${id}" does not resolve to an admitted REQUIREMENT.`,
+      });
+    }
+  }
+
+  for (const id of config.obligations.filter?.derived_from_codex ?? []) {
+    if (!codexIds.has(id)) {
+      findings.push({
+        code: 'COMPIMP-REF',
+        severity: 'error',
+        message: `obligations.filter.derived_from_codex: "${id}" does not resolve to an admitted codex artefact.`,
+      });
+    }
+  }
+
+  return findings;
 }
 
 /**

--- a/packages/diagrams/src/compliance/index.ts
+++ b/packages/diagrams/src/compliance/index.ts
@@ -5,15 +5,22 @@ export { buildGapReport } from './gap-report.js';
 export type { GapReport, GapReportOptions } from './gap-report.js';
 export { emptyCanon, ingestComplianceDoc } from './classify.js';
 export type { ComplianceCanon, ComplianceProduct, ComplianceCodexDoc } from './classify.js';
+export {
+  admitDocumentToCatalog,
+  buildComplianceScan,
+  catalogFromMap,
+} from './canon-catalog.js';
+export type { ComplianceScanResult, ScannedYamlDoc } from './canon-catalog.js';
 export { renderComplianceMarkdown } from './markdown.js';
 export type { ReportScope, MarkdownOptions } from './markdown.js';
 export { renderComplianceHtml, renderImpactMatrixHtml } from './html.js';
 export type { HtmlOptions, ImpactMatrixHtmlOptions } from './html.js';
-export { buildImpactMatrix, renderImpactMarkdown, parseImpactViewConfig, COMPLIANCE_IMPACT_DEFAULTS, extractObjectDetails, extractProcessFlowTasks, mergeStageTaskDetails, computeDeadlineStatus } from './impact.js';
+export { buildImpactMatrix, renderImpactMarkdown, parseImpactViewConfig, collectImpactViewResolutionFindings, COMPLIANCE_IMPACT_DEFAULTS, extractObjectDetails, extractProcessFlowTasks, mergeStageTaskDetails, computeDeadlineStatus } from './impact.js';
 export type {
   ImpactCell,
   ImpactColumn,
   ImpactEmptyCellLabels,
+  ImpactFinding,
   ImpactGrouping,
   ImpactMatrix,
   ImpactObligationFilter,
@@ -31,6 +38,7 @@ export {
 export {
   parseCoverageMetricConfig,
   buildCoverageMatrix,
+  collectCoverageViewResolutionFindings,
 } from './coverage-metric.js';
 export type {
   CoverageMetricConfig,
@@ -40,6 +48,7 @@ export type {
   CoverageMetricThresholds,
   CoverageMatrix,
   CoverageRow,
+  CoverageViewFinding,
   ParseCoverageMetricResult,
   RagStatus,
 } from './coverage-metric.js';

--- a/src/repo-validate.ts
+++ b/src/repo-validate.ts
@@ -20,6 +20,19 @@ import {
   type RepoModelInput,
 } from '@transitrix/diagrams/repo-validate';
 import {
+  buildComplianceScan,
+  buildComplianceIndex,
+  buildGapReport,
+  buildImpactMatrix,
+  buildCoverageMatrix,
+  collectImpactViewResolutionFindings,
+  collectCoverageViewResolutionFindings,
+  parseImpactViewConfig,
+  parseCoverageMetricConfig,
+  type ComplianceScanResult,
+  type ScannedYamlDoc,
+} from '@transitrix/diagrams/compliance';
+import {
   validateNotationDoc,
   isFileValidatableNotation,
   notationOf,
@@ -113,7 +126,51 @@ export interface RepoScopeResult {
   views: ViewFinding[];
   /** Per-file codex artefact findings from `codex/**` (#518 Phase C2). */
   codex: ViewFinding[];
+  /** REQUIREMENT / ASSERTION element files validated with the repo catalogue (#518 C3). */
+  compliance: ViewFinding[];
   skipped: Array<{ file: string; notation: string }>;
+}
+
+export interface RepoValidateContext {
+  catalog: ComplianceScanResult['catalog'];
+  complianceCanon: ComplianceScanResult['complianceCanon'];
+  pathById: ComplianceScanResult['pathById'];
+}
+
+/** Collect parsed YAML under `<root>/canon/**` and `<root>/codex/**` for the
+ *  compliance catalogue (#518 Phase C3). */
+export function loadComplianceYamlDocs(root: string): ScannedYamlDoc[] {
+  const docs: ScannedYamlDoc[] = [];
+  for (const zone of ['canon', 'codex'] as const) {
+    let entries: string[] = [];
+    try {
+      entries = readdirSync(path.join(root, zone), { recursive: true }) as string[];
+    } catch {
+      continue;
+    }
+    for (const rel of entries) {
+      if (typeof rel !== 'string' || !isYaml(rel) || shouldSkip(rel)) continue;
+      const fullRel = path.join(zone, rel).replace(/\\/g, '/');
+      try {
+        const text = readFileSync(path.join(root, fullRel), 'utf-8');
+        docs.push({ path: fullRel, data: loadNotationYaml(text) });
+      } catch {
+        // YAML syntax errors are surfaced by the per-file validators.
+        continue;
+      }
+    }
+  }
+  return docs;
+}
+
+/** Build the compliance projection + `CanonCatalog` from a repo root. */
+export function buildRepoValidateContext(root: string): RepoValidateContext {
+  const scan = buildComplianceScan(loadComplianceYamlDocs(root));
+  return {
+    catalog: scan.catalog,
+    complianceCanon: scan.complianceCanon,
+    pathById: scan.pathById,
+  };
 }
 
 /** Collect the raw text of every YAML doc under `<root>/canon/views/**`. */
@@ -142,7 +199,10 @@ function loadViewDocs(root: string): Array<{ path: string; text: string }> {
 /** Validate every Group A notation file under canon/views/** with the same
  *  per-notation validator the VS Code preview uses, so a repo-scope run surfaces
  *  the per-file errors an adopter would otherwise read off each preview. */
-export function runViewValidate(root: string): {
+export function runViewValidate(
+  root: string,
+  ctx?: RepoValidateContext,
+): {
   findings: ViewFinding[];
   skipped: Array<{ file: string; notation: string }>;
 } {
@@ -196,7 +256,73 @@ export function runViewValidate(root: string): {
       skipped.push({ file: doc.path, notation });
       continue;
     }
-    for (const f of validateNotationDoc(notation, data).findings) {
+
+    const validateOpts = { catalog: ctx?.catalog };
+
+    if (notation === 'compliance-impact' && ctx) {
+      for (const f of validateNotationDoc(notation, data, validateOpts).findings) {
+        if (f.severity === 'info') continue;
+        findings.push({
+          file: doc.path,
+          notation,
+          ruleId: f.ruleId,
+          severity: f.severity,
+          message: f.message,
+        });
+      }
+      const parsed = parseImpactViewConfig(data);
+      if (parsed.ok) {
+        for (const f of collectImpactViewResolutionFindings(parsed.config, ctx.catalog, ctx.complianceCanon)) {
+          findings.push({
+            file: doc.path,
+            notation,
+            ruleId: f.code,
+            severity: f.severity,
+            message: f.message,
+          });
+        }
+        const matrix = buildImpactMatrix(ctx.complianceCanon, parsed.config);
+        for (const f of matrix.findings) {
+          findings.push({
+            file: doc.path,
+            notation,
+            ruleId: f.code,
+            severity: f.severity,
+            message: f.message,
+          });
+        }
+      }
+      continue;
+    }
+
+    if (notation === 'coverage-metric' && ctx) {
+      for (const f of validateNotationDoc(notation, data, validateOpts).findings) {
+        if (f.severity === 'info') continue;
+        findings.push({
+          file: doc.path,
+          notation,
+          ruleId: f.ruleId,
+          severity: f.severity,
+          message: f.message,
+        });
+      }
+      const parsed = parseCoverageMetricConfig(data);
+      if (parsed.ok) {
+        for (const f of collectCoverageViewResolutionFindings(parsed.config, ctx.catalog, ctx.complianceCanon)) {
+          findings.push({
+            file: doc.path,
+            notation,
+            ruleId: f.code,
+            severity: f.severity,
+            message: f.message,
+          });
+        }
+        buildCoverageMatrix(ctx.complianceCanon, parsed.config);
+      }
+      continue;
+    }
+
+    for (const f of validateNotationDoc(notation, data, validateOpts).findings) {
       if (f.severity === 'info') continue;
       findings.push({
         file: doc.path,
@@ -266,13 +392,139 @@ export function runCodexValidate(root: string): ViewFinding[] {
   return findings;
 }
 
+/** Validate REQUIREMENT elements under `canon/elements/**` and ASSERTION files
+ *  under `canon/assertions/**` with the repo catalogue (#518 Phase C3). */
+export function runComplianceValidate(root: string, ctx: RepoValidateContext): ViewFinding[] {
+  const findings: ViewFinding[] = [];
+  const validateOpts = { catalog: ctx.catalog };
+
+  let elementEntries: string[] = [];
+  try {
+    elementEntries = readdirSync(path.join(root, 'canon', 'elements'), { recursive: true }) as string[];
+  } catch {
+    elementEntries = [];
+  }
+  for (const rel of elementEntries) {
+    if (typeof rel !== 'string' || !isYaml(rel) || shouldSkip(rel)) continue;
+    const fullRel = path.join('canon', 'elements', rel).replace(/\\/g, '/');
+    let data: unknown;
+    try {
+      data = loadNotationYaml(readFileSync(path.join(root, fullRel), 'utf-8'));
+    } catch (e) {
+      findings.push({
+        file: fullRel,
+        notation: '',
+        ruleId: 'YAML',
+        severity: 'error',
+        message: (e as Error).message,
+      });
+      continue;
+    }
+    const notation = notationOf(data);
+    if (notation !== 'requirement') continue;
+    for (const f of validateNotationDoc('requirement', data, validateOpts).findings) {
+      if (f.severity === 'info') continue;
+      findings.push({
+        file: fullRel,
+        notation: 'requirement',
+        ruleId: f.ruleId,
+        severity: f.severity,
+        message: f.message,
+      });
+    }
+  }
+
+  let assertionEntries: string[] = [];
+  try {
+    assertionEntries = readdirSync(path.join(root, 'canon', 'assertions'), { recursive: true }) as string[];
+  } catch {
+    assertionEntries = [];
+  }
+  for (const rel of assertionEntries) {
+    if (typeof rel !== 'string' || !isYaml(rel) || shouldSkip(rel)) continue;
+    const fullRel = path.join('canon', 'assertions', rel).replace(/\\/g, '/');
+    let data: unknown;
+    try {
+      data = loadNotationYaml(readFileSync(path.join(root, fullRel), 'utf-8'));
+    } catch (e) {
+      findings.push({
+        file: fullRel,
+        notation: '',
+        ruleId: 'YAML',
+        severity: 'error',
+        message: (e as Error).message,
+      });
+      continue;
+    }
+    const notation = notationOf(data);
+    if (notation !== 'assertion') continue;
+    for (const f of validateNotationDoc('assertion', data, validateOpts).findings) {
+      if (f.severity === 'info') continue;
+      findings.push({
+        file: fullRel,
+        notation: 'assertion',
+        ruleId: f.ruleId,
+        severity: f.severity,
+        message: f.message,
+      });
+    }
+  }
+
+  return findings;
+}
+
+/** Optional repo-scope gap-dashboard aggregates as warnings (#518 C3). */
+export function runGapDashboardWarnings(ctx: RepoValidateContext): ViewFinding[] {
+  const findings: ViewFinding[] = [];
+  const index = buildComplianceIndex({
+    requirements: ctx.complianceCanon.requirements,
+    assertions: ctx.complianceCanon.assertions,
+  });
+  const report = buildGapReport(index, { today: new Date().toISOString().slice(0, 10) });
+
+  for (const req of report.requirementsWithoutAssertions) {
+    findings.push({
+      file: ctx.pathById.get(req.id) ?? req.id,
+      notation: 'requirement',
+      ruleId: 'GAP-REQ-NO-ASSERT',
+      severity: 'warning',
+      message: `Requirement "${req.id}" has no assertion targeting it.`,
+    });
+  }
+  for (const a of report.assertionsWithoutEvidence) {
+    findings.push({
+      file: ctx.pathById.get(a.id) ?? a.id,
+      notation: 'assertion',
+      ruleId: 'ASSERT-007',
+      severity: 'warning',
+      message: `Assertion "${a.id}" has status ${a.status} but no evidence.`,
+    });
+  }
+  for (const a of report.staleAssertions) {
+    findings.push({
+      file: ctx.pathById.get(a.id) ?? a.id,
+      notation: 'assertion',
+      ruleId: 'ASSERT-008',
+      severity: 'warning',
+      message: `Assertion "${a.id}" next_review_at (${a.next_review_at}) is in the past.`,
+    });
+  }
+
+  return findings;
+}
+
 /** Load the canon model under `root` and run the repo-scope checks: canon
  *  cross-references plus per-file notation sweep over canon/views/** and codex/**. */
 export function runRepoValidate(root: string): RepoScopeResult {
+  const ctx = buildRepoValidateContext(root);
   const canon = validateRepoModel(loadRepoModel(root));
-  const { findings: views, skipped } = runViewValidate(root);
+  const { findings: views, skipped } = runViewValidate(root, ctx);
   const codex = runCodexValidate(root);
-  return { canon, views, codex, skipped };
+  const compliance = [
+    ...runComplianceValidate(root, ctx),
+    ...runGapDashboardWarnings(ctx),
+  ];
+  return { canon, views, codex, compliance, skipped };
 }
 
 /** True when the run has a blocking finding — a canon finding or a view error.
@@ -282,18 +534,25 @@ export function repoScopeHasErrors(result: RepoScopeResult): boolean {
     result.canon.length > 0
     || result.views.some((v) => v.severity === 'error')
     || result.codex.some((c) => c.severity === 'error')
+    || result.compliance.some((c) => c.severity === 'error')
   );
 }
 
 /** Print the repo-scope result (human or JSON). Returns nothing; the caller sets
  *  the exit code via repoScopeHasErrors(). */
 export function reportRepoFindings(root: string, result: RepoScopeResult, useJson: boolean): void {
-  const { canon, views, codex, skipped } = result;
+  const { canon, views, codex, compliance, skipped } = result;
   const viewErrors = views.filter((v) => v.severity === 'error');
   const viewWarnings = views.filter((v) => v.severity === 'warning');
   const codexErrors = codex.filter((c) => c.severity === 'error');
   const codexWarnings = codex.filter((c) => c.severity === 'warning');
-  const valid = canon.length === 0 && viewErrors.length === 0 && codexErrors.length === 0;
+  const complianceErrors = compliance.filter((c) => c.severity === 'error');
+  const complianceWarnings = compliance.filter((c) => c.severity === 'warning');
+  const valid =
+    canon.length === 0
+    && viewErrors.length === 0
+    && codexErrors.length === 0
+    && complianceErrors.length === 0;
 
   if (useJson) {
     console.log(
@@ -305,6 +564,7 @@ export function reportRepoFindings(root: string, result: RepoScopeResult, useJso
           findings: canon,
           views: { valid: viewErrors.length === 0, findings: views },
           codex: { valid: codexErrors.length === 0, findings: codex },
+          compliance: { valid: complianceErrors.length === 0, findings: compliance },
           skipped,
         },
         null,
@@ -363,6 +623,21 @@ export function reportRepoFindings(root: string, result: RepoScopeResult, useJso
     console.log();
   }
 
+  if (compliance.length > 0) {
+    console.log('Compliance (requirements / assertions):');
+    let currentFile = '';
+    for (const c of compliance) {
+      if (c.file !== currentFile) {
+        console.log(`  ${c.file} [${c.notation || 'yaml'}]`);
+        currentFile = c.file;
+      }
+      const mark =
+        c.severity === 'error' ? `\x1b[31m✗ ${c.ruleId}\x1b[0m` : `\x1b[33m⚠ ${c.ruleId}\x1b[0m`;
+      console.log(`    ${mark} ${c.message}`);
+    }
+    console.log();
+  }
+
   if (skipped.length > 0) {
     console.log(
       `Skipped — notation not yet validated by the CLI (check in the preview): ${skipped.length} file${skipped.length === 1 ? '' : 's'}`,
@@ -391,6 +666,16 @@ export function reportRepoFindings(root: string, result: RepoScopeResult, useJso
   if (codexWarnings.length > 0) {
     parts.push(
       `\x1b[33m${codexWarnings.length}\x1b[0m codex warning${codexWarnings.length === 1 ? '' : 's'}`,
+    );
+  }
+  if (complianceErrors.length > 0) {
+    parts.push(
+      `\x1b[31m${complianceErrors.length}\x1b[0m compliance error${complianceErrors.length === 1 ? '' : 's'}`,
+    );
+  }
+  if (complianceWarnings.length > 0) {
+    parts.push(
+      `\x1b[33m${complianceWarnings.length}\x1b[0m compliance warning${complianceWarnings.length === 1 ? '' : 's'}`,
     );
   }
   if (parts.length > 0) {

--- a/src/validate-notation.ts
+++ b/src/validate-notation.ts
@@ -49,7 +49,7 @@ import {
   folderJurisdictionFromPath,
 } from '@transitrix/diagrams/codex/validate.js';
 import { CODEX_ARTEFACT_TYPES } from '@transitrix/diagrams/codex/types.js';
-import { typeOfId } from '@transitrix/diagrams/typed-id.js';
+import { typeOfId, type CanonCatalog } from '@transitrix/diagrams/typed-id.js';
 
 /** The shape every notation validator returns: code/message findings split into
  *  blocking errors and advisory warnings. The concrete result types carry extra
@@ -60,7 +60,11 @@ interface NotationValidationResult {
   warnings: Array<{ code: string; message: string }>;
 }
 
-type NotationValidator = (input: unknown) => NotationValidationResult;
+type NotationValidator = (input: unknown, options?: ValidateNotationOptions) => NotationValidationResult;
+
+function wrapValidator(fn: (input: unknown) => NotationValidationResult): NotationValidator {
+  return (input, _options = {}) => fn(input);
+}
 
 function mapPackageResult(result: {
   valid: boolean;
@@ -74,14 +78,13 @@ function mapPackageResult(result: {
   };
 }
 
-function validateRequirementDoc(input: unknown): NotationValidationResult {
-  // Structural / TYPE rules only — REQ-002 catalog resolution is Phase C3 (#518).
-  return mapPackageResult(validateRequirement(input));
+function validateRequirementDoc(input: unknown, options: ValidateNotationOptions = {}): NotationValidationResult {
+  return mapPackageResult(validateRequirement(input, { catalog: options.catalog }));
 }
 
-function validateAssertionDoc(input: unknown): NotationValidationResult {
+function validateAssertionDoc(input: unknown, options: ValidateNotationOptions = {}): NotationValidationResult {
   const today = new Date().toISOString().slice(0, 10);
-  return mapPackageResult(validateAssertion(input, { today }));
+  return mapPackageResult(validateAssertion(input, { catalog: options.catalog, today }));
 }
 
 function validateComplianceImpactDoc(input: unknown): NotationValidationResult {
@@ -115,7 +118,7 @@ function validateCoverageMetricDoc(input: unknown): NotationValidationResult {
   return { valid: true, errors: [], warnings };
 }
 
-function validateCodexDoc(input: unknown): NotationValidationResult {
+function validateCodexDoc(input: unknown, _options: ValidateNotationOptions = {}): NotationValidationResult {
   return mapPackageResult(validateCodex(input));
 }
 
@@ -123,24 +126,24 @@ function validateCodexDoc(input: unknown): NotationValidationResult {
 // tests/fixtures/notation-corpus/<notation>/.
 const VALIDATORS: Record<string, NotationValidator> = {
   // Group A — validator lives in the shared package and is the one the preview calls.
-  goals: parseCanonicalGoals,
-  dgca: parseCanonicalFGCA,
-  dga: parseCanonicalFGA,
-  action: validateActivities,
-  'action-card': validateActivityCard,
-  'process-blueprint': validateProcessBlueprint,
-  blocks: validateNestedBlocks,
+  goals: wrapValidator(parseCanonicalGoals),
+  dgca: wrapValidator(parseCanonicalFGCA),
+  dga: wrapValidator(parseCanonicalFGA),
+  action: wrapValidator(validateActivities),
+  'action-card': wrapValidator(validateActivityCard),
+  'process-blueprint': wrapValidator(validateProcessBlueprint),
+  blocks: wrapValidator(validateNestedBlocks),
   // Group B — deduped from inline preview copies in Phase B; package is now canonical.
-  applications: validateApplicationsCatalogue,
-  'capability-map': validateCapabilityMap,
-  products: validateProductsCatalogue,
-  scenarios: validateScenario,
-  'process-map': validateProcessMap,
-  // Group C — compliance suite (#518 Phase C1).
+  applications: wrapValidator(validateApplicationsCatalogue),
+  'capability-map': wrapValidator(validateCapabilityMap),
+  products: wrapValidator(validateProductsCatalogue),
+  scenarios: wrapValidator(validateScenario),
+  'process-map': wrapValidator(validateProcessMap),
+  // Group C — compliance suite (#518 Phase C1–C3).
   requirement: validateRequirementDoc,
   assertion: validateAssertionDoc,
-  'compliance-impact': validateComplianceImpactDoc,
-  'coverage-metric': validateCoverageMetricDoc,
+  'compliance-impact': wrapValidator(validateComplianceImpactDoc),
+  'coverage-metric': wrapValidator(validateCoverageMetricDoc),
   // Group C — codex zone (#518 Phase C2); `zone: codex`, not a notation: tag.
   codex: validateCodexDoc,
 };
@@ -216,6 +219,8 @@ export function resolveValidatorKey(data: unknown): string | undefined {
 export interface ValidateNotationOptions {
   /** Repo-relative or absolute path — used for codex folder-jurisdiction checks. */
   filePath?: string;
+  /** Admitted canon catalogue — enables REQ-002 and ASSERT-002..005 (#518 C3). */
+  catalog?: CanonCatalog;
 }
 
 /** Parse + date-coerce a YAML string exactly as the previews do, so validator
@@ -242,7 +247,7 @@ export function validateNotationDoc(
               : undefined,
           }),
         )
-      : VALIDATORS[notation](data);
+      : VALIDATORS[notation](data, options);
   const findings: ValidationFinding[] = [
     ...result.errors.map(
       (e): ValidationFinding => ({ ruleId: e.code, severity: 'error', message: e.message }),

--- a/tests/fixtures/notation-corpus/codex/external/ge/LAW-PERSONAL-DATA-2017-1.yaml
+++ b/tests/fixtures/notation-corpus/codex/external/ge/LAW-PERSONAL-DATA-2017-1.yaml
@@ -1,0 +1,18 @@
+# Fixture — Georgian personal-data law for REQ-002 corpus tests (#518 C3).
+
+zone: codex
+id: LAW-PERSONAL-DATA-2017-1
+name: "Law on Personal Data Protection"
+type: LAW
+jurisdiction: ge
+authority: "Parliament of Georgia"
+effective_date: "2017-05-01"
+description: >
+  Georgian law on the protection of personal data.
+
+admitted_at: "2026-06-01"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass

--- a/tests/fixtures/notation-corpus/compliance-c3/CAPABILITY-V2.yaml
+++ b/tests/fixtures/notation-corpus/compliance-c3/CAPABILITY-V2.yaml
@@ -1,0 +1,14 @@
+notation: capability
+id: CAPABILITY-V2
+name: "Customer Relationship Management"
+description: "CRM capability referenced by assertion fixtures."
+
+zone: canon
+admitted_at: "2026-05-28"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+valid_from: "2026-01-01"
+valid_to: null

--- a/tests/fixtures/notation-corpus/compliance-c3/PROCESS-USER-DATA-PURGE-1.yaml
+++ b/tests/fixtures/notation-corpus/compliance-c3/PROCESS-USER-DATA-PURGE-1.yaml
@@ -1,0 +1,14 @@
+notation: process
+id: PROCESS-USER-DATA-PURGE-1
+name: "User data purge workflow"
+description: "Operational purge workflow referenced by assertion fixtures."
+
+zone: canon
+admitted_at: "2026-05-28"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+valid_from: "2026-01-01"
+valid_to: null

--- a/tests/fixtures/notation-corpus/compliance-c3/PRODUCT-MOBILE-1.yaml
+++ b/tests/fixtures/notation-corpus/compliance-c3/PRODUCT-MOBILE-1.yaml
@@ -1,0 +1,14 @@
+notation: product
+id: PRODUCT-MOBILE-1
+name: "Acme Mobile"
+description: "Mobile product line for compliance C3 fixtures."
+
+zone: canon
+admitted_at: "2026-05-28"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+valid_from: "2026-01-01"
+valid_to: null

--- a/tests/repo-validate-codex.test.ts
+++ b/tests/repo-validate-codex.test.ts
@@ -83,6 +83,7 @@ describe('repo-scope codex sweep (#518 C2)', () => {
   it('runRepoValidate includes codex findings in error gate', () => {
     const result = runRepoValidate(root);
     expect(result.codex.some((c) => c.ruleId === 'CODEX-005')).toBe(true);
+    expect(result.compliance).toEqual([]);
     expect(repoScopeHasErrors(result)).toBe(true);
   });
 });
@@ -108,6 +109,7 @@ describe('repo-scope codex sweep — clean tree passes (#518 C2)', () => {
   it('clean codex tree passes with no codex errors', () => {
     const result = runRepoValidate(root);
     expect(result.codex.filter((c) => c.severity === 'error')).toEqual([]);
+    expect(result.compliance.filter((c) => c.severity === 'error')).toEqual([]);
     expect(repoScopeHasErrors(result)).toBe(false);
   });
 });

--- a/tests/repo-validate-compliance.test.ts
+++ b/tests/repo-validate-compliance.test.ts
@@ -1,0 +1,168 @@
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { afterAll, beforeAll, describe, it, expect } from 'vitest';
+
+import {
+  runComplianceValidate,
+  runRepoValidate,
+  repoScopeHasErrors,
+  buildRepoValidateContext,
+} from '../src/repo-validate.js';
+
+const corpus = join(
+  dirname(fileURLToPath(import.meta.url)),
+  'fixtures',
+  'notation-corpus',
+);
+
+function write(root: string, rel: string, body: string): void {
+  const p = join(root, rel);
+  mkdirSync(dirname(p), { recursive: true });
+  writeFileSync(p, body, 'utf8');
+}
+
+function copyCorpus(root: string, rel: string, corpusRel: string): void {
+  write(root, rel, readFileSync(join(corpus, corpusRel), 'utf8'));
+}
+
+describe('repo-scope compliance catalogue (#518 C3)', () => {
+  let root: string;
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), 'tx-compliance-'));
+    copyCorpus(root, 'codex/external/ge/LAW-PERSONAL-DATA-2017-1.yaml', 'codex/external/ge/LAW-PERSONAL-DATA-2017-1.yaml');
+    copyCorpus(
+      root,
+      'canon/elements/01_motivation/requirements/REQUIREMENT-DATA-ERASURE-1.yaml',
+      'requirement/REQUIREMENT-DATA-ERASURE-1.yaml',
+    );
+    copyCorpus(
+      root,
+      'canon/elements/02_business/products/PRODUCT-MOBILE-1.yaml',
+      'compliance-c3/PRODUCT-MOBILE-1.yaml',
+    );
+    copyCorpus(
+      root,
+      'canon/elements/02_business/processes/PROCESS-USER-DATA-PURGE-1.yaml',
+      'compliance-c3/PROCESS-USER-DATA-PURGE-1.yaml',
+    );
+    copyCorpus(
+      root,
+      'canon/elements/02_business/capabilities/CAPABILITY-V2.yaml',
+      'compliance-c3/CAPABILITY-V2.yaml',
+    );
+    copyCorpus(
+      root,
+      'codex/internal/INTERNAL_STANDARD-coding-conventions-1.yaml',
+      'codex/internal/INTERNAL_STANDARD-coding-conventions-1.yaml',
+    );
+    copyCorpus(
+      root,
+      'canon/assertions/ASSERTION-MOBILE-DATA-ERASURE-1.yaml',
+      'assertion/ASSERTION-MOBILE-DATA-ERASURE-1.yaml',
+    );
+    write(
+      root,
+      'canon/elements/01_motivation/requirements/REQUIREMENT-BAD-REF-1.yaml',
+      [
+        'notation: requirement',
+        'id: REQUIREMENT-BAD-REF-1',
+        'name: Bad ref',
+        'description: Dangling codex ref',
+        'zone: canon',
+        'admitted_at: "2026-06-01"',
+        'admitted_by: test',
+        'gate_checks:',
+        '  uniqueness: pass',
+        'valid_from: "2026-01-01"',
+        'valid_to: null',
+        'derived_from:',
+        '  - LAW-DOES-NOT-EXIST-1',
+        '',
+      ].join('\n'),
+    );
+  });
+
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('buildRepoValidateContext resolves codex refs for REQ-002', () => {
+    const ctx = buildRepoValidateContext(root);
+    expect(ctx.catalog.typeOf('LAW-PERSONAL-DATA-2017-1')).toBe('LAW');
+    expect(ctx.catalog.typeOf('PRODUCT-MOBILE-1')).toBe('PRODUCT');
+  });
+
+  it('runComplianceValidate passes clean requirement/assertion with full catalogue', () => {
+    const ctx = buildRepoValidateContext(root);
+    const findings = runComplianceValidate(root, ctx);
+    const clean = findings.filter(
+      (f) =>
+        f.severity === 'error'
+        && (f.file.endsWith('REQUIREMENT-DATA-ERASURE-1.yaml')
+          || f.file.endsWith('ASSERTION-MOBILE-DATA-ERASURE-1.yaml')),
+    );
+    expect(clean).toEqual([]);
+  });
+
+  it('flags REQ-002 when derived_from codex id is missing from the catalogue', () => {
+    const ctx = buildRepoValidateContext(root);
+    const findings = runComplianceValidate(root, ctx);
+    expect(
+      findings.some(
+        (f) => f.file.endsWith('REQUIREMENT-BAD-REF-1.yaml') && f.ruleId === 'REQ-002',
+      ),
+    ).toBe(true);
+  });
+
+  it('runRepoValidate includes compliance findings in the error gate', () => {
+    const result = runRepoValidate(root);
+    expect(result.compliance.some((f) => f.ruleId === 'REQ-002')).toBe(true);
+    expect(repoScopeHasErrors(result)).toBe(true);
+  });
+});
+
+describe('repo-scope compliance-impact build-time (#518 C3)', () => {
+  let root: string;
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), 'tx-compimp-'));
+    copyCorpus(root, 'codex/external/EU/LAW-GDPR-1.yaml', 'codex/external/EU/LAW-GDPR-1.yaml');
+    copyCorpus(
+      root,
+      'canon/views/compliance-impact/ci.compliance-impact.view.yaml',
+      'compliance-impact/gdpr-nis2.compliance-impact.view.yaml',
+    );
+    write(
+      root,
+      'canon/views/compliance-impact/bad-ref.compliance-impact.transitrix.yaml',
+      [
+        'notation: compliance-impact',
+        'view:',
+        '  id: bad-ref',
+        '  name: Bad refs',
+        '  subjects:',
+        '    products:',
+        '      - PRODUCT-NOT-HERE-1',
+        '  obligations:',
+        '    filter:',
+        '      derived_from_codex:',
+        '        - LAW-NOT-HERE-1',
+        '',
+      ].join('\n'),
+    );
+  });
+
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('surfaces COMPIMP-REF for unresolved view config refs', () => {
+    const result = runRepoValidate(root);
+    const bad = result.views.filter((f) => f.file.endsWith('bad-ref.compliance-impact.transitrix.yaml'));
+    expect(bad.some((f) => f.ruleId === 'COMPIMP-REF')).toBe(true);
+  });
+});

--- a/tests/repo-validate-views.test.ts
+++ b/tests/repo-validate-views.test.ts
@@ -105,6 +105,25 @@ describe('repo-scope views sweep — clean tree passes (#258)', () => {
     copyCorpus(root, 'canon/views/applications/p.applications.transitrix.yaml', 'applications/portfolio-2026.applications.transitrix.yaml');
     copyCorpus(root, 'canon/views/coverage-metric/c.coverage-metric.transitrix.yaml', 'coverage-metric/eu-coverage.coverage-metric.transitrix.yaml');
     copyCorpus(root, 'canon/views/compliance-impact/ci.compliance-impact.view.yaml', 'compliance-impact/gdpr-nis2.compliance-impact.view.yaml');
+    // C3 cross-doc refs: codex + product subjects referenced by the compliance views.
+    copyCorpus(root, 'codex/external/EU/LAW-GDPR-1.yaml', 'codex/external/EU/LAW-GDPR-1.yaml');
+    copyCorpus(root, 'codex/external/EU/LAW-NIS2-1.yaml', 'codex/external/EU/LAW-NIS2-1.yaml');
+    write(
+      root,
+      'canon/elements/02_business/products/PRODUCT-ECOMM-1.yaml',
+      readFileSync(join(corpus, 'compliance-c3/PRODUCT-MOBILE-1.yaml'), 'utf8').replace(
+        'PRODUCT-MOBILE-1',
+        'PRODUCT-ECOMM-1',
+      ).replace('Acme Mobile', 'E-Commerce'),
+    );
+    write(
+      root,
+      'canon/elements/02_business/products/PRODUCT-SUPPORT-1.yaml',
+      readFileSync(join(corpus, 'compliance-c3/PRODUCT-MOBILE-1.yaml'), 'utf8').replace(
+        'PRODUCT-MOBILE-1',
+        'PRODUCT-SUPPORT-1',
+      ).replace('Acme Mobile', 'Support'),
+    );
   });
 
   afterAll(() => {

--- a/tests/validate-notation.test.ts
+++ b/tests/validate-notation.test.ts
@@ -311,4 +311,26 @@ describe('validate-notation — parity with the preview validator (#258, #518 C1
     expect(report.findings.filter((f) => f.severity === 'error').map((f) => f.ruleId))
       .toEqual(raw.errors.map((e) => e.code));
   });
+
+  it('requirement: CLI applies REQ-002 when catalog is supplied (#518 C3)', () => {
+    const doc = {
+      notation: 'requirement',
+      id: 'REQUIREMENT-TEST-1',
+      name: 'T',
+      description: 'D',
+      zone: 'canon',
+      admitted_at: '2026-01-01',
+      admitted_by: 't',
+      gate_checks: {},
+      valid_from: '2026-01-01',
+      valid_to: null,
+      derived_from: ['LAW-MISSING-1'],
+    };
+    const without = validateNotationDoc('requirement', doc);
+    expect(without.findings.some((f) => f.ruleId === 'REQ-002')).toBe(false);
+    const withCatalog = validateNotationDoc('requirement', doc, {
+      catalog: { typeOf: () => undefined },
+    });
+    expect(withCatalog.findings.some((f) => f.ruleId === 'REQ-002')).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- Build `CanonCatalog` + `ComplianceCanon` from `canon/**` and `codex/**` during `--scope=repo`.
- Re-validate `canon/elements/**` requirements and `canon/assertions/**` with catalogue → REQ-002, ASSERT-002..005.
- For `compliance-impact` / `coverage-metric` views: `COMPIMP-REF` / `COVMET-REF` resolution checks plus `buildImpactMatrix` findings (COMPIMP-009..011).
- Optional repo-scope gap-dashboard warnings (`GAP-REQ-NO-ASSERT`, ASSERT-007/008 aggregates).
- Document compliance validate loop in `docs/validation.md`; bump `@transitrix/diagrams` to **1.7.4**.

Phase **C3** of epic **#518** (follows merged #361 / C2).

## Test plan
- [x] `npm run test:diagrams` — canon-catalog + view-resolution tests green
- [x] `tests/repo-validate-compliance.test.ts` — REQ-002 + COMPIMP-REF
- [x] `tests/repo-validate-views.test.ts` — clean tree with codex/product refs
- [x] `acme-corp --scope=repo` — surfaces expected ASSERT-004 STAGE refs + codex CODEX-002 (data fixes separate)
