### PR TITLE
fix(goals): preserve canonical GOAL-* ids in diagram previews

### DIFF
--- a/extension/src/goals-preview.ts
+++ b/extension/src/goals-preview.ts
@@ -134,9 +134,9 @@ export class GoalsPreview {
         const docDate = (typeof meta.generated_at === 'string' ? meta.generated_at : undefined)
           ?? (typeof meta.date === 'string' ? meta.date : undefined)
           ?? todayIso();
-        goalOptions = v.parsed.goals.map(g => ({ id: String(g.id), name: g.name ?? '' }));
+        goalOptions = v.parsed.goals.map(g => ({ id: g.canonical_id ?? String(g.id), name: g.name ?? '' }));
         maxLevelPresent = v.parsed.goals.reduce((m, g) => Math.max(m, typeof g.level === 'number' ? g.level : 0), 0);
-        const scopeWarning = checkScopeRoot(scope, v.parsed.goals.map(g => g.id));
+        const scopeWarning = checkScopeRoot(scope, v.parsed.goals.map(g => g.canonical_id ?? g.id));
         if (scopeWarning) warnings.push(`${scopeWarning.code}: ${scopeWarning.message}`);
         const layout = layoutGoalTree(v.parsed, {
           nodeWidth: NODE_W,

--- a/organizations/acme_corp/canon/views/goals/eu-strategy.dgca.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/goals/eu-strategy.dgca.transitrix.yaml
@@ -15,7 +15,7 @@ author: "Acme Strategy Office"
 goal_types:
   - { name: "Strategy",       level: 0 }
   - { name: "Strategic Goal", level: 1 }
-  - { name: "Enabling Goal",  level: 2 }
+  - { name: "Project Goal",   level: 2 }
 
 goals:
   - id: GOAL-REVENUE-1
@@ -35,7 +35,7 @@ goals:
 
   - id: GOAL-EU-COMPLIANCE-1
     name: "Achieve full GDPR & NIS2 compliance"
-    type: "Enabling Goal"
+    type: "Project Goal"
     level: 2
     parent: GOAL-EU-1
     description: >

--- a/organizations/acme_corp/canon/views/quadrant/strategy-goals.quadrant.md
+++ b/organizations/acme_corp/canon/views/quadrant/strategy-goals.quadrant.md
@@ -6,9 +6,9 @@
     - canon/views/goals/eu-strategy.dgca.transitrix.yaml
         goal hierarchy: id, name, type (level 0/1/2), parent linkage.
         Y-axis (Strategic Importance): goal level — level 0 (Strategy) = highest;
-          level 1 (Strategic Goal) = high; level 2 (Enabling Goal) = medium.
+          level 1 (Strategic Goal) = high; level 2 (Project Goal) = medium.
         X-axis (Implementation Urgency): inferred from goal type and description —
-          an enabling goal described as an explicit gate condition for a near-term
+          a project goal described as an explicit gate condition for a near-term
           milestone ranks most urgent; a 2028-horizon strategy goal ranks least.
 
   Not a duplicate of the Goals tree: the goals tree shows hierarchy.
@@ -45,7 +45,7 @@ quadrantChart
 |---|---|---|---|
 | `GOAL-REVENUE-1` | 0 | Strategy | Highest importance (root goal); 2028 horizon = low urgency |
 | `GOAL-EU-1` | 1 | Strategic Goal | EU launch gate — near-term, very high impact |
-| `GOAL-EU-COMPLIANCE-1` | 2 | Enabling Goal | Explicit gate condition for `GOAL-EU-1`; most urgent |
+| `GOAL-EU-COMPLIANCE-1` | 2 | Project Goal | Explicit gate condition for `GOAL-EU-1`; most urgent |
 | `GOAL-CUST-1` | 1 | Strategic Goal | Medium-horizon; high but not gate-critical |
 | `GOAL-OPS-1` | 1 | Strategic Goal | Ongoing operational; moderate urgency and importance |
 

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",

--- a/packages/diagrams/src/goals/GoalNode.tsx
+++ b/packages/diagrams/src/goals/GoalNode.tsx
@@ -1,6 +1,7 @@
 import React, { memo, useState } from 'react';
 import { Handle, Position } from 'reactflow';
 import type { Factor, Goal } from './types.js';
+import { displayGoalId } from './parse-canonical.js';
 import type { ThemeTokens } from './theme.js';
 
 const NODE_WIDTH = 250;
@@ -92,7 +93,7 @@ const GoalNode = memo(({ data }: { data: GoalNodeData }) => {
           {goal.name}
         </div>
         <div style={{ fontSize: 10, color: theme.cardMetaColor, marginTop: 2 }}>
-          ID: {goal.id} | Lvl: {goal.level}
+          ID: {displayGoalId(goal)} | Lvl: {goal.level}
           {goal.tag ? ` | #${goal.tag}` : ''}
         </div>
       </div>

--- a/packages/diagrams/src/goals/__tests__/parse-canonical.test.ts
+++ b/packages/diagrams/src/goals/__tests__/parse-canonical.test.ts
@@ -122,8 +122,10 @@ describe('parseCanonicalGoals', () => {
   it('maps canonical IDs to internal numeric ids; parent_id is the parent\'s mapped id', () => {
     const r = parseCanonicalGoals(VALID);
     expect(r.parsed?.goals[0].id).toBe(1);
+    expect(r.parsed?.goals[0].canonical_id).toBe('GOAL-1');
     expect(r.parsed?.goals[0].parent_id).toBe(0);
     expect(r.parsed?.goals[1].id).toBe(2);
+    expect(r.parsed?.goals[1].canonical_id).toBe('GOAL-2');
     expect(r.parsed?.goals[1].parent_id).toBe(1);
   });
 });

--- a/packages/diagrams/src/goals/layout.ts
+++ b/packages/diagrams/src/goals/layout.ts
@@ -1,5 +1,6 @@
 import type { Goal, GoalTree, LayoutOptions, GoalTreeLayout, LaidOutNode, LaidOutEdge } from './types.js';
 import type { Scope } from '../scope.js';
+import { displayGoalId } from './parse-canonical.js';
 
 const DEFAULT_NODE_WIDTH = 250;
 const DEFAULT_NODE_HEIGHT = 80;
@@ -23,7 +24,7 @@ export function selectScopedGoals(goals: Goal[], scope: Scope): Goal[] {
     if (!children.has(g.parent_id)) children.set(g.parent_id, []);
     children.get(g.parent_id)!.push(g.id);
   }
-  const root = goals.find(g => String(g.id) === scope.rootGoalId);
+  const root = goals.find(g => displayGoalId(g) === scope.rootGoalId);
   if (!root) return [];
   const keep = new Set<number>();
   const stack = [root.id];

--- a/packages/diagrams/src/goals/parse-canonical.ts
+++ b/packages/diagrams/src/goals/parse-canonical.ts
@@ -36,6 +36,11 @@ export interface CanonicalGoalsResult extends ValidationResult {
 const GOAL_ID_RE = /^GOAL(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
 const GOALS_DOC_ID_RE = /^GOALS(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
 
+/** Display id for previews — canonical `GOAL-…` when present, else internal numeric id. */
+export function displayGoalId(goal: { id: number; canonical_id?: string }): string {
+  return goal.canonical_id ?? String(goal.id);
+}
+
 function isNonEmptyString(v: unknown): v is string {
   return typeof v === 'string' && v.trim().length > 0;
 }
@@ -267,6 +272,7 @@ export function parseCanonicalGoals(input: unknown): CanonicalGoalsResult {
       isNonEmptyString(parent) && idToInternal.has(parent) ? idToInternal.get(parent)! : 0;
     return {
       id: idToInternal.get(o['id'] as string)!,
+      canonical_id: o['id'] as string,
       name: o['name'] as string,
       type: o['type'] as string,
       level: o['level'] as number,

--- a/packages/diagrams/src/goals/types.ts
+++ b/packages/diagrams/src/goals/types.ts
@@ -10,6 +10,8 @@ export interface Factor {
 
 export interface Goal {
   id: number;
+  /** Canonical typed id from the YAML (`GOAL-…`) when parsed from canonical form. */
+  canonical_id?: string;
   name: string;
   type: string;
   level: number;

--- a/packages/diagrams/src/webview/__tests__/render-goals.test.ts
+++ b/packages/diagrams/src/webview/__tests__/render-goals.test.ts
@@ -65,8 +65,22 @@ describe('renderGoalsSvg', () => {
     expect(svg).toContain('height="0"');
   });
 
-  it('omits the title block when treeName is missing', () => {
-    const svg = renderGoalsSvg(SIMPLE_TREE);
-    expect(svg).not.toContain('Goal tree —');
+  it('shows canonical goal ids in node labels when present', () => {
+    const tree: GoalTree = {
+      goal_types: [{ name: 'Strategy', level: 0 }],
+      goals: [
+        {
+          id: 1,
+          canonical_id: 'GOAL-REVENUE-1',
+          name: 'Triple revenue',
+          type: 'Strategy',
+          level: 0,
+          parent_id: 0,
+        },
+      ],
+    };
+    const svg = renderGoalsSvg(tree);
+    expect(svg).toContain('GOAL-REVENUE-1');
+    expect(svg).not.toMatch(/>\s*1\s*</);
   });
 });

--- a/packages/diagrams/src/webview/render-goals.ts
+++ b/packages/diagrams/src/webview/render-goals.ts
@@ -12,6 +12,7 @@
  */
 import { layoutGoalTree } from '../goals/layout.js';
 import type { GoalTree, GoalTreeLayout, LaidOutEdge } from '../goals/types.js';
+import { displayGoalId } from '../goals/parse-canonical.js';
 import { horizontalCubicEdgePath, DEFAULT_EDGE_CURVATURE } from '../edge-path.js';
 import { generateSvgEmbedCss, type ThemeId } from '../theme/index.js';
 import { escXml } from './render-util.js';
@@ -129,7 +130,7 @@ export function renderGoalsLayoutSvg(layout: GoalTreeLayout, options: RenderGoal
       const typeY = twoLines ? y + 43 : y + 35;
       const idY = twoLines ? y + 59 : y + 55;
       const typeLabel = n.data.type ?? '';
-      const idText = String(n.data.id);
+      const idText = displayGoalId(n.data);
       return `<g>
   <rect class="diagram-node level-${level}" x="${x}" y="${y}" width="${n.width}" height="${n.height}" rx="${ENTITY_NODE_RX}"/>
   <text class="text-primary" x="${x + n.width / 2}" y="${nameY1}" text-anchor="middle" dominant-baseline="central">${escXml(line1)}</text>${twoLines ? `


### PR DESCRIPTION
## Summary
- Goals preview/SVG/React nodes now show canonical `GOAL-*` ids from YAML instead of internal numeric ids (same regression class as FGCA fix in 2.6.0).
- Scope root picker and subtree filter match on canonical ids.
- `organizations/acme_corp` eu-strategy: replace non-methodology `Enabling Goal` with `Project Goal` (level 2).
- Bump `@transitrix/diagrams` to 1.7.6.

## Test plan
- [x] `npm run test:diagrams` — `parse-canonical.test.ts`, `render-goals.test.ts`
- [ ] Reload VS Code window; open `eu-strategy.dgca.transitrix.yaml` — cards show `GOAL-REVENUE-1` etc.
- [ ] Scope root dropdown lists canonical ids; subtree scope works for `GOAL-EU-1`
- [ ] Follow-up: mirror data fix in `acme-corp` repo if still using standalone clone
