### PR TITLE
chore(release): 2.10.0 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,22 @@
 
 ## Unreleased
 
+## [2.10.0] — 2026-07-06
+
 ### Added
+
+- **Compliance validators in CLI and repo-scope scan (#518).** `transitrix validate`
+  now covers the compliance notation family end-to-end:
+  - **Requirement, Assertion, Compliance-impact, Coverage-metric** — per-notation
+    validators wired into `validate-notation` and `transitrix validate --scope=repo`
+    (#360).
+  - **Codex** — `CODEX-*` element validator plus a `codex/**` sweep in repo-scope
+    (#361).
+  - **Canon catalogue + cross-document checks** — `CanonCatalog` builds a typed
+    element index; repo-scope validates `derived_from` / `about` / `realised_via`
+    cross-references and compliance-matrix build-time invariants (#362).
+  - **Constraint** — `CONSTRAINT-*` primitive validator (`CONST-001` … `CONST-005`)
+    (#363).
 
 - **Requirement traceability + hierarchy view.** A new
   `transitrixStudio.previewRequirementTrace` command opens a script-less
@@ -26,12 +41,28 @@
   `@transitrix/diagrams` gains a pure `buildRequirementTrace` builder over
   the existing compliance reverse-index (extended with `requirementsByParent`).
 
+- **Goals — optional `onFactorClick` callback on `GoalNode` / `GoalTreeView`.**
+  Host apps (e.g. DSM) can restore factor-badge navigation without the library
+  hardcoding a route (#358).
+
+### Fixed
+
+- **DGCA — accept `ACTION-*` ids and DGA mode without a `changes` array.**
+  Canonical action terminology from methodology 1.0 is recognised in DGCA/DGA
+  validators and previews (#359).
+
+- **Goals preview — canonical `GOAL-*` ids in diagram nodes.** Parsed goals
+  retain `canonical_id` from YAML; SVG/React previews and scope root picker
+  show `GOAL-REVENUE-1` instead of internal numeric ids (#364). Regresses the
+  same class of bug fixed for FGCA in 2.6.0.
+
 ### Changed
 
-- **`@transitrix/diagrams` patch bump (1.6.0 → 1.6.1).** Comment-only change
-  in `repo-validate/types.ts` — cites the validation-convergence ADRs by
-  title instead of by repo-local file path, following the ADR
-  centralization migration. No source or API change.
+- **`@transitrix/diagrams` 1.6.0 → 1.7.6** — compliance trace builder,
+  repo-scope validation primitives, goals `canonical_id` display, DGCA action-id
+  acceptance, and `onFactorClick` extension point.
+- **`@transitrix/cli` 1.1.1 → 1.2.0** — bundles the compliance validator suite
+  for `transitrix validate` / `validate --scope=repo`.
 
 ## [2.9.1] — 2026-07-03
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "2.9.1",
+  "version": "2.10.0",
   "description": "Architecture-as-code for the modern enterprise. Author 17 notations — goals, processes, capabilities, BPMN, applications, more — as plain YAML, get live diagrams in VS Code. Diffable in git. AI-friendly. Open source. Built on ArchiMate 3.2 and BPMN 2.0.",
   "license": "MIT",
   "icon": "icon.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "2.9.1",
+  "version": "2.10.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/cli",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "type": "module",
   "description": "Transitrix CLI — compile, validate, and report on Transitrix diagrams (BPMN, Goals, FGCA, …) from any shell or CI pipeline.",
   "license": "MIT",


### PR DESCRIPTION
Release prep for **2.10.0**.

## Changes

- **CHANGELOG**: `[Unreleased]` → `[2.10.0] — 2026-07-06` — compliance validators (#518 / #360–363), requirement trace, `onFactorClick` (#358), DGCA action-id fix (#359), Goals canonical ids (#364).
- **Versions**: root + extension `2.9.1 → 2.10.0`; `@transitrix/cli` `1.1.1 → 1.2.0`; `@transitrix/diagrams` stays **1.7.6** (already bumped on `main`).

## Pre-flight (`docs/release-runbook.md`)

- [x] branch cut from current `main` (`c5e6068`)
- [x] `npm run build` green
- [x] `npm run compile` + `npm run compile:extension` green
- [x] `npm test` — 453/456 green; **3 `cli-migrate` failures** when sibling `methodology/` repo is present (recipes now chain to `1.0.0`; CI skips these tests — same as prior releases)
- [x] CHANGELOG heading matches version fields

## After merge (Valerii)

1. Publish the **draft** GitHub Release `v2.10.0` (already created, targets this branch until merge — re-point to `main` if needed).
2. Publishing the release triggers npm + VS Code Marketplace + Open VSX + JetBrains workflows.
