### PR TITLE
fix(intellij): stop webview bundle pulling React via capability-map barrel

### DIFF
--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.7.6",
+  "version": "1.7.7",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",

--- a/packages/diagrams/src/webview/entry.ts
+++ b/packages/diagrams/src/webview/entry.ts
@@ -19,6 +19,10 @@
  * (SVG for the diagram notations, an HTML fragment for the catalogue
  * notations). The JVM host drops whatever `svg` carries into the DOM, so the
  * field name is historical — it transports any self-contained markup.
+ *
+ * Import validators/types from leaf modules (e.g. `capability-map/validate.js`),
+ * never from package `index.ts` barrels that also re-export React views —
+ * esbuild cannot tree-shake those and the JCEF bundle would pull in React.
  */
 import yaml from 'js-yaml';
 
@@ -30,8 +34,8 @@ import { validateApplicationsCatalogue } from '../applications/index.js';
 import type { ApplicationsCatalogueFile } from '../applications/index.js';
 import { validateNestedBlocks } from '../blocks/index.js';
 import type { BlocksFile } from '../blocks/index.js';
-import { validateCapabilityMap } from '../capability-map/index.js';
-import type { CapabilityMapFile } from '../capability-map/index.js';
+import { validateCapabilityMap } from '../capability-map/validate.js';
+import type { CapabilityMapFile } from '../capability-map/types.js';
 import { parseCanonicalFGCA, parseCanonicalFGA } from '../fgca/parse-canonical.js';
 import { parseCanonicalGoals } from '../goals/parse-canonical.js';
 import { validateProcessBlueprint } from '../process-blueprint/index.js';


### PR DESCRIPTION
## Problem

JetBrains publish for **2.10.0** failed at `Build webview bundle`:

```
Browser-bundle leaked Node-only token(s): require(
```

## Root cause

`packages/diagrams/src/webview/entry.ts` imported `validateCapabilityMap` from `capability-map/index.js`. Since #358, that barrel also re-exports `CapabilityMapView` (React + reactflow). esbuild pulled the whole React stack into the JCEF IIFE (~650 KB) and emitted a `__require` CJS shim, tripping the browser-safety guard.

## Fix

Import from leaf modules (`validate.js`, `types.js`) instead of the barrel. Bundle back to ~278 KB; guard passes.

## Test plan

- [x] `node scripts/build-webview-bundle.mjs` green locally

## After merge

Re-run JetBrains publish for 2.10.0:

```
gh workflow run jetbrains-publish.yml -R transitrix/transitrix-studio -f version=2.10.0
```
