### PR TITLE
chore(release): bump extension to 3.0.2 — preview UX fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+## [3.0.2] — 2026-07-10
+
+### Fixed
+
+- **Blocks / Process Blueprint / Capability Map previews didn't live-update on a node-size change** — an already-open panel kept the previous **Size** preset's dimensions/spacing until an unrelated theme toggle or save forced a rebuild.
+
+### Changed
+
+- **Extension 3.0.2** — unified `$(graph)` preview icon across every notation; auto-preview now follows the active editor instead of every background `openTextDocument` call, with a new `transitrix.preview.autoOpenOnFileOpen` setting to disable it.
+
 ## [3.0.1] — 2026-07-10
 
 ### Fixed

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+## 3.0.2 — 2026-07-10
+
+Preview UX pass — unified toolbar icon, background-open false positives fixed, and a node-size refresh bug closed.
+
+### Fixed
+
+- **Blocks / Process Blueprint / Capability Map previews didn't live-update on a node-size change.** An already-open panel kept showing the previous **Size** preset's box dimensions and text spacing until an unrelated theme toggle or file save forced a rebuild — most noticeable when reverting from a larger preset back to a smaller one. `transitrix.nodeSize.blocks` / `.processBlueprint` / `.capabilityMap` now refresh the open preview immediately, matching Goals/DGCA/DGA/Activities.
+
+### Changed
+
+- **Unified preview toolbar icon.** Every notation's "Preview" editor-title button now shares the same `$(graph)` icon (previously varied per notation — `$(type-hierarchy)`, `$(list-unordered)`, `$(law)`, etc.).
+- **Auto-preview now follows the active editor**, not every `openTextDocument` call. Previously, anything that silently read a file's content in the background (e.g. SCM diff/decoration providers) could pop a preview panel per notation type — most noticeable when a lot of files change at once (bulk edits, tooling). The preview now opens only when a recognised file actually becomes the visible/active editor.
+- **New setting `transitrix.preview.autoOpenOnFileOpen`** (default `true`) — turn off to disable auto-open entirely and only open previews via the toolbar button.
+
 ## 3.0.1 — 2026-07-10
 
 Diagram node layout polish — fixes Goals tree label overlap and unifies **Size** presets across previews.

--- a/extension/README.md
+++ b/extension/README.md
@@ -38,7 +38,7 @@ Transitrix flips that:
 
 Every preview ships with a toolbar: title toggle, discrete zoom (50–200%), save as SVG, save as PNG (2× for crisp output), and copy PNG to clipboard (Windows today; macOS / Linux planned).
 
-The preview opens automatically when you open a recognised file and refreshes on every save.
+The preview opens automatically when a recognised file becomes the active editor, and refreshes on every save. Turn this off with `transitrix.preview.autoOpenOnFileOpen` if you'd rather open previews on demand — the toolbar preview icon (same `$(graph)` icon across every notation) always works regardless of the setting.
 
 ## Pairs well with Mermaid
 
@@ -62,6 +62,7 @@ Configure under **Settings → Transitrix Studio**. The canonical keys are `tran
 |---------|---------|-------------|
 | `transitrix.fileExtensions` | `[".bpmn.transitrix.yaml"]` | File suffixes recognised as Transitrix BPMN source files (leading dot required). |
 | `transitrix.exportEnabled` | `false` | Show the experimental BPMN/SVG/PNG export commands. |
+| `transitrix.preview.autoOpenOnFileOpen` | `true` | Auto-open the matching preview when a recognised file becomes the active editor. Set to `false` to only open previews via the toolbar button. |
 | `transitrix.nodeSize.goals` | `normal` | Block size preset for Goals preview (`compact` / `normal` / `wide`). Also in the in-preview **Controls** panel. |
 | `transitrix.nodeSize.dgca` / `.dga` | `normal` | Block size preset for DGCA/DGA chain previews. |
 | `transitrix.nodeSize.action` | `normal` | Block size preset for Activities network preview. |

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Architecture-as-code for the modern enterprise. Author 17 notations — goals, processes, capabilities, BPMN, applications, more — as plain YAML, get live diagrams in VS Code. Diffable in git. AI-friendly. Open source. Built on ArchiMate 3.2 and BPMN 2.0.",
   "license": "MIT",
   "icon": "icon.png",

--- a/extension/package.json
+++ b/extension/package.json
@@ -89,6 +89,11 @@
           "default": false,
           "description": "Show experimental BPMN/SVG/PNG export commands (not finished yet)."
         },
+        "transitrix.preview.autoOpenOnFileOpen": {
+          "type": "boolean",
+          "default": true,
+          "description": "Automatically open the matching preview panel beside a recognized notation file when it becomes the active editor. Turn off if you drive many file opens through tooling/automation and don't want a preview panel per notation type. The preview icon in the editor title bar always opens it on demand regardless of this setting."
+        },
         "transitrix.bpmn.laneGap": {
           "type": "number",
           "default": 0,
@@ -564,37 +569,37 @@
         "command": "transitrixStudio.previewGoals",
         "title": "Transitrix: Preview goal tree",
         "category": "Transitrix",
-        "icon": "$(type-hierarchy)"
+        "icon": "$(graph)"
       },
       {
         "command": "transitrixStudio.previewDGCA",
         "title": "Transitrix: Preview DGCA diagram",
         "category": "Transitrix",
-        "icon": "$(type-hierarchy)"
+        "icon": "$(graph)"
       },
       {
         "command": "transitrixStudio.previewDGA",
         "title": "Transitrix: Preview DGA diagram",
         "category": "Transitrix",
-        "icon": "$(type-hierarchy)"
+        "icon": "$(graph)"
       },
       {
         "command": "transitrixStudio.previewActivities",
         "title": "Transitrix: Preview action network diagram (PSND + Gantt + Tree)",
         "category": "Transitrix",
-        "icon": "$(type-hierarchy)"
+        "icon": "$(graph)"
       },
       {
         "command": "transitrixStudio.previewActionsTree",
         "title": "Transitrix: Preview action catalogue tree",
         "category": "Transitrix",
-        "icon": "$(type-hierarchy)"
+        "icon": "$(graph)"
       },
       {
         "command": "transitrixStudio.previewBlocks",
         "title": "Transitrix: Preview nested block diagram",
         "category": "Transitrix",
-        "icon": "$(type-hierarchy)"
+        "icon": "$(graph)"
       },
       {
         "command": "transitrixStudio.saveBlocksAsSvg",
@@ -636,37 +641,37 @@
         "command": "transitrixStudio.previewProducts",
         "title": "Transitrix: Preview product catalogue",
         "category": "Transitrix",
-        "icon": "$(list-unordered)"
+        "icon": "$(graph)"
       },
       {
         "command": "transitrixStudio.previewApplications",
         "title": "Transitrix: Preview application catalogue",
         "category": "Transitrix",
-        "icon": "$(list-unordered)"
+        "icon": "$(graph)"
       },
       {
         "command": "transitrixStudio.previewProcessMap",
         "title": "Transitrix: Preview process landscape map",
         "category": "Transitrix",
-        "icon": "$(list-tree)"
+        "icon": "$(graph)"
       },
       {
         "command": "transitrixStudio.previewScenarios",
         "title": "Transitrix: Preview scenario",
         "category": "Transitrix",
-        "icon": "$(milestone)"
+        "icon": "$(graph)"
       },
       {
         "command": "transitrixStudio.previewCapabilityMap",
         "title": "Transitrix: Preview capability map",
         "category": "Transitrix",
-        "icon": "$(type-hierarchy)"
+        "icon": "$(graph)"
       },
       {
         "command": "transitrixStudio.previewProcessBlueprint",
         "title": "Transitrix: Preview process blueprint",
         "category": "Transitrix",
-        "icon": "$(layout)"
+        "icon": "$(graph)"
       },
       {
         "command": "transitrixStudio.saveProcessBlueprintAsSvg",
@@ -678,7 +683,7 @@
         "command": "transitrixStudio.previewActivityCard",
         "title": "Transitrix: Preview activity card",
         "category": "Transitrix",
-        "icon": "$(type-hierarchy)"
+        "icon": "$(graph)"
       },
       {
         "command": "transitrixStudio.saveActivityCardAsSvg",
@@ -765,7 +770,7 @@
         "command": "transitrixStudio.previewComplianceMatrix",
         "title": "Transitrix: Preview compliance matrix",
         "category": "Transitrix",
-        "icon": "$(table)"
+        "icon": "$(graph)"
       },
       {
         "command": "transitrixStudio.refreshComplianceMatrix",
@@ -789,7 +794,7 @@
         "command": "transitrixStudio.previewSingleLaw",
         "title": "Transitrix: Preview compliance — single law",
         "category": "Transitrix",
-        "icon": "$(law)"
+        "icon": "$(graph)"
       },
       {
         "command": "transitrixStudio.refreshSingleLaw",
@@ -801,7 +806,7 @@
         "command": "transitrixStudio.previewSingleProduct",
         "title": "Transitrix: Preview compliance — single product",
         "category": "Transitrix",
-        "icon": "$(package)"
+        "icon": "$(graph)"
       },
       {
         "command": "transitrixStudio.refreshSingleProduct",
@@ -813,7 +818,7 @@
         "command": "transitrixStudio.previewRequirementTrace",
         "title": "Transitrix: Preview requirement trace + hierarchy",
         "category": "Transitrix",
-        "icon": "$(references)"
+        "icon": "$(graph)"
       },
       {
         "command": "transitrixStudio.refreshRequirementTrace",
@@ -825,7 +830,7 @@
         "command": "transitrixStudio.previewGapDashboard",
         "title": "Transitrix: Preview compliance gap dashboard",
         "category": "Transitrix",
-        "icon": "$(checklist)"
+        "icon": "$(graph)"
       },
       {
         "command": "transitrixStudio.refreshGapDashboard",

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -522,15 +522,21 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       void dgcaPreview.refreshConfig();
       void dgaPreview.refreshConfig();
       void actionPreview.refreshConfig();
+      // Blocks, Process Blueprint, and Capability Map also carry a
+      // `transitrix.nodeSize.*` setting (see NodeSizeNotation), so — like the
+      // four previews above — they must refresh on a node-size change, not
+      // just a theme change. Previously gated behind `isThemeChange` only, so
+      // an already-open panel kept showing the old box size/spacing until an
+      // unrelated theme toggle or file save forced a rebuild.
+      void blocksPreview.refreshConfig();
+      void processBlueprintPreview.refreshConfig();
+      void capabilityMapPreview.refreshConfig();
       if (isThemeChange) {
-        void blocksPreview.refreshConfig();
-        void processBlueprintPreview.refreshConfig();
         void activityCardPreview.refreshConfig();
         void applicationsPreview.refreshConfig();
         void productsPreview.refreshConfig();
         void processMapPreview.refreshConfig();
         void scenariosPreview.refreshConfig();
-        void capabilityMapPreview.refreshConfig();
         void complianceMatrixPreview.refresh();
         void complianceImpactPreview.refresh();
         void singleLawPreview.refresh();
@@ -581,33 +587,51 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       void preview.refreshSaved(doc);
       void processPreview.refreshSaved(doc);
     }),
-    vscode.workspace.onDidOpenTextDocument(async (doc) => {
-      if (isGoalsFile(doc)) { await goalsPreview.showOrReveal(doc); return; }
-      if (isDGCAFile(doc)) {
-        const notation = probeDocNotation(doc);
-        if (notation === 'goals') { await goalsPreview.showOrReveal(doc); return; }
-        if (notation === 'action') { await actionPreview.showOrReveal(doc); return; }
-        await dgcaPreview.showOrReveal(doc); return;
-      }
-      if (isDGAFile(doc)) { await dgaPreview.showOrReveal(doc); return; }
-      if (isActivitiesFile(doc)) { await actionPreview.showOrReveal(doc); return; }
-      if (isActionsTreeFileName(doc.fileName)) { await actionsTreePreview.showOrReveal(doc); return; }
-      if (isBlocksFile(doc)) { await blocksPreview.showOrReveal(doc); return; }
-      if (isApplicationsFile(doc)) { await applicationsPreview.showOrReveal(doc); return; }
-      if (isProductsFile(doc)) { await productsPreview.showOrReveal(doc); return; }
-      if (isProcessMapFile(doc)) { await processMapPreview.showOrReveal(doc); return; }
-      if (isScenariosFile(doc)) { await scenariosPreview.showOrReveal(doc); return; }
-      if (isCapabilityMapFile(doc)) { await capabilityMapPreview.showOrReveal(doc); return; }
-      if (isProcessBlueprintFile(doc)) { await processBlueprintPreview.showOrReveal(doc); return; }
-      if (isActivityCardFile(doc)) { await activityCardPreview.showOrReveal(doc); return; }
-      if (isCoverageMetricFile(doc)) { await coverageMetricPreview.showOrReveal(doc); return; }
-      if (isComplianceImpactFile(doc)) { await complianceImpactPreview.showOrReveal(); return; }
-      if (isSingleLawFile(doc)) { await singleLawPreview.showOrReveal(doc); return; }
-      if (isSingleProductFile(doc)) { await singleProductPreview.showOrReveal(doc); return; }
-      if (isRequirementTraceFile(doc)) { await requirementTracePreview.showOrReveal(doc); return; }
-      if (documentMatchesTransitrixSource(doc)) { await openBpmnPreviewForDocument(doc); return; }
+    // Auto-preview follows the active editor rather than every `openTextDocument`
+    // call — the latter also fires for documents opened silently in the
+    // background (e.g. SCM diff/decoration providers reading changed files),
+    // which used to pop a preview panel per notation type touched by anything
+    // that reads file content, not just the user actually looking at a file.
+    vscode.window.onDidChangeActiveTextEditor((editor) => {
+      if (editor) void autoOpenPreviewForDocument(editor.document);
     }),
   );
+
+  // The document that triggered activation is typically already the active
+  // editor by the time `activate()` runs, and it won't fire another
+  // `onDidChangeActiveTextEditor` event on its own — so check it once here.
+  if (vscode.window.activeTextEditor) {
+    void autoOpenPreviewForDocument(vscode.window.activeTextEditor.document);
+  }
+
+  async function autoOpenPreviewForDocument(doc: vscode.TextDocument): Promise<void> {
+    if (doc.uri.scheme !== 'file') return;
+    if (!vscode.workspace.getConfiguration('transitrix').get<boolean>('preview.autoOpenOnFileOpen', true)) return;
+    if (isGoalsFile(doc)) { await goalsPreview.showOrReveal(doc); return; }
+    if (isDGCAFile(doc)) {
+      const notation = probeDocNotation(doc);
+      if (notation === 'goals') { await goalsPreview.showOrReveal(doc); return; }
+      if (notation === 'action') { await actionPreview.showOrReveal(doc); return; }
+      await dgcaPreview.showOrReveal(doc); return;
+    }
+    if (isDGAFile(doc)) { await dgaPreview.showOrReveal(doc); return; }
+    if (isActivitiesFile(doc)) { await actionPreview.showOrReveal(doc); return; }
+    if (isActionsTreeFileName(doc.fileName)) { await actionsTreePreview.showOrReveal(doc); return; }
+    if (isBlocksFile(doc)) { await blocksPreview.showOrReveal(doc); return; }
+    if (isApplicationsFile(doc)) { await applicationsPreview.showOrReveal(doc); return; }
+    if (isProductsFile(doc)) { await productsPreview.showOrReveal(doc); return; }
+    if (isProcessMapFile(doc)) { await processMapPreview.showOrReveal(doc); return; }
+    if (isScenariosFile(doc)) { await scenariosPreview.showOrReveal(doc); return; }
+    if (isCapabilityMapFile(doc)) { await capabilityMapPreview.showOrReveal(doc); return; }
+    if (isProcessBlueprintFile(doc)) { await processBlueprintPreview.showOrReveal(doc); return; }
+    if (isActivityCardFile(doc)) { await activityCardPreview.showOrReveal(doc); return; }
+    if (isCoverageMetricFile(doc)) { await coverageMetricPreview.showOrReveal(doc); return; }
+    if (isComplianceImpactFile(doc)) { await complianceImpactPreview.showOrReveal(); return; }
+    if (isSingleLawFile(doc)) { await singleLawPreview.showOrReveal(doc); return; }
+    if (isSingleProductFile(doc)) { await singleProductPreview.showOrReveal(doc); return; }
+    if (isRequirementTraceFile(doc)) { await requirementTracePreview.showOrReveal(doc); return; }
+    if (documentMatchesTransitrixSource(doc)) { await openBpmnPreviewForDocument(doc); return; }
+  }
 }
 
 export function deactivate(): void {}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
## Summary
- Unify the "Preview" editor-title icon to `$(graph)` across every notation (previously a different glyph per notation).
- Auto-preview now follows the active editor instead of firing on every `openTextDocument` call, which also fires for documents opened silently in the background (e.g. SCM diff/decoration providers) — that could pop a preview panel per notation type. New setting `transitrix.preview.autoOpenOnFileOpen` (default `true`) turns it off entirely.
- Fix: Blocks / Process Blueprint / Capability Map previews weren't refreshing on a `transitrix.nodeSize.*` change — only on a theme change. An already-open panel kept showing the previous Size preset's box dimensions/spacing until an unrelated save or theme toggle forced a rebuild (most visible when reverting from a larger preset back to a smaller one).
- Bump extension + root package version 3.0.1 → 3.0.2 (no `@transitrix/diagrams` changes this round, stays at 1.8.2).

## Test plan
- [x] `npm run compile:extension` (tsc --noEmit) passes
- [x] `node scripts/package-extension.mjs` builds a local VSIX cleanly (`output/transitrix-studio-3.0.2.vsix`)
- [ ] Manual: install the VSIX, open a Blocks/Process Blueprint/Capability Map file, switch Size preset back and forth, confirm the open preview updates live
- [ ] Manual: confirm the preview no longer auto-opens for files touched only in the background (e.g. during a large git operation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)