### PR TITLE
feat(validate): add CONSTRAINT validator (#518 C4)

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -48,6 +48,7 @@ validators the VS Code preview uses:
 | Path | File-scope | Repo-scope cross-document |
 |------|------------|---------------------------|
 | `canon/elements/**/REQUIREMENT-*.yaml` | `REQ-*` shape | `REQ-002`/`003` with scanned `CanonCatalog` |
+| `canon/elements/**/CONSTRAINT-*.yaml` | `CONST-*` shape | `CONST-004`/`005` with scanned `CanonCatalog` |
 | `canon/assertions/ASSERTION-*.yaml` | `ASSERT-*` shape | `ASSERT-002`..`005` + `ASSERT-007`/`008` warnings |
 | `codex/**` | `CODEX-*` | folder jurisdiction (`CODEX-005`) |
 | `canon/views/**.compliance-impact.*` | `COMPIMP-001` parse | `COMPIMP-REF`, `COMPIMP-009`..`011`, `buildImpactMatrix` |

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",

--- a/packages/diagrams/src/constraint/__tests__/example.test.ts
+++ b/packages/diagrams/src/constraint/__tests__/example.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import yaml from 'js-yaml';
+import { validateConstraint } from '../validate.js';
+
+const dir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../../../tests/fixtures/notation-corpus/constraint',
+);
+
+describe('constraint worked example (notation-corpus)', () => {
+  it('validates CONSTRAINT-GDPR-RESIDENCY-1.yaml without error', () => {
+    const data = yaml.load(readFileSync(path.join(dir, 'CONSTRAINT-GDPR-RESIDENCY-1.yaml'), 'utf-8'));
+    const v = validateConstraint(data);
+    expect(v.valid, JSON.stringify(v.errors)).toBe(true);
+  });
+});

--- a/packages/diagrams/src/constraint/__tests__/validate.test.ts
+++ b/packages/diagrams/src/constraint/__tests__/validate.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { validateConstraint } from '../validate.js';
+import type { CanonCatalog } from '../../typed-id.js';
+
+function valid(): Record<string, unknown> {
+  return {
+    notation: 'constraint',
+    id: 'CONSTRAINT-GDPR-RESIDENCY-1',
+    name: 'EU customer personal data must be stored within EU/EEA jurisdictions',
+    statement: 'Personal data of EU customers MUST NOT be persisted outside EU / EEA jurisdictions.',
+    status: 'active',
+    zone: 'canon',
+    admitted_at: '2026-05-29',
+    admitted_by: 'v.korobeinikov',
+    gate_checks: { uniqueness: 'pass', consistency: 'pass', completeness: 'pass' },
+    valid_from: '2018-05-25',
+    valid_to: null,
+    severity: 'mandatory',
+    owner_role: 'ROLE-DPO-1',
+    applies_to: ['APPLICATION-CRM-1'],
+  };
+}
+
+const codes = (input: unknown, opts?: Parameters<typeof validateConstraint>[1]): string[] =>
+  validateConstraint(input, opts).errors.map((e) => e.code);
+
+describe('validateConstraint — positive', () => {
+  it('accepts a well-formed constraint', () => {
+    const r = validateConstraint(valid());
+    expect(r.valid, JSON.stringify(r.errors)).toBe(true);
+  });
+});
+
+describe('validateConstraint — CONST-001', () => {
+  it('flags missing required fields and wrong notation', () => {
+    const r = valid();
+    delete r.statement;
+    expect(codes(r)).toContain('CONST-001');
+    expect(codes({ ...valid(), notation: 'requirement' })).toContain('CONST-001');
+    expect(codes({ ...valid(), id: 'CONSTRAINT-001' })).toContain('CONST-001');
+  });
+});
+
+describe('validateConstraint — CONST-002/003', () => {
+  it('flags invalid status and severity', () => {
+    expect(codes({ ...valid(), status: 'enabled' })).toContain('CONST-002');
+    expect(codes({ ...valid(), severity: 'critical' })).toContain('CONST-003');
+  });
+});
+
+describe('validateConstraint — CONST-004/005 (catalog)', () => {
+  it('flags unresolved applies_to and owner_role with catalog', () => {
+    const catalog: CanonCatalog = { typeOf: () => undefined };
+    expect(codes(valid(), { catalog })).toContain('CONST-004');
+    expect(codes(valid(), { catalog })).toContain('CONST-005');
+  });
+
+  it('does not flag CONST-004 without catalog for well-formed applies_to', () => {
+    expect(codes(valid())).not.toContain('CONST-004');
+  });
+
+  it('resolves applies_to when catalogue admits the target', () => {
+    const catalog: CanonCatalog = {
+      typeOf: (id) => (id === 'APPLICATION-CRM-1' ? 'APPLICATION' : id === 'ROLE-DPO-1' ? 'ROLE' : undefined),
+    };
+    expect(validateConstraint(valid(), { catalog }).valid).toBe(true);
+  });
+});

--- a/packages/diagrams/src/constraint/index.ts
+++ b/packages/diagrams/src/constraint/index.ts
@@ -1,0 +1,4 @@
+export { CONSTRAINT_STATUSES, CONSTRAINT_SEVERITIES } from './types.js';
+export type { ConstraintStatus, ConstraintSeverity } from './types.js';
+export { validateConstraint } from './validate.js';
+export type { ConstraintValidateOptions } from './validate.js';

--- a/packages/diagrams/src/constraint/types.ts
+++ b/packages/diagrams/src/constraint/types.ts
@@ -1,0 +1,5 @@
+export const CONSTRAINT_STATUSES = ['active', 'proposed', 'deprecated', 'retired'] as const;
+export type ConstraintStatus = (typeof CONSTRAINT_STATUSES)[number];
+
+export const CONSTRAINT_SEVERITIES = ['mandatory', 'recommended', 'advisory'] as const;
+export type ConstraintSeverity = (typeof CONSTRAINT_SEVERITIES)[number];

--- a/packages/diagrams/src/constraint/validate.ts
+++ b/packages/diagrams/src/constraint/validate.ts
@@ -1,0 +1,131 @@
+// CONSTRAINT validator — methodology ELEMENT_PRIMITIVES.md §7.13 (sibling to
+// 15-requirement.md). Implements CONST-001..005 for the compliance suite (#518 C4).
+
+import type { ValidationError, ValidationWarning, ValidationResult } from '../validation-types.js';
+import { typeOfId, isCanonicalIdOfType, type CanonCatalog } from '../typed-id.js';
+import { CONSTRAINT_STATUSES, CONSTRAINT_SEVERITIES } from './types.js';
+
+export interface ConstraintValidateOptions {
+  /** When provided, CONST-004/005 enforce artefact existence for cross-refs. */
+  catalog?: CanonCatalog;
+}
+
+const REQUIRED_FIELDS = [
+  'notation',
+  'name',
+  'statement',
+  'status',
+  'zone',
+  'admitted_at',
+  'admitted_by',
+  'gate_checks',
+  'valid_from',
+] as const;
+
+export function validateConstraint(
+  input: unknown,
+  options: ConstraintValidateOptions = {},
+): ValidationResult {
+  const errors: ValidationError[] = [];
+  const warnings: ValidationWarning[] = [];
+
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    errors.push({ code: 'CONST-001', message: 'Constraint must be a YAML mapping.' });
+    return { valid: false, errors, warnings };
+  }
+  const c = input as Record<string, unknown>;
+
+  if (!isCanonicalIdOfType(c.id, 'CONSTRAINT')) {
+    errors.push({
+      code: 'CONST-001',
+      message: `id "${String(c.id)}" must match CONSTRAINT-[<middle>-]<INTEGER>.`,
+      path: 'id',
+    });
+  }
+  if (c.notation !== 'constraint') {
+    errors.push({ code: 'CONST-001', message: 'notation must be the fixed value "constraint".', path: 'notation' });
+  }
+  for (const f of REQUIRED_FIELDS) {
+    if (f === 'notation') continue;
+    if (f === 'gate_checks') {
+      if (c.gate_checks === null || typeof c.gate_checks !== 'object') {
+        errors.push({ code: 'CONST-001', message: 'gate_checks is required and must be a mapping.', path: 'gate_checks' });
+      }
+      continue;
+    }
+    const v = c[f];
+    if (typeof v !== 'string' || v.trim() === '') {
+      errors.push({ code: 'CONST-001', message: `${f} is required.`, path: f });
+    }
+  }
+  if (c.zone !== 'canon') {
+    errors.push({ code: 'CONST-001', message: 'zone must be "canon" for a CONSTRAINT.', path: 'zone' });
+  }
+  if (!('valid_to' in c) || !(typeof c.valid_to === 'string' || c.valid_to === null)) {
+    errors.push({ code: 'CONST-001', message: 'valid_to is required (an ISO date string or null).', path: 'valid_to' });
+  }
+
+  const status = typeof c.status === 'string' ? c.status.trim() : '';
+  if (status && !(CONSTRAINT_STATUSES as readonly string[]).includes(status)) {
+    errors.push({
+      code: 'CONST-002',
+      message: `status must be one of ${CONSTRAINT_STATUSES.join(', ')}.`,
+      path: 'status',
+    });
+  }
+
+  if (c.severity !== undefined) {
+    const severity = typeof c.severity === 'string' ? c.severity.trim() : '';
+    if (!severity || !(CONSTRAINT_SEVERITIES as readonly string[]).includes(severity)) {
+      errors.push({
+        code: 'CONST-003',
+        message: `severity must be one of ${CONSTRAINT_SEVERITIES.join(', ')}.`,
+        path: 'severity',
+      });
+    }
+  }
+
+  if (c.applies_to !== undefined) {
+    if (!Array.isArray(c.applies_to)) {
+      errors.push({ code: 'CONST-001', message: 'applies_to must be a list of typed IDs.', path: 'applies_to' });
+    } else {
+      c.applies_to.forEach((ref, i) => {
+        const type = typeOfId(ref);
+        if (!type) {
+          errors.push({
+            code: 'CONST-004',
+            message: `applies_to[${i}] "${String(ref)}" is not a resolvable typed ID.`,
+            path: `applies_to[${i}]`,
+          });
+          return;
+        }
+        if (options.catalog && options.catalog.typeOf(ref as string) === undefined) {
+          errors.push({
+            code: 'CONST-004',
+            message: `applies_to[${i}] "${String(ref)}" does not resolve to an admitted artefact.`,
+            path: `applies_to[${i}]`,
+          });
+        }
+      });
+    }
+  }
+
+  if (c.owner_role !== undefined) {
+    const role = c.owner_role;
+    if (typeof role !== 'string' || !isCanonicalIdOfType(role, 'ROLE')) {
+      errors.push({
+        code: 'CONST-005',
+        message: `owner_role "${String(role)}" must be a typed ROLE id.`,
+        path: 'owner_role',
+      });
+    } else if (options.catalog && options.catalog.typeOf(role) === undefined) {
+      errors.push({
+        code: 'CONST-005',
+        message: `owner_role "${role}" does not resolve to an admitted artefact.`,
+        path: 'owner_role',
+      });
+    }
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -291,8 +291,8 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
     console.error('             BPMN, or any diagram notation routed by its notation: field');
     console.error('             (goals, dgca, dga, fgca, fga, activities, activity-card,');
     console.error('             process-blueprint, blocks, applications, capability-map,');
-    console.error('             products, scenarios, process-map, requirement, assertion,');
-    console.error('             compliance-impact, coverage-metric, codex) — same checks as the preview.');
+    console.error('             products, scenarios, process-map, requirement, constraint,');
+    console.error('             assertion, compliance-impact, coverage-metric, codex) — same checks as the preview.');
     console.error('             Canonical notation extensions are accepted without --ext.');
     console.error('repo scope — whole-canon checks (referential integrity, atomicity,');
     console.error('             id uniqueness, policy) over <root> (default: cwd).');

--- a/src/repo-validate.ts
+++ b/src/repo-validate.ts
@@ -421,12 +421,12 @@ export function runComplianceValidate(root: string, ctx: RepoValidateContext): V
       continue;
     }
     const notation = notationOf(data);
-    if (notation !== 'requirement') continue;
-    for (const f of validateNotationDoc('requirement', data, validateOpts).findings) {
+    if (notation !== 'requirement' && notation !== 'constraint') continue;
+    for (const f of validateNotationDoc(notation, data, validateOpts).findings) {
       if (f.severity === 'info') continue;
       findings.push({
         file: fullRel,
-        notation: 'requirement',
+        notation,
         ruleId: f.ruleId,
         severity: f.severity,
         message: f.message,
@@ -485,10 +485,10 @@ export function runGapDashboardWarnings(ctx: RepoValidateContext): ViewFinding[]
   for (const req of report.requirementsWithoutAssertions) {
     findings.push({
       file: ctx.pathById.get(req.id) ?? req.id,
-      notation: 'requirement',
+      notation: req.element_kind ?? 'requirement',
       ruleId: 'GAP-REQ-NO-ASSERT',
       severity: 'warning',
-      message: `Requirement "${req.id}" has no assertion targeting it.`,
+      message: `${req.element_kind === 'constraint' ? 'Constraint' : 'Requirement'} "${req.id}" has no assertion targeting it.`,
     });
   }
   for (const a of report.assertionsWithoutEvidence) {

--- a/src/validate-notation.ts
+++ b/src/validate-notation.ts
@@ -40,6 +40,7 @@ import { validateProductsCatalogue } from '@transitrix/diagrams/products/validat
 import { validateScenario } from '@transitrix/diagrams/scenarios/validate.js';
 import { validateProcessMap } from '@transitrix/diagrams/process-map/validate.js';
 import { validateRequirement } from '@transitrix/diagrams/requirement/validate.js';
+import { validateConstraint } from '@transitrix/diagrams/constraint/validate.js';
 import { validateAssertion } from '@transitrix/diagrams/assertion/validate.js';
 import { parseImpactViewConfig } from '@transitrix/diagrams/compliance/impact.js';
 import { parseCoverageMetricConfig } from '@transitrix/diagrams/compliance/coverage-metric.js';
@@ -85,6 +86,10 @@ function validateRequirementDoc(input: unknown, options: ValidateNotationOptions
 function validateAssertionDoc(input: unknown, options: ValidateNotationOptions = {}): NotationValidationResult {
   const today = new Date().toISOString().slice(0, 10);
   return mapPackageResult(validateAssertion(input, { catalog: options.catalog, today }));
+}
+
+function validateConstraintDoc(input: unknown, options: ValidateNotationOptions = {}): NotationValidationResult {
+  return mapPackageResult(validateConstraint(input, { catalog: options.catalog }));
 }
 
 function validateComplianceImpactDoc(input: unknown): NotationValidationResult {
@@ -139,8 +144,9 @@ const VALIDATORS: Record<string, NotationValidator> = {
   products: wrapValidator(validateProductsCatalogue),
   scenarios: wrapValidator(validateScenario),
   'process-map': wrapValidator(validateProcessMap),
-  // Group C — compliance suite (#518 Phase C1–C3).
+  // Group C — compliance suite (#518 Phase C1–C4).
   requirement: validateRequirementDoc,
+  constraint: validateConstraintDoc,
   assertion: validateAssertionDoc,
   'compliance-impact': wrapValidator(validateComplianceImpactDoc),
   'coverage-metric': wrapValidator(validateCoverageMetricDoc),
@@ -152,7 +158,7 @@ const VALIDATORS: Record<string, NotationValidator> = {
 export const FILE_VALIDATABLE_NOTATIONS = Object.keys(VALIDATORS);
 
 /** View notations whose on-disk suffix is `.<notation>.transitrix.yaml`.
- *  Element notations (requirement, assertion) use typed-id filenames instead. */
+ *  Element notations (requirement, constraint, assertion) use typed-id filenames instead. */
 export const NOTATIONS_WITH_CANONICAL_VIEW_EXTENSION: readonly string[] = [
   'goals',
   'dgca',
@@ -185,6 +191,7 @@ export function inferNotationFromFilename(filePath: string): string | undefined 
   }
   const base = lower.split('/').pop() ?? lower;
   if (base.startsWith('requirement-') && base.endsWith('.yaml')) return 'requirement';
+  if (base.startsWith('constraint-') && base.endsWith('.yaml')) return 'constraint';
   if (base.startsWith('assertion-') && base.endsWith('.yaml')) return 'assertion';
   const rawBase = (filePath.replace(/\\/g, '/').split('/').pop() ?? '').replace(/\.ya?ml$/i, '');
   const idType = typeOfId(rawBase);

--- a/tests/fixtures/notation-corpus/constraint/CONSTRAINT-GDPR-RESIDENCY-1.yaml
+++ b/tests/fixtures/notation-corpus/constraint/CONSTRAINT-GDPR-RESIDENCY-1.yaml
@@ -1,0 +1,33 @@
+notation: constraint
+id: CONSTRAINT-GDPR-RESIDENCY-1
+name: "EU customer personal data must be stored within EU/EEA jurisdictions"
+statement: >
+  Personal data of EU customers MUST NOT be persisted, processed, or backed up
+  outside EU / EEA jurisdictions unless an adequacy decision or an approved
+  data-transfer mechanism (SCC, BCR, or derogation under Art. 49) is in
+  effect for the destination jurisdiction.
+status: active
+
+applies_to:
+  - APPLICATION-OMS-1
+  - APPLICATION-CRM-1
+  - PROCESS-ORDER-FULFILMENT-1
+
+source: "GDPR (Regulation (EU) 2016/679) Art. 44–49"
+owner_role: ROLE-DPO-1
+severity: mandatory
+rationale: >
+  EU data-protection law restricts the transfer of personal data to third
+  countries. Non-compliance carries administrative fines under Art. 83 (up
+  to 4% of global annual turnover) and reputational risk; storage decisions
+  for any system holding EU customer PII MUST reflect this constraint.
+
+zone: canon
+admitted_at: "2026-05-29"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+valid_from: "2018-05-25"
+valid_to: null

--- a/tests/repo-validate-compliance.test.ts
+++ b/tests/repo-validate-compliance.test.ts
@@ -64,6 +64,35 @@ describe('repo-scope compliance catalogue (#518 C3)', () => {
       'canon/assertions/ASSERTION-MOBILE-DATA-ERASURE-1.yaml',
       'assertion/ASSERTION-MOBILE-DATA-ERASURE-1.yaml',
     );
+    copyCorpus(
+      root,
+      'canon/elements/01_motivation/constraints/CONSTRAINT-GDPR-RESIDENCY-1.yaml',
+      'constraint/CONSTRAINT-GDPR-RESIDENCY-1.yaml',
+    );
+    for (const [rel, id, notation] of [
+      ['canon/elements/03_application/applications/APPLICATION-OMS-1.yaml', 'APPLICATION-OMS-1', 'application'],
+      ['canon/elements/03_application/applications/APPLICATION-CRM-1.yaml', 'APPLICATION-CRM-1', 'application'],
+      ['canon/elements/02_business/processes/PROCESS-ORDER-FULFILMENT-1.yaml', 'PROCESS-ORDER-FULFILMENT-1', 'process'],
+      ['canon/elements/02_business/roles/ROLE-DPO-1.yaml', 'ROLE-DPO-1', 'role'],
+    ] as const) {
+      write(
+        root,
+        rel,
+        [
+          `notation: ${notation}`,
+          `id: ${id}`,
+          `name: ${id}`,
+          'zone: canon',
+          'admitted_at: "2026-06-01"',
+          'admitted_by: test',
+          'gate_checks:',
+          '  uniqueness: pass',
+          'valid_from: "2026-01-01"',
+          'valid_to: null',
+          '',
+        ].join('\n'),
+      );
+    }
     write(
       root,
       'canon/elements/01_motivation/requirements/REQUIREMENT-BAD-REF-1.yaml',
@@ -106,6 +135,16 @@ describe('repo-scope compliance catalogue (#518 C3)', () => {
           || f.file.endsWith('ASSERTION-MOBILE-DATA-ERASURE-1.yaml')),
     );
     expect(clean).toEqual([]);
+  });
+
+  it('runComplianceValidate validates constraint elements with catalogue', () => {
+    const ctx = buildRepoValidateContext(root);
+    const findings = runComplianceValidate(root, ctx);
+    const constraint = findings.filter(
+      (f) => f.file.endsWith('CONSTRAINT-GDPR-RESIDENCY-1.yaml') && f.severity === 'error',
+    );
+    // applies_to / owner_role resolve once APPLICATION-* and ROLE-DPO-1 are in the catalogue.
+    expect(constraint).toEqual([]);
   });
 
   it('flags REQ-002 when derived_from codex id is missing from the catalogue', () => {

--- a/tests/validate-notation.test.ts
+++ b/tests/validate-notation.test.ts
@@ -50,8 +50,8 @@ const GROUP_B = [
   'process-map',
 ];
 
-// Group C — compliance suite wired in #518 Phase C1–C2.
-const GROUP_C = ['requirement', 'assertion', 'compliance-impact', 'coverage-metric', 'codex'];
+// Group C — compliance suite wired in #518 Phase C1–C4.
+const GROUP_C = ['requirement', 'constraint', 'assertion', 'compliance-impact', 'coverage-metric', 'codex'];
 
 const ALL_NOTATIONS = [...GROUP_A, ...GROUP_B, ...GROUP_C];
 
@@ -96,6 +96,10 @@ describe('validate-notation — canonical extension helpers (#343)', () => {
   it('inferNotationFromFilename recognises codex typed-id filenames', () => {
     expect(inferNotationFromFilename('codex/external/eu/LAW-GDPR-1.yaml')).toBe('codex');
     expect(inferNotationFromFilename('codex/internal/INTERNAL_STANDARD-coding-conventions-1.yaml')).toBe('codex');
+  });
+
+  it('inferNotationFromFilename recognises constraint typed-id filenames', () => {
+    expect(inferNotationFromFilename('canon/elements/constraints/CONSTRAINT-GDPR-1.yaml')).toBe('constraint');
   });
 
   it('inferNotationFromFilename returns undefined for non-canonical names', () => {
@@ -165,6 +169,19 @@ describe('validate-notation — element notation corpus validates clean (#518 C1
         expect(report.isValid).toBe(true);
       });
     }
+  }
+});
+
+describe('validate-notation — constraint corpus validates clean (#518 C4)', () => {
+  const dir = join(corpusRoot, 'constraint');
+  for (const f of readdirSync(dir).filter((x) => x.endsWith('.yaml'))) {
+    it(`${f} → valid`, () => {
+      const data = loadNotationYaml(readFileSync(join(dir, f), 'utf8'));
+      const report = validateNotationDoc('constraint', data);
+      const errors = report.findings.filter((x) => x.severity === 'error');
+      expect(errors, JSON.stringify(errors, null, 2)).toEqual([]);
+      expect(report.isValid).toBe(true);
+    });
   }
 });
 


### PR DESCRIPTION
## Summary
- Add `@transitrix/diagrams` `validateConstraint` (CONST-001..005): shape, status/severity vocab, `applies_to` and `owner_role` cross-refs with optional `CanonCatalog`.
- Wire `constraint` into file-scope `transitrix validate` (`CONSTRAINT-*.yaml` filename inference) and repo-scope compliance sweep under `canon/elements/**`.
- Corpus fixture + tests; `docs/validation.md` updated. Bump **1.7.5**.

Final phase **C4** of epic **#518** — completes the compliance validator programme.

## Test plan
- [x] `npm run test:diagrams` — constraint validate + example tests green
- [x] `tests/validate-notation.test.ts` — constraint corpus clean
- [x] `tests/repo-validate-compliance.test.ts` — constraint passes with full catalogue
