### PR TITLE
fix(ci): JetBrains publish — read version from release tag_name

### DIFF
--- a/.github/workflows/jetbrains-publish.yml
+++ b/.github/workflows/jetbrains-publish.yml
@@ -41,12 +41,18 @@ jobs:
       - name: Set plugin version
         run: |
           if [ "${{ github.event_name }}" = "release" ]; then
-            VERSION="${GITHUB_REF_NAME#v}"
+            # GITHUB_REF_NAME is not the release tag on release events — use tag_name.
+            VERSION="${{ github.event.release.tag_name }}"
+            VERSION="${VERSION#v}"
           elif [ -n "${{ inputs.version }}" ]; then
             VERSION="${{ inputs.version }}"
           else
             echo "Using version from gradle.properties (workflow_dispatch, no version input)"
             exit 0
+          fi
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not determine plugin version (release tag or workflow input)."
+            exit 1
           fi
           sed -i "s/^pluginVersion = .*/pluginVersion = $VERSION/" intellij/gradle.properties
           echo "Plugin version set to: $VERSION"


### PR DESCRIPTION
## Summary

JetBrains publish failed on **v3.0.0** release (and 2.10.0) with:

`Invalid plugin descriptor plugin.xml. The property <version> is not specified.`

Root cause: the workflow set `pluginVersion` from `GITHUB_REF_NAME`, which is **empty** on `release` events — log showed `Plugin version set to:` blank.

Fix: use `github.event.release.tag_name` (strip `v` prefix) and fail fast if still empty.

## Test plan

- [ ] Merge → **Re-run** JetBrains workflow: Actions → JetBrains Marketplace — publish → Run workflow → version `3.0.0`
- [ ] Next GitHub Release publish picks up tag automatically