### PR TITLE
chore: sync acme_corp mirror (acme-corp #32)

### DIFF
--- a/organizations/acme_corp/.github/workflows/discovery.yml
+++ b/organizations/acme_corp/.github/workflows/discovery.yml
@@ -1,0 +1,45 @@
+name: Discovery
+
+# Realises the scheduled-trigger contract from
+# transitrix/methodology §7 of methodology-update-propagation.md.
+#
+# For each consumer in adopters.yaml, compares its pinned acme-corp commit SHA
+# against the current HEAD of this repo and scans its decision folder for
+# status:proposed ADRs older than 14 days. Emits a digest to the workflow summary.
+#
+# Note on pin comparison: acme-corp does not yet publish semver releases.
+# Consumers (transitrix-studio, transitrix-dsm) pin to commit SHAs.
+# The job flags a consumer as `behind` when its pinned SHA differs from HEAD.
+#
+# Scope: READ-ONLY. This workflow does not open PRs on consumer repos.
+# The write side (opening bounded upgrade PRs when a consumer is behind)
+# requires cross-repo write auth (CONSUMER_WRITE_TOKEN) — see
+# transitrix/methodology §7.7. Provision a fine-grained PAT with
+# `contents:write` + `pull-requests:write` on each consumer repo and add it
+# as a repository secret named CONSUMER_WRITE_TOKEN to enable the write step.
+#
+# Runs Mondays 08:00 UTC and on workflow_dispatch.
+
+on:
+  schedule:
+    - cron: '0 8 * * 1'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Scan consumers
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source repo
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run discovery (read-only digest)
+        run: node scripts/discovery.mjs

--- a/organizations/acme_corp/.source-version
+++ b/organizations/acme_corp/.source-version
@@ -1,4 +1,4 @@
 version: 1
 source_repo: transitrix/acme-corp
-source_commit: 8b8a8fb77721f52be9bd2b4123ceacc4e3735cd8
-synced_at: "2026-07-03"
+source_commit: 9fb6c31bf4edb70f9de8c16bb0fd81aefa4e4691
+synced_at: "2026-07-07"

--- a/organizations/acme_corp/.templates/EXAMPLES.md
+++ b/organizations/acme_corp/.templates/EXAMPLES.md
@@ -35,7 +35,7 @@ External authority (`codex/external/<jurisdiction>/LAW-…`, `REGULATION-…`) a
 
 ## View documents — `canon/views/<notation>/`
 
-One worked skeleton per notation under `canon/views/` (fgca, fga, goals, capabilities, processmap, products, applications, action, issues, blocks, scenarios, bpmn, process-blueprint). Each references the element primitives above by canonical ID.
+One worked skeleton per notation under `canon/views/` (dgca, goals, capabilities, processmap, products, applications, action, issues, blocks, scenarios, bpmn, process-blueprint). The deprecated [`fga/`](../../canon/views/fga/) stub remains for migration reference only. Each example references the element primitives above by canonical ID.
 
 ## Copy-and-fill templates — `.templates/`
 

--- a/organizations/acme_corp/AGENTS.md
+++ b/organizations/acme_corp/AGENTS.md
@@ -76,7 +76,7 @@ The canonical layout an adopter inherits from the `acme_corp` template:
 │   │   ├── 03_application/         # APPLICATION, SERVICE, INTERFACE, DATA_OBJECT
 │   │   └── 04_technology/          # NODE, ARTIFACT, DEVICE, …
 │   └── views/                      # one subfolder per notation (extensions in canon/views/README.md)
-│       ├── bpmn/   dgca/   fga/   goals/   capabilities/   processmap/
+│       ├── bpmn/   dgca/   goals/   action/   capabilities/   processmap/
 │       ├── action/   blocks/   scenarios/
 │       └── applications/   products/   issues/   process-blueprint/
 ├── field/                          # raw inputs — interviews, surveys, observations, drafts
@@ -139,9 +139,9 @@ spec_version: "0.1"         # accepted; will become required at notation v1.0
 
 The file extension is always `*.<short-name>.transitrix.yaml`. The validator rejects extension/content mismatch (rule `HDR-003`).
 
-Naming convention for view files: `<DOMAIN>.<short-name>.transitrix.yaml`, where `<DOMAIN>` is a short kebab-case or upper-snake-case label for the area (e.g. `order-fulfilment.bpmn.transitrix.yaml`, `RETENTION-2026.fgca.transitrix.yaml`). One canonical instance per notation per domain.
+Naming convention for view files: `<DOMAIN>.<short-name>.transitrix.yaml`, where `<DOMAIN>` is a short kebab-case or upper-snake-case label for the area (e.g. `order-fulfilment.bpmn.transitrix.yaml`, `EU-EXPANSION-2026.dgca.transitrix.yaml`). One canonical instance per notation per domain.
 
-The agent never strips the `notation:` and `spec_version:` headers, and never introduces alias extensions (`*.bpmn.yaml`, `*.fgca.yml`) — they fail validation.
+The agent never strips the `notation:` and `spec_version:` headers, and never introduces alias extensions (`*.bpmn.yaml`, `*.dgca.yml`, `*.fgca.transitrix.yaml`) — they fail validation.
 
 ---
 
@@ -169,11 +169,11 @@ Deprecated three-letter abbreviations (`ACT`, `CHG`, `FAC`, `CAP`, `SCN`) — do
 Every notation file is validated before commit. Two sanctioned paths:
 
 - **Transitrix Studio (VS Code extension)** — install from the Marketplace (`transitrix.transitrix-studio`). The extension validates on save and shows error annotations in the editor.
-- **Transitrix CLI** — `npx @transitrix/cli validate path/to/your.fgca.transitrix.yaml`. Use in CI or when working without VS Code. All canonical `*.transitrix.yaml` notation extensions are accepted without `--ext`; pass `--ext <notation-name>` only for a non-canonical extension outside the built-in registry. On Windows PowerShell with a restricted execution policy, invoke as `npx.cmd @transitrix/cli validate <file>` — plain `npx` resolves to a `.ps1` wrapper that the policy refuses to launch.
+- **Transitrix CLI** — `npx @transitrix/cli validate path/to/your.dgca.transitrix.yaml`. Use in CI or when working without VS Code. All canonical `*.transitrix.yaml` notation extensions are accepted without `--ext`; pass `--ext <notation-name>` only for a non-canonical extension outside the built-in registry. On Windows PowerShell with a restricted execution policy, invoke as `npx.cmd @transitrix/cli validate <file>` — plain `npx` resolves to a `.ps1` wrapper that the policy refuses to launch.
 
 The agent does **not** commit files with `error`-level validation findings. `warning`-level findings are surfaced to the adopter and committed only with explicit acknowledgement. The agent does not auto-suppress validation rules.
 
-Every notation spec carries its own validation-codes table (e.g. `FGCA-001..015`, `GOALS-001..013`, `BL-001..009`, `ISS-001..006`). When surfacing a validation error to the adopter, the agent includes the canonical code so the rule is traceable to the spec.
+Every notation spec carries its own validation-codes table (e.g. `DGCA-001..015`, `GOALS-001..013`, `ACT-001..020`, `BL-001..009`, `ISS-001..006`). When surfacing a validation error to the adopter, the agent includes the canonical code so the rule is traceable to the spec.
 
 ---
 
@@ -236,7 +236,7 @@ The agent reads, edits, and validates this file the same way as any other notati
 - Does **not** edit files under the methodology canon at `transitrix/methodology` from inside this repo.
 - Does **not** invent new notations, new TYPE prefixes, or new validation rules. Those decisions happen upstream.
 - Does **not** change the canonical repository layout — `canon/views/<notation>/`, `canon/elements/<NN>_<layer>/`, `.templates/` — without an explicit adopter decision recorded in the PR.
-- Does **not** strip the `notation:` / `spec_version:` headers, rename canonical extensions, or rewrite files into alias formats (`*.bpmn.yaml`, `*.fgca.yml`).
+- Does **not** strip the `notation:` / `spec_version:` headers, rename canonical extensions, or rewrite files into alias formats (`*.bpmn.yaml`, `*.dgca.yml`, retired `*.fgca.transitrix.yaml`).
 - Does **not** auto-merge PRs. All PRs go through the gating in §11.
 - Does **not** push to `main` directly. Use a feature branch + PR every time.
 - Does **not** run destructive operations (`git push --force`, `git reset --hard`, deleting branches that aren't local-only) without an explicit instruction from the adopter.

--- a/organizations/acme_corp/GETTING_STARTED.md
+++ b/organizations/acme_corp/GETTING_STARTED.md
@@ -67,8 +67,8 @@ Architecture changes review as a diff, like code.
 
 Based on what you built, add the adjacent artefact ([`notations/README.md`](../../notations/README.md) family selection):
 
-- Built a **Goals tree** → add an **FGCA**/**FGA** to link goals to driving factors and delivery actions.
-- Built **FGCA** → add a **Capability map** for the same domain.
+- Built a **Goals tree** → add a **DGCA** or **DGA** chain to link goals to driving drivers and delivery actions.
+- Built **DGCA** → add a **Capability map** for the same domain.
 - Built a **Capability map** → add an **Applications catalogue**.
 
 ## Naming conventions

--- a/organizations/acme_corp/README.md
+++ b/organizations/acme_corp/README.md
@@ -36,7 +36,7 @@ The three **zones** (`canon` / `field` / `codex`) are parallel, not stacked — 
 
 One model, every layer, every stakeholder.
 
-**Native notation** (Transitrix Studio or CLI) covers the business layers — Motivation through Business: Goals, FGA/FGCA, Capability Map, Process Map, BPMN, Process Blueprint, Scenarios, Compliance Impact.
+**Native notation** (Transitrix Studio or CLI) covers the business layers — Motivation through Business: Goals, DGCA/DGA, Capability Map, Process Map, BPMN, Process Blueprint, Scenarios, Compliance Impact.
 
 **Mermaid complementary views** (any Markdown preview, no extra tooling) extend coverage to the technical and strategic-planning layers:
 

--- a/organizations/acme_corp/WALKTHROUGH.md
+++ b/organizations/acme_corp/WALKTHROUGH.md
@@ -32,7 +32,7 @@ Each beat links to where it lives in this repo.
 2. **The pressure — why they had to change.**
    External drivers (a GDPR enforcement wave, incoming NIS2) and the real obligations
    behind them; the coverage read shows where the model was still "dark".
-   → [`canon/views/fgca/`](canon/views/fgca/) (factors) ·
+   → [`canon/views/dgca/`](canon/views/dgca/) (drivers) ·
      [`codex/`](codex/) (the obligations) ·
      [`canon/views/coverage-metric/`](canon/views/coverage-metric/)
 
@@ -40,12 +40,12 @@ Each beat links to where it lives in this repo.
    The goal tree: compliance, resilience, growth — and the portfolio quadrant that
    shows which goals demand immediate action versus which shape the longer horizon.
    → [`canon/views/goals/`](canon/views/goals/) ·
-     [`canon/views/fgca/`](canon/views/fgca/) ·
+     [`canon/views/dgca/`](canon/views/dgca/) ·
      [`canon/views/quadrant/`](canon/views/quadrant/) (goal prioritisation — Strategy layer, Mermaid)
 
 4. **The transformation — how.**
    The changes, target capability maturity, alternative paths considered.
-   → [`canon/views/fgca/`](canon/views/fgca/) ·
+   → [`canon/views/dgca/`](canon/views/dgca/) ·
      [`canon/views/capabilities/`](canon/views/capabilities/) ·
      [`canon/views/scenarios/`](canon/views/scenarios/)
 

--- a/organizations/acme_corp/adopters.yaml
+++ b/organizations/acme_corp/adopters.yaml
@@ -1,0 +1,22 @@
+# adopters.yaml — machine-readable registry of downstream consumers of this repo.
+# Read by the Discovery job (scripts/discovery.mjs); never edited by the job itself.
+# Schema and semantics: transitrix/methodology §7.4 of methodology-update-propagation.md.
+#
+# acme-corp's consumers are pinned by commit SHA (not semver), because acme-corp
+# does not yet publish versioned releases. The discovery job compares each pin
+# against the current HEAD commit of this repository.
+version: 1
+consumers:
+  - repo: transitrix/transitrix-studio
+    clone: https://github.com/transitrix/transitrix-studio.git
+    role: demo-mirror
+    pin_file: organizations/acme_corp/.source-version
+    pin_key: source_commit
+    decisions_path: organizations/acme_corp/operations/decisions
+
+  - repo: transitrix/transitrix-dsm
+    clone: https://github.com/transitrix/transitrix-dsm.git
+    role: demo-consumer
+    pin_file: acme-corp-source.yaml
+    pin_key: acme_corp_version
+    decisions_path: docs/decisions

--- a/organizations/acme_corp/canon/elements/01_motivation/constraints/README.md
+++ b/organizations/acme_corp/canon/elements/01_motivation/constraints/README.md
@@ -2,7 +2,7 @@
 
 Constraint elements — design / operating constraints that bind the organisation. Each constraint is one file under this folder. Constraints sit on the ArchiMate 3.2 **motivation** layer.
 
-Constraints are referenced by FGCA factors via `references_constraint:` — the existence of a constraint is itself a factor for the organisation that acts on it. They may also be referenced from any other notation via `applies_to:` once a register-view notation lands; v1 ships the elements only.
+Constraints are referenced by DGCA drivers via `references_constraint:` — the existence of a constraint is itself a driver for the organisation that acts on it. They may also be referenced from any other notation via `applies_to:` once a register-view notation lands; v1 ships the elements only.
 
 TYPE registry: see [`notations/IDS_AND_REFERENCES.md`](../../../../../../notations/IDS_AND_REFERENCES.md) §3.1 (`CONSTRAINT`).
 
@@ -78,4 +78,4 @@ valid_to: null
 
 - TYPE registry: [`notations/IDS_AND_REFERENCES.md`](../../../../../../notations/IDS_AND_REFERENCES.md) §3.1 (`CONSTRAINT`), §4 (uniqueness scope).
 - Sibling rules catalogue: [`../../02_business/rules/`](../../02_business/rules/).
-- FGCA cross-reference field `references_constraint:` on DRIVER: [`notations/views/02-fgca.md`](../../../../../../notations/views/02-fgca.md) § Fields → `factors[]`.
+- DGCA cross-reference field `references_constraint:` on DRIVER: [`notations/views/02-dgca.md`](../../../../../../notations/views/02-dgca.md) § Fields → `factors[]`.

--- a/organizations/acme_corp/canon/elements/01_motivation/factors/README.md
+++ b/organizations/acme_corp/canon/elements/01_motivation/factors/README.md
@@ -1,6 +1,6 @@
 # `canon/elements/01_motivation/factors/`
 
-Driver element primitives — each file is one **neutral driver** (external or internal) on the ArchiMate 3.2 **motivation** layer (ArchiMate **Driver**). A driver names the standing force the organisation acts on (a regulatory regime, a market shift, an internal performance dimension); it carries no findings and no polarity. Drivers open the strategy chain: they justify the goals that follow. The FGCA / FGA views (`../../../views/fgca/`, `../../../views/fga/`) are the authoring surface; a driver shared across documents is materialised here as its canonical record.
+Driver element primitives — each file is one **neutral driver** (external or internal) on the ArchiMate 3.2 **motivation** layer (ArchiMate **Driver**). A driver names the standing force the organisation acts on (a regulatory regime, a market shift, an internal performance dimension); it carries no findings and no polarity. Drivers open the strategy chain: they justify the goals that follow. The DGCA / DGA views ([`../../../views/dgca/`](../../../views/dgca/)) are the authoring surface; a driver shared across documents is materialised here as its canonical record.
 
 **Driver vs finding.** A DRIVER is the *thing* (e.g. "Support response time"), not a statement about its current state. Dated findings about a driver's state — measurements, trends, observations — are `ASSESSMENT` records that `assesses` the DRIVER ([`../assessments/`](../assessments/), schema [`ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEMENT_PRIMITIVES.md) §7.16). Polarity (whether a finding helps or harms a particular goal) lives on the `assessment_influences_goal` REL ([`17-relations.md`](../../../../../../notations/elements/17-relations.md) §3) — never on the DRIVER or the ASSESSMENT.
 
@@ -30,5 +30,5 @@ Defined in [`notations/ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEME
 - Element-primitive schema: [`notations/ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEMENT_PRIMITIVES.md) §7.1.
 - ASSESSMENT (findings about a driver): [`../assessments/`](../assessments/), [`ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEMENT_PRIMITIVES.md) §7.16.
 - `assessment_influences_goal` REL (where polarity / SWOT lives): [`notations/elements/17-relations.md`](../../../../../../notations/elements/17-relations.md) §3.
-- FGCA / FGA notations: [`notations/views/02-fgca.md`](../../../../../../notations/views/02-fgca.md), [`notations/views/03-fga.md`](../../../../../../notations/views/03-fga.md).
-- Views over these elements: [`../../../views/fgca/`](../../../views/fgca/), [`../../../views/fga/`](../../../views/fga/).
+- DGCA / DGA notation: [`notations/views/02-dgca.md`](../../../../../../notations/views/02-dgca.md) (DGA = `view_config.layers.changes: off`).
+- Views over these elements: [`../../../views/dgca/`](../../../views/dgca/), [`../../../views/goals/`](../../../views/goals/).

--- a/organizations/acme_corp/canon/elements/01_motivation/goals/README.md
+++ b/organizations/acme_corp/canon/elements/01_motivation/goals/README.md
@@ -1,6 +1,6 @@
 # `canon/elements/01_motivation/goals/`
 
-Goal element primitives — each file is one strategic or tactical goal on the ArchiMate 3.2 **motivation** layer. Goals are the most cross-referenced strategy-chain element (goals tree, FGCA, FGA, activities). The goals-tree view (`../../../views/goals/`) arranges them into a hierarchy; this folder holds their canonical records.
+Goal element primitives — each file is one strategic or tactical goal on the ArchiMate 3.2 **motivation** layer. Goals are the most cross-referenced strategy-chain element (goals tree, DGCA, DGA). The goals-tree view (`../../../views/goals/`) arranges them into a hierarchy; this folder holds their canonical records.
 
 TYPE registry: [`notations/IDS_AND_REFERENCES.md`](../../../../../../notations/IDS_AND_REFERENCES.md) §3.1 (`GOAL`).
 
@@ -30,4 +30,4 @@ A goal's **`parent`** (`GOAL → GOAL`) is a first-class time-aware relation (`g
 
 - Element-primitive schema: [`notations/ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEMENT_PRIMITIVES.md) §7.2.
 - Goals-tree notation: [`notations/views/04-goals.md`](../../../../../../notations/views/04-goals.md).
-- Views over these elements: [`../../../views/goals/`](../../../views/goals/), [`../../../views/fgca/`](../../../views/fgca/), [`../../../views/fga/`](../../../views/fga/).
+- Views over these elements: [`../../../views/goals/`](../../../views/goals/), [`../../../views/dgca/`](../../../views/dgca/).

--- a/organizations/acme_corp/canon/elements/02_business/capabilities/CAPABILITY-H1.yaml
+++ b/organizations/acme_corp/canon/elements/02_business/capabilities/CAPABILITY-H1.yaml
@@ -1,0 +1,26 @@
+# Cross-cutting compliance capability — referenced by products, scenarios,
+# and the process landscape. Diagram address H1 in the capability-map view.
+# Schema: notations/views/05-capability-map.md §13 + CONTRACT.md §6–§7.
+
+notation: capability
+id: CAPABILITY-H1
+name: "Compliance & Data Protection"
+type: supporting
+description: >
+  Cross-cutting capability covering GDPR/NIS2 obligations: data-subject
+  rights, breach reporting, and data residency. Lowest current maturity —
+  the focus of the 2026 remediation programme.
+
+target_maturity: 3
+business_process: PROCESS-DSR-HANDLE-1
+
+zone: canon
+admitted_at: "2026-07-06"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2026-05-26"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/02_business/registries/REGISTRY-REG-SOURCES-1.runstate.yaml
+++ b/organizations/acme_corp/canon/elements/02_business/registries/REGISTRY-REG-SOURCES-1.runstate.yaml
@@ -12,12 +12,12 @@ rows:
     review_needed: false
     latest_snapshot: "snapshots/SOURCE-GDPR-1/2026-06-04.html"
 
-  SOURCE-EU-AI-ACT-1:
+  SOURCE-EU-AIACT-2024-1:
     last_scanned_at: "2026-06-04"
     next_scan_due: "2026-07-04"            # last + P30D (row override)
     change_detected: true
     review_needed: true
-    latest_snapshot: "snapshots/SOURCE-EU-AI-ACT-1/2026-06-04.html"
+    latest_snapshot: "snapshots/SOURCE-EU-AIACT-2024-1/2026-06-04.html"
 
   SOURCE-EDPB-GUIDE-1:
     last_scanned_at: "2026-06-04"

--- a/organizations/acme_corp/canon/elements/02_business/registries/REGISTRY-REG-SOURCES-1.yaml
+++ b/organizations/acme_corp/canon/elements/02_business/registries/REGISTRY-REG-SOURCES-1.yaml
@@ -22,7 +22,7 @@ rows:
     change_signal_method: version-date    # harvesting hint pre-admission; superseded by the codex scan block once linked
     # scan_frequency omitted → registry default (P90D)
 
-  - id: SOURCE-EU-AI-ACT-1
+  - id: SOURCE-EU-AIACT-2024-1
     name: "EU AI Act — Regulation (EU) 2024/1689"
     type: regulation
     jurisdiction: EU

--- a/organizations/acme_corp/canon/elements/05_implementation/actions/ACTION-EU-COMPLIANCE-1.yaml
+++ b/organizations/acme_corp/canon/elements/05_implementation/actions/ACTION-EU-COMPLIANCE-1.yaml
@@ -1,0 +1,25 @@
+# Initiative-level Action — parent of the GDPR remediation programme.
+# Schema: notations/ELEMENT_PRIMITIVES.md §7.4. WBS root in
+# canon/views/action/gdpr-remediation.dgca.transitrix.yaml.
+
+notation: action
+id: ACTION-EU-COMPLIANCE-1
+name: "EU Data Protection Compliance Initiative"
+type: Initiative
+goals:
+  - GOAL-EU-1
+owner: ROLE-DPO-1
+description: >
+  Top-level initiative covering EU GDPR and NIS2 compliance workstreams,
+  including the 2026 GDPR remediation programme.
+
+zone: canon
+admitted_at: "2026-07-06"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2026-01-01"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/05_implementation/actions/ACTION-GDPR-REMEDIATION-1.yaml
+++ b/organizations/acme_corp/canon/elements/05_implementation/actions/ACTION-GDPR-REMEDIATION-1.yaml
@@ -1,0 +1,31 @@
+# Programme-level Action — the project the GDPR remediation action-card binds to.
+# Schema: notations/ELEMENT_PRIMITIVES.md §7.4 + envelope §3.
+# WBS parent of the project nodes in canon/views/action/gdpr-remediation.dgca.transitrix.yaml.
+# Child projects remain in the action view until promoted to canon/elements/.
+
+notation: action
+id: ACTION-GDPR-REMEDIATION-1
+name: "GDPR Remediation 2026"
+type: Programme
+parent: ACTION-EU-COMPLIANCE-1
+goals:
+  - GOAL-EU-1
+delivers_changes:
+  - CHANGE-GDPR-COMPLIANCE-1
+description: >
+  Programme of work closing the EU data-protection gaps surfaced by the 2026
+  gap assessment: extending the erasure pipeline to the cold-storage archive,
+  standing up data-subject-request handling, and reworking onboarding consent.
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-07-03"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-03-01"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/05_implementation/actions/README.md
+++ b/organizations/acme_corp/canon/elements/05_implementation/actions/README.md
@@ -1,6 +1,6 @@
 # `canon/elements/05_implementation/actions/`
 
-Action element primitives — each file is one initiative / workstream (an ArchiMate 3.2 *Work Package*) on the **Implementation & Migration** layer. Actions are recursive: an initiative aggregates programmes → projects → tasks, all one TYPE via `parent`. They are arranged by the action view (`../../../views/action/`) as a precedence network, and by the FGCA / FGA chains.
+Action element primitives — each file is one initiative / workstream (an ArchiMate 3.2 *Work Package*) on the **Implementation & Migration** layer. Actions are recursive: an initiative aggregates programmes → projects → tasks, all one TYPE via `parent`. They are arranged by the action view ([`../../../views/action/`](../../../views/action/)) as a precedence network, and by the DGCA / DGA chains ([`../../../views/dgca/`](../../../views/dgca/)).
 
 TYPE registry: [`notations/IDS_AND_REFERENCES.md`](../../../../../../notations/IDS_AND_REFERENCES.md) §3.1 (`ACTION`). Layer rationale: [`notations/ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEMENT_PRIMITIVES.md) §6.1.
 
@@ -21,8 +21,8 @@ Defined in [`notations/ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEME
 
 | File | Notes |
 |---|---|
-| `ACTION-CRM-EU-1.yaml` | Delivers `CHANGE-EU-CRM-1` (FGCA chain) |
-| `ACTION-SUPPORT-1.yaml` | Serves `GOAL-OPS-1` (FGA chain) |
+| `ACTION-CRM-EU-1.yaml` | Delivers `CHANGE-EU-CRM-1` (DGCA chain) |
+| `ACTION-SUPPORT-1.yaml` | Serves `GOAL-OPS-1` (DGA chain — DGCA with Changes layer off) |
 | `ACTION-DISCOVERY-1.yaml` … `ACTION-LAUNCH-1.yaml` | Onboarding precedence network, linked by `predecessors` |
 
 ## See also

--- a/organizations/acme_corp/canon/elements/05_implementation/changes/CHANGE-GDPR-COMPLIANCE-1.yaml
+++ b/organizations/acme_corp/canon/elements/05_implementation/changes/CHANGE-GDPR-COMPLIANCE-1.yaml
@@ -1,0 +1,26 @@
+# Programme-level change delivered by the GDPR remediation workstream.
+# Schema: notations/ELEMENT_PRIMITIVES.md §7.3 + envelope §3.
+# Referenced by canon/views/action-card/eu-gdpr-remediation.action-card.transitrix.yaml milestones.
+
+notation: change
+id: CHANGE-GDPR-COMPLIANCE-1
+name: "Close EU data-protection compliance gaps"
+goals:
+  - GOAL-EU-1
+description: >
+  The delta required to operate in EU markets under GDPR and NIS2: archive
+  erasure coverage, data-subject-request handling, and consent capture aligned
+  with supervisory expectations.
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-07-03"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-03-01"
+valid_to: null

--- a/organizations/acme_corp/canon/elements/05_implementation/changes/README.md
+++ b/organizations/acme_corp/canon/elements/05_implementation/changes/README.md
@@ -1,6 +1,6 @@
 # `canon/elements/05_implementation/changes/`
 
-Change element primitives — each file is one BDN **business change** (an ArchiMate 3.2 *Gap*) on the **Implementation & Migration** layer. A change is a required delta to reach the target state, at any granularity; higher-level changes decompose into lower-level ones via a `parent` relation. Changes are arranged by the FGCA view (`../../../views/fgca/`) and delivered by actions (`../actions/`).
+Change element primitives — each file is one BDN **business change** (an ArchiMate 3.2 *Gap*) on the **Implementation & Migration** layer. A change is a required delta to reach the target state, at any granularity; higher-level changes decompose into lower-level ones via a `parent` relation. Changes are arranged by the DGCA view ([`../../../views/dgca/`](../../../views/dgca/)) and delivered by actions ([`../actions/`](../actions/)).
 
 TYPE registry: [`notations/IDS_AND_REFERENCES.md`](../../../../../../notations/IDS_AND_REFERENCES.md) §3.1 (`CHANGE`). Layer rationale: [`notations/ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEMENT_PRIMITIVES.md) §6.1.
 
@@ -25,5 +25,5 @@ Defined in [`notations/ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEME
 ## See also
 
 - Element-primitive schema: [`notations/ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEMENT_PRIMITIVES.md) §7.3, layer §6.1.
-- FGCA notation: [`notations/views/02-fgca.md`](../../../../../../notations/views/02-fgca.md).
+- DGCA notation: [`notations/views/02-dgca.md`](../../../../../../notations/views/02-dgca.md).
 - Sibling actions catalogue: [`../actions/`](../actions/).

--- a/organizations/acme_corp/canon/views/README.md
+++ b/organizations/acme_corp/canon/views/README.md
@@ -8,14 +8,15 @@ See [`method/methodology.md` §6](../../../method/methodology.md) for the full n
 
 | Folder | Notation | File extension | What it holds |
 | --- | --- | --- | --- |
-| [`goals/`](goals/) | Goals tree | `*.dgca.transitrix.yaml` | Hierarchical goals trees |
+| [`goals/`](goals/) | Goals tree | `*.goals.transitrix.yaml` | Hierarchical goals trees |
+| [`dgca/`](dgca/) | DGCA chain (4-layer) | `*.dgca.transitrix.yaml` | Driver → Goal → Change → Action |
+| [`dgca/`](dgca/) | DGA chain (3-layer) | `*.dgca.transitrix.yaml` with `view_config.layers.changes: off` | Driver → Goal → Action (no Changes layer) |
 | [`capabilities/`](capabilities/) | Capabilities map | `*.capability-map.transitrix.yaml` | Capability hierarchies with maturity overlay |
 | [`processmap/`](processmap/) | Process landscape map | `*.process-map.transitrix.yaml` | Top-level process catalogues |
 | [`bpmn/`](bpmn/) | Process diagram (BPMN) | `*.bpmn.transitrix.yaml` | Detailed process flows |
-| [`fgca/`](fgca/) | FGCA chain | `*.fgca.transitrix.yaml` | Factor → Goal → Change → Action |
-| [`fga/`](fga/) | FGA chain | `*.fga.transitrix.yaml` | Factor → Goal → Action |
+| [`fga/`](fga/) | ~~FGA chain~~ **deprecated** | ~~`*.fga.transitrix.yaml`~~ | Stub only — see [`fga/README.md`](fga/); use [`dgca/`](dgca/) |
 | [`blocks/`](blocks/) | Nested block diagrams | `*.blocks.transitrix.yaml` | Recursive `block` tree rendered as nested containers |
-| [`action/`](action/) | Action network | `*.dgca.transitrix.yaml` | PSND (Action-on-Node) with Gantt projection and critical path |
+| [`action/`](action/) | Action network | `*.action.transitrix.yaml` | PSND (Action-on-Node) with Gantt projection and critical path |
 | [`products/`](products/) | Products view | `*.products.transitrix.yaml` | Filtered views over Product elements |
 | [`applications/`](applications/) | Applications view | `*.applications.transitrix.yaml` | Filtered views over Application elements |
 | [`scenarios/`](scenarios/) | Scenarios | `*.scenarios.transitrix.yaml` | Alternative strategic development paths |
@@ -30,10 +31,11 @@ See [`method/methodology.md` §6](../../../method/methodology.md) for the full n
 File names use `kebab-case` or descriptive `[DOMAIN]-[CONTEXT]` prefixes. Examples:
 
 ```
-canon/views/goals/strategy-2026.dgca.transitrix.yaml
+canon/views/goals/eu-strategy.goals.transitrix.yaml
+canon/views/dgca/eu-expansion.dgca.transitrix.yaml
 canon/views/capabilities/customer-domain.capability-map.transitrix.yaml
 canon/views/bpmn/order-fulfillment.bpmn.transitrix.yaml
-canon/views/fgca/eu-expansion.fgca.transitrix.yaml
+canon/views/action/gdpr-remediation.action.transitrix.yaml
 canon/views/products/active-portfolio.products.transitrix.yaml
 ```
 

--- a/organizations/acme_corp/canon/views/action-card/README.md
+++ b/organizations/acme_corp/canon/views/action-card/README.md
@@ -1,6 +1,6 @@
 # `canon/views/action-card/`
 
-Single-project narrative cards. Each card binds to one project Action (`project: ACTION-…`) and adds narrative milestones; the motivation chain and child actions are pulled by reference from the FGCA and Action documents rather than duplicated.
+Single-project narrative cards. Each card binds to one project Action (`project: ACTION-…`) and adds narrative milestones; the motivation chain and child actions are pulled by reference from the DGCA/DGA and Action documents rather than duplicated.
 
 ## File convention
 

--- a/organizations/acme_corp/canon/views/action/README.md
+++ b/organizations/acme_corp/canon/views/action/README.md
@@ -4,7 +4,7 @@ Project schedule as an **Action-on-Node** precedence network (PSND), with an opt
 
 ## File convention
 
-`*.dgca.transitrix.yaml`
+`*.action.transitrix.yaml`
 
 See [`notations/views/07-action.md`](../../../../../notations/views/07-action.md) for the full spec — including PSND semantics, the critical-path computation, and the Gantt projection contract.
 
@@ -55,8 +55,8 @@ Actions form a DAG via `predecessors:`. The renderer computes Early Start / Late
 
 ## Cross-references
 
-- `goals: [GOAL-…]` — Goal IDs from the goals tree / FGCA chain.
-- `delivers_changes: [CHANGE-…]` — Change IDs from the FGCA chain.
+- `goals: [GOAL-…]` — Goal IDs from the goals tree / DGCA or DGA chain.
+- `delivers_changes: [CHANGE-…]` — Change IDs from the DGCA chain.
 - `predecessors: [ACTION-…]` — other action IDs in the same file.
 
 All IDs follow the canonical `<TYPE>-[<middle>-]<INTEGER>` grammar from [`notations/IDS_AND_REFERENCES.md`](../../../../../notations/IDS_AND_REFERENCES.md).
@@ -64,5 +64,5 @@ All IDs follow the canonical `<TYPE>-[<middle>-]<INTEGER>` grammar from [`notati
 ## See also
 
 - [`notations/views/07-action.md`](../../../../../notations/views/07-action.md) — the notation spec
-- [`notations/examples/action/platform-launch.dgca.transitrix.yaml`](../../../../../notations/examples/action/platform-launch.dgca.transitrix.yaml) — worked example
+- [`notations/examples/action/platform-launch.action.transitrix.yaml`](../../../../../notations/examples/action/platform-launch.action.transitrix.yaml) — worked example
 - `method/methodology.md` §6 — notation kit

--- a/organizations/acme_corp/canon/views/action/gdpr-remediation.dgca.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/action/gdpr-remediation.dgca.transitrix.yaml
@@ -1,6 +1,19 @@
 # Action-on-Node network (PSND) — the GDPR remediation programme schedule.
 # Notation spec: notations/views/07-action.md. Inline actions carry
 # CONTRACT.md §7 lifecycle, distinct from the schedule fields (start_date / duration_days).
+#
+# WBS hierarchy (type + parent):
+#   Initiative: ACTION-EU-COMPLIANCE-1
+#     Programme: ACTION-GDPR-REMEDIATION-1
+#       Project: ACTION-GDPR-GAP-1
+#       Project: ACTION-GDPR-ERASURE-PIPELINE-1   ← phase; dates roll up from Tasks below
+#         Task: ACTION-GDPR-ERASURE-ARCHIVE-1
+#         Task: ACTION-GDPR-ERASURE-VALIDATE-1
+#       Project: ACTION-GDPR-DSR-WORKFLOW-1
+#       Project: ACTION-GDPR-CONSENT-1
+#       Project: ACTION-GDPR-AUDIT-1
+#
+# predecessors: chain is independent of parent: and drives CPM / Gantt as before.
 
 notation: action
 spec_version: "0.1"
@@ -10,16 +23,41 @@ description: |
   Critical path for closing the EU data-protection gaps surfaced by the 2026
   gap assessment — including the cold-storage archive erasure gap that holds
   ASSERTION-ECOMM-GDPR-ERASURE-1 in a non_compliant state.
-version: "0.1"
-date: "2026-06-10"
+version: "0.2"
+date: "2026-07-03"
 author: "Acme Compliance Office"
 
 project:
   start_date: "2026-03-01"
 
 actions:
+  # ---- Initiative (top of WBS) -------------------------------------------
+  # No duration / dates — rolls up from all children.
+  - id: ACTION-EU-COMPLIANCE-1
+    name: "EU Data Protection Compliance Initiative"
+    type: Initiative
+    goals: [GOAL-EU-1]
+    owner: ROLE-DPO-1
+    valid_from: "2026-01-01"
+    valid_to: null
+
+  # ---- Programme ---------------------------------------------------------
+  # No duration / dates — rolls up from Project children.
+  - id: ACTION-GDPR-REMEDIATION-1
+    name: "GDPR Remediation 2026"
+    type: Programme
+    parent: ACTION-EU-COMPLIANCE-1
+    goals: [GOAL-EU-1]
+    owner: ROLE-DPO-1
+    valid_from: "2026-03-01"
+    valid_to: null
+
+  # ---- Projects ----------------------------------------------------------
+
   - id: ACTION-GDPR-GAP-1
     name: "GDPR & NIS2 gap assessment"
+    type: Project
+    parent: ACTION-GDPR-REMEDIATION-1
     duration_days: 15
     start_date: "2026-03-01"
     predecessors: []
@@ -28,10 +66,11 @@ actions:
     valid_from: "2026-05-26"
     valid_to: null
 
+  # Phase with Task children below — omits duration / dates per validation rule 017.
   - id: ACTION-GDPR-ERASURE-PIPELINE-1
     name: "Extend erasure pipeline to cold-storage archive"
-    duration_days: 30
-    start_date: "2026-06-15"
+    type: Project
+    parent: ACTION-GDPR-REMEDIATION-1
     predecessors: [ACTION-GDPR-GAP-1]
     goals: [GOAL-EU-1]
     delivers_changes: [CHANGE-EU-CRM-1]
@@ -41,6 +80,8 @@ actions:
 
   - id: ACTION-GDPR-DSR-WORKFLOW-1
     name: "Stand up data-subject-request workflow"
+    type: Project
+    parent: ACTION-GDPR-REMEDIATION-1
     duration_days: 20
     start_date: "2026-06-15"
     predecessors: [ACTION-GDPR-GAP-1]
@@ -51,6 +92,8 @@ actions:
 
   - id: ACTION-GDPR-CONSENT-1
     name: "Rework onboarding consent capture"
+    type: Project
+    parent: ACTION-GDPR-REMEDIATION-1
     duration_days: 18
     start_date: "2026-06-20"
     predecessors: [ACTION-GDPR-GAP-1]
@@ -62,6 +105,8 @@ actions:
 
   - id: ACTION-GDPR-AUDIT-1
     name: "Supervisory-authority pre-audit"
+    type: Project
+    parent: ACTION-GDPR-REMEDIATION-1
     duration_days: 5
     start_date: "2026-08-15"
     predecessors:
@@ -71,4 +116,33 @@ actions:
     goals: [GOAL-EU-1]
     owner: ROLE-DPO-1
     valid_from: "2026-05-26"
+    valid_to: null
+
+  # ---- Tasks (children of ACTION-GDPR-ERASURE-PIPELINE-1) ---------------
+  # Demonstrates the fourth WBS level. Together span the 30 days that
+  # ERASURE-PIPELINE-1 previously carried as its own duration.
+
+  - id: ACTION-GDPR-ERASURE-ARCHIVE-1
+    name: "Extend archive storage erasure path"
+    type: Task
+    parent: ACTION-GDPR-ERASURE-PIPELINE-1
+    duration_days: 20
+    start_date: "2026-06-15"
+    predecessors: [ACTION-GDPR-GAP-1]
+    goals: [GOAL-EU-1]
+    delivers_changes: [CHANGE-EU-CRM-1]
+    owner: ROLE-TECH-1
+    valid_from: "2026-06-10"
+    valid_to: null
+
+  - id: ACTION-GDPR-ERASURE-VALIDATE-1
+    name: "Validate erasure pipeline end-to-end"
+    type: Task
+    parent: ACTION-GDPR-ERASURE-PIPELINE-1
+    duration_days: 10
+    start_date: "2026-07-10"
+    predecessors: [ACTION-GDPR-ERASURE-ARCHIVE-1]
+    goals: [GOAL-EU-1]
+    owner: ROLE-TECH-1
+    valid_from: "2026-06-10"
     valid_to: null

--- a/organizations/acme_corp/canon/views/compliance-impact/eu-compliance.compliance-impact.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/compliance-impact/eu-compliance.compliance-impact.transitrix.yaml
@@ -5,6 +5,7 @@ notation: compliance-impact
 spec_version: "0.1"
 
 view:
+  report_type: product
   id: COMPLIANCE_IMPACT-ACME-EU-1
   name: "acme_corp — EU Compliance Impact (GDPR + NIS2)"
   description: >

--- a/organizations/acme_corp/canon/views/dgca/eu-compliance-dga.dgca.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/dgca/eu-compliance-dga.dgca.transitrix.yaml
@@ -33,6 +33,8 @@ goals:
     valid_from: "2026-05-26"
     valid_to: null
 
+changes: []
+
 actions:
   - id: ACTION-DISCOVERY-1
     name: "GDPR & NIS2 gap assessment"
@@ -50,7 +52,7 @@ actions:
     due_date: "2026-09-30"
     valid_from: "2026-05-26"
     valid_to: null
-  - id: ACTION-SUPPORT-1
+  - id: ACTION-GDPR-DSR-WORKFLOW-1
     name: "Stand up data-subject-request handling"
     goals: [GOAL-EU-1]
     owner: ROLE-DPO-1

--- a/organizations/acme_corp/canon/views/goals/README.md
+++ b/organizations/acme_corp/canon/views/goals/README.md
@@ -4,7 +4,7 @@ Hierarchical goals trees. Each tree references Goal elements stored atomically u
 
 ## File convention
 
-`*.dgca.transitrix.yaml`
+`*.goals.transitrix.yaml`
 
 ## Skeleton
 

--- a/organizations/acme_corp/canon/views/quadrant/README.md
+++ b/organizations/acme_corp/canon/views/quadrant/README.md
@@ -13,12 +13,12 @@ No Transitrix Studio required.
 
 Quadrant views project **portfolio positioning** — placing goals, capabilities,
 or changes on a 2 × 2 matrix to support prioritisation. They complement the
-Goals tree, FGA, and Scenarios (native notation) without duplicating them.
+Goals tree, DGCA/DGA chains, and Scenarios (native notation) without duplicating them.
 
-**Hard rule:** no Mermaid version of Goals, Capability Map, FGA/FGCA, Process Map,
+**Hard rule:** no Mermaid version of Goals, Capability Map, DGCA/DGA, Process Map,
 BPMN, or Gantt — those are native notation and must not be duplicated.
 
 ## See also
 
 - `canon/views/goals/` — Goals tree (native notation)
-- `canon/views/fga/` and `canon/views/fgca/` — factor–goal analysis (native notation)
+- `canon/views/dgca/` — Driver → Goal → Change → Action (4-layer) and Driver → Goal → Action (3-layer DGA mode)

--- a/organizations/acme_corp/canon/views/scenarios/eu-go-live.scenarios.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/scenarios/eu-go-live.scenarios.transitrix.yaml
@@ -33,7 +33,7 @@ scenario:
     - capability_id: CAPABILITY-V2
     - capability_id: CAPABILITY-H1
 
-  activities:
+  actions:
     - activity_id: ACTION-CRM-EU-1
     - activity_id: ACTION-GDPR-ERASURE-PIPELINE-1
     - activity_id: ACTION-GDPR-DSR-WORKFLOW-1

--- a/organizations/acme_corp/operations/decisions/ADR-0003-pin-methodology-1-0-0.md
+++ b/organizations/acme_corp/operations/decisions/ADR-0003-pin-methodology-1-0-0.md
@@ -1,0 +1,35 @@
+---
+id: ADR-0003
+title: "Pin methodology_version to 1.0.0 for the acme-corp model"
+status: accepted
+date: "2026-07-06"
+author: agent
+source: ad-hoc
+relates_to: []
+superseded_by: null
+---
+
+## Context
+
+The methodology released 1.0.0. The Discovery job, comparing the pinned
+`methodology_version` against the latest released tag on the source repository,
+found this repository behind and prepared this record. Per the architecture
+decision log, a consequential change made by an agent leaves a `proposed`
+decision for human ratification, not an unannounced edit.
+
+The 0.7 → 1.0 migration recipe (`migrations/0.7-to-1.0/` in the source
+methodology repository) was applied before ratification: scenarios
+`activities:` → `actions:`, compliance-impact `report_type` added, registry
+ID `SOURCE-EU-AI-ACT-1` renamed to `SOURCE-EU-AIACT-2024-1` (avoids false
+`ACT-*` abbreviated-prefix match on "AI Act"), post-migration validate clean.
+
+## Decision
+
+Pin `methodology_version: "1.0.0"` in `transitrix.yaml`.
+**Accepted** by maintainer 2026-07-06 after migration recipe applied.
+
+## Consequences
+
+- The model is validated against 1.0.0 semantics.
+- The 0.7 → 1.0 migration recipe was applied; `validate.mjs` exits 0.
+- Supersedes the effective scope of ADR-0002 (0.5.0 pin) for methodology-version purposes.

--- a/organizations/acme_corp/scripts/discovery.mjs
+++ b/organizations/acme_corp/scripts/discovery.mjs
@@ -1,0 +1,284 @@
+#!/usr/bin/env node
+// Discovery — noticing drift on a schedule.
+//
+// Realises the scheduled-trigger contract in
+// transitrix/methodology §7 of methodology-update-propagation.md. For each
+// consumer listed in adopters.yaml, per run:
+//   * clones the consumer's default branch (shallow, read-only);
+//   * reads its `pin_key` from `pin_file` and compares against the HEAD commit
+//     of this repo (acme-corp does not publish semver tags; pins are commit SHAs);
+//   * scans its `decisions_path` for ADR-NNNN-*.md at `status: proposed` whose
+//     `date:` is older than fourteen calendar days.
+//
+// Emits one digest to stdout (YAML) and, when running under GitHub Actions,
+// a Markdown summary appended to $GITHUB_STEP_SUMMARY.
+//
+// Scope: READ-ONLY. This script never pushes, never opens a PR, never edits
+// a consumer.
+//
+// Args (all optional):
+//   --registry <path>       default: <repo-root>/adopters.yaml
+//   --source-repo <path>    default: <repo-root>
+//   --workdir <path>        default: OS tmpdir + "/acme-corp-discovery"
+//   --now <YYYY-MM-DD>      default: today (UTC)
+//   --stale-days <n>        default: 14
+//
+// Exit codes:  0 clean run (findings are informational, not failures)
+//              2 script-internal error (registry missing, clone failed)
+
+import { readFile, readdir, mkdir, rm, appendFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = join(dirname(__filename), '..');
+
+const args = process.argv.slice(2);
+function argVal(flag, dflt) {
+  const i = args.indexOf(flag);
+  return i >= 0 && args[i + 1] ? args[i + 1] : dflt;
+}
+const REGISTRY = resolve(argVal('--registry', join(REPO_ROOT, 'adopters.yaml')));
+const SOURCE_REPO = resolve(argVal('--source-repo', REPO_ROOT));
+const WORKDIR = resolve(argVal('--workdir', join(tmpdir(), 'acme-corp-discovery')));
+const NOW = argVal('--now', new Date().toISOString().slice(0, 10));
+const STALE_DAYS = parseInt(argVal('--stale-days', '14'), 10);
+
+// --- helpers ---------------------------------------------------------------
+
+function daysBetween(isoA, isoB) {
+  const a = Date.parse(isoA + 'T00:00:00Z');
+  const b = Date.parse(isoB + 'T00:00:00Z');
+  if (Number.isNaN(a) || Number.isNaN(b)) return null;
+  return Math.round((b - a) / (24 * 60 * 60 * 1000));
+}
+
+function splitFrontMatter(text) {
+  const normalised = text.replace(/\r\n/g, '\n');
+  const m = normalised.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+  if (!m) return { fm: null, body: normalised };
+  return { fm: m[1], body: m[2] };
+}
+
+function parseFm(fmText) {
+  const out = {};
+  if (!fmText) return out;
+  for (const line of fmText.split('\n')) {
+    const m = line.match(/^([a-z_]+):\s*(.*?)\s*$/i);
+    if (!m) continue;
+    let v = m[2];
+    v = v.replace(/\s+#.*$/, '').trim();
+    v = v.replace(/^["']|["']$/g, '');
+    out[m[1]] = v;
+  }
+  return out;
+}
+
+function stripQuotes(v) {
+  return v.replace(/^["']|["']$/g, '');
+}
+
+function parseRegistry(text) {
+  const consumers = [];
+  const lines = text.split(/\r?\n/);
+  let cur = null;
+  let inConsumers = false;
+  for (const raw of lines) {
+    const line = raw.replace(/\s+#.*$/, '');
+    if (/^\s*#/.test(raw)) continue;
+    if (/^consumers\s*:/.test(line)) { inConsumers = true; continue; }
+    if (!inConsumers) continue;
+    const item = line.match(/^\s{2}-\s+([a-z_]+)\s*:\s*(.*)$/);
+    if (item) {
+      if (cur) consumers.push(cur);
+      cur = {};
+      cur[item[1]] = stripQuotes(item[2].trim());
+      continue;
+    }
+    const field = line.match(/^\s{4,}([a-z_]+)\s*:\s*(.*)$/);
+    if (field && cur) {
+      cur[field[1]] = stripQuotes(field[2].trim());
+    }
+  }
+  if (cur) consumers.push(cur);
+  return { consumers };
+}
+
+function extractPin(text, pinKey) {
+  const re = new RegExp(`^${pinKey}\\s*:\\s*(.*)$`, 'm');
+  const m = text.match(re);
+  if (!m) return null;
+  return stripQuotes(m[1].replace(/\s+#.*$/, '').trim());
+}
+
+// HEAD commit SHA of the source repo (acme-corp has no version tags).
+function headCommit(repoRoot) {
+  try {
+    return execFileSync('git', ['rev-parse', 'HEAD'],
+      { cwd: repoRoot, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+  } catch {
+    return null;
+  }
+}
+
+// Compare a pinned SHA against the source HEAD SHA.
+// Returns 'current', 'behind', or 'unparseable'.
+function shaStatus(pin, head) {
+  if (!pin || !head) return 'unparseable';
+  // Accept short-SHA prefix match so 7-char and 40-char SHAs interoperate.
+  const shorter = pin.length <= head.length ? pin : head;
+  const longer = pin.length <= head.length ? head : pin;
+  if (longer.startsWith(shorter)) return 'current';
+  return 'behind';
+}
+
+async function checkoutConsumer(consumer) {
+  const safeName = consumer.repo.replace(/[^a-zA-Z0-9._-]+/g, '_');
+  const dest = join(WORKDIR, safeName);
+  await mkdir(WORKDIR, { recursive: true });
+  if (existsSync(dest)) {
+    try {
+      execFileSync('git', ['-C', dest, 'fetch', '--depth', '1', 'origin'],
+        { stdio: ['ignore', 'ignore', 'pipe'] });
+      execFileSync('git', ['-C', dest, 'reset', '--hard', 'origin/HEAD'],
+        { stdio: ['ignore', 'ignore', 'pipe'] });
+      return dest;
+    } catch {
+      await rm(dest, { recursive: true, force: true });
+    }
+  }
+  execFileSync('git', ['clone', '--depth', '1', consumer.clone, dest],
+    { stdio: ['ignore', 'ignore', 'pipe'] });
+  return dest;
+}
+
+async function findAdrs(root, subpath) {
+  const dir = join(root, subpath);
+  if (!existsSync(dir)) return [];
+  const out = [];
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const e of entries) {
+    if (!e.isFile()) continue;
+    if (/^ADR-\d{4}-.+\.md$/.test(e.name)) out.push(join(dir, e.name));
+  }
+  return out.sort();
+}
+
+// --- main ------------------------------------------------------------------
+
+async function main() {
+  if (!existsSync(REGISTRY)) {
+    process.stderr.write(`discovery: registry not found: ${REGISTRY}\n`);
+    process.exit(2);
+  }
+  const registryText = await readFile(REGISTRY, 'utf8');
+  const { consumers } = parseRegistry(registryText);
+  if (consumers.length === 0) {
+    process.stderr.write(`discovery: registry lists no consumers\n`);
+    process.exit(2);
+  }
+
+  const head = headCommit(SOURCE_REPO);
+  if (!head) {
+    process.stderr.write(`discovery: could not determine HEAD commit of ${SOURCE_REPO}\n`);
+    process.exit(2);
+  }
+
+  const entries = [];
+  for (const c of consumers) {
+    const entry = { repo: c.repo, role: c.role || null, head_commit: head };
+    try {
+      const dest = await checkoutConsumer(c);
+      const pinText = await readFile(join(dest, c.pin_file), 'utf8');
+      const pin = extractPin(pinText, c.pin_key);
+      entry.pin = pin;
+      entry.status = shaStatus(pin, head);
+
+      const adrs = await findAdrs(dest, c.decisions_path);
+      const stale = [];
+      for (const abs of adrs) {
+        const text = await readFile(abs, 'utf8');
+        const { fm } = splitFrontMatter(text);
+        const parsed = parseFm(fm);
+        if (parsed.status !== 'proposed') continue;
+        const age = daysBetween(parsed.date, NOW);
+        if (age === null) continue;
+        if (age >= STALE_DAYS) {
+          stale.push({ id: parsed.id || abs.split(/[\\/]/).pop(), age_days: age, date: parsed.date });
+        }
+      }
+      entry.stale_proposed = stale;
+    } catch (err) {
+      entry.status = 'error';
+      entry.error = err.message.split('\n')[0];
+    }
+    entries.push(entry);
+  }
+
+  emitDigest(entries, head);
+}
+
+// --- output ----------------------------------------------------------------
+
+function emitDigest(entries, head) {
+  const y = [];
+  y.push('# Discovery digest');
+  y.push(`# source_repo: transitrix/acme-corp`);
+  y.push(`# head_commit: ${head}`);
+  y.push(`# run_at: ${new Date().toISOString()}`);
+  y.push(`# stale_threshold_days: ${STALE_DAYS}`);
+  y.push('entries:');
+  for (const e of entries) {
+    y.push(`  - repo: ${e.repo}`);
+    if (e.role) y.push(`    role: ${e.role}`);
+    y.push(`    head_commit: ${e.head_commit}`);
+    y.push(`    pin: ${e.pin ?? 'null'}`);
+    y.push(`    status: ${e.status}`);
+    if (e.error) y.push(`    error: ${JSON.stringify(e.error)}`);
+    if (e.stale_proposed && e.stale_proposed.length) {
+      y.push(`    stale_proposed:`);
+      for (const s of e.stale_proposed) {
+        y.push(`      - id: ${s.id}`);
+        y.push(`        age_days: ${s.age_days}`);
+        y.push(`        date: ${s.date}`);
+      }
+    } else {
+      y.push(`    stale_proposed: []`);
+    }
+  }
+  const out = y.join('\n') + '\n';
+  process.stdout.write(out);
+
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    const md = renderMarkdown(entries, head);
+    appendFile(process.env.GITHUB_STEP_SUMMARY, md).catch(() => { /* best-effort */ });
+  }
+}
+
+function renderMarkdown(entries, head) {
+  const lines = [];
+  lines.push(`## Discovery digest`);
+  lines.push('');
+  lines.push(`- Source repo: \`transitrix/acme-corp\``);
+  lines.push(`- HEAD commit: \`${head}\``);
+  lines.push(`- Run at: ${new Date().toISOString()}`);
+  lines.push(`- Stale-proposed threshold: ${STALE_DAYS} days`);
+  lines.push('');
+  lines.push(`| Consumer | Role | Pin | Status | Stale-proposed ADRs |`);
+  lines.push(`|---|---|---|---|---|`);
+  for (const e of entries) {
+    const pinShort = e.pin ? e.pin.slice(0, 8) : '—';
+    const stale = (e.stale_proposed || []).map(s => `${s.id} (${s.age_days}d)`).join(', ') || '—';
+    lines.push(`| \`${e.repo}\` | ${e.role || '—'} | \`${pinShort}\` | ${e.status}${e.error ? ` — ${e.error}` : ''} | ${stale} |`);
+  }
+  lines.push('');
+  return lines.join('\n') + '\n';
+}
+
+main().catch((err) => {
+  process.stderr.write(`discovery: ${err.stack || err.message}\n`);
+  process.exit(2);
+});

--- a/organizations/acme_corp/tools/README.md
+++ b/organizations/acme_corp/tools/README.md
@@ -6,7 +6,7 @@ example and not intended for end users.
 ## dsm-demo-seed.sql
 
 Populates a running [DSM](https://github.com/transitrix/transitrix-dsm) instance with the
-acme-corp FGCA chain (Factor → Goal → Change → Activity) for demo and development purposes.
+acme-corp DGCA chain (Driver → Goal → Change → Action) for demo and development purposes.
 
 **When to use:** after starting DSM locally or on a dev instance, to load meaningful example
 data that mirrors the acme-corp canon.

--- a/organizations/acme_corp/transitrix.yaml
+++ b/organizations/acme_corp/transitrix.yaml
@@ -1,6 +1,6 @@
 # Adopter manifest — schema defined in the methodology's notations/MANIFEST.md
 transitrix: 1
-methodology_version: "0.7.0"
+methodology_version: "1.0.0"
 notations:
   - bpmn
   - dgca


### PR DESCRIPTION
## Summary

- Sync \organizations/acme_corp/\ from \	ransitrix/acme-corp\ @ \9fb6c31\ (merged PR #32 — hub #523 FGCA/FGA → DGCA/DGA docs hygiene).
- Updates \.source-version\ pin; 8 added + 23 updated files (docs, GDPR remediation chain elements/views, discovery workflow).

## Test plan

- [ ] \.source-version\ commit matches acme-corp \main\
- [ ] CI green (no src/ changes)

Made with [Cursor](https://cursor.com)