### PR TITLE
chore(release): bump extension to 3.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+## [3.0.3] — 2026-07-10
+
+### Fixed
+
+- **Entity box text could render above the box's top border** (#380) — a 2-line name + type + id (e.g. a Strategic/Project Goal node) left almost no vertical padding in the default and compact **Size** presets; the shared text layout now enforces real edge padding and degrades to fewer name lines instead of overflowing. Applies to Goals, FGCA/DGCA, Activities, and Nested Blocks.
+- **`@transitrix/diagrams` 1.8.3** — same fix; `entity-text-layout.ts` edge-padding rework.
+
+### Changed
+
+- **BPMN preview settings panel renamed "Display" → "Controls"** (#381), matching every other notation's panel. The swimlane spacing setting (`transitrix.bpmn.laneGap`) is now also adjustable directly in the panel, not just via the top-menu Settings link.
+
 ## [3.0.2] — 2026-07-10
 
 ### Fixed

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+## 3.0.3 — 2026-07-10
+
+Diagram text-layout fix and a BPMN preview panel consistency pass.
+
+### Fixed
+
+- **Entity box text could render above the box's top border.** Goals, FGCA/DGCA, Activities, and Nested Blocks nodes with a 2-line name plus a type row (e.g. a Strategic or Project Goal) left almost no vertical padding in the default (250×80) and compact (200×72) **Size** presets — with dominant-baseline centring, the name's first line could render a few pixels above the box outline. The shared text layout now reserves real padding on every edge and, when a preset genuinely can't fit two name lines with that padding, degrades gracefully to one line with an ellipsis instead of overflowing.
+
+### Changed
+
+- **BPMN preview settings panel renamed "Display" → "Controls"**, matching every other notation's panel (Goals, DGCA/DGA, Action). The swimlane spacing setting (`transitrix.bpmn.laneGap`) is now also adjustable directly in the panel via a slider, not only through the top-menu "…" → Settings link.
+
 ## 3.0.2 — 2026-07-10
 
 Preview UX pass — unified toolbar icon, background-open false positives fixed, and a node-size refresh bug closed.

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Architecture-as-code for the modern enterprise. Author 17 notations — goals, processes, capabilities, BPMN, applications, more — as plain YAML, get live diagrams in VS Code. Diffable in git. AI-friendly. Open source. Built on ArchiMate 3.2 and BPMN 2.0.",
   "license": "MIT",
   "icon": "icon.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
## Summary
- Release notes + version bump for #380 (entity-box text edge-padding fix) and #381 (BPMN preview panel "Display" → "Controls" rename + in-panel lane-gap spacing), both already merged to `main`.
- `extension/package.json` and root `package.json` 3.0.2 → 3.0.3. `@transitrix/diagrams` was already bumped to 1.8.3 in #380.

## Test plan
- [x] Verified both source PRs' changes are present on `main` before drafting this release entry (`git show origin/main:...` for the key files/symbols).
- [x] CHANGELOG.md / extension/CHANGELOG.md entries follow the same structure as the 3.0.2 release entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)