### PR TITLE
chore(release): Transitrix Studio 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+## [3.0.1] — 2026-07-10
+
+### Fixed
+
+- **Goals tree node layout** (#377) — name and type labels no longer overlap; shared `layoutCenteredEntityText` vertical span fix.
+- **Unified entity node Size presets** (#377) — Compact **200×72**, Normal **250×80**, Wide **320×96** across Goals, DGCA/DGA, Blocks, Activities, Capability Map; Process Blueprint scales from the same tier ratios.
+
+### Changed
+
+- **Extension 3.0.1** — in-preview control label **Size** (was "Block size").
+- **`@transitrix/diagrams` 1.8.2** — `ENTITY_NODE_SIZE` ladder, layout default alignment.
+
 ## [3.0.0] — 2026-07-07
 
 ### Added

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+## 3.0.1 — 2026-07-10
+
+Diagram node layout polish — fixes Goals tree label overlap and unifies **Size** presets across previews.
+
+### Fixed
+
+- **Goals tree — name and type labels no longer overlap** (#377). `layoutCenteredEntityText` now accounts for each text line's full height when centring name → type → id inside the node box.
+- **Unified entity node sizes** across Goals, DGCA/DGA, Nested Blocks, Activities, and Capability Map (#377). All box-based previews now share the same **Size** ladder: Compact **200×72**, Normal **250×80**, Wide **320×96** px (was inconsistent per notation).
+
+### Changed
+
+- **Controls → Size** — the in-preview block-size dropdown is labelled **Size** (was "Block size") for consistency across notation previews (#377).
+
 ## 3.0.0 — 2026-07-07
 
 Legacy identifier sunset — completes the Cervin → Transitrix migration for the VS Code extension.

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Architecture-as-code for the modern enterprise. Author 17 notations — goals, processes, capabilities, BPMN, applications, more — as plain YAML, get live diagrams in VS Code. Diffable in git. AI-friendly. Open source. Built on ArchiMate 3.2 and BPMN 2.0.",
   "license": "MIT",
   "icon": "icon.png",
@@ -141,43 +141,71 @@
         },
         "transitrix.nodeSize.goals": {
           "type": "string",
-          "enum": ["compact", "normal", "wide"],
+          "enum": [
+            "compact",
+            "normal",
+            "wide"
+          ],
           "default": "normal",
           "description": "Block size preset for Goals tree preview nodes."
         },
         "transitrix.nodeSize.dgca": {
           "type": "string",
-          "enum": ["compact", "normal", "wide"],
+          "enum": [
+            "compact",
+            "normal",
+            "wide"
+          ],
           "default": "normal",
           "description": "Block size preset for DGCA chain preview nodes."
         },
         "transitrix.nodeSize.dga": {
           "type": "string",
-          "enum": ["compact", "normal", "wide"],
+          "enum": [
+            "compact",
+            "normal",
+            "wide"
+          ],
           "default": "normal",
           "description": "Block size preset for DGA chain preview nodes."
         },
         "transitrix.nodeSize.blocks": {
           "type": "string",
-          "enum": ["compact", "normal", "wide"],
+          "enum": [
+            "compact",
+            "normal",
+            "wide"
+          ],
           "default": "normal",
           "description": "Block size preset for Nested Blocks leaf nodes."
         },
         "transitrix.nodeSize.action": {
           "type": "string",
-          "enum": ["compact", "normal", "wide"],
+          "enum": [
+            "compact",
+            "normal",
+            "wide"
+          ],
           "default": "normal",
           "description": "Block size preset for Activities network preview nodes."
         },
         "transitrix.nodeSize.processBlueprint": {
           "type": "string",
-          "enum": ["compact", "normal", "wide"],
+          "enum": [
+            "compact",
+            "normal",
+            "wide"
+          ],
           "default": "normal",
           "description": "Cell size preset for Process Blueprint preview (columns, pills, row heights)."
         },
         "transitrix.nodeSize.capabilityMap": {
           "type": "string",
-          "enum": ["compact", "normal", "wide"],
+          "enum": [
+            "compact",
+            "normal",
+            "wide"
+          ],
           "default": "normal",
           "description": "Node size preset for Capability Map tree preview."
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump **Transitrix Studio extension** and root package to **3.0.1**.
- Bump **`@transitrix/diagrams`** to **1.8.2** (node layout + unified Size presets merged in #377).
- Release notes in `CHANGELOG.md` and `extension/CHANGELOG.md`.
- **`@transitrix/cli`** unchanged (no `src/` changes since 3.0.0).

## Test plan
- [x] `npm run build` green
- [x] `npm run compile` + `npm run compile:extension` green
- [x] `npm run test:diagrams` — 1271 passed
- [ ] After merge: publish draft release `v3.0.1` → CI publishes npm, VS Code Marketplace, Open VSX, JetBrains
