### PR TITLE
chore(release): bump extension to 3.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+## [3.0.4] — 2026-07-10
+
+### Added
+
+- **Transitrix brand theme is now the default for diagram rendering** (#383). Petrol (`#004d67`) drives node/edge structure and hierarchy-depth fill tints (never a hue switch); amber/orange are reserved for author emphasis (e.g. the Activities critical path). Applies across Goals, DGCA/DGA, Nested Blocks, Activities, Process Blueprint, Capability Map, and BPMN.
+
+### Fixed
+
+- **Maturity Likert (L1–L5) badge colors harmonized into one WCAG-verified ramp** (#383) — the capability-tree badge previously used grey for L1 (the worst rating) and had white-label contrast as low as 1.07:1 in VS Code high-contrast mode; now a single red→green ramp shared by every maturity badge, verified ≥4.5:1 (AA) light/dark and ≥7:1 (AAA) high-contrast.
+
+### Changed
+
+- **`@transitrix/diagrams` 1.8.4** — brand theme tokens, maturity color ramp.
+
 ## [3.0.3] — 2026-07-10
 
 ### Fixed

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+## 3.0.4 — 2026-07-10
+
+Transitrix brand is now the default diagram theme, plus a harmonized maturity color scale.
+
+### Added
+
+- **Transitrix brand theme is now the default for diagram rendering.** Petrol (`#004d67`) drives node/edge structure and hierarchy-depth fill tints — deeper tint for deeper levels, never a hue switch — across Goals, DGCA/DGA, Nested Blocks, Activities, Process Blueprint, Capability Map, and BPMN. Amber/orange are reserved for author emphasis (currently the Activities critical path and the Action "Strategic Initiative" badge). Neutral (**VS Code Adaptive**) and **Transitrix Dark** remain selectable via the existing **Theme** setting for teams that need vendor-neutral or their own branded output.
+
+### Fixed
+
+- **Maturity Likert (L1–L5) badge colors harmonized into one WCAG-verified ramp.** The capability-tree maturity badge previously used a grey fill for L1 — the *worst* rating — with white-label-text contrast as low as 1.07:1 in VS Code high-contrast mode; the cards/compliance-view badge used a different palette that dipped to 2.94:1. Both now share a single red→orange→gold→yellow-green→green ramp, verified ≥4.5:1 (AA) against the badge's white label text in light/dark and ≥7:1 (AAA) in high-contrast.
+
 ## 3.0.3 — 2026-07-10
 
 Diagram text-layout fix and a BPMN preview panel consistency pass.

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Architecture-as-code for the modern enterprise. Author 17 notations — goals, processes, capabilities, BPMN, applications, more — as plain YAML, get live diagrams in VS Code. Diffable in git. AI-friendly. Open source. Built on ArchiMate 3.2 and BPMN 2.0.",
   "license": "MIT",
   "icon": "icon.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
## Summary
- Release notes + version bump for #383 (Transitrix brand default theme + harmonized maturity color ramp), already merged to `main`.
- `extension/package.json` and root `package.json` 3.0.3 → 3.0.4. `@transitrix/diagrams` was already bumped to 1.8.4 in #383.

## Test plan
- [x] Verified #383's changes are present on `main` before drafting this release entry (`git show origin/main:...` for `nodeStroke`/`MATURITY_COLORS`/diagrams version).
- [x] CHANGELOG.md / extension/CHANGELOG.md entries follow the same structure as prior releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)