### PR TITLE
feat(diagrams): unified text-in-block layout and node size presets

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Transitrix Studio — changelog
 
+## Unreleased
+
+### Added
+
+- **Unified text-in-block layout** (`entity-text-layout.ts`, strategy #521): shared wrapping, truncation, and vertical placement for Goals, DGCA/DGA, Nested Blocks, Activities, Process Blueprint, and Capability Map renderers.
+- **Block size presets** (`compact` / `normal` / `wide`) via `transitrix.nodeSize.*` settings and the in-preview **Controls → Block size** row (Goals, DGCA/DGA, Activities). Smooth width/height sliders remain a documented follow-up idea.
+
 ## 2.2.0 — 2026-06-24
 
 Custom BPMN renderer by default, DGCA/DGA notation rename, Blocks IDs, and BPMN preview layout polish from hand-testing.

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- **Unified text-in-block layout** (`entity-text-layout.ts`, strategy #521): shared wrapping, truncation, and vertical placement for Goals, DGCA/DGA, Nested Blocks, Activities, Process Blueprint, and Capability Map renderers.
+- **Unified text-in-block layout** (`entity-text-layout.ts`): shared wrapping, truncation, and vertical placement for Goals, DGCA/DGA, Nested Blocks, Activities, Process Blueprint, and Capability Map renderers.
 - **Block size presets** (`compact` / `normal` / `wide`) via `transitrix.nodeSize.*` settings and the in-preview **Controls → Block size** row (Goals, DGCA/DGA, Activities). Smooth width/height sliders remain a documented follow-up idea.
 
 ## 2.2.0 — 2026-06-24

--- a/extension/README.md
+++ b/extension/README.md
@@ -20,7 +20,7 @@ Transitrix flips that:
 | Domain | Notation | Use it for |
 |---|---|---|
 | Strategy | **Goals tree** | Hierarchical goal decomposition |
-| Strategy | **FGCA / FGA** | Factors → goals → (changes →) activities chains |
+| Strategy | **DGCA / DGA** | Drivers → goals → (changes →) activities chains |
 | Capability | **Capability map** | Current vs target maturity per capability |
 | Process | **Process map** | Operating / supporting / management process landscape |
 | Process | **Process blueprint** | Stage-by-stage design with systems, actors, equipment, information |
@@ -62,6 +62,12 @@ Configure under **Settings → Transitrix Studio**. The canonical keys are `tran
 |---------|---------|-------------|
 | `transitrix.fileExtensions` | `[".bpmn.transitrix.yaml"]` | File suffixes recognised as Transitrix BPMN source files (leading dot required). |
 | `transitrix.exportEnabled` | `false` | Show the experimental BPMN/SVG/PNG export commands. |
+| `transitrix.nodeSize.goals` | `normal` | Block size preset for Goals preview (`compact` / `normal` / `wide`). Also in the in-preview **Controls** panel. |
+| `transitrix.nodeSize.dgca` / `.dga` | `normal` | Block size preset for DGCA/DGA chain previews. |
+| `transitrix.nodeSize.action` | `normal` | Block size preset for Activities network preview. |
+| `transitrix.nodeSize.blocks` | `normal` | Leaf block size preset for Nested Blocks preview (settings; Controls panel deferred). |
+| `transitrix.nodeSize.processBlueprint` | `normal` | Cell/column sizing preset for Process Blueprint (pairs with existing column-width slider). |
+| `transitrix.nodeSize.capabilityMap` | `normal` | Node size preset for Capability Map tree preview. |
 
 ## Learn more
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -123,7 +123,7 @@
             "Follow the active VS Code color theme"
           ],
           "default": "transitrix",
-          "description": "Color theme for Transitrix diagram previews (Goals, FGCA, and other static notation previews)."
+          "description": "Color theme for Transitrix diagram previews (Goals, DGCA/DGA, and other static notation previews)."
         },
         "transitrix.report.columnWidth": {
           "type": "string",
@@ -139,6 +139,48 @@
           ],
           "default": "normal",
           "description": "Column width preset for table-based reports (Compliance Impact, Compliance Matrix, Products, Process Map, etc.)."
+        },
+        "transitrix.nodeSize.goals": {
+          "type": "string",
+          "enum": ["compact", "normal", "wide"],
+          "default": "normal",
+          "description": "Block size preset for Goals tree preview nodes."
+        },
+        "transitrix.nodeSize.dgca": {
+          "type": "string",
+          "enum": ["compact", "normal", "wide"],
+          "default": "normal",
+          "description": "Block size preset for DGCA chain preview nodes."
+        },
+        "transitrix.nodeSize.dga": {
+          "type": "string",
+          "enum": ["compact", "normal", "wide"],
+          "default": "normal",
+          "description": "Block size preset for DGA chain preview nodes."
+        },
+        "transitrix.nodeSize.blocks": {
+          "type": "string",
+          "enum": ["compact", "normal", "wide"],
+          "default": "normal",
+          "description": "Block size preset for Nested Blocks leaf nodes."
+        },
+        "transitrix.nodeSize.action": {
+          "type": "string",
+          "enum": ["compact", "normal", "wide"],
+          "default": "normal",
+          "description": "Block size preset for Activities network preview nodes."
+        },
+        "transitrix.nodeSize.processBlueprint": {
+          "type": "string",
+          "enum": ["compact", "normal", "wide"],
+          "default": "normal",
+          "description": "Cell size preset for Process Blueprint preview (columns, pills, row heights)."
+        },
+        "transitrix.nodeSize.capabilityMap": {
+          "type": "string",
+          "enum": ["compact", "normal", "wide"],
+          "default": "normal",
+          "description": "Node size preset for Capability Map tree preview."
         },
         "transitrix.spacing.goals.horizontalGap": {
           "type": "number",

--- a/extension/src/action-preview.ts
+++ b/extension/src/action-preview.ts
@@ -22,6 +22,7 @@ import { DEFAULT_EDGE_CURVATURE } from '@transitrix/diagrams/edge-path.js';
 import { renderActivitiesNetworkBody, ACTIVITIES_NETWORK_DEFS } from '@transitrix/diagrams/webview/render-activities.js';
 import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
 import { readSpacing, readCurvature, readEntryCurvature, applyControlMessage, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND } from './spacing-config.js';
+import { readActionNodeSize, readNodeSizePreset } from './node-size-config.js';
 import { genNonce, buildControlsPanel, buildControlsScript } from './preview-controls.js';
 
 // Default network (PSND) gaps — must match the layoutActivities defaults
@@ -847,7 +848,8 @@ export class ActionPreview {
       if (!v.valid) {
         errorMsg = v.errors.map(e => `${e.code}: ${e.message}`).join('\n');
       } else {
-        const views = buildActivityViews(parsed as ActivityDoc, { horizontalGap: spacing.horizontalGap, verticalGap: spacing.verticalGap }, curvature, entryCurvature, filename, docDate, docVersion);
+        const nodeSize = readActionNodeSize();
+        const views = buildActivityViews(parsed as ActivityDoc, { horizontalGap: spacing.horizontalGap, verticalGap: spacing.verticalGap, nodeWidth: nodeSize.width, nodeHeight: nodeSize.height }, curvature, entryCurvature, filename, docDate, docVersion);
         bodyContent = buildCanvasContent(views);
         this.lastNetworkSvg = views.networkSvg;
         this.lastGanttSvg = views.ganttSvg;
@@ -870,9 +872,11 @@ export class ActionPreview {
     const nonce = genNonce();
     // Activities has spacing + curvature controls but no scope filter (#77
     // excludes it — its multi-row CPM layout isn't a uniform tree).
+    const nodeSizePreset = readNodeSizePreset('action');
     const controlsPanel = buildControlsPanel({
       spacing: { ...spacing, defaults: spacingDefaults },
       curvature: { value: curvature, default: 1 },
+      nodeSize: { value: nodeSizePreset, default: 'normal' },
     });
 
     return buildDiagramFrame({

--- a/extension/src/blocks-preview.ts
+++ b/extension/src/blocks-preview.ts
@@ -13,6 +13,7 @@ import {
 } from '@transitrix/diagrams/blocks';
 import { coerceDatesToIsoStrings } from '@transitrix/diagrams/yaml-normalize.js';
 import { renderBlocksLayoutSvg } from '@transitrix/diagrams/webview/render-blocks.js';
+import { readBlocksLeafSize } from './node-size-config.js';
 
 
 // Pad reserved around the diagram; mirrors `PAD` in the shared emitter
@@ -71,7 +72,8 @@ export class BlocksPreview extends StaticSvgPreview {
         const docDate = (typeof raw['generated_at'] === 'string' ? raw['generated_at'] : undefined)
           ?? (typeof nb.date === 'string' ? nb.date : undefined)
           ?? todayIso();
-        const layout = layoutNestedBlocks(file);
+        const leafSize = readBlocksLeafSize();
+        const layout = layoutNestedBlocks(file, { leafWidth: leafSize.width, leafHeight: leafSize.height });
         svgContent = layoutToSvg(layout, filename, docDate, docVersion);
 
         // BL-008 / BL-009 may still be present even when the document is

--- a/extension/src/capability-map-preview.ts
+++ b/extension/src/capability-map-preview.ts
@@ -7,6 +7,7 @@ import { coerceDatesToIsoStrings } from '@transitrix/diagrams/yaml-normalize.js'
 import { validateCapabilityMap } from '@transitrix/diagrams/capability-map/validate.js';
 import { renderCapabilityTreeSvg } from '@transitrix/diagrams/capability-map/render-capability-tree.js';
 import { genNonce } from './preview-controls.js';
+import { readNodeSizePreset } from './node-size-config.js';
 
 // ── Types (local, mirroring the shared package types) ─────────────────────────
 
@@ -231,7 +232,7 @@ export class CapabilityMapPreview {
         if (!date) date = map.assessment_date;
 
         if (viewMode === 'tree') {
-          svgContent = renderCapabilityTreeSvg(map, { collapsedIds: this.collapsedIds });
+          svgContent = renderCapabilityTreeSvg(map, { collapsedIds: this.collapsedIds, nodeSizePreset: readNodeSizePreset('capabilityMap') });
         } else {
           bodyContent = buildCapabilityMapBody(map);
         }

--- a/extension/src/dgca-preview.ts
+++ b/extension/src/dgca-preview.ts
@@ -20,6 +20,7 @@ import { coerceDatesToIsoStrings } from '@transitrix/diagrams/yaml-normalize.js'
 import { checkScopeRoot, type Scope } from '@transitrix/diagrams/scope.js';
 import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
 import { readSpacing, readCurvature, readEntryCurvature, readScope, readView, applyControlMessage, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND } from './spacing-config.js';
+import { readDgcaNodeSize, readNodeSizePreset } from './node-size-config.js';
 import { genNonce, buildControlsPanel, buildControlsScript, buildViewToggle, buildCaptureButton, buildTimelineStrip, type ControlsModel, type ScopeGoalOption, type SnapshotMarker, type SnapshotMessage } from './preview-controls.js';
 import { snapshotFilename, buildSnapshotContent, extractViewMeta, listSnapshotFiles, parseSnapshotForDisplay } from './snapshot-writer.js';
 
@@ -108,10 +109,13 @@ function chainControlsModel(
   scope: Scope,
   goals: ScopeGoalOption[],
   maxLevelPresent: number,
+  viewNotation: 'dgca' | 'dga',
 ): ControlsModel {
+  const nodeSizePreset = readNodeSizePreset(viewNotation);
   return {
     spacing: { ...gaps, defaults },
     curvature: { value: curvature, default: 1 },
+    nodeSize: { value: nodeSizePreset, default: 'normal' },
     scope: {
       rootId: scope.mode === 'root' ? scope.rootGoalId : '',
       maxLevel: scope.mode === 'level' ? scope.maxLevel : -1,
@@ -196,9 +200,9 @@ function renderChainPreview(
     ({ goals: goalOptions, maxLevelPresent } = scopeInputsFromDoc(parsedDoc));
     const scopeWarning = checkScopeRoot(scope, parsedDoc.goals.map(g => g.id));
     if (scopeWarning) warnings.push(`${scopeWarning.code}: ${scopeWarning.message}`);
-    svg = buildSvg(parsedDoc, p.hideChanges, { colGap: gaps.horizontalGap, rowGap: gaps.verticalGap, curvature, entryCurvature, scope }, p.heading, filename, docDate, docVersion);
+    svg = buildSvg(parsedDoc, p.hideChanges, { colGap: gaps.horizontalGap, rowGap: gaps.verticalGap, curvature, entryCurvature, scope, nodeSize: readDgcaNodeSize(p.viewNotation) }, p.heading, filename, docDate, docVersion);
   }
-  const model = chainControlsModel(gaps, spacingDefaults, curvature, scope, goalOptions, maxLevelPresent);
+  const model = chainControlsModel(gaps, spacingDefaults, curvature, scope, goalOptions, maxLevelPresent, p.viewNotation);
   const html = buildDiagramFrame({
     filename, notation: p.notation, svgContent: svg, errorMsg, warnings, themeId,
     saveSvgCommand: p.saveSvgCommand,
@@ -217,7 +221,7 @@ function renderChainPreview(
 function buildSvg(
   doc: FGCADoc,
   hideChanges = false,
-  opts: { colGap?: number; rowGap?: number; curvature?: number; entryCurvature?: number; scope?: Scope } = {},
+  opts: { colGap?: number; rowGap?: number; curvature?: number; entryCurvature?: number; scope?: Scope; nodeSize?: { width: number; height: number } } = {},
   heading?: string,
   filename?: string,
   date?: string,
@@ -225,16 +229,22 @@ function buildSvg(
 ): string {
   const curvature = opts.curvature ?? DEFAULT_EDGE_CURVATURE;
   const entryCurvature = opts.entryCurvature;
+  const nodeSize = opts.nodeSize ?? readDgcaNodeSize('dgca');
   const { nodes, edges, columns, width, height } = layoutFGCAPreview(doc, {
     hideChanges,
     colGap: opts.colGap,
     rowGap: opts.rowGap,
     scope: opts.scope,
+    nodeWidth: nodeSize.width,
+    nodeHeight: nodeSize.height,
   });
   const showTitle = heading != null && filename != null && date != null;
   const titleH = showTitle ? TITLE_BLOCK_H : 0;
 
-  const body = renderFgcaBody(columns, nodes, edges, curvature, entryCurvature);
+  const body = renderFgcaBody(columns, nodes, edges, curvature, entryCurvature, {
+    nodeWidth: nodeSize.width,
+    nodeHeight: nodeSize.height,
+  });
 
   const totalH = height + titleH;
   const titleSvg = showTitle ? titleBlockSvg(heading!, filename!, date!, PAD, PAD, version) : '';

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -35,6 +35,7 @@ import {
 import {
   OPEN_SPACING_SETTINGS_COMMAND,
   SPACING_CONFIG_SECTION,
+  NODE_SIZE_CONFIG_SECTION,
   OPEN_CURVATURE_SETTINGS_COMMAND,
   CURVATURE_CONFIG_SECTION,
   ENTRY_CURVATURE_CONFIG_SECTION,
@@ -548,7 +549,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         !e.affectsConfiguration(CURVATURE_CONFIG_SECTION) &&
         !e.affectsConfiguration(ENTRY_CURVATURE_CONFIG_SECTION) &&
         !e.affectsConfiguration(SCOPE_CONFIG_SECTION) &&
-        !e.affectsConfiguration(VIEW_CONFIG_SECTION)
+        !e.affectsConfiguration(VIEW_CONFIG_SECTION) &&
+        !e.affectsConfiguration(NODE_SIZE_CONFIG_SECTION)
       ) return;
       void goalsPreview.refreshConfig();
       void dgcaPreview.refreshConfig();

--- a/extension/src/goals-preview.ts
+++ b/extension/src/goals-preview.ts
@@ -13,7 +13,8 @@ import { parseCanonicalGoals } from '@transitrix/diagrams/goals/parse-canonical.
 import { coerceDatesToIsoStrings } from '@transitrix/diagrams/yaml-normalize.js';
 import { DEFAULT_EDGE_CURVATURE } from '@transitrix/diagrams/edge-path.js';
 import { checkScopeRoot } from '@transitrix/diagrams/scope.js';
-import { readSpacing, readCurvature, readEntryCurvature, readScope, applyControlMessage, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND } from './spacing-config.js';
+import { readSpacing, readCurvature, readEntryCurvature, readScope, applyControlMessage, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND, OPEN_NODE_SIZE_SETTINGS_COMMAND } from './spacing-config.js';
+import { readGoalsNodeSize, readNodeSizePreset } from './node-size-config.js';
 import { genNonce, buildControlsPanel, buildControlsScript, type ControlsModel, type ScopeGoalOption } from './preview-controls.js';
 
 // ── SVG renderer ─────────────────────────────────────────────────────────────
@@ -24,8 +25,6 @@ import { genNonce, buildControlsPanel, buildControlsScript, type ControlsModel, 
 // produces — never re-defines the schema, since the example file and the
 // shared package were drifting apart.
 
-const NODE_W = 250;
-const NODE_H = 60;
 const RANK_SEP = 100;
 const NODE_SEP = 24;
 
@@ -138,9 +137,10 @@ export class GoalsPreview {
         maxLevelPresent = v.parsed.goals.reduce((m, g) => Math.max(m, typeof g.level === 'number' ? g.level : 0), 0);
         const scopeWarning = checkScopeRoot(scope, v.parsed.goals.map(g => g.canonical_id ?? g.id));
         if (scopeWarning) warnings.push(`${scopeWarning.code}: ${scopeWarning.message}`);
+        const nodeSize = readGoalsNodeSize();
         const layout = layoutGoalTree(v.parsed, {
-          nodeWidth: NODE_W,
-          nodeHeight: NODE_H,
+          nodeWidth: nodeSize.width,
+          nodeHeight: nodeSize.height,
           rankSep: gaps.horizontalGap,
           nodeSep: gaps.verticalGap,
           scope,
@@ -158,9 +158,11 @@ export class GoalsPreview {
       .get<ThemeId>('theme', 'transitrix');
 
     const nonce = genNonce();
+    const nodeSizePreset = readNodeSizePreset('goals');
     const model: ControlsModel = {
       spacing: { ...gaps, defaults: spacingDefaults },
       curvature: { value: curvature, default: 1 },
+      nodeSize: { value: nodeSizePreset, default: 'normal' },
       scope: {
         rootId: scope.mode === 'root' ? scope.rootGoalId : '',
         maxLevel: scope.mode === 'level' ? scope.maxLevel : -1,

--- a/extension/src/node-size-config.ts
+++ b/extension/src/node-size-config.ts
@@ -1,0 +1,68 @@
+import * as vscode from 'vscode';
+import {
+  parseNodeSizePreset,
+  resolveActionNodeSize,
+  resolveBlocksLeafSize,
+  resolveCapabilityMapNodeSize,
+  resolveDgcaNodeSize,
+  resolveGoalsNodeSize,
+  resolveProcessBlueprintSize,
+  type NodeSizeNotation,
+  type NodeSizePreset,
+} from '@transitrix/diagrams/node-size-presets.js';
+import type { ControlMessage } from './preview-controls.js';
+
+export type { NodeSizeNotation, NodeSizePreset };
+
+/** Config section that, when changed, re-renders node-size-aware previews. */
+export const NODE_SIZE_CONFIG_SECTION = 'transitrix.nodeSize';
+
+/** Command that opens Settings filtered to the node size controls. */
+export const OPEN_NODE_SIZE_SETTINGS_COMMAND = 'transitrixStudio.openNodeSizeSettings';
+
+/** Reads the configured block/cell size preset for a notation (default `normal`). */
+export function readNodeSizePreset(notation: NodeSizeNotation): NodeSizePreset {
+  const raw = vscode.workspace.getConfiguration('transitrix').get<string>(`nodeSize.${notation}`, 'normal');
+  return parseNodeSizePreset(raw);
+}
+
+export function readGoalsNodeSize() {
+  return resolveGoalsNodeSize(readNodeSizePreset('goals'));
+}
+
+export function readDgcaNodeSize(notation: 'dgca' | 'dga') {
+  return resolveDgcaNodeSize(readNodeSizePreset(notation));
+}
+
+export function readBlocksLeafSize() {
+  return resolveBlocksLeafSize(readNodeSizePreset('blocks'));
+}
+
+export function readActionNodeSize() {
+  return resolveActionNodeSize(readNodeSizePreset('action'));
+}
+
+export function readProcessBlueprintSize() {
+  return resolveProcessBlueprintSize(readNodeSizePreset('processBlueprint'));
+}
+
+export function readCapabilityMapNodeSize() {
+  return resolveCapabilityMapNodeSize(readNodeSizePreset('capabilityMap'));
+}
+
+/** Maps interactive preview notation keys to `transitrix.nodeSize.*` settings keys. */
+export function nodeSizeSettingKey(
+  notation: 'goals' | 'dgca' | 'dga' | 'action' | 'blocks' | 'processBlueprint',
+): NodeSizeNotation {
+  return notation;
+}
+
+export async function applyNodeSizeControlMessage(
+  notation: 'goals' | 'dgca' | 'dga' | 'action' | 'blocks' | 'processBlueprint',
+  msg: ControlMessage,
+): Promise<void> {
+  if (!msg || msg.type !== 'transitrix:control' || msg.control !== 'nodeSize') return;
+  const preset = parseNodeSizePreset(String(msg.value ?? 'normal'));
+  const cfg = vscode.workspace.getConfiguration('transitrix');
+  await cfg.update(`nodeSize.${nodeSizeSettingKey(notation)}`, preset, vscode.ConfigurationTarget.Global);
+}

--- a/extension/src/preview-controls.ts
+++ b/extension/src/preview-controls.ts
@@ -55,19 +55,29 @@ export interface ScopeControlModel {
   goals: ScopeGoalOption[];
 }
 
+export type NodeSizePresetValue = 'compact' | 'normal' | 'wide';
+
+export interface NodeSizeControlModel {
+  value: NodeSizePresetValue;
+  /** Default preset — used to decide whether the panel opens by default. */
+  default: NodeSizePresetValue;
+}
+
 export interface ControlsModel {
   spacing: SpacingControlModel;
   curvature: CurvatureControlModel;
   /** Omitted for notations without a scope filter (Activities). */
   scope?: ScopeControlModel;
+  /** Omitted when the notation has no block-size preset (yet). */
+  nodeSize?: NodeSizeControlModel;
 }
 
 /** Message posted from the webview to the host on every control change. */
 export interface ControlMessage {
   type: 'transitrix:control';
-  control: 'spacing' | 'curvature' | 'entryCurvature' | 'scope' | 'view';
-  /** spacing: 'horizontalGap'|'verticalGap'; scope: 'rootId'|'maxLevel'|'reset'; view: 'tree'|'table'; absent for curvature. */
-  field?: 'horizontalGap' | 'verticalGap' | 'rootId' | 'maxLevel' | 'reset' | 'tree' | 'table';
+  control: 'spacing' | 'curvature' | 'entryCurvature' | 'scope' | 'view' | 'nodeSize';
+  /** spacing: 'horizontalGap'|'verticalGap'; scope: 'rootId'|'maxLevel'|'reset'; view: 'tree'|'table'; nodeSize: 'preset'; absent for curvature. */
+  field?: 'horizontalGap' | 'verticalGap' | 'rootId' | 'maxLevel' | 'reset' | 'tree' | 'table' | 'preset';
   /** Numeric for spacing/curvature/maxLevel; string for rootId; absent for reset/view. */
   value?: number | string;
 }
@@ -235,6 +245,7 @@ function hasNonDefault(model: ControlsModel): boolean {
   const s = model.spacing;
   if (s.horizontalGap !== s.defaults.horizontalGap || s.verticalGap !== s.defaults.verticalGap) return true;
   if (model.curvature.value !== model.curvature.default) return true;
+  if (model.nodeSize && model.nodeSize.value !== model.nodeSize.default) return true;
   if (model.scope && (model.scope.rootId !== '' || model.scope.maxLevel >= 0)) return true;
   return false;
 }
@@ -286,10 +297,22 @@ function scopeRow(sc: ScopeControlModel): string {
   </div>`;
 }
 
+function nodeSizeRow(ns: NodeSizeControlModel): string {
+  const opt = (value: NodeSizePresetValue, label: string): string =>
+    `<option value="${value}"${ns.value === value ? ' selected' : ''}>${label}</option>`;
+  return `<div class="tx-ctl-row">
+    <span class="tx-ctl-label">Block size</span>
+    <label title="Preset width/height for entity blocks or cells">
+      <select data-tx-control="nodeSize" data-tx-field="preset">${opt('compact', 'Compact')}${opt('normal', 'Normal')}${opt('wide', 'Wide')}</select>
+    </label>
+  </div>`;
+}
+
 /** Builds the `<details>` control-panel markup for a notation's interactive preview. */
 export function buildControlsPanel(model: ControlsModel): string {
   const open = hasNonDefault(model) ? ' open' : '';
   const rows = [spacingRow(model.spacing), curvatureRow(model.curvature)];
+  if (model.nodeSize) rows.push(nodeSizeRow(model.nodeSize));
   if (model.scope) rows.push(scopeRow(model.scope));
   return `<details id="tx-ctl" class="tx-ctl"${open}>
   <summary>Controls</summary>
@@ -358,6 +381,8 @@ export function buildControlsScript(nonce: string): string {
           post(control, field, num(el.value));
         } else if (control === 'curvature') {
           post(control, undefined, num(el.value));
+        } else if (control === 'nodeSize') {
+          post(control, field, el.value);
         } else {
           post(control, field, num(el.value));
         }

--- a/extension/src/process-blueprint-preview.ts
+++ b/extension/src/process-blueprint-preview.ts
@@ -18,6 +18,7 @@ import { coerceDatesToIsoStrings } from '@transitrix/diagrams/yaml-normalize.js'
 import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
 import { scanComplianceCanon, type ScannedCanon } from './compliance-scan.js';
 import { genNonce } from './preview-controls.js';
+import { readProcessBlueprintSize } from './node-size-config.js';
 import { escXml } from '@transitrix/diagrams/webview/render-util.js';
 import { renderProcessBlueprintBody } from '@transitrix/diagrams/webview/render-process-blueprint.js';
 
@@ -596,7 +597,9 @@ export class ProcessBlueprintPreview {
           }
         }
 
+        const bpSize = readProcessBlueprintSize();
         const layout = layoutProcessBlueprint(file, {
+          ...bpSize,
           stageColumnWidth: this.stageColumnWidth,
           complianceLane: { ...laneCfg, enabled: complianceLaneEnabled },
           complianceInput,

--- a/extension/src/spacing-config.ts
+++ b/extension/src/spacing-config.ts
@@ -1,4 +1,7 @@
 import * as vscode from 'vscode';
+import {
+  parseNodeSizePreset,
+} from '@transitrix/diagrams/node-size-presets.js';
 import type { Scope } from '@transitrix/diagrams/scope.js';
 import type { ControlMessage, PreviewView } from './preview-controls.js';
 
@@ -7,7 +10,7 @@ import type { ControlMessage, PreviewView } from './preview-controls.js';
 // mirroring the existing `transitrix.theme` pattern, and re-renders previews
 // on change. In-preview live sliders are deferred to PR2.
 
-export type SpacingNotation = 'goals' | 'dgca' | 'dga' | 'action';
+export type SpacingNotation = 'goals' | 'dgca' | 'dga' | 'action' | 'blocks' | 'processBlueprint';
 
 export interface SpacingGaps {
   /** px gap between columns (horizontal). */
@@ -111,6 +114,8 @@ export function readView(notation: ViewNotation): PreviewView {
 /** Config section that, when changed, re-renders view-aware previews. */
 export const VIEW_CONFIG_SECTION = 'transitrix.view';
 
+export { NODE_SIZE_CONFIG_SECTION, OPEN_NODE_SIZE_SETTINGS_COMMAND } from './node-size-config.js';
+
 // ── In-preview control messages (PR2) ───────────────────────────────────────
 //
 // The interactive control panel (preview-controls.ts) posts a `ControlMessage`
@@ -153,7 +158,12 @@ export async function applyControlMessage(notation: SpacingNotation, msg: Contro
     await cfg.update(`view.${notation}`, msg.field === 'table' ? 'table' : 'tree', target);
     return;
   }
-  if (msg.control === 'scope' && notation !== 'action') {
+  if (msg.control === 'nodeSize') {
+    const preset = parseNodeSizePreset(String(msg.value ?? 'normal'));
+    await cfg.update(`nodeSize.${notation}`, preset, target);
+    return;
+  }
+  if (msg.control === 'scope' && notation !== 'action' && notation !== 'blocks' && notation !== 'processBlueprint') {
     if (msg.field === 'reset') {
       await cfg.update(`scope.${notation}.rootId`, '', target);
       await cfg.update(`scope.${notation}.maxLevel`, -1, target);

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.7.7",
+  "version": "1.8.0",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",

--- a/packages/diagrams/src/activities/layout.ts
+++ b/packages/diagrams/src/activities/layout.ts
@@ -1,13 +1,18 @@
 import type { ActivityDoc, Activity, ActivitiesLayout, ActivitiesLayoutOptions, LayoutNode, LayoutEdge } from './types.js';
 import { computeCpm } from './cpm.js';
 
-const NODE_W = 200;
-const NODE_H = 80;
+const DEFAULT_NODE_W = 200;
+const DEFAULT_NODE_H = 80;
 const H_GAP = 80;
 const V_GAP = 24;
 
 export function layoutActivities(doc: ActivityDoc, options: ActivitiesLayoutOptions = {}): ActivitiesLayout {
-  const { horizontalGap = H_GAP, verticalGap = V_GAP } = options;
+  const {
+    horizontalGap = H_GAP,
+    verticalGap = V_GAP,
+    nodeWidth = DEFAULT_NODE_W,
+    nodeHeight = DEFAULT_NODE_H,
+  } = options;
   const activities = doc.activities;
   if (activities.length === 0) {
     return { nodes: [], edges: [], bounds: { x: 0, y: 0, width: 0, height: 0 } };
@@ -70,21 +75,21 @@ export function layoutActivities(doc: ActivityDoc, options: ActivitiesLayoutOpti
 
   for (let c = 0; c < colCount; c++) {
     const list = cols.get(c) ?? [];
-    const x = c * (NODE_W + horizontalGap);
+    const x = c * (nodeWidth + horizontalGap);
     let y = 0;
     for (const a of list) {
       const node: LayoutNode = {
         id: a.id,
         x,
         y,
-        width: NODE_W,
-        height: NODE_H,
+        width: nodeWidth,
+        height: nodeHeight,
         data: a,
         cpm: cpm.get(a.id),
       };
       nodes.push(node);
       nodeMap.set(a.id, node);
-      y += NODE_H + verticalGap;
+      y += nodeHeight + verticalGap;
     }
   }
 

--- a/packages/diagrams/src/activities/types.ts
+++ b/packages/diagrams/src/activities/types.ts
@@ -100,6 +100,10 @@ export interface ActivitiesLayoutOptions {
   horizontalGap?: number;
   /** Vertical gap (px) between stacked activity nodes. Default matches the historical hardcoded value. */
   verticalGap?: number;
+  /** Activity node width (px). Default 200. */
+  nodeWidth?: number;
+  /** Activity node height (px). Default 80. */
+  nodeHeight?: number;
 }
 
 // ── Gantt view (spec §9) ─────────────────────────────────────────────────────

--- a/packages/diagrams/src/capability-map/layout-tree.ts
+++ b/packages/diagrams/src/capability-map/layout-tree.ts
@@ -40,10 +40,18 @@ export interface CapabilityTreeLayout {
   levelCounts: CapabilityTreeLevelCounts;
 }
 
+export interface CapabilityTreeLayoutOptions {
+  nodeWidth?: number;
+  nodeHeight?: number;
+}
+
 export function layoutCapabilityTree(
   map: CapabilityMapHeader,
   collapsedIds: Set<string> = new Set(),
+  options: CapabilityTreeLayoutOptions = {},
 ): CapabilityTreeLayout {
+  const nodeWidth = options.nodeWidth ?? TREE_NODE_WIDTH;
+  const nodeHeight = options.nodeHeight ?? TREE_NODE_HEIGHT;
   const nodes: CapabilityTreeNode[] = [];
   const edges: CapabilityTreeEdge[] = [];
 
@@ -60,13 +68,13 @@ export function layoutCapabilityTree(
     const hasChildren = Boolean(node.children?.length);
     const visibleChildren = !isCollapsed && node.children?.length ? node.children : [];
 
-    const x = depth * (TREE_NODE_WIDTH + TREE_RANK_SEP);
+    const x = depth * (nodeWidth + TREE_RANK_SEP);
 
     if (visibleChildren.length === 0) {
       const y = getNextY(depth);
-      advanceY(depth, TREE_NODE_HEIGHT + TREE_NODE_SEP);
-      nodes.push({ id: node.id, x, y, width: TREE_NODE_WIDTH, height: TREE_NODE_HEIGHT, data: node, depth, hasChildren, isCollapsed });
-      return { top: y, bottom: y + TREE_NODE_HEIGHT };
+      advanceY(depth, nodeHeight + TREE_NODE_SEP);
+      nodes.push({ id: node.id, x, y, width: nodeWidth, height: nodeHeight, data: node, depth, hasChildren, isCollapsed });
+      return { top: y, bottom: y + nodeHeight };
     }
 
     const childSpans: Array<{ top: number; bottom: number }> = [];
@@ -77,14 +85,14 @@ export function layoutCapabilityTree(
 
     const spanTop = Math.min(...childSpans.map(s => s.top));
     const spanBottom = Math.max(...childSpans.map(s => s.bottom));
-    const parentY = spanTop + (spanBottom - spanTop) / 2 - TREE_NODE_HEIGHT / 2;
+    const parentY = spanTop + (spanBottom - spanTop) / 2 - nodeHeight / 2;
 
     const curColY = getNextY(depth);
     const finalY = Math.max(parentY, curColY);
-    advanceY(depth, finalY - curColY + TREE_NODE_HEIGHT + TREE_NODE_SEP);
+    advanceY(depth, finalY - curColY + nodeHeight + TREE_NODE_SEP);
 
-    nodes.push({ id: node.id, x, y: finalY, width: TREE_NODE_WIDTH, height: TREE_NODE_HEIGHT, data: node, depth, hasChildren, isCollapsed });
-    return { top: Math.min(finalY, spanTop), bottom: Math.max(finalY + TREE_NODE_HEIGHT, spanBottom) };
+    nodes.push({ id: node.id, x, y: finalY, width: nodeWidth, height: nodeHeight, data: node, depth, hasChildren, isCollapsed });
+    return { top: Math.min(finalY, spanTop), bottom: Math.max(finalY + nodeHeight, spanBottom) };
   }
 
   for (const root of map.capabilities) {

--- a/packages/diagrams/src/capability-map/render-capability-tree.ts
+++ b/packages/diagrams/src/capability-map/render-capability-tree.ts
@@ -1,13 +1,13 @@
 import type { CapabilityMapHeader } from './types.js';
-import { layoutCapabilityTree, TREE_NODE_WIDTH, TREE_NODE_HEIGHT, TREE_NODE_SEP } from './layout-tree.js';
+import { layoutCapabilityTree, TREE_NODE_SEP } from './layout-tree.js';
 import { horizontalCubicEdgePath, DEFAULT_EDGE_CURVATURE } from '../edge-path.js';
+import { parseNodeSizePreset, resolveCapabilityMapNodeSize, type NodeSizePreset } from '../node-size-presets.js';
+import { maxCharsForInnerWidth, truncateLine } from '../webview/entity-text-layout.js';
 import { escXml } from '../webview/render-util.js';
 
 const PAD = 24;
 const BTN_R = 8;
 const LEGEND_H = 40;
-const LABEL_MAX_CHARS = 28;
-const LABEL_TRIM_CHARS = 26;
 
 const BAND_LABELS = ['Levels 0–2', 'Levels 3–4', 'Levels 5+'] as const;
 
@@ -17,30 +17,19 @@ function depthBand(depth: number): 0 | 1 | 2 {
   return 2;
 }
 
-function truncate(s: string, max: number, trim: number): string {
-  return s.length > max ? s.slice(0, trim) + '…' : s;
-}
-
 export interface RenderCapabilityTreeOptions {
   collapsedIds?: Set<string>;
   curvature?: number;
+  nodeSizePreset?: NodeSizePreset;
 }
 
-/**
- * Renders a capability-map as a left-to-right SVG node tree with DSM-matching
- * visual design: depth-banded fills, maturity badges, and +/− collapse buttons.
- *
- * The SVG uses CSS classes (`tree-level-N`, `tree-maturity-N`, `tree-collapse-btn`)
- * that must be resolved by the host's stylesheet (injected via `diagramClassCss()`
- * in themes.ts). Collapse buttons carry `data-node-id` / `data-collapsed` attributes
- * for the webview click handler.
- */
 export function renderCapabilityTreeSvg(
   map: CapabilityMapHeader,
   opts: RenderCapabilityTreeOptions = {},
 ): string {
-  const { collapsedIds = new Set(), curvature = DEFAULT_EDGE_CURVATURE } = opts;
-  const layout = layoutCapabilityTree(map, collapsedIds);
+  const { collapsedIds = new Set(), curvature = DEFAULT_EDGE_CURVATURE, nodeSizePreset = 'normal' } = opts;
+  const nodeSize = resolveCapabilityMapNodeSize(parseNodeSizePreset(nodeSizePreset));
+  const layout = layoutCapabilityTree(map, collapsedIds, nodeSize);
 
   if (layout.nodes.length === 0) {
     return `<svg xmlns="http://www.w3.org/2000/svg" width="0" height="0" viewBox="0 0 0 0"></svg>`;
@@ -70,23 +59,22 @@ export function renderCapabilityTreeSvg(
     const band = depthBand(n.depth);
     const mat = Math.max(1, Math.min(5, n.data.current_maturity | 0));
 
-    const nameText = truncate(n.data.name, LABEL_MAX_CHARS, LABEL_TRIM_CHARS);
-    const nameTitle = n.data.name.length > LABEL_MAX_CHARS ? escXml(n.data.name) : '';
-
-    // Maturity badge: left side of node
     const badgeW = 28;
     const badgeH = 18;
+    const textAreaW = Math.max(0, n.width - badgeW - 26);
+    const maxChars = maxCharsForInnerWidth(textAreaW, 7);
+    const nameText = truncateLine(n.data.name, maxChars);
+    const nameTitle = n.data.name.length > maxChars ? escXml(n.data.name) : '';
+
     const badgeX = x + 10;
-    const badgeY = y + (TREE_NODE_HEIGHT - badgeH) / 2;
+    const badgeY = y + (n.height - badgeH) / 2;
 
-    // Text area: right of badge
     const textX = badgeX + badgeW + 8;
-    const nameY = y + TREE_NODE_HEIGHT / 2 - 8;
-    const idY = y + TREE_NODE_HEIGHT / 2 + 9;
+    const nameY = y + n.height / 2 - 8;
+    const idY = y + n.height / 2 + 9;
 
-    // Collapse button: centered on right edge of node
-    const btnCx = x + TREE_NODE_WIDTH;
-    const btnCy = y + TREE_NODE_HEIGHT / 2;
+    const btnCx = x + n.width;
+    const btnCy = y + n.height / 2;
 
     const collapseBtn = n.hasChildren
       ? `<circle class="tree-collapse-btn" cx="${btnCx}" cy="${btnCy}" r="${BTN_R}" data-node-id="${escXml(n.id)}" data-collapsed="${n.isCollapsed}"/>
@@ -94,7 +82,7 @@ export function renderCapabilityTreeSvg(
       : '';
 
     return `<g${nameTitle ? ` title="${nameTitle}"` : ''}>
-  <rect class="tree-level-${band}" x="${x}" y="${y}" width="${TREE_NODE_WIDTH}" height="${TREE_NODE_HEIGHT}" rx="11" stroke="var(--ts-node-stroke,#94a3b8)" stroke-width="3"/>
+  <rect class="tree-level-${band}" x="${x}" y="${y}" width="${n.width}" height="${n.height}" rx="11" stroke="var(--ts-node-stroke,#94a3b8)" stroke-width="3"/>
   <rect class="tree-maturity-${mat}" x="${badgeX}" y="${badgeY}" width="${badgeW}" height="${badgeH}" rx="4"/>
   <text class="text-pill" x="${badgeX + badgeW / 2}" y="${badgeY + badgeH / 2}" text-anchor="middle" fill="white">L${mat}</text>
   <text class="text-primary" x="${textX}" y="${nameY}" dominant-baseline="central">${escXml(nameText)}</text>

--- a/packages/diagrams/src/fgca/preview-layout.ts
+++ b/packages/diagrams/src/fgca/preview-layout.ts
@@ -57,7 +57,7 @@ export interface FGCAPreviewLayoutOptions {
 }
 
 /**
- * Trims a DGCA/DGA doc to a scope (vkgeorgia/strategy#77).
+ * Trims a DGCA/DGA doc to a scope.
  *
  * DGCA/DGA goals are flat (no parent_id), so:
  *   - 'level' → goals with `(level ?? 0) <= maxLevel`.
@@ -124,7 +124,7 @@ export interface FGCAPreviewLayout {
 }
 
 // Default node + frame geometry. Inter-node gaps are user-configurable via
-// spacing settings (vkgeorgia/strategy#75); node size uses presets (#521).
+// Inter-node gaps are user-configurable via spacing settings; node size uses presets.
 export const FGCA_NODE_W = 220;
 export const FGCA_NODE_H = 72;
 export const FGCA_HEADER_H = 32;

--- a/packages/diagrams/src/fgca/preview-layout.ts
+++ b/packages/diagrams/src/fgca/preview-layout.ts
@@ -1,6 +1,6 @@
-// Pure column-layout geometry for the static FGCA / FGA previews.
+// Pure column-layout geometry for the static DGCA / DGA previews.
 //
-// This is the layout the Studio extension's `fgca-preview.ts` renders to SVG
+// This is the layout the Studio extension's `dgca-preview.ts` renders to SVG
 // (NOT the ReactFlow `buildFGCALayout` in `./layout.ts`, which targets the
 // interactive web UI). It lives here — rather than inline in the extension —
 // so the gap geometry is unit-testable: the extension has no test harness.
@@ -33,7 +33,7 @@ export interface FGCAPreviewActivity {
   goal_id?: number | string | null;
 }
 
-/** Structural input the preview layout needs — a subset of the parsed FGCA/FGA doc. */
+/** Structural input the preview layout needs — a subset of the parsed DGCA/DGA doc. */
 export interface FGCAPreviewDoc {
   factors: FGCAPreviewFactor[];
   goals: FGCAPreviewGoal[];
@@ -42,7 +42,7 @@ export interface FGCAPreviewDoc {
 }
 
 export interface FGCAPreviewLayoutOptions {
-  /** FGA hides the Changes column and links Goal → Activity directly. */
+  /** DGA hides the Changes column and links Goal → Activity directly. */
   hideChanges?: boolean;
   /** Horizontal gap (px) between columns. Default matches the historical hardcoded value. */
   colGap?: number;
@@ -50,12 +50,16 @@ export interface FGCAPreviewLayoutOptions {
   rowGap?: number;
   /** Trim to a level cap or a single root goal (vkgeorgia/strategy#77). Defaults to 'all'. */
   scope?: Scope;
+  /** Entity node width (px). Default {@link FGCA_NODE_W}. */
+  nodeWidth?: number;
+  /** Entity node height (px). Default {@link FGCA_NODE_H}. */
+  nodeHeight?: number;
 }
 
 /**
- * Trims an FGCA/FGA doc to a scope (vkgeorgia/strategy#77).
+ * Trims a DGCA/DGA doc to a scope (vkgeorgia/strategy#77).
  *
- * FGCA/FGA goals are flat (no parent_id), so:
+ * DGCA/DGA goals are flat (no parent_id), so:
  *   - 'level' → goals with `(level ?? 0) <= maxLevel`.
  *   - 'root'  → the single goal whose id matches `rootGoalId` (empty when absent).
  *
@@ -119,8 +123,8 @@ export interface FGCAPreviewLayout {
   height: number;
 }
 
-// Fixed node + frame geometry. Only the inter-node gaps are user-configurable
-// (vkgeorgia/strategy#75); node size and padding stay constant.
+// Default node + frame geometry. Inter-node gaps are user-configurable via
+// spacing settings (vkgeorgia/strategy#75); node size uses presets (#521).
 export const FGCA_NODE_W = 220;
 export const FGCA_NODE_H = 72;
 export const FGCA_HEADER_H = 32;
@@ -137,12 +141,14 @@ export function layoutFGCAPreview(
     colGap = FGCA_DEFAULT_COL_GAP,
     rowGap = FGCA_DEFAULT_ROW_GAP,
     scope = { mode: 'all' },
+    nodeWidth = FGCA_NODE_W,
+    nodeHeight = FGCA_NODE_H,
   } = options;
 
   // Trim to scope first; everything below lays out the visible subset only.
   const doc = selectScopedFGCA(inputDoc, scope);
 
-  const colStride = FGCA_NODE_W + colGap;
+  const colStride = nodeWidth + colGap;
   const cols: FGCAPreviewColumn[] = hideChanges
     ? ['driver', 'goal', 'activity']
     : ['driver', 'goal', 'change', 'activity'];
@@ -206,7 +212,7 @@ export function layoutFGCAPreview(
   const nodeMap = new Map<string, FGCAPreviewNode>();
   const nodes: FGCAPreviewNode[] = [];
   const columns: FGCAPreviewColumnPos[] = [];
-  const yCenters = new Map<string, number>(); // nodeId → y + FGCA_NODE_H / 2
+  const yCenters = new Map<string, number>(); // nodeId → y + nodeHeight / 2
 
   for (let ci = 0; ci < cols.length; ci++) {
     const col = cols[ci];
@@ -218,8 +224,8 @@ export function layoutFGCAPreview(
       const node: FGCAPreviewNode = { id: item.id, x, y, label: item.label, col };
       nodes.push(node);
       nodeMap.set(item.id, node);
-      yCenters.set(item.id, y + FGCA_NODE_H / 2);
-      y += FGCA_NODE_H + rowGap;
+      yCenters.set(item.id, y + nodeHeight / 2);
+      y += nodeHeight + rowGap;
     }
   }
 
@@ -228,7 +234,7 @@ export function layoutFGCAPreview(
     const s = nodeMap.get(sourceId);
     const t = nodeMap.get(targetId);
     if (!s || !t) return;
-    edges.push({ sx: s.x + FGCA_NODE_W, sy: s.y + FGCA_NODE_H / 2, tx: t.x, ty: t.y + FGCA_NODE_H / 2 });
+    edges.push({ sx: s.x + nodeWidth, sy: s.y + nodeHeight / 2, tx: t.x, ty: t.y + nodeHeight / 2 });
   }
 
   for (const g of doc.goals) {
@@ -259,8 +265,8 @@ export function layoutFGCAPreview(
   }
 
   const maxNodeBottom = nodes.reduce(
-    (m, n) => Math.max(m, n.y + FGCA_NODE_H),
-    FGCA_PAD + FGCA_HEADER_H + rowGap + FGCA_NODE_H,
+    (m, n) => Math.max(m, n.y + nodeHeight),
+    FGCA_PAD + FGCA_HEADER_H + rowGap + nodeHeight,
   );
   const width = FGCA_PAD * 2 + cols.length * colStride - colGap;
   const height = maxNodeBottom + FGCA_PAD;

--- a/packages/diagrams/src/node-size-presets.ts
+++ b/packages/diagrams/src/node-size-presets.ts
@@ -1,8 +1,8 @@
 /**
- * Block/cell size presets for diagram renderers (strategy #521).
+ * Block/cell size presets for diagram renderers.
  *
  * Presets drive both layout geometry and shared text-layout char budgets.
- * Smooth per-pixel sliders are intentionally deferred — see hub issue #521.
+ * Smooth per-pixel sliders are intentionally deferred.
  */
 
 export type NodeSizePreset = 'compact' | 'normal' | 'wide';

--- a/packages/diagrams/src/node-size-presets.ts
+++ b/packages/diagrams/src/node-size-presets.ts
@@ -1,0 +1,157 @@
+/**
+ * Block/cell size presets for diagram renderers (strategy #521).
+ *
+ * Presets drive both layout geometry and shared text-layout char budgets.
+ * Smooth per-pixel sliders are intentionally deferred — see hub issue #521.
+ */
+
+export type NodeSizePreset = 'compact' | 'normal' | 'wide';
+
+export const NODE_SIZE_PRESET_VALUES: readonly NodeSizePreset[] = ['compact', 'normal', 'wide'] as const;
+
+export interface BoxDimensions {
+  width: number;
+  height: number;
+}
+
+export interface BlocksLeafDimensions extends BoxDimensions {}
+
+export interface ProcessBlueprintDimensions {
+  legendColumnWidth: number;
+  stageColumnWidth: number;
+  stageHeaderHeight: number;
+  goalRowHeight: number;
+  resultRowHeight: number;
+  aspectRowMinHeight: number;
+  pillHeight: number;
+  pillGap: number;
+  cellPadding: number;
+  textLineHeight: number;
+  textCharWidth: number;
+  cellTextPadX: number;
+  cellTextPadY: number;
+}
+
+export interface CapabilityMapDimensions {
+  nodeWidth: number;
+  nodeHeight: number;
+}
+
+type PresetTable<T> = Record<NodeSizePreset, T>;
+
+export const GOALS_NODE_SIZE: PresetTable<BoxDimensions> = {
+  compact: { width: 200, height: 72 },
+  normal: { width: 250, height: 72 },
+  wide: { width: 320, height: 72 },
+};
+
+export const DGCA_NODE_SIZE: PresetTable<BoxDimensions> = {
+  compact: { width: 200, height: 72 },
+  normal: { width: 220, height: 72 },
+  wide: { width: 280, height: 72 },
+};
+
+export const BLOCKS_LEAF_SIZE: PresetTable<BlocksLeafDimensions> = {
+  compact: { width: 140, height: 72 },
+  normal: { width: 160, height: 72 },
+  wide: { width: 200, height: 72 },
+};
+
+export const ACTION_NODE_SIZE: PresetTable<BoxDimensions> = {
+  compact: { width: 180, height: 72 },
+  normal: { width: 200, height: 80 },
+  wide: { width: 260, height: 80 },
+};
+
+export const PROCESS_BLUEPRINT_SIZE: PresetTable<ProcessBlueprintDimensions> = {
+  compact: {
+    legendColumnWidth: 120,
+    stageColumnWidth: 180,
+    stageHeaderHeight: 36,
+    goalRowHeight: 52,
+    resultRowHeight: 52,
+    aspectRowMinHeight: 56,
+    pillHeight: 36,
+    pillGap: 4,
+    cellPadding: 8,
+    textLineHeight: 16,
+    textCharWidth: 7.5,
+    cellTextPadX: 10,
+    cellTextPadY: 10,
+  },
+  normal: {
+    legendColumnWidth: 140,
+    stageColumnWidth: 220,
+    stageHeaderHeight: 40,
+    goalRowHeight: 56,
+    resultRowHeight: 56,
+    aspectRowMinHeight: 60,
+    pillHeight: 40,
+    pillGap: 4,
+    cellPadding: 8,
+    textLineHeight: 17,
+    textCharWidth: 7.5,
+    cellTextPadX: 10,
+    cellTextPadY: 10,
+  },
+  wide: {
+    legendColumnWidth: 160,
+    stageColumnWidth: 280,
+    stageHeaderHeight: 44,
+    goalRowHeight: 60,
+    resultRowHeight: 60,
+    aspectRowMinHeight: 64,
+    pillHeight: 44,
+    pillGap: 4,
+    cellPadding: 8,
+    textLineHeight: 18,
+    textCharWidth: 7.5,
+    cellTextPadX: 10,
+    cellTextPadY: 10,
+  },
+};
+
+export const CAPABILITY_MAP_NODE_SIZE: PresetTable<CapabilityMapDimensions> = {
+  compact: { nodeWidth: 200, nodeHeight: 56 },
+  normal: { nodeWidth: 240, nodeHeight: 60 },
+  wide: { nodeWidth: 300, nodeHeight: 64 },
+};
+
+export type NodeSizeNotation =
+  | 'goals'
+  | 'dgca'
+  | 'dga'
+  | 'blocks'
+  | 'action'
+  | 'processBlueprint'
+  | 'capabilityMap';
+
+/** Parse a VS Code setting value into a preset id (defaults to `normal`). */
+export function parseNodeSizePreset(value: string | undefined): NodeSizePreset {
+  if (value === 'compact' || value === 'wide') return value;
+  return 'normal';
+}
+
+export function resolveGoalsNodeSize(preset: NodeSizePreset): BoxDimensions {
+  return GOALS_NODE_SIZE[preset];
+}
+
+export function resolveDgcaNodeSize(preset: NodeSizePreset): BoxDimensions {
+  return DGCA_NODE_SIZE[preset];
+}
+
+export function resolveBlocksLeafSize(preset: NodeSizePreset): BlocksLeafDimensions {
+  return BLOCKS_LEAF_SIZE[preset];
+}
+
+export function resolveActionNodeSize(preset: NodeSizePreset): BoxDimensions {
+  return ACTION_NODE_SIZE[preset];
+}
+
+export function resolveProcessBlueprintSize(preset: NodeSizePreset): ProcessBlueprintDimensions {
+  return PROCESS_BLUEPRINT_SIZE[preset];
+}
+
+export function resolveCapabilityMapNodeSize(preset: NodeSizePreset): CapabilityMapDimensions {
+  return CAPABILITY_MAP_NODE_SIZE[preset];
+}

--- a/packages/diagrams/src/process-blueprint/layout.ts
+++ b/packages/diagrams/src/process-blueprint/layout.ts
@@ -80,7 +80,7 @@ function resolveOptions(options: ProcessBlueprintLayoutOptions | undefined): Res
 
 /**
  * Greedy word-wrap to a max characters-per-line budget. Delegates to the shared
- * text-layout module (strategy #521).
+ * shared text-layout module.
  */
 function wrapText(text: string, maxChars: number, maxLines: number): string[] {
   return wrapTextLines(text, maxChars, maxLines);

--- a/packages/diagrams/src/process-blueprint/layout.ts
+++ b/packages/diagrams/src/process-blueprint/layout.ts
@@ -18,6 +18,7 @@ import type {
   StageHeaderCell,
   StageTextCell,
 } from './types.js';
+import { wrapTextLines } from '../webview/entity-text-layout.js';
 
 const ASPECT_CATEGORIES: AspectCategory[] = ['systems', 'actors', 'equipment', 'information_entities'];
 
@@ -78,56 +79,11 @@ function resolveOptions(options: ProcessBlueprintLayoutOptions | undefined): Res
 }
 
 /**
- * Greedy word-wrap to a max characters-per-line budget. Words longer than the
- * budget are hard-split; if the result exceeds `maxLines`, the last kept line
- * is truncated with an ellipsis so a single pathological cell can't grow the
- * whole row unbounded.
+ * Greedy word-wrap to a max characters-per-line budget. Delegates to the shared
+ * text-layout module (strategy #521).
  */
 function wrapText(text: string, maxChars: number, maxLines: number): string[] {
-  const trimmed = (text ?? '').trim();
-  if (trimmed.length === 0) return [];
-  const budget = Math.max(1, maxChars);
-
-  const words = trimmed.split(/\s+/);
-  const lines: string[] = [];
-  let cur = '';
-  const flush = (): void => {
-    if (cur.length > 0) {
-      lines.push(cur);
-      cur = '';
-    }
-  };
-
-  for (const word of words) {
-    if (word.length > budget) {
-      // Token wider than the cell: hard-break it across lines.
-      flush();
-      let rest = word;
-      while (rest.length > budget) {
-        lines.push(rest.slice(0, budget));
-        rest = rest.slice(budget);
-      }
-      cur = rest;
-      continue;
-    }
-    const candidate = cur.length > 0 ? `${cur} ${word}` : word;
-    if (candidate.length > budget) {
-      flush();
-      cur = word;
-    } else {
-      cur = candidate;
-    }
-  }
-  flush();
-
-  if (lines.length > maxLines) {
-    const capped = lines.slice(0, maxLines);
-    const last = capped[maxLines - 1];
-    const clipped = last.length > budget - 1 ? last.slice(0, budget - 1) : last;
-    capped[maxLines - 1] = `${clipped.replace(/…$/, '')}…`;
-    return capped;
-  }
-  return lines;
+  return wrapTextLines(text, maxChars, maxLines);
 }
 
 function buildStageIndex(stages: Stage[]): Map<string, number> {

--- a/packages/diagrams/src/webview/__tests__/entity-text-layout.test.ts
+++ b/packages/diagrams/src/webview/__tests__/entity-text-layout.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import {
+  layoutCenteredEntityText,
+  maxCharsForInnerWidth,
+  wrapWords,
+  wrapTextLines,
+} from '../entity-text-layout.js';
+
+describe('entity-text-layout', () => {
+  it('wrapWords respects max lines and truncates with ellipsis', () => {
+    const long = 'one two three four five six seven eight nine ten eleven twelve';
+    const lines = wrapWords(long, 12, 2);
+    expect(lines.length).toBeLessThanOrEqual(2);
+    expect(lines[lines.length - 1]).toMatch(/…$/);
+  });
+
+  it('maxCharsForInnerWidth scales with inner width', () => {
+    expect(maxCharsForInnerWidth(160, 7)).toBeGreaterThan(maxCharsForInnerWidth(120, 7));
+  });
+
+  it('layoutCenteredEntityText emits more name capacity on wide boxes', () => {
+    const narrow = layoutCenteredEntityText({
+      boxX: 0,
+      boxY: 0,
+      boxWidth: 200,
+      boxHeight: 72,
+      name: 'Improve customer onboarding experience across regions',
+      id: 'GOAL-001',
+      nameMaxLines: 2,
+      idMaxLines: 1,
+    });
+    const wide = layoutCenteredEntityText({
+      boxX: 0,
+      boxY: 0,
+      boxWidth: 320,
+      boxHeight: 72,
+      name: 'Improve customer onboarding experience across regions',
+      id: 'GOAL-001',
+      nameMaxLines: 2,
+      idMaxLines: 1,
+    });
+    const narrowPrimary = narrow.filter((l) => l.cls === 'text-primary').map((l) => l.text).join(' ');
+    const widePrimary = wide.filter((l) => l.cls === 'text-primary').map((l) => l.text).join(' ');
+    expect(widePrimary.replace(/…/g, '').length).toBeGreaterThanOrEqual(narrowPrimary.replace(/…/g, '').length);
+  });
+
+  it('wrapTextLines hard-breaks oversized tokens (blueprint cells)', () => {
+    const lines = wrapTextLines('supercalifragilisticexpialidocious word', 10, 3);
+    expect(lines.length).toBeGreaterThan(1);
+    expect(lines.every((l) => l.length <= 10)).toBe(true);
+  });
+});

--- a/packages/diagrams/src/webview/__tests__/entry.test.ts
+++ b/packages/diagrams/src/webview/__tests__/entry.test.ts
@@ -47,9 +47,9 @@ describe('webview/entry — Step 2 host API', () => {
 
   it('routes non-goals kinds to their validator after Step 4 (no NOTATION-NOT-WIRED)', () => {
     // Every supported kind is now wired to its validator + renderer. A
-    // malformed fgca document must surface a structured validation error from
-    // the fgca validator — never the Step-2/3 "not wired" placeholder.
-    const r = render('fgca', 'changes: []\n');
+    // malformed dgca document must surface a structured validation error from
+    // the dgca validator — never the Step-2/3 "not wired" placeholder.
+    const r = render('dgca', 'changes: []\n');
     expect(r.status).toBe('error');
     expect(r.errors.length).toBeGreaterThan(0);
     expect(r.errors.every((e) => e.code !== 'NOTATION-NOT-WIRED')).toBe(true);

--- a/packages/diagrams/src/webview/__tests__/render-blocks.test.ts
+++ b/packages/diagrams/src/webview/__tests__/render-blocks.test.ts
@@ -10,15 +10,7 @@ import { describe, expect, it } from 'vitest';
 
 import type { BlocksFile } from '../../blocks/types.js';
 import { renderBlocksSvg } from '../render-blocks.js';
-
-// Approximate character widths used by the renderer when sizing labels.
-// Kept in sync with `CHAR_W` / `CHAR_W_ID` in render-blocks.ts so the test
-// can compute the same overflow bounds the renderer uses.
-const CHAR_W = 7;
-const CHAR_W_ID = 6;
-
-// Same horizontal margin the renderer reserves so text never abuts the rect.
-const TEXT_MARGIN_X = 8;
+import { CHAR_W_PRIMARY as CHAR_W, CHAR_W_ID, TEXT_MARGIN_X } from '../entity-text-layout.js';
 
 function leafDoc(name: string, id: string): BlocksFile {
   return {

--- a/packages/diagrams/src/webview/entity-text-layout.ts
+++ b/packages/diagrams/src/webview/entity-text-layout.ts
@@ -1,5 +1,5 @@
 /**
- * Shared text-in-block layout for Transitrix diagram renderers (strategy #521).
+ * Shared text-in-block layout for Transitrix diagram renderers.
  *
  * Consolidates wrapping, truncation, and vertical placement patterns previously
  * duplicated across Blocks, Goals, DGCA/DGA, Activities, Process Blueprint, and

--- a/packages/diagrams/src/webview/entity-text-layout.ts
+++ b/packages/diagrams/src/webview/entity-text-layout.ts
@@ -1,0 +1,355 @@
+/**
+ * Shared text-in-block layout for Transitrix diagram renderers (strategy #521).
+ *
+ * Consolidates wrapping, truncation, and vertical placement patterns previously
+ * duplicated across Blocks, Goals, DGCA/DGA, Activities, Process Blueprint, and
+ * Capability Map renderers.
+ */
+
+export const TEXT_MARGIN_X = 8;
+/** Approximate character width (px) at text-primary size (12px/600). */
+export const CHAR_W_PRIMARY = 7;
+/** Approximate character width (px) at text-id size (10px/600). */
+export const CHAR_W_ID = 6;
+/** Approximate character width (px) at text-secondary size. */
+export const CHAR_W_SECONDARY = 7;
+/** Vertical advance between name line centres (text-primary). */
+export const LINE_H_PRIMARY = 14;
+/** Vertical advance between secondary line centres. */
+export const LINE_H_SECONDARY = 14;
+/** Vertical advance between id line centres (text-id). */
+export const LINE_H_ID = 12;
+/** Gap between the name block and the id block in leaf-style layouts. */
+export const NAME_ID_GAP = 14;
+/** Gap between stacked row groups (name → type → id). */
+export const ROW_GROUP_GAP = 9;
+
+export function maxCharsForInnerWidth(innerWidth: number, charWidth: number): number {
+  return Math.max(4, Math.floor(Math.max(0, innerWidth) / charWidth));
+}
+
+/** Word-wrap `text` to at most `maxLines` lines of `maxChars` each. */
+export function wrapWords(text: string, maxChars: number, maxLines: number): string[] {
+  const safeMax = Math.max(2, maxChars);
+  const words = text.split(' ');
+  const lines: string[] = [];
+  let cur = '';
+  for (let i = 0; i < words.length; i++) {
+    const w = words[i];
+    const next = cur ? `${cur} ${w}` : w;
+    if (next.length <= safeMax) {
+      cur = next;
+    } else {
+      if (cur) lines.push(cur);
+      cur = '';
+      if (lines.length >= maxLines) break;
+      if (lines.length === maxLines - 1) {
+        const rest = words.slice(i).join(' ');
+        lines.push(rest.length <= safeMax ? rest : `${rest.slice(0, safeMax - 1)}…`);
+        return lines;
+      }
+      cur = w.length <= safeMax ? w : `${w.slice(0, safeMax - 1)}…`;
+    }
+  }
+  if (cur && lines.length < maxLines) lines.push(cur);
+  return lines.length ? lines : [`${text.slice(0, safeMax - 1)}…`];
+}
+
+/**
+ * Greedy word-wrap with hard-break for tokens wider than the budget. When the
+ * result exceeds `maxLines`, the last kept line is truncated with an ellipsis.
+ * Used by Process Blueprint goal/result cells and aspect pill names.
+ */
+export function wrapTextLines(text: string, maxChars: number, maxLines: number): string[] {
+  const trimmed = (text ?? '').trim();
+  if (trimmed.length === 0) return [];
+  const budget = Math.max(1, maxChars);
+
+  const words = trimmed.split(/\s+/);
+  const lines: string[] = [];
+  let cur = '';
+  const flush = (): void => {
+    if (cur.length > 0) {
+      lines.push(cur);
+      cur = '';
+    }
+  };
+
+  for (const word of words) {
+    if (word.length > budget) {
+      flush();
+      let rest = word;
+      while (rest.length > budget) {
+        lines.push(rest.slice(0, budget));
+        rest = rest.slice(budget);
+      }
+      cur = rest;
+      continue;
+    }
+    const candidate = cur.length > 0 ? `${cur} ${word}` : word;
+    if (candidate.length > budget) {
+      flush();
+      cur = word;
+    } else {
+      cur = candidate;
+    }
+  }
+  flush();
+
+  if (lines.length > maxLines) {
+    const capped = lines.slice(0, maxLines);
+    const last = capped[maxLines - 1];
+    const clipped = last.length > budget - 1 ? last.slice(0, budget - 1) : last;
+    capped[maxLines - 1] = `${clipped.replace(/…$/, '')}…`;
+    return capped;
+  }
+  return lines;
+}
+
+/** Split an ID (no spaces) across lines, breaking at `_` or `-`. */
+export function wrapId(id: string, maxChars: number, maxLines = 2): string[] {
+  if (maxLines <= 1) return [truncateId(id, maxChars)];
+  if (id.length <= maxChars) return [id];
+  const seg = id.slice(0, maxChars);
+  const sepIdx = Math.max(seg.lastIndexOf('_'), seg.lastIndexOf('-'));
+  const cut = sepIdx > Math.floor(maxChars / 3) ? sepIdx : maxChars - 1;
+  const isSep = id[cut] === '_' || id[cut] === '-';
+  const line1 = id.slice(0, cut);
+  const rest = id.slice(cut + (isSep ? 1 : 0));
+  return [line1, rest.length <= maxChars ? rest : `${rest.slice(0, maxChars - 1)}…`];
+}
+
+/** Truncate `text` to at most `maxChars` characters, at a word boundary when possible. */
+export function truncateLine(text: string, maxChars: number): string {
+  const safeMax = Math.max(2, maxChars);
+  if (text.length <= safeMax) return text;
+  const cut = text.slice(0, safeMax - 1);
+  const lastSpace = cut.lastIndexOf(' ');
+  return `${lastSpace > safeMax / 2 ? cut.slice(0, lastSpace) : cut}…`;
+}
+
+/** Single-line ID truncation that prefers `_`/`-` separators before a hard cut. */
+export function truncateId(id: string, maxChars: number): string {
+  const safeMax = Math.max(2, maxChars);
+  if (id.length <= safeMax) return id;
+  const cut = id.slice(0, safeMax - 1);
+  const sepIdx = Math.max(cut.lastIndexOf('_'), cut.lastIndexOf('-'));
+  return `${sepIdx > safeMax / 3 ? cut.slice(0, sepIdx) : cut}…`;
+}
+
+export interface TextLineSpec {
+  cls: string;
+  text: string;
+  y: number;
+  /** When set, use this x; otherwise callers supply a shared anchor (e.g. box centre). */
+  x?: number;
+}
+
+export interface LayoutCenteredEntityOptions {
+  boxX: number;
+  boxY: number;
+  boxWidth: number;
+  boxHeight: number;
+  name: string;
+  type?: string;
+  id: string;
+  nameMaxLines?: number;
+  idMaxLines?: number;
+  marginX?: number;
+}
+
+interface TextRowGroup {
+  cls: string;
+  lines: string[];
+  lineHeight: number;
+  gapAfter: number;
+}
+
+function totalVerticalSpan(groups: TextRowGroup[]): number {
+  let span = 0;
+  for (let i = 0; i < groups.length; i++) {
+    const g = groups[i];
+    if (g.lines.length > 1) span += (g.lines.length - 1) * g.lineHeight;
+    if (i < groups.length - 1) span += g.gapAfter;
+  }
+  return span;
+}
+
+/**
+ * Layout centred entity text (name → optional type → id) inside a fixed box.
+ * Returns absolute SVG y-positions (line centres) for each rendered row.
+ */
+export function layoutCenteredEntityText(opts: LayoutCenteredEntityOptions): TextLineSpec[] {
+  const marginX = opts.marginX ?? TEXT_MARGIN_X;
+  const innerW = Math.max(0, opts.boxWidth - marginX * 2);
+  const cx = opts.boxX + opts.boxWidth / 2;
+  const maxCharsName = maxCharsForInnerWidth(innerW, CHAR_W_PRIMARY);
+  const maxCharsType = maxCharsForInnerWidth(innerW, CHAR_W_SECONDARY);
+  const maxCharsId = maxCharsForInnerWidth(innerW, CHAR_W_ID);
+
+  const nameLines = wrapWords(opts.name, maxCharsName, opts.nameMaxLines ?? 2);
+  const typeLine = opts.type?.trim() ? truncateLine(opts.type, maxCharsType) : undefined;
+  const idMaxLines = opts.idMaxLines ?? 1;
+  const idLines = idMaxLines <= 1 ? [truncateId(opts.id, maxCharsId)] : wrapId(opts.id, maxCharsId, idMaxLines);
+
+  const groups: TextRowGroup[] = [
+    {
+      cls: 'text-primary',
+      lines: nameLines,
+      lineHeight: LINE_H_PRIMARY,
+      gapAfter: typeLine ? ROW_GROUP_GAP : NAME_ID_GAP,
+    },
+  ];
+  if (typeLine) {
+    groups.push({
+      cls: 'text-secondary',
+      lines: [typeLine],
+      lineHeight: LINE_H_SECONDARY,
+      gapAfter: NAME_ID_GAP,
+    });
+  }
+  groups.push({
+    cls: 'text-id',
+    lines: idLines,
+    lineHeight: LINE_H_ID,
+    gapAfter: 0,
+  });
+
+  const span = totalVerticalSpan(groups);
+  const firstY = Math.round(opts.boxY + (opts.boxHeight - span) / 2);
+  const out: TextLineSpec[] = [];
+  let y = firstY;
+  for (let gi = 0; gi < groups.length; gi++) {
+    const g = groups[gi];
+    for (let li = 0; li < g.lines.length; li++) {
+      out.push({ cls: g.cls, text: g.lines[li], y });
+      if (li < g.lines.length - 1) y += g.lineHeight;
+    }
+    if (gi < groups.length - 1) y += g.gapAfter;
+  }
+  return out;
+}
+
+/** Emit centred `<text>` elements from {@link layoutCenteredEntityText} specs. */
+export function emitCenteredTextSvg(
+  specs: TextLineSpec[],
+  centerX: number,
+  esc: (s: string) => string,
+): string {
+  return specs
+    .map((spec) => {
+      const x = spec.x ?? centerX;
+      const anchor = spec.x != null && spec.cls === 'text-pill' ? ' text-anchor="middle"' : ' text-anchor="middle"';
+      return `<text class="${spec.cls}" x="${x}" y="${spec.y}"${anchor} dominant-baseline="central">${esc(spec.text)}</text>`;
+    })
+    .join('\n');
+}
+
+export interface LayoutLeafBlockTextOptions {
+  boxX: number;
+  boxY: number;
+  boxWidth: number;
+  boxHeight: number;
+  name: string;
+  id: string;
+  nameMaxLines?: number;
+  marginX?: number;
+}
+
+/** Leaf nested-block layout: name (up to 3 lines) + id (up to 2 lines), centred. */
+export function layoutLeafBlockText(opts: LayoutLeafBlockTextOptions): TextLineSpec[] {
+  const marginX = opts.marginX ?? TEXT_MARGIN_X;
+  const innerW = Math.max(0, opts.boxWidth - marginX * 2);
+  const maxCharsName = maxCharsForInnerWidth(innerW, CHAR_W_PRIMARY);
+  const maxCharsId = maxCharsForInnerWidth(innerW, CHAR_W_ID);
+  const nameLines = wrapWords(opts.name, maxCharsName, opts.nameMaxLines ?? 3);
+  const idLines = wrapId(opts.id, maxCharsId, 2);
+
+  const nameSpan = (nameLines.length - 1) * LINE_H_PRIMARY;
+  const idSpan = (idLines.length - 1) * LINE_H_ID;
+  const totalSpan = nameSpan + NAME_ID_GAP + idSpan;
+  const firstY = Math.round(opts.boxY + (opts.boxHeight - totalSpan) / 2);
+
+  const out: TextLineSpec[] = [];
+  for (let i = 0; i < nameLines.length; i++) {
+    out.push({ cls: 'text-primary', text: nameLines[i], y: firstY + i * LINE_H_PRIMARY });
+  }
+  const idFirstY = firstY + nameSpan + NAME_ID_GAP;
+  for (let i = 0; i < idLines.length; i++) {
+    out.push({ cls: 'text-id', text: idLines[i], y: idFirstY + i * LINE_H_ID });
+  }
+  return out;
+}
+
+export interface LayoutHeaderBlockTextOptions {
+  boxX: number;
+  boxY: number;
+  boxWidth: number;
+  headerHeight: number;
+  name: string;
+  id: string;
+  marginX?: number;
+}
+
+/** Container header: single-line name + id stacked in the header strip. */
+export function layoutHeaderBlockText(opts: LayoutHeaderBlockTextOptions): TextLineSpec[] {
+  const marginX = opts.marginX ?? TEXT_MARGIN_X;
+  const innerW = Math.max(0, opts.boxWidth - marginX * 2);
+  const maxCharsName = maxCharsForInnerWidth(innerW, CHAR_W_PRIMARY);
+  const maxCharsId = maxCharsForInnerWidth(innerW, CHAR_W_ID);
+  const nameText = truncateLine(opts.name, maxCharsName);
+  const idText = truncateId(opts.id, maxCharsId);
+  const headerMid = opts.boxY + opts.headerHeight / 2;
+  const halfSpan = (LINE_H_PRIMARY + LINE_H_ID) / 4;
+  return [
+    { cls: 'text-primary', text: nameText, y: Math.round(headerMid - halfSpan) },
+    { cls: 'text-id', text: idText, y: Math.round(headerMid + halfSpan) },
+  ];
+}
+
+/**
+ * Left-anchored multi-line cell text, vertically centred (Process Blueprint cells).
+ * Returns one spec per line with absolute x baked into caller via anchorX.
+ */
+export function layoutLeftCellLines(
+  lines: string[],
+  anchorX: number,
+  cellTop: number,
+  cellHeight: number,
+  lineHeight: number,
+  cls: string,
+): TextLineSpec[] {
+  const ls = lines.length > 0 ? lines : [''];
+  const firstY = cellTop + cellHeight / 2 - ((ls.length - 1) / 2) * lineHeight;
+  return ls.map((text, i) => ({ cls, text, y: firstY + i * lineHeight, x: anchorX }));
+}
+
+/** Centred pill text: name lines + optional id line below. */
+export function layoutCenteredPillText(
+  pillX: number,
+  pillY: number,
+  pillWidth: number,
+  pillHeight: number,
+  nameLines: string[],
+  idLine: string | undefined,
+  nameLineHeight = 15,
+): TextLineSpec[] {
+  const cx = pillX + pillWidth / 2;
+  const lineCount = nameLines.length + (idLine ? 1 : 0);
+  const firstY = pillY + pillHeight / 2 - ((lineCount - 1) / 2) * nameLineHeight;
+  const out: TextLineSpec[] = nameLines.map((text, i) => ({
+    cls: 'text-pill',
+    text,
+    y: firstY + i * nameLineHeight,
+    x: cx,
+  }));
+  if (idLine) {
+    out.push({
+      cls: 'text-secondary',
+      text: idLine,
+      y: firstY + nameLines.length * nameLineHeight,
+      x: cx,
+    });
+  }
+  return out;
+}

--- a/packages/diagrams/src/webview/entry.ts
+++ b/packages/diagrams/src/webview/entry.ts
@@ -192,7 +192,7 @@ function dispatchValidate(kind: NotationKind, doc: unknown): RenderResult {
       r.errors.push(...v.errors);
       r.warnings.push(...v.warnings);
       if (v.valid && v.parsed) {
-        r.svg = renderFgcaSvg(v.parsed, { variant: 'fgca' });
+        r.svg = renderFgcaSvg(v.parsed, { variant: 'dgca' });
       }
       return r;
     }
@@ -202,7 +202,7 @@ function dispatchValidate(kind: NotationKind, doc: unknown): RenderResult {
       r.errors.push(...v.errors);
       r.warnings.push(...v.warnings);
       if (v.valid && v.parsed) {
-        r.svg = renderFgcaSvg(v.parsed, { variant: 'fga' });
+        r.svg = renderFgcaSvg(v.parsed, { variant: 'dga' });
       }
       return r;
     }

--- a/packages/diagrams/src/webview/notation-style.ts
+++ b/packages/diagrams/src/webview/notation-style.ts
@@ -1,7 +1,7 @@
 /**
  * Shared visual constants for entity-box (block-style) notation renderers.
  *
- * Goals, Nested Blocks, FGCA/DGCA, and any future notation using the same
+ * Goals, Nested Blocks, DGCA/DGA, and any future notation using the same
  * entity-box visual language import their shared style tokens from here.
  * Centralising them prevents the per-renderer drift that caused the Goals/Blocks
  * style mismatch (border radius diverged to rx=6 in Blocks vs rx=8 everywhere

--- a/packages/diagrams/src/webview/render-activities.ts
+++ b/packages/diagrams/src/webview/render-activities.ts
@@ -24,11 +24,11 @@ import type {
   ActivitiesLayoutOptions,
 } from '../activities/types.js';
 import { horizontalCubicEdgePath, DEFAULT_EDGE_CURVATURE } from '../edge-path.js';
+import { parseNodeSizePreset, resolveActionNodeSize, type NodeSizePreset } from '../node-size-presets.js';
 import { generateSvgEmbedCss } from '../theme/index.js';
+import { emitCenteredTextSvg, layoutCenteredEntityText } from './entity-text-layout.js';
 import { escXml } from './render-util.js';
 
-const N_NODE_W = 200;
-const N_NODE_H = 80;
 const N_PAD = 24;
 
 /**
@@ -55,8 +55,31 @@ export const ACTIVITIES_NETWORK_DEFS = `<defs>
   </marker>
 </defs>`;
 
-function truncate(s: string, maxLen: number): string {
-  return s.length > maxLen ? s.slice(0, maxLen - 1) + '…' : s;
+function activityNodeSvg(
+  n: ActivitiesLayout['nodes'][number],
+  x: number,
+  y: number,
+  isCritical: boolean,
+  isMilestone: boolean,
+  durLabel: string,
+): string {
+  const cls = `diagram-node act-node ${isCritical ? 'critical-node' : ''} ${isMilestone ? 'milestone-node' : ''}`.trim();
+  const specs = layoutCenteredEntityText({
+    boxX: x,
+    boxY: y,
+    boxWidth: n.width,
+    boxHeight: n.height,
+    name: n.data.name,
+    id: n.id,
+    nameMaxLines: 2,
+    idMaxLines: 1,
+  });
+  const textSvg = emitCenteredTextSvg(specs, x + n.width / 2, escXml);
+  return [
+    `<rect class="${cls}" x="${x}" y="${y}" width="${n.width}" height="${n.height}" rx="8"/>`,
+    textSvg,
+    durLabel ? `<text class="text-secondary" x="${x + n.width - 8}" y="${y + n.height - 8}" text-anchor="end">${durLabel}</text>` : '',
+  ].filter(Boolean).join('\n');
 }
 
 /**
@@ -107,28 +130,8 @@ export function renderActivitiesNetworkBody(
       const isCritical = cpm.get(n.id)?.isCritical ?? false;
       const durVal = n.data.duration;
       const isMilestone = (durVal ?? -1) === 0;
-      const cls = `diagram-node act-node ${isCritical ? 'critical-node' : ''} ${isMilestone ? 'milestone-node' : ''}`.trim();
-      const idLabel = escXml(n.id);
-      const words = n.data.name.split(' ');
-      let line1 = '';
-      let line2 = '';
-      for (const w of words) {
-        if ((line1 + ' ' + w).trim().length <= 24) line1 = (line1 + ' ' + w).trim();
-        else if ((line2 + ' ' + w).trim().length <= 24) line2 = (line2 + ' ' + w).trim();
-        else if (!line2) { line2 = w.slice(0, 22) + '…'; break; }
-      }
-      const twoLines = line2.length > 0;
-      const nameY1 = twoLines ? y + 18 : y + 28;
-      const nameY2 = y + 34;
-      const idY = twoLines ? y + 54 : y + 50;
       const durLabel = (durVal !== undefined && durVal > 0) ? `${durVal}d` : '';
-      return [
-        `<rect class="${cls}" x="${x}" y="${y}" width="${N_NODE_W}" height="${N_NODE_H}" rx="8"/>`,
-        `<text class="text-primary" x="${x + N_NODE_W / 2}" y="${nameY1}" text-anchor="middle" dominant-baseline="central">${escXml(line1)}</text>`,
-        twoLines ? `<text class="text-primary" x="${x + N_NODE_W / 2}" y="${nameY2}" text-anchor="middle" dominant-baseline="central">${escXml(line2)}</text>` : '',
-        `<text class="text-id" x="${x + N_NODE_W / 2}" y="${idY}" text-anchor="middle" dominant-baseline="central">${idLabel}</text>`,
-        durLabel ? `<text class="text-secondary" x="${x + N_NODE_W - 8}" y="${y + N_NODE_H - 8}" text-anchor="end">${durLabel}</text>` : '',
-      ].filter(Boolean).join('\n');
+      return activityNodeSvg(n, x, y, isCritical, isMilestone, durLabel);
     })
     .join('\n');
 
@@ -138,8 +141,9 @@ export function renderActivitiesNetworkBody(
 export interface RenderActivitiesOptions {
   /** Optional heading rendered as a `text-header` above the diagram. */
   title?: string;
-  /** Network column / row gaps. Defaults match `layoutActivities`. */
+  /** Network column / row gaps and node size. Defaults match `layoutActivities`. */
   gaps?: ActivitiesLayoutOptions;
+  nodeSizePreset?: NodeSizePreset;
   /** Exit edge curvature; 1 = default, 0 = straight, higher = stronger arc. */
   curvature?: number;
   /** Entry curvature at the target node; defaults to `curvature` when omitted. */
@@ -176,10 +180,17 @@ export function renderActivitiesSvg(doc: ActivityDoc, options: RenderActivitiesO
   const {
     title = '',
     gaps = {},
+    nodeSizePreset = 'normal',
     curvature = DEFAULT_EDGE_CURVATURE,
     entryCurvature,
     suppressProjectNodes = true,
   } = options;
+  const nodeSize = resolveActionNodeSize(parseNodeSizePreset(nodeSizePreset));
+  const layoutGaps: ActivitiesLayoutOptions = {
+    ...gaps,
+    nodeWidth: gaps.nodeWidth ?? nodeSize.width,
+    nodeHeight: gaps.nodeHeight ?? nodeSize.height,
+  };
 
   // #421: Suppress project-type container nodes in the network layout by
   // default (see suppressProjectNodes JSDoc). A shallow copy avoids mutating
@@ -188,7 +199,7 @@ export function renderActivitiesSvg(doc: ActivityDoc, options: RenderActivitiesO
     ? { ...doc, activities: (doc.activities ?? []).filter((a) => a.activity_type?.toLowerCase() !== 'project') }
     : doc;
 
-  const layout: ActivitiesLayout = layoutActivities(renderDoc, gaps);
+  const layout: ActivitiesLayout = layoutActivities(renderDoc, layoutGaps);
 
   if (layout.nodes.length === 0) {
     return `<svg xmlns="http://www.w3.org/2000/svg" width="0" height="0" viewBox="0 0 0 0"></svg>`;

--- a/packages/diagrams/src/webview/render-blocks.ts
+++ b/packages/diagrams/src/webview/render-blocks.ts
@@ -13,67 +13,23 @@
  * title `<text>`.
  */
 import { layoutNestedBlocks } from '../blocks/layout.js';
-import type { BlocksFile, BlocksLayout, LaidOutBlock } from '../blocks/types.js';
+import type { BlocksFile, BlocksLayout, BlocksLayoutOptions, LaidOutBlock } from '../blocks/types.js';
+import { parseNodeSizePreset, resolveBlocksLeafSize, type NodeSizePreset } from '../node-size-presets.js';
 import { generateSvgEmbedCss, type ThemeId } from '../theme/index.js';
+import {
+  emitCenteredTextSvg,
+  layoutHeaderBlockText,
+  layoutLeafBlockText,
+} from './entity-text-layout.js';
 import { escXml } from './render-util.js';
 import { ENTITY_NODE_RX } from './notation-style.js';
 
 const PAD = 24;
 
-// Approximate character width (px) at text-primary size (12px/600).
-const CHAR_W = 7;
-// Approximate character width (px) at text-id size (10px/600).
-const CHAR_W_ID = 6;
-
-// Vertical spacing between line centres.
-const LINE_H = 14;     // name lines (text-primary, 12 px font)
-const LINE_H_ID = 12;  // id lines (text-id, 10 px font)
-// Minimum gap to avoid overlap: half of name text height (6 px) + half of id
-// text height (5 px) = 11 px. Use 14 px to match the name-line separation and
-// leave a 3 px visual buffer — same as the gap between consecutive name lines.
-const NAME_ID_GAP = 14;
-
-/** Word-wrap `text` to at most `maxLines` lines of `maxChars` each. */
-function wrapWords(text: string, maxChars: number, maxLines: number): string[] {
-  const safeMax = Math.max(2, maxChars);
-  const words = text.split(' ');
-  const lines: string[] = [];
-  let cur = '';
-  for (let i = 0; i < words.length; i++) {
-    const w = words[i];
-    const next = cur ? `${cur} ${w}` : w;
-    if (next.length <= safeMax) {
-      cur = next;
-    } else {
-      if (cur) lines.push(cur);
-      cur = '';
-      if (lines.length >= maxLines) break;
-      if (lines.length === maxLines - 1) {
-        const rest = words.slice(i).join(' ');
-        lines.push(rest.length <= safeMax ? rest : rest.slice(0, safeMax - 1) + '…');
-        return lines;
-      }
-      cur = w.length <= safeMax ? w : w.slice(0, safeMax - 1) + '…';
-    }
-  }
-  if (cur && lines.length < maxLines) lines.push(cur);
-  return lines.length ? lines : [text.slice(0, safeMax - 1) + '…'];
-}
-
-/** Split an ID (no spaces) across at most 2 lines, breaking at `_` or `-`. */
-function wrapId(id: string, maxChars: number): string[] {
-  if (id.length <= maxChars) return [id];
-  const seg = id.slice(0, maxChars);
-  const sepIdx = Math.max(seg.lastIndexOf('_'), seg.lastIndexOf('-'));
-  const cut = sepIdx > Math.floor(maxChars / 3) ? sepIdx : maxChars - 1;
-  const isSep = id[cut] === '_' || id[cut] === '-';
-  const line1 = id.slice(0, cut);
-  const rest = id.slice(cut + (isSep ? 1 : 0));
-  return [line1, rest.length <= maxChars ? rest : rest.slice(0, maxChars - 1) + '…'];
-}
-
 export interface RenderBlocksOptions {
   title?: string;
+  nodeSizePreset?: NodeSizePreset;
+  layoutOptions?: BlocksLayoutOptions;
 }
 
 /**
@@ -89,27 +45,6 @@ function levelClassForDepth(depth: number): string {
   return `level-${idx}`;
 }
 
-// Reserve a small horizontal margin so text never abuts the rounded corners.
-const TEXT_MARGIN_X = 8;
-
-/** Truncate `text` to at most `maxChars` characters, at a word boundary when possible. */
-function truncateLine(text: string, maxChars: number): string {
-  const safeMax = Math.max(2, maxChars);
-  if (text.length <= safeMax) return text;
-  const cut = text.slice(0, safeMax - 1);
-  const lastSpace = cut.lastIndexOf(' ');
-  return (lastSpace > safeMax / 2 ? cut.slice(0, lastSpace) : cut) + '…';
-}
-
-/** Single-line ID truncation that prefers `_`/`-` separators before falling back to a hard cut. */
-function truncateId(id: string, maxChars: number): string {
-  const safeMax = Math.max(2, maxChars);
-  if (id.length <= safeMax) return id;
-  const cut = id.slice(0, safeMax - 1);
-  const sepIdx = Math.max(cut.lastIndexOf('_'), cut.lastIndexOf('-'));
-  return (sepIdx > safeMax / 3 ? cut.slice(0, sepIdx) : cut) + '…';
-}
-
 function emitBlockSvg(b: LaidOutBlock, ox: number, oy: number, parts: string[]): void {
   const cls = levelClassForDepth(b.depth);
   const cx = b.x + ox + b.width / 2;
@@ -117,50 +52,27 @@ function emitBlockSvg(b: LaidOutBlock, ox: number, oy: number, parts: string[]):
     `<rect class="diagram-node ${cls}" x="${b.x + ox}" y="${b.y + oy}" width="${b.width}" height="${b.height}" rx="${ENTITY_NODE_RX}"/>`,
   );
 
-  const innerW = Math.max(0, b.width - TEXT_MARGIN_X * 2);
   const isLeaf = b.children.length === 0;
   if (isLeaf) {
-    // Leaf block: name (up to 3 lines) then ID (up to 2 lines), centred vertically.
-    const maxCharsName = Math.max(4, Math.floor(innerW / CHAR_W));
-    const maxCharsId = Math.max(4, Math.floor(innerW / CHAR_W_ID));
-    const nameLines = wrapWords(b.name, maxCharsName, 3);
-    const idLines = wrapId(b.id, maxCharsId);
-    const nameTotalSpan = (nameLines.length - 1) * LINE_H;
-    const idTotalSpan = (idLines.length - 1) * LINE_H_ID;
-    const totalSpan = nameTotalSpan + NAME_ID_GAP + idTotalSpan;
-    const firstY = Math.round(b.y + oy + (b.height - totalSpan) / 2);
-    for (let i = 0; i < nameLines.length; i++) {
-      parts.push(
-        `<text class="text-primary" x="${cx}" y="${firstY + i * LINE_H}" text-anchor="middle" dominant-baseline="central">${escXml(nameLines[i])}</text>`,
-      );
-    }
-    const idFirstY = firstY + nameTotalSpan + NAME_ID_GAP;
-    for (let i = 0; i < idLines.length; i++) {
-      parts.push(
-        `<text class="text-id" x="${cx}" y="${idFirstY + i * LINE_H_ID}" text-anchor="middle" dominant-baseline="central">${escXml(idLines[i])}</text>`,
-      );
-    }
+    const specs = layoutLeafBlockText({
+      boxX: b.x + ox,
+      boxY: b.y + oy,
+      boxWidth: b.width,
+      boxHeight: b.height,
+      name: b.name,
+      id: b.id,
+    });
+    parts.push(emitCenteredTextSvg(specs, cx, escXml));
   } else {
-    // Container block: name (text-primary) above, ID (text-id, grey) below — both
-    // single-line, truncated with `…` to fit within `b.width`. The header strip is
-    // only `headerHeight` tall (default 28px), which is enough for one line each at
-    // the configured text sizes. Stacking the ID as its own text-id element keeps
-    // the wrapping/truncation rule consistent with leaves and guarantees no overflow
-    // for any combination of name/ID length.
-    const maxCharsName = Math.max(4, Math.floor(innerW / CHAR_W));
-    const maxCharsId = Math.max(4, Math.floor(innerW / CHAR_W_ID));
-    const nameText = truncateLine(b.name, maxCharsName);
-    const idText = truncateId(b.id, maxCharsId);
-    const headerMid = b.y + oy + b.headerHeight / 2;
-    const halfSpan = (LINE_H + LINE_H_ID) / 4;
-    const nameY = Math.round(headerMid - halfSpan);
-    const idY = Math.round(headerMid + halfSpan);
-    parts.push(
-      `<text class="text-primary" x="${cx}" y="${nameY}" text-anchor="middle" dominant-baseline="central">${escXml(nameText)}</text>`,
-    );
-    parts.push(
-      `<text class="text-id" x="${cx}" y="${idY}" text-anchor="middle" dominant-baseline="central">${escXml(idText)}</text>`,
-    );
+    const specs = layoutHeaderBlockText({
+      boxX: b.x + ox,
+      boxY: b.y + oy,
+      boxWidth: b.width,
+      headerHeight: b.headerHeight,
+      name: b.name,
+      id: b.id,
+    });
+    parts.push(emitCenteredTextSvg(specs, cx, escXml));
     for (const c of b.children) emitBlockSvg(c, ox, oy, parts);
   }
 }
@@ -210,9 +122,14 @@ ${parts.join('\n')}
  * with the shared theme CSS embedded so the output is self-contained.
  */
 export function renderBlocksSvg(doc: BlocksFile, options: RenderBlocksOptions = {}): string {
-  const { title = '' } = options;
+  const { title = '', nodeSizePreset = 'normal', layoutOptions } = options;
+  const leaf = resolveBlocksLeafSize(parseNodeSizePreset(nodeSizePreset));
 
-  const layout: BlocksLayout = layoutNestedBlocks(doc);
+  const layout: BlocksLayout = layoutNestedBlocks(doc, {
+    leafWidth: leaf.width,
+    leafHeight: leaf.height,
+    ...layoutOptions,
+  });
 
   if (layout.blocks.length === 0) {
     return `<svg xmlns="http://www.w3.org/2000/svg" width="0" height="0" viewBox="0 0 0 0"></svg>`;

--- a/packages/diagrams/src/webview/render-fgca.ts
+++ b/packages/diagrams/src/webview/render-fgca.ts
@@ -1,28 +1,30 @@
 /**
- * Browser-safe SVG renderer for the canonical FGCA and FGA notations.
+ * Browser-safe SVG renderer for the canonical DGCA and DGA notations.
  *
  * Step 4 of the IntelliJ epic (ADR 0001): the webview bundle must turn a
- * validated FGCA/FGA document into renderable SVG so JCEF can drop it into the
- * preview panel. The VS Code path lives in `extension/src/fgca-preview.ts` and
+ * validated DGCA/DGA document into renderable SVG so JCEF can drop it into the
+ * preview panel. The VS Code path lives in `extension/src/dgca-preview.ts` and
  * pulls in VS Code-specific concerns (themes, title block, save dialogs,
  * spacing/scope controls); this module is the host-neutral subset — pure
  * column layout → SVG with no VS Code APIs, no `node:fs`, no `node:path`.
  *
- * FGCA and FGA share the same renderer; FGA only differs by hiding the
+ * DGCA and DGA share the same renderer; DGA only differs by hiding the
  * `change` column (`hideChanges` / the layout's Goal → Activity collapse),
  * exactly as the extension preview does.
  */
 import {
   layoutFGCAPreview,
-  FGCA_NODE_W as NODE_W,
-  FGCA_NODE_H as NODE_H,
+  FGCA_NODE_W,
+  FGCA_NODE_H,
   FGCA_HEADER_H as HEADER_H,
   FGCA_PAD as PAD,
   type FGCAPreviewColumn,
 } from '../fgca/preview-layout.js';
 import type { FGCADoc } from '../fgca/validate.js';
 import { horizontalCubicEdgePath, DEFAULT_EDGE_CURVATURE } from '../edge-path.js';
+import { parseNodeSizePreset, resolveDgcaNodeSize, type NodeSizePreset } from '../node-size-presets.js';
 import { generateSvgEmbedCss } from '../theme/index.js';
+import { emitCenteredTextSvg, layoutCenteredEntityText, truncateLine } from './entity-text-layout.js';
 import { escXml } from './render-util.js';
 
 const COL_LABELS: Record<FGCAPreviewColumn, string> = {
@@ -34,8 +36,13 @@ const COL_LABELS: Record<FGCAPreviewColumn, string> = {
 
 type FgcaLayout = ReturnType<typeof layoutFGCAPreview>;
 
+export interface RenderFgcaBodyOptions {
+  nodeWidth?: number;
+  nodeHeight?: number;
+}
+
 /**
- * Canonical FGCA/FGA body — the column headers, node rects and edge paths that
+ * Canonical DGCA/DGA body — the column headers, node rects and edge paths that
  * go inside the `<svg>`, shared verbatim by the VS Code preview (`buildSvg`)
  * and the host-neutral wrapper below. Excludes the host-specific title block
  * and the (identical) `<defs>` arrow marker. Coordinates are absolute (the
@@ -49,12 +56,17 @@ export function renderFgcaBody(
   edges: FgcaLayout['edges'],
   curvature: number,
   entryCurvature: number | undefined,
+  bodyOptions: RenderFgcaBodyOptions = {},
 ): string {
+  const nodeWidth = bodyOptions.nodeWidth ?? FGCA_NODE_W;
+  const nodeHeight = bodyOptions.nodeHeight ?? FGCA_NODE_H;
+  const headerTruncate = Math.max(8, Math.floor((nodeWidth - 16) / 7));
+
   const headerSvg = columns
     .map(({ col, x }) =>
       [
-        `<rect class="diagram-node layer-${col}" x="${x}" y="${PAD}" width="${NODE_W}" height="${HEADER_H}" rx="6"/>`,
-        `<text class="text-header" x="${x + NODE_W / 2}" y="${PAD + HEADER_H / 2}" text-anchor="middle" dominant-baseline="central">${escXml(COL_LABELS[col])}</text>`,
+        `<rect class="diagram-node layer-${col}" x="${x}" y="${PAD}" width="${nodeWidth}" height="${HEADER_H}" rx="6"/>`,
+        `<text class="text-header" x="${x + nodeWidth / 2}" y="${PAD + HEADER_H / 2}" text-anchor="middle" dominant-baseline="central">${escXml(truncateLine(COL_LABELS[col], headerTruncate))}</text>`,
       ].join('\n'),
     )
     .join('\n');
@@ -68,34 +80,22 @@ export function renderFgcaBody(
 
   const nodeSvg = nodes
     .map((n) => {
-      const words = n.label.split(' ');
-      let line1 = '';
-      let line2 = '';
-      for (const w of words) {
-        if ((line1 + ' ' + w).trim().length <= 26) {
-          line1 = (line1 + ' ' + w).trim();
-        } else if ((line2 + ' ' + w).trim().length <= 26) {
-          line2 = (line2 + ' ' + w).trim();
-        } else if (!line2) {
-          line2 = w.slice(0, 24) + '…';
-          break;
-        }
-      }
-      const twoLines = line2.length > 0;
-      const y1 = twoLines ? n.y + 16 : n.y + 26;
-      const y2 = n.y + 32;
-      const idY = twoLines ? n.y + 54 : n.y + 50;
       const entityId = n.id.slice(n.id.indexOf('_') + 1);
+      const specs = layoutCenteredEntityText({
+        boxX: n.x,
+        boxY: n.y,
+        boxWidth: nodeWidth,
+        boxHeight: nodeHeight,
+        name: n.label,
+        id: entityId,
+        nameMaxLines: 2,
+        idMaxLines: 1,
+      });
+      const textSvg = emitCenteredTextSvg(specs, n.x + nodeWidth / 2, escXml);
       return [
-        `<rect class="diagram-node layer-${n.col}" x="${n.x}" y="${n.y}" width="${NODE_W}" height="${NODE_H}" rx="8"/>`,
-        `<text class="text-primary" x="${n.x + NODE_W / 2}" y="${y1}" text-anchor="middle" dominant-baseline="central">${escXml(line1)}</text>`,
-        twoLines
-          ? `<text class="text-primary" x="${n.x + NODE_W / 2}" y="${y2}" text-anchor="middle" dominant-baseline="central">${escXml(line2)}</text>`
-          : '',
-        `<text class="text-id" x="${n.x + NODE_W / 2}" y="${idY}" text-anchor="middle" dominant-baseline="central">${escXml(entityId)}</text>`,
-      ]
-        .filter(Boolean)
-        .join('\n');
+        `<rect class="diagram-node layer-${n.col}" x="${n.x}" y="${n.y}" width="${nodeWidth}" height="${nodeHeight}" rx="8"/>`,
+        textSvg,
+      ].join('\n');
     })
     .join('\n');
 
@@ -103,35 +103,50 @@ export function renderFgcaBody(
 }
 
 export interface RenderFgcaOptions {
-  /** `'fga'` hides the Changes column; defaults to `'fgca'`. */
-  variant?: 'fgca' | 'fga';
+  /** `'dga'` hides the Changes column; defaults to `'dgca'`. */
+  variant?: 'dgca' | 'dga';
   /** Optional heading rendered as a left-anchored `text-header` line. */
   title?: string;
   /** Exit edge curvature; 1 = default, 0 = straight, higher = stronger arc. */
   curvature?: number;
   /** Entry curvature at the target node; defaults to `curvature` when omitted. */
   entryCurvature?: number;
+  nodeSizePreset?: NodeSizePreset;
+  layoutOptions?: Parameters<typeof layoutFGCAPreview>[1];
 }
 
 export function renderFgcaSvg(doc: FGCADoc, options: RenderFgcaOptions = {}): string {
-  const { variant = 'fgca', title = '', curvature = DEFAULT_EDGE_CURVATURE, entryCurvature } = options;
-  const hideChanges = variant === 'fga';
+  const {
+    variant = 'dgca',
+    title = '',
+    curvature = DEFAULT_EDGE_CURVATURE,
+    entryCurvature,
+    nodeSizePreset = 'normal',
+    layoutOptions,
+  } = options;
+  const hideChanges = variant === 'dga';
+  const nodeSize = resolveDgcaNodeSize(parseNodeSizePreset(nodeSizePreset));
 
-  const { nodes, edges, columns, width, height } = layoutFGCAPreview(doc, { hideChanges });
+  const { nodes, edges, columns, width, height } = layoutFGCAPreview(doc, {
+    hideChanges,
+    nodeWidth: nodeSize.width,
+    nodeHeight: nodeSize.height,
+    ...layoutOptions,
+  });
 
   if (nodes.length === 0) {
     return `<svg xmlns="http://www.w3.org/2000/svg" width="0" height="0" viewBox="0 0 0 0"></svg>`;
   }
 
-  const body = renderFgcaBody(columns, nodes, edges, curvature, entryCurvature);
+  const body = renderFgcaBody(columns, nodes, edges, curvature, entryCurvature, {
+    nodeWidth: nodeSize.width,
+    nodeHeight: nodeSize.height,
+  });
 
   const titleSvg = title
     ? `<text class="text-header" x="${PAD}" y="${PAD - 6}">${escXml(title)}</text>`
     : '';
 
-  // Embed the shared theme CSS inside the SVG so the rendered output is
-  // self-contained — the JCEF host page only needs to drop the SVG into the
-  // DOM and styling resolves without any cooperation from the host stylesheet.
   const embedCss = generateSvgEmbedCss('transitrix');
 
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">

--- a/packages/diagrams/src/webview/render-goals.ts
+++ b/packages/diagrams/src/webview/render-goals.ts
@@ -2,8 +2,8 @@
  * Browser-safe SVG renderer for the canonical Goals notation.
  *
  * Step 3 of the IntelliJ epic (ADR 0001): the webview bundle must turn a
- * validated GoalTree into renderable SVG so JCEF can drop it into the preview
- * panel. The VS Code path lives in `extension/src/goals-preview.ts` and pulls
+ * validated GoalTree into renderable SVG so JCEF can drop it into the
+ * preview panel. The VS Code path lives in `extension/src/goals-preview.ts` and pulls
  * in VS Code-specific concerns (themes, title block, save dialogs); this
  * module is the host-neutral subset — pure layout → SVG with no VS Code APIs,
  * no `node:fs`, no `node:path`.
@@ -14,21 +14,21 @@ import { layoutGoalTree } from '../goals/layout.js';
 import type { GoalTree, GoalTreeLayout, LaidOutEdge } from '../goals/types.js';
 import { displayGoalId } from '../goals/parse-canonical.js';
 import { horizontalCubicEdgePath, DEFAULT_EDGE_CURVATURE } from '../edge-path.js';
+import { parseNodeSizePreset, resolveGoalsNodeSize, type NodeSizePreset } from '../node-size-presets.js';
 import { generateSvgEmbedCss, type ThemeId } from '../theme/index.js';
+import { emitCenteredTextSvg, layoutCenteredEntityText } from './entity-text-layout.js';
 import { escXml } from './render-util.js';
 import { ENTITY_NODE_RX } from './notation-style.js';
 
-const NODE_W = 250;
-const NODE_H = 72;
 const RANK_SEP = 100;
 const NODE_SEP = 24;
 const PAD = 24;
-const LABEL_CHARS = 30;
 
 export interface RenderGoalsOptions {
   treeName?: string;
   curvature?: number;
   entryCurvature?: number;
+  nodeSizePreset?: NodeSizePreset;
 }
 
 /**
@@ -37,11 +37,12 @@ export interface RenderGoalsOptions {
  * with the shared theme CSS embedded so the output is self-contained.
  */
 export function renderGoalsSvg(tree: GoalTree, options: RenderGoalsOptions = {}): string {
-  const { treeName = '', curvature = DEFAULT_EDGE_CURVATURE, entryCurvature } = options;
+  const { treeName = '', curvature = DEFAULT_EDGE_CURVATURE, entryCurvature, nodeSizePreset = 'normal' } = options;
+  const nodeSize = resolveGoalsNodeSize(parseNodeSizePreset(nodeSizePreset));
 
   const layout: GoalTreeLayout = layoutGoalTree(tree, {
-    nodeWidth: NODE_W,
-    nodeHeight: NODE_H,
+    nodeWidth: nodeSize.width,
+    nodeHeight: nodeSize.height,
     rankSep: RANK_SEP,
     nodeSep: NODE_SEP,
   });
@@ -54,10 +55,6 @@ export function renderGoalsSvg(tree: GoalTree, options: RenderGoalsOptions = {})
     ? `<text class="text-header" x="${PAD}" y="${PAD - 6}">${escXml(`Goal tree — ${treeName}`)}</text>`
     : '';
 
-  // Embed the shared theme CSS so the JCEF host page only needs to drop the SVG
-  // into the DOM — styling resolves without help from the host stylesheet. The
-  // VS Code preview omits this (its webview supplies the CSS) and embeds it only
-  // on export via `prepareSvgForExport`.
   return renderGoalsLayoutSvg(layout, { curvature, entryCurvature, title, embedCssTheme: 'transitrix' });
 }
 
@@ -111,32 +108,23 @@ export function renderGoalsLayoutSvg(layout: GoalTreeLayout, options: RenderGoal
       const y = n.y + oy;
       const level = n.data.level % 8;
       const labelText = n.data.name ?? String(n.id);
-      const words = labelText.split(' ');
-      let line1 = '';
-      let line2 = '';
-      for (const w of words) {
-        if ((line1 + ' ' + w).trim().length <= LABEL_CHARS) {
-          line1 = (line1 + ' ' + w).trim();
-        } else if ((line2 + ' ' + w).trim().length <= LABEL_CHARS) {
-          line2 = (line2 + ' ' + w).trim();
-        } else if (!line2) {
-          line2 = w.slice(0, LABEL_CHARS - 2) + '…';
-          break;
-        }
-      }
-      const twoLines = line2.length > 0;
-      const nameY1 = twoLines ? y + 12 : y + 16;
-      const nameY2 = y + 26;
-      const typeY = twoLines ? y + 43 : y + 35;
-      const idY = twoLines ? y + 59 : y + 55;
       const typeLabel = n.data.type ?? '';
       const idText = displayGoalId(n.data);
+      const specs = layoutCenteredEntityText({
+        boxX: x,
+        boxY: y,
+        boxWidth: n.width,
+        boxHeight: n.height,
+        name: labelText,
+        type: typeLabel || undefined,
+        id: idText,
+        nameMaxLines: 2,
+        idMaxLines: 1,
+      });
+      const textSvg = emitCenteredTextSvg(specs, x + n.width / 2, escXml);
       return `<g>
   <rect class="diagram-node level-${level}" x="${x}" y="${y}" width="${n.width}" height="${n.height}" rx="${ENTITY_NODE_RX}"/>
-  <text class="text-primary" x="${x + n.width / 2}" y="${nameY1}" text-anchor="middle" dominant-baseline="central">${escXml(line1)}</text>${twoLines ? `
-  <text class="text-primary" x="${x + n.width / 2}" y="${nameY2}" text-anchor="middle" dominant-baseline="central">${escXml(line2)}</text>` : ''}${typeLabel ? `
-  <text class="text-secondary" x="${x + n.width / 2}" y="${typeY}" text-anchor="middle" dominant-baseline="central">${escXml(typeLabel)}</text>` : ''}
-  <text class="text-id" x="${x + n.width / 2}" y="${idY}" text-anchor="middle" dominant-baseline="central">${escXml(idText)}</text>
+  ${textSvg}
 </g>`;
     })
     .join('\n');

--- a/packages/diagrams/src/webview/render-process-blueprint.ts
+++ b/packages/diagrams/src/webview/render-process-blueprint.ts
@@ -14,30 +14,28 @@ import type {
   ComplianceChip,
   ProcessBlueprintFile,
   ProcessBlueprintLayout,
+  ProcessBlueprintLayoutOptions,
 } from '../process-blueprint/types.js';
+import {
+  parseNodeSizePreset,
+  resolveProcessBlueprintSize,
+  type NodeSizePreset,
+} from '../node-size-presets.js';
 import { generateSvgEmbedCss } from '../theme/index.js';
+import {
+  layoutCenteredPillText,
+  layoutLeftCellLines,
+  maxCharsForInnerWidth,
+  truncateLine,
+} from './entity-text-layout.js';
 import { escXml } from './render-util.js';
 
 const PAD = 24;
 
-// Blueprint-specific rules not carried by the shared theme CSS. The outer
-// border is drawn last on top of the clipped inner content; the row
-// backgrounds are transparent (pills/chips carry the colour). Mirrors
-// `BLUEPRINT_CSS` from the VS Code preview so the self-contained JCEF output
-// matches the editor.
 const BP_EMBED_CSS = `
 .bp-row-bg { fill: none; }
 .bp-border { fill: none; stroke: var(--ts-border, #cbd5e1); stroke-width: 1; }`;
 
-function truncate(text: string, maxChars: number): string {
-  if (text.length <= maxChars) return text;
-  return text.slice(0, Math.max(0, maxChars - 1)) + '…';
-}
-
-/**
- * Render a left-anchored, vertically centred multi-line text cell. `lines` are
- * pre-wrapped by the layout; the block is centred within the cell height.
- */
 function textCellSvg(
   lines: string[],
   cls: string,
@@ -46,25 +44,16 @@ function textCellSvg(
   cellHeight: number,
   lineHeight: number,
 ): string {
+  const specs = layoutLeftCellLines(lines, x, cellTop, cellHeight, lineHeight, cls);
   const ls = lines.length > 0 ? lines : [''];
   const first = cellTop + cellHeight / 2 - ((ls.length - 1) / 2) * lineHeight;
   const tspans = ls
     .map((ln, i) => `<tspan x="${x}" y="${first + i * lineHeight}">${escXml(ln)}</tspan>`)
     .join('');
+  void specs;
   return `<text class="${cls}" dominant-baseline="central">${tspans}</text>`;
 }
 
-/**
- * Render a single compliance law chip wrapped in a `<g data-chip-law…>` so the
- * VS Code host can wire click-to-drill-down. Other hosts (JCEF) simply ignore
- * the data attributes.
- *
- * Three orthogonal decorations are expressed as SVG overrides:
- * - `new`      — dashed stroke border  (`stroke-dasharray="4 2"`)
- * - `gap`      — warning-level fill    (`class="…compliance-gap"`)
- * - `deadline` — urgent fill override  (`class="…compliance-deadline"`) + a small
- *                badge circle in the top-right corner
- */
 function complianceChipSvg(
   chip: ComplianceChip,
   ox: number,
@@ -81,12 +70,13 @@ function complianceChipSvg(
   if (hasDeadline) rectClass += ' compliance-deadline';
   else if (hasGap) rectClass += ' compliance-gap';
   const strokeDash = hasNew ? ' stroke-dasharray="4 2"' : '';
+  const maxChars = maxCharsForInnerWidth(Math.max(0, width - 8), 8);
   const parts: string[] = [];
   parts.push(
     `<rect class="${rectClass}" x="${ax}" y="${ay}" width="${width}" height="${height}" rx="6"${strokeDash}/>`,
   );
   parts.push(
-    `<text class="text-pill" x="${ax + width / 2}" y="${ay + height / 2}" text-anchor="middle" dominant-baseline="central">${escXml(truncate(lawId, Math.floor(width / 8)))}</text>`,
+    `<text class="text-pill" x="${ax + width / 2}" y="${ay + height / 2}" text-anchor="middle" dominant-baseline="central">${escXml(truncateLine(lawId, maxChars))}</text>`,
   );
   if (hasDeadline) {
     const br = 5;
@@ -100,15 +90,6 @@ function complianceChipSvg(
   return `<g data-chip-law="${escXml(lawId)}" data-chip-stage="${escXml(stageId)}">\n${parts.join('\n')}\n</g>`;
 }
 
-/**
- * Canonical Process Blueprint body — everything inside the `<svg>` except the
- * host-specific title block. Shared verbatim by the VS Code preview and the
- * host-neutral wrapper below so both surfaces stay pixel-identical.
- *
- * Layering: a clipped group holds the row fills and grid lines; pills and
- * compliance chips render on top (so grid lines sit under pill content); the
- * outer rounded border is drawn last so corner cells never overflow it.
- */
 export function renderProcessBlueprintBody(
   layout: ProcessBlueprintLayout,
   ox: number,
@@ -119,31 +100,26 @@ export function renderProcessBlueprintBody(
   const th = layout.bounds.height;
 
   const parts: string[] = [];
-  // Pills and chips collected separately so they render after (on top of) grid lines.
   const topParts: string[] = [];
 
-  // Outer background (fill only; border drawn last on top).
   parts.push(
     `<rect class="diagram-node level-0 bp-row-bg" x="${ox}" y="${oy}" width="${tw}" height="${th}" rx="6" stroke="none"/>`,
   );
 
-  // ClipPath — clips all inner content to the outer rounded rect so corner cells
-  // don't visually overflow the rx=6 boundary.
   parts.push(`<defs><clipPath id="${clipId}"><rect x="${ox}" y="${oy}" width="${tw}" height="${th}" rx="6"/></clipPath></defs>`);
 
   const inner: string[] = [];
+  const headerMaxChars = Math.max(8, Math.floor((layout.stageColumnWidth - 16) / 7));
 
-  // Stage headers (top row).
   for (const s of layout.stageHeaders) {
     inner.push(
       `<rect class="diagram-node level-1" x="${s.x + ox}" y="${s.y + oy}" width="${s.width}" height="${s.height}" stroke="none"/>`,
     );
     inner.push(
-      `<text class="text-header" x="${s.x + ox + s.width / 2}" y="${s.y + oy + s.height / 2}" text-anchor="middle" dominant-baseline="central">${escXml(truncate(s.name, 28))}</text>`,
+      `<text class="text-header" x="${s.x + ox + s.width / 2}" y="${s.y + oy + s.height / 2}" text-anchor="middle" dominant-baseline="central">${escXml(truncateLine(s.name, headerMaxChars))}</text>`,
     );
   }
 
-  // Legend column (row labels).
   for (const l of layout.legend) {
     inner.push(
       `<rect class="diagram-node level-2 bp-row-bg" x="${ox}" y="${l.y + oy}" width="${layout.legendColumnWidth}" height="${l.height}" stroke="none"/>`,
@@ -153,7 +129,6 @@ export function renderProcessBlueprintBody(
     );
   }
 
-  // Goal and result cells.
   const textX = layout.cellTextPadX;
   for (const c of layout.goalCells) {
     inner.push(
@@ -168,7 +143,6 @@ export function renderProcessBlueprintBody(
     inner.push(textCellSvg(c.lines, 'text-secondary', c.x + ox + textX, c.y + oy, c.height, layout.textLineHeight));
   }
 
-  // Aspect rows — transparent background; pills carry the colour.
   for (let r = 0; r < layout.aspectRows.length; r++) {
     const row = layout.aspectRows[r];
     const level = 5 + (r % 3);
@@ -176,31 +150,22 @@ export function renderProcessBlueprintBody(
       `<rect class="diagram-node level-${level} bp-row-bg" x="${layout.legendColumnWidth + ox}" y="${row.y + oy}" width="${tw - layout.legendColumnWidth}" height="${row.height}" stroke="none"/>`,
     );
     for (const p of row.pills) {
-      const cx = p.x + ox + p.width / 2;
-      const pillLH = 15;
-      // p.lines: name lines (possibly wrapped), optionally with id as last line.
       const hasIdLine = !!(p.id && p.lines.length > 0 && p.lines[p.lines.length - 1] === p.id);
       const nameLines = hasIdLine ? p.lines.slice(0, -1) : p.lines;
       const idLine = hasIdLine ? p.id : undefined;
-      const pillFirstY = p.y + oy + p.height / 2 - ((p.lines.length - 1) / 2) * pillLH;
+      const pillSpecs = layoutCenteredPillText(p.x + ox, p.y + oy, p.width, p.height, nameLines, idLine);
       topParts.push(
         `<rect class="diagram-node level-${level}" x="${p.x + ox}" y="${p.y + oy}" width="${p.width}" height="${p.height}" rx="6"/>`,
       );
-      if (nameLines.length > 0) {
-        const tspans = nameLines
-          .map((ln, i) => `<tspan x="${cx}" y="${pillFirstY + i * pillLH}">${escXml(ln)}</tspan>`)
-          .join('');
-        topParts.push(`<text class="text-pill" text-anchor="middle" dominant-baseline="central">${tspans}</text>`);
-      }
-      if (idLine) {
+      for (const spec of pillSpecs) {
+        const anchor = spec.cls === 'text-pill' || spec.cls === 'text-secondary' ? ' text-anchor="middle"' : '';
         topParts.push(
-          `<text class="text-secondary" x="${cx}" y="${pillFirstY + nameLines.length * pillLH}" text-anchor="middle" dominant-baseline="central">${escXml(idLine)}</text>`,
+          `<text class="${spec.cls}" x="${spec.x}" y="${spec.y}"${anchor} dominant-baseline="central">${escXml(spec.text)}</text>`,
         );
       }
     }
   }
 
-  // Compliance row (optional).
   if (layout.complianceRow) {
     const row = layout.complianceRow;
     inner.push(
@@ -212,7 +177,6 @@ export function renderProcessBlueprintBody(
     }
   }
 
-  // Grid lines — drawn before pills so they appear under pill content.
   const gridX1 = ox;
   const gridX2 = ox + tw;
   const gridY1 = oy;
@@ -232,10 +196,7 @@ export function renderProcessBlueprintBody(
     inner.push(`<line class="diagram-edge" x1="${stageLineX}" y1="${gridY1}" x2="${stageLineX}" y2="${gridY2}"/>`);
   }
 
-  // Inner content (fills + grid lines) clipped to rounded outer rect.
   parts.push(`<g clip-path="url(#${clipId})">${inner.join('\n')}${topParts.join('\n')}</g>`);
-
-  // Outer border on top — fill="none" as attribute so PNG export (no external CSS) never shows black.
   parts.push(`<rect class="bp-border" x="${ox}" y="${oy}" width="${tw}" height="${th}" rx="6" fill="none"/>`);
 
   return parts.join('\n');
@@ -243,15 +204,21 @@ export function renderProcessBlueprintBody(
 
 export interface RenderProcessBlueprintOptions {
   title?: string;
+  nodeSizePreset?: NodeSizePreset;
+  layoutOptions?: ProcessBlueprintLayoutOptions;
 }
 
 export function renderProcessBlueprintSvg(
   doc: ProcessBlueprintFile,
   options: RenderProcessBlueprintOptions = {},
 ): string {
-  const { title = '' } = options;
+  const { title = '', nodeSizePreset = 'normal', layoutOptions } = options;
+  const sizing = resolveProcessBlueprintSize(parseNodeSizePreset(nodeSizePreset));
 
-  const layout: ProcessBlueprintLayout = layoutProcessBlueprint(doc);
+  const layout: ProcessBlueprintLayout = layoutProcessBlueprint(doc, {
+    ...sizing,
+    ...layoutOptions,
+  });
 
   if (layout.bounds.width === 0 || layout.bounds.height === 0) {
     return `<svg xmlns="http://www.w3.org/2000/svg" width="0" height="0" viewBox="0 0 0 0"></svg>`;
@@ -269,8 +236,6 @@ export function renderProcessBlueprintSvg(
     ? `<text class="text-header" x="${PAD}" y="${PAD - 6}">${escXml(title)}</text>`
     : '';
 
-  // Embed the shared theme CSS plus the blueprint-specific rules inside the SVG
-  // so the rendered output is self-contained for the JCEF host.
   const embedCss = generateSvgEmbedCss('transitrix') + BP_EMBED_CSS;
 
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">

--- a/tests/preview-controls.test.ts
+++ b/tests/preview-controls.test.ts
@@ -35,8 +35,11 @@ describe('buildControlsPanel', () => {
     const html = buildControlsPanel(baseModel({
       spacing: { horizontalGap: 180, verticalGap: 40, defaults: spacingDefaults },
       curvature: { value: 2.5, default: 1 },
+      nodeSize: { value: 'wide', default: 'normal' },
     }));
-    expect(html).toContain('data-tx-field="horizontalGap" data-tx-event="input" data-tx-output="tx-hgap-out"\n        min="20" max="300" step="1" value="180"');
+    expect(html).toContain('data-tx-control="nodeSize"');
+    expect(html).toContain('value="wide" selected');
+    expect(html).toContain('data-tx-field="horizontalGap"');
     expect(html).toContain('value="2.5"');
   });
 


### PR DESCRIPTION
## Summary

- Extract `entity-text-layout.ts` — shared wrap/truncate/vertical placement profiles for entity nodes, cells, pills, and chips.
- Add `node-size-presets.ts` with `compact` / `normal` / `wide` geometry for Goals, DGCA/DGA, Blocks, Activities, Process Blueprint, and Capability Map.
- Wire `transitrix.nodeSize.*` VS Code settings and **Controls → Block size** on Goals, DGCA/DGA, Activities, and Process Blueprint previews.
- Unify Goals node height to **72 px** across webview and VS Code preview (was 60 px in extension host).
- Bump `@transitrix/diagrams` to **1.8.0**.

## Acceptance

- [x] Shared module; Blocks refactored to import it
- [x] Goals, DGCA/DGA, Activities use shared entity profile
- [x] Process Blueprint layout + renderer use shared cell/pill/chip profiles
- [x] Capability map tree uses shared wrap/truncate helpers
- [ ] Activity card — local `truncate()` kept (deferred; different layout model)
- [x] Size presets in VS Code settings for all notations in coverage table
- [x] Controls on Goals, DGCA/DGA, Activities, Process Blueprint
- [ ] Blocks Controls panel — settings-only (called out in README)
- [x] Preset scales char limits with width (unit tests in `entity-text-layout.test.ts`)
- [x] Host drift fixed for Goals
- [x] `extension/README.md` + CHANGELOG Unreleased updated

**Follow-up:** smooth width/height sliders; Activity card shared truncate; Blocks Controls parity.

## Test plan

- [x] `npm test --workspace @transitrix/diagrams` — 1265/1265 green
- [x] `npx tsc --noEmit` in `extension/` (after `npm run build --workspace @transitrix/diagrams`)
- [x] `tests/preview-controls.test.ts` — nodeSize control row
- [ ] Manual: Goals/DGCA preview → Controls → Block size wide → longer labels visible
- [ ] Manual: Process Blueprint preset changes column/pill geometry