### PR TITLE
feat(previews): unify webview chrome under one shell

### DIFF
--- a/extension/src/compliance-matrix-preview.ts
+++ b/extension/src/compliance-matrix-preview.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { escXml } from '@transitrix/diagrams/webview/render-util.js';
-import { generateWebviewCss, type ThemeId } from '@transitrix/diagrams/theme';
+import { type ThemeId } from '@transitrix/diagrams/theme';
 import {
   buildComplianceMatrix,
   filterComplianceMatrix,
@@ -11,7 +11,7 @@ import type { AssertionStatus } from '@transitrix/diagrams/assertion/types.js';
 import { genNonce, colWidthPxFromSetting, colWidthRootCss } from './preview-controls.js';
 import { scanComplianceCanon } from './compliance-scan.js';
 import type { ScannedCanon } from './compliance-scan.js';
-import { ERROR_BLOCK_CSS, buildErrorHtml, WARN_BLOCK_CSS, buildWarnHtml } from './diagram-frame.js';
+import { buildDiagramFrame, OPEN_THEME_COMMAND } from './diagram-frame.js';
 
 // Compliance matrix preview (vkgeorgia/strategy#84 Phase 2).
 //
@@ -156,8 +156,6 @@ export class ComplianceMatrixPreview {
 
   private buildHtml(matrix: ComplianceMatrix | undefined, themeId: ThemeId): string {
     const nonce = genNonce();
-    const { input: errInput, block: errBlock } = buildErrorHtml(this.errorMsg);
-    const { input: warnInput, block: warnBlock } = buildWarnHtml(this.skippedWarnings);
 
     const summary = matrix?.summary ?? { products: 0, requirements: 0, gaps: 0, assertions: 0 };
     const empty = !matrix || matrix.requirements.length === 0 || matrix.products.length === 0;
@@ -183,9 +181,7 @@ export class ComplianceMatrixPreview {
     ).join('');
 
     // Jurisdiction chips come from the union of jurisdictions resolved on the
-    // full matrix's columns. Hidden entirely when no requirement resolved one
-    // (e.g. no codex files in the workspace) so the toolbar doesn't claim a
-    // dimension that has no values.
+    // full matrix's columns. Hidden entirely when no requirement resolved one.
     const jurisdictionUniverse = this.fullMatrix ? collectJurisdictions(this.fullMatrix) : [];
     const jurisdictionBoxes = jurisdictionUniverse.map(j =>
       `<label class="cm-chip"><input type="checkbox" data-cm-jurisdiction="${escXml(j)}"${filterJurisdictions.has(j) ? ' checked' : ''}> ${escXml(j)}</label>`,
@@ -203,36 +199,14 @@ export class ComplianceMatrixPreview {
       ).join('') +
       `</select>`;
 
-    return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8"/>
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';">
-  <style>
-${colWCss}
-${generateWebviewCss(themeId)}
-${MATRIX_CSS}
-${ERROR_BLOCK_CSS}
-${WARN_BLOCK_CSS}
-  </style>
-</head>
-<body data-theme="${escXml(themeId)}">
-  ${errInput}${warnInput}
-  <div id="cm-toolbar">
-    <div class="cm-title">Compliance Matrix</div>
-    <div class="cm-summary">${summary.products} products × ${summary.requirements} requirements · <strong>${summary.gaps}</strong> gaps · ${summary.assertions} claims shown</div>
-    <a href="command:transitrixStudio.changeTheme" class="cm-btn" title="Change the color scheme for all diagram previews">Theme…</a>
-    <a href="command:${REFRESH_COMMAND}" class="cm-btn" title="Re-scan the workspace">Refresh</a>
-  </div>
-  ${errBlock}${warnBlock}
-  <div id="cm-filters">
+    const filtersPanel = `<div id="cm-filters">
     <span class="cm-filter-label">Status</span>${statusBoxes}
     <span class="cm-filter-label">Severity</span>${severityBoxes}
     ${jurisdictionRow}
     ${colWidthSelect}
-  </div>
-  ${body}
-  <script nonce="${nonce}">
+  </div>`;
+
+    const filterScript = `<script nonce="${nonce}">
 (function () {
   var vscode = acquireVsCodeApi();
   function collect(attr) {
@@ -259,9 +233,27 @@ ${WARN_BLOCK_CSS}
     });
   }
 }());
-  </script>
-</body>
-</html>`;
+</script>`;
+
+    const summaryTitle = `${summary.products} products × ${summary.requirements} requirements · ${summary.gaps} gaps · ${summary.assertions} claims shown`;
+
+    return buildDiagramFrame({
+      notation: 'Compliance matrix',
+      filename: '',
+      title: summaryTitle,
+      themeId,
+      errorMsg: this.errorMsg,
+      warnings: this.skippedWarnings,
+      bodyContent: body,
+      themeCommand: OPEN_THEME_COMMAND,
+      refreshCommand: REFRESH_COMMAND,
+      extraStyles: `${colWCss}\n${MATRIX_CSS}`,
+      interactive: {
+        nonce,
+        controlsPanel: filtersPanel,
+        controlsScript: filterScript,
+      },
+    });
   }
 
   private gridHtml(matrix: ComplianceMatrix): string {
@@ -315,13 +307,7 @@ ${WARN_BLOCK_CSS}
 }
 
 const MATRIX_CSS = `
-body { padding: 0; }
-#cm-toolbar { display: flex; align-items: center; gap: 14px; padding: 10px 16px; border-bottom: 1px solid var(--ts-border, #cbd5e1); flex-wrap: wrap; }
-.cm-title { font-size: 13px; font-weight: 700; color: var(--ts-header-text, #0f172a); }
-.cm-summary { font-size: 12px; color: var(--ts-text-muted, #64748b); }
-.cm-summary strong { color: var(--ts-text, #0f172a); }
-.cm-btn { font-size: 11px; padding: 2px 10px; border-radius: 4px; color: var(--ts-text-muted, #64748b); text-decoration: none; border: 1px solid var(--ts-border, #cbd5e1); }
-.cm-btn:hover { color: var(--ts-text, #0f172a); background: var(--ts-bg-elevated, #f1f5f9); }
+#canvas { padding: 0; }
 #cm-filters { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; padding: 8px 16px; border-bottom: 1px solid var(--ts-border, #cbd5e1); font-size: 11px; }
 .cm-filter-label { font-weight: 600; color: var(--ts-text, #0f172a); margin-left: 8px; }
 .cm-filter-label:first-child { margin-left: 0; }

--- a/extension/src/compliance-render.ts
+++ b/extension/src/compliance-render.ts
@@ -120,9 +120,8 @@ export interface ComplianceShellOptions {
   bodyHtml: string;
   /**
    * View-level composite confidence for the rendered element set
-   * (CONTRACT §11.6). Rendered in the frame-header below the title
-   * (DQ-2, vkgeorgia/strategy#162). Omit or pass an empty composite to
-   * suppress the line entirely.
+   * (CONTRACT §11.6). Rendered in the frame-header below the title (DQ-2).
+   * Omit or pass an empty composite to suppress the line entirely.
    */
   confidence?: ViewScore;
   /** Non-fatal advisory messages. Rendered as a collapsible warnings block below the toolbar. */

--- a/extension/src/compliance-render.ts
+++ b/extension/src/compliance-render.ts
@@ -1,10 +1,10 @@
-import { generateWebviewCss, type ThemeId } from '@transitrix/diagrams/theme';
+import { type ThemeId } from '@transitrix/diagrams/theme';
 import { escXml } from '@transitrix/diagrams/webview/render-util.js';
 export { escXml };
 import type { AssertionStatus } from '@transitrix/diagrams/assertion/types.js';
 import type { ViewScore } from '@transitrix/diagrams/confidence';
 import { computeDeadlineStatus } from '@transitrix/diagrams/compliance/impact.js';
-import { ERROR_BLOCK_CSS, buildErrorHtml, WARN_BLOCK_CSS, buildWarnHtml } from './diagram-frame.js';
+import { buildDiagramFrame, OPEN_THEME_COMMAND } from './diagram-frame.js';
 
 // Shared HTML rendering for the script-less compliance views — the single-law
 // tree and single-product view (vkgeorgia/strategy#84 Phase 3). These previews
@@ -47,21 +47,14 @@ export function openLink(command: string, fsPath: string | undefined, inner: str
 }
 
 const COMPLIANCE_CSS = `
-body { padding: 0; }
-#cmp-toolbar { display: flex; align-items: baseline; gap: 12px; padding: 12px 16px; border-bottom: 1px solid var(--ts-border, #cbd5e1); flex-wrap: wrap; }
-.cmp-title { font-size: 13px; font-weight: 700; color: var(--ts-header-text, #0f172a); }
-.cmp-subtitle { font-size: 11px; color: var(--ts-text-secondary, #475569); }
-.cmp-meta { width: 100%; font-size: 11px; color: var(--ts-text-secondary, #475569); letter-spacing: 0.04em; }
-.cmp-confidence { width: 100%; font-size: 11px; color: var(--ts-text-secondary, #475569); }
+#canvas { padding: 0; }
+.cmp-body { padding: 12px 16px 28px; }
+.cmp-confidence { font-size: 11px; color: var(--ts-text-secondary, #475569); }
 .cmp-confidence-band { display: inline-block; padding: 0 6px; margin-right: 4px; border-radius: 3px; font-weight: 700; background: var(--ts-bg-subtle, #f1f5f9); color: var(--ts-text, #0f172a); }
 .cmp-confidence-band[data-band="A"] { background: var(--ts-status-success-bg, #d1fae5); color: var(--ts-status-success-fg, #065f46); }
 .cmp-confidence-band[data-band="B"] { background: var(--ts-status-info-bg, #e0f2fe); color: var(--ts-status-info-fg, #0c4a6e); }
 .cmp-confidence-band[data-band="C"] { background: var(--ts-status-warning-bg, #fef9c3); color: var(--ts-status-warning-fg, #854d0e); }
 .cmp-confidence-band[data-band="D"] { background: var(--ts-status-error-bg, #fee2e2); color: var(--ts-status-error-fg, #991b1b); }
-.cmp-toolbar-actions { margin-left: auto; display: inline-flex; gap: 6px; }
-.cmp-btn { font-size: 11px; padding: 2px 10px; border-radius: 4px; color: var(--ts-text-muted, #64748b); text-decoration: none; border: 1px solid var(--ts-border, #cbd5e1); }
-.cmp-btn:hover { color: var(--ts-text, #0f172a); background: var(--ts-bg-elevated, #f1f5f9); }
-#cmp-body { padding: 12px 16px 28px; }
 .cmp-link { color: var(--ts-brand-primary, #004d67); text-decoration: none; }
 .cmp-link:hover { text-decoration: underline; }
 .cmp-badge { display: inline-block; padding: 1px 8px; border-radius: 10px; font-size: 11px; font-weight: 600; }
@@ -108,9 +101,11 @@ body { padding: 0; }
 `;
 
 export interface ComplianceShellOptions {
+  /** Short notation-type label for the toolbar (e.g. "Law", "Gap dashboard"). */
+  notation?: string;
   title: string;
   subtitle?: string;
-  /** Source filename shown as the second line of the header (e.g. "gdpr.law.transitrix.yaml"). Omit for workspace-wide views. */
+  /** Source filename shown in the toolbar label (e.g. "gdpr.law.transitrix.yaml"). Omit for workspace-wide views. */
   filename?: string;
   /** Generation date shown as "Generated: YYYY-MM-DD". Pass today's ISO date from the caller. */
   date?: string;
@@ -125,9 +120,9 @@ export interface ComplianceShellOptions {
   bodyHtml: string;
   /**
    * View-level composite confidence for the rendered element set
-   * (CONTRACT §11.6). Rendered next to the formation date as a small subline
-   * under the title (DQ-2, vkgeorgia/strategy#162). Omit or pass an empty
-   * composite to suppress the line entirely.
+   * (CONTRACT §11.6). Rendered in the frame-header below the title
+   * (DQ-2, vkgeorgia/strategy#162). Omit or pass an empty composite to
+   * suppress the line entirely.
    */
   confidence?: ViewScore;
   /** Non-fatal advisory messages. Rendered as a collapsible warnings block below the toolbar. */
@@ -140,47 +135,35 @@ export interface ComplianceShellOptions {
  * Renders the §11.6 confidence header as a coloured-band pill plus the
  * formation date + mean + sourced %. Suppresses itself for an empty
  * element set (no view to score). Static / script-less — pure HTML.
+ * Returns a block-level div so it renders correctly inside frame-header.
  */
 export function confidenceLineHtml(view: ViewScore): string {
   const c = view.composite;
   if (c.element_count === 0) return '';
   const mean = c.mean.toFixed(2);
   const coverage = Math.round(c.coverage * 100);
-  return `<span class="cmp-confidence" title="Data confidence per CONTRACT §11.6 — weakest-link headline.">`
+  return `<div class="cmp-confidence" title="Data confidence per CONTRACT §11.6 — weakest-link headline.">`
     + `<span class="cmp-confidence-band" data-band="${escXml(c.band)}">${escXml(c.band)}</span>`
     + `Data confidence (as of ${escXml(view.today)}) · ${escXml(mean)} mean · ${coverage}% sourced`
-    + `</span>`;
+    + `</div>`;
 }
 
 /** Full webview document for a script-less compliance view (static CSP). */
 export function complianceShell(opts: ComplianceShellOptions): string {
-  const { input: errInput, block: errBlock } = buildErrorHtml(opts.errorMsg ?? '');
-  const { input: warnInput, block: warnBlock } = buildWarnHtml(opts.warnings ?? []);
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8"/>
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline';">
-  <style>
-${generateWebviewCss(opts.themeId)}
-${COMPLIANCE_CSS}
-${ERROR_BLOCK_CSS}
-${WARN_BLOCK_CSS}
-  </style>
-</head>
-<body data-theme="${escXml(opts.themeId)}">
-  ${errInput}${warnInput}
-  <div id="cmp-toolbar">
-    <span class="cmp-title">${escXml(opts.title)}</span>
-    ${opts.subtitle ? `<span class="cmp-subtitle">${escXml(opts.subtitle)}</span>` : ''}
-    ${(opts.filename || opts.date) ? `<span class="cmp-meta">${[opts.filename ? escXml(opts.filename) : '', opts.date ? `Generated: ${escXml(opts.date)}` : ''].filter(Boolean).join(' · ')}</span>` : ''}
-    <span class="cmp-toolbar-actions">${(opts.extraButtons ?? []).map(b => `<a href="command:${b.command}" class="cmp-btn" title="${escXml(b.title)}">${escXml(b.label)}</a>`).join('')}${opts.themeCommand ? `<a href="command:${opts.themeCommand}" class="cmp-btn" title="Change the color scheme for all diagram previews">Theme…</a>` : ''}<a href="command:${opts.refreshCommand}" class="cmp-btn" title="Re-scan the workspace">Refresh</a></span>
-    ${opts.confidence ? confidenceLineHtml(opts.confidence) : ''}
-  </div>
-  ${errBlock}${warnBlock}
-  <div id="cmp-body">
-    ${opts.bodyHtml}
-  </div>
-</body>
-</html>`;
+  return buildDiagramFrame({
+    notation: opts.notation ?? 'Compliance',
+    filename: opts.filename ?? '',
+    title: opts.title,
+    subtitle: opts.subtitle,
+    date: opts.date,
+    themeId: opts.themeId,
+    bodyContent: `<div class="cmp-body">${opts.bodyHtml}</div>`,
+    errorMsg: opts.errorMsg,
+    warnings: opts.warnings,
+    themeCommand: opts.themeCommand ?? OPEN_THEME_COMMAND,
+    refreshCommand: opts.refreshCommand,
+    extraButtons: opts.extraButtons,
+    confidenceLine: opts.confidence ? confidenceLineHtml(opts.confidence) : undefined,
+    extraStyles: COMPLIANCE_CSS,
+  });
 }

--- a/extension/src/coverage-metric-preview.ts
+++ b/extension/src/coverage-metric-preview.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { escXml } from '@transitrix/diagrams/webview/render-util.js';
 import yaml from 'js-yaml';
-import { generateWebviewCss, type ThemeId } from '@transitrix/diagrams/theme';
+import { type ThemeId } from '@transitrix/diagrams/theme';
 import {
   parseCoverageMetricConfig,
   buildCoverageMatrix,
@@ -11,7 +11,7 @@ import {
 } from '@transitrix/diagrams/compliance/coverage-metric.js';
 import { scanComplianceCanon, openComplianceFile } from './compliance-scan.js';
 import type { ScannedCanon } from './compliance-scan.js';
-import { WARN_BLOCK_CSS, buildWarnHtml, ERROR_BLOCK_CSS, buildErrorHtml } from './diagram-frame.js';
+import { buildDiagramFrame, OPEN_THEME_COMMAND } from './diagram-frame.js';
 
 // Coverage-metric view preview — strategy#185.
 //
@@ -94,13 +94,7 @@ function buildTableHtml(matrix: CoverageMatrix): string {
 }
 
 const COVERAGE_CSS = `
-body { padding: 0; margin: 0; font-family: var(--vscode-font-family, sans-serif); font-size: 13px; color: var(--ts-text, #0f172a); }
-#cm-toolbar { display: flex; align-items: center; gap: 12px; padding: 10px 16px; border-bottom: 1px solid var(--ts-border, #cbd5e1); flex-wrap: wrap; }
-.cm-title { font-size: 13px; font-weight: 700; color: var(--ts-header-text, #0f172a); }
-.cm-subtitle { font-size: 11px; color: var(--ts-text-secondary, #475569); }
-.cm-meta { font-size: 11px; color: var(--ts-text-secondary, #475569); letter-spacing: 0.04em; flex-basis: 100%; }
-.cm-btn { font-size: 11px; padding: 2px 10px; border-radius: 4px; color: var(--ts-text-muted, #64748b); text-decoration: none; border: 1px solid var(--ts-border, #cbd5e1); margin-left: auto; }
-.cm-btn:hover { color: var(--ts-text, #0f172a); background: var(--ts-bg-elevated, #f1f5f9); }
+#canvas { padding: 0; }
 .cm-wrap { padding: 16px 20px 24px; overflow-x: auto; }
 .cm-table { border-collapse: collapse; font-size: 12px; width: 100%; }
 .cm-table th, .cm-table td { border: 1px solid var(--ts-border, #cbd5e1); padding: 6px 10px; text-align: left; }
@@ -223,40 +217,19 @@ export class CoverageMetricPreview {
       titleLine = 'Coverage Metric — error';
     }
 
-    const { input: errInput, block: errBlock } = buildErrorHtml(errorMsg);
-    const { input: warnInput, block: warnBlock } = buildWarnHtml(warnings);
-
-    return (
-      '<!DOCTYPE html>\n' +
-      '<html lang="en">\n' +
-      '<head>\n' +
-      '  <meta charset="UTF-8"/>\n' +
-      '  <meta http-equiv="Content-Security-Policy" content="default-src \'none\'; style-src \'unsafe-inline\';">\n' +
-      '  <style>\n' +
-      `:root { --ts-col-w: ${colWPx}px; }\n` +
-      generateWebviewCss(themeId) +
-      '\n' +
-      COVERAGE_CSS +
-      '\n' +
-      ERROR_BLOCK_CSS +
-      '\n' +
-      WARN_BLOCK_CSS +
-      '\n  </style>\n' +
-      '</head>\n' +
-      '<body>\n' +
-      errInput +
-      warnInput +
-      '  <div id="cm-toolbar">\n' +
-      `    <div class="cm-title">${titleLine}</div>\n` +
-      (subtitleLine ? `    <div class="cm-subtitle">${subtitleLine}</div>\n` : '') +
-      (filename ? `    <div class="cm-meta">${escXml(filename)} · Generated: ${new Date().toISOString().slice(0, 10)}</div>\n` : '') +
-      `    <a href="command:transitrixStudio.changeTheme" class="cm-btn" title="Change the color scheme for all diagram previews">Theme…</a>\n` +
-      `    <a href="command:${REFRESH_COMMAND}" class="cm-btn" title="Re-scan the workspace and reload">Refresh</a>\n` +
-      '  </div>\n' +
-      errBlock +
-      warnBlock +
-      bodyHtml +
-      '</body>\n</html>'
-    );
+    return buildDiagramFrame({
+      notation: 'Coverage metric',
+      filename,
+      title: titleLine || undefined,
+      subtitle: subtitleLine || undefined,
+      date: metaDate || new Date().toISOString().slice(0, 10),
+      themeId,
+      errorMsg,
+      warnings,
+      bodyContent: bodyHtml,
+      themeCommand: OPEN_THEME_COMMAND,
+      refreshCommand: REFRESH_COMMAND,
+      extraStyles: `:root { --ts-col-w: ${colWPx}px; }\n${COVERAGE_CSS}`,
+    });
   }
 }

--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -115,6 +115,18 @@ export interface DiagramFrameOpts {
    */
   extraButtons?: Array<{ command: string; label: string; title: string }>;
   /**
+   * Command ID for the "Refresh" toolbar button. Shown on report/compliance
+   * views that don't export diagrams (no `saveSvgCommand`). Rendered after
+   * `extraButtons` and before the spacing/theme settings links.
+   */
+  refreshCommand?: string;
+  /**
+   * Pre-built HTML for a confidence-score line (compliance views, CONTRACT
+   * §11.6). Rendered inside the `frame-header` block, below the meta strip.
+   * Produced by `confidenceLineHtml()` in `compliance-render.ts`.
+   */
+  confidenceLine?: string;
+  /**
    * When true, adds a "Legend" toggle button to the toolbar (CSS-only, no scripts).
    * The SVG must wrap its legend elements in `<g class="diagram-legend-col">`.
    * Follows the same pattern as the title toggle (TX-R009).
@@ -422,6 +434,7 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
     title, subtitle, version, date,
     saveSvgCommand, savePngCommand, copyPngCommand, spacingCommand, curvatureCommand, scopeCommand, themeCommand,
     extraButtons = [],
+    refreshCommand, confidenceLine,
     interactive, legendToggle, snapshotUi,
   } = opts;
 
@@ -460,6 +473,7 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
   <div class="frame-title">${escXml(title)}</div>
   ${subtitle ? `<div class="frame-subtitle">${escXml(subtitle)}</div>` : ''}
   ${metaParts.length > 0 ? `<div class="frame-meta">${metaParts.join(' · ')}</div>` : ''}
+  ${confidenceLine ?? ''}
 </div>`
     : '';
 
@@ -478,6 +492,7 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
   const showCopyPng = Boolean(canvasContent) && Boolean(copyPngCommand);
   // Spacing/curvature/scope links show whenever the preview opts in — including
   // error renders, so the user can adjust the settings and trigger a re-render.
+  const showRefresh = Boolean(refreshCommand);
   const showSpacing = Boolean(spacingCommand);
   const showCurvature = Boolean(curvatureCommand);
   const showScope = Boolean(scopeCommand);
@@ -531,6 +546,9 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
       actionParts.push(`<a href="command:${escXml(b.command)}" class="toolbar-btn" title="${escXml(b.title)}">${escXml(b.label)}</a>`);
     }
   }
+  if (showRefresh) {
+    actionParts.push(`<a href="command:${escXml(refreshCommand!)}" class="toolbar-btn" title="Re-scan the workspace">Refresh</a>`);
+  }
   if (showSpacing) {
     actionParts.push(`<a href="command:${escXml(spacingCommand!)}" class="toolbar-btn" title="Adjust the horizontal/vertical spacing for this notation in Settings">Spacing…</a>`);
   }
@@ -564,6 +582,10 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
     ? `<div id="tx-snap-info" class="tx-snap-info" style="display:none"></div>`
     : '';
 
+  const toolbarLabel = filename
+    ? `${escXml(notation)}: ${escXml(filename)}`
+    : escXml(notation);
+
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -588,7 +610,7 @@ ${extraStyles}
   ${zoomInputs}
   ${errToggleInput}
   ${warnToggleInput}
-  <div id="toolbar"><span class="toolbar-label">${escXml(notation)}: ${escXml(filename)}</span>${toolbarRight}</div>
+  <div id="toolbar"><span class="toolbar-label">${toolbarLabel}</span>${toolbarRight}</div>
   ${controlsPanel}
   ${timelineStrip}
   ${snapInfoBox}

--- a/extension/src/gap-dashboard-preview.ts
+++ b/extension/src/gap-dashboard-preview.ts
@@ -129,6 +129,7 @@ export class GapDashboardPreview {
       ${section('Past-deadline requirements (CV-5)', report.pastDeadlineRequirements.length, pastDlRows, 'No requirement has a past deadline without full compliance.')}`;
 
     return complianceShell({
+      notation: 'Gap dashboard',
       title: 'Compliance Gap Dashboard',
       subtitle: total === 0 ? 'No gaps found' : `${total} gap(s) across 4 checks`,
       date: todayIso(),

--- a/extension/src/preview.ts
+++ b/extension/src/preview.ts
@@ -190,8 +190,8 @@ export class CervinPreview {
     /* flex chain so layout height reaches #canvas — otherwise diagram-js measures ~0px */
     body{display:flex;flex-direction:column;min-height:0;}
     #toolbar{flex-shrink:0;border-bottom:1px solid var(--vscode-panel-border);padding:6px 8px;font-family:var(--vscode-font-family);font-size:12px;display:flex;flex-direction:column;gap:6px;}
-    .toolbar-btn{cursor:pointer;user-select:none;font-size:11px;padding:1px 8px;border-radius:4px;color:var(--vscode-button-foreground,#fff);background:var(--vscode-button-background,#007acc);border:none;white-space:nowrap;align-self:flex-end;}
-    .toolbar-btn:hover:not(:disabled){opacity:0.85;}
+    .toolbar-btn{cursor:pointer;user-select:none;font-size:11px;padding:1px 8px;border-radius:4px;color:var(--ts-text-muted,#64748b);background:transparent;border:none;white-space:nowrap;align-self:flex-end;text-decoration:none;}
+    .toolbar-btn:hover:not(:disabled){color:var(--ts-text,#0f172a);background:var(--ts-bg-elevated,#f1f5f9);}
     .toolbar-btn:disabled{opacity:0.4;cursor:default;}
     #toolbar-message{flex-shrink:0;}
     #metrics-display{display:flex;gap:16px;flex-wrap:wrap;align-items:center;font-size:11px;color:var(--vscode-descriptionForeground);}

--- a/extension/src/requirement-trace-preview.ts
+++ b/extension/src/requirement-trace-preview.ts
@@ -87,6 +87,7 @@ export class RequirementTracePreview {
 
     if (!elementId) {
       this.panel.webview.html = complianceShell({
+        notation: 'Requirement trace',
         title: 'Requirement trace',
         themeId, refreshCommand: REFRESH_COMMAND, themeCommand: 'transitrixStudio.changeTheme',
         bodyHtml: `<div class="cmp-empty">This file has no <code>id</code> — open a REQUIREMENT or CONSTRAINT file.</div>`,
@@ -115,6 +116,7 @@ export class RequirementTracePreview {
     ].filter(Boolean).join(' · ');
 
     this.panel.webview.html = complianceShell({
+      notation: 'Requirement trace',
       title: trace.requirement.name,
       subtitle: subtitleBits,
       filename: path.basename(doc.fileName),

--- a/extension/src/single-law-preview.ts
+++ b/extension/src/single-law-preview.ts
@@ -80,6 +80,7 @@ export class SingleLawPreview {
 
     if (!lawId) {
       this.panel.webview.html = complianceShell({
+        notation: 'Law',
         title: 'Single-law tree',
         themeId, refreshCommand: REFRESH_COMMAND, themeCommand: 'transitrixStudio.changeTheme',
         bodyHtml: `<div class="cmp-empty">This file has no <code>id</code> — open a codex artefact (LAW / REGULATION / POLICY / INTERNAL_STANDARD).</div>`,
@@ -98,6 +99,7 @@ export class SingleLawPreview {
     const confidence = scoreComplianceView(treeRequirements, treeAssertions, todayIso());
 
     this.panel.webview.html = complianceShell({
+      notation: 'Law',
       title: lawName,
       subtitle: `${lawId} · ${tree.requirements.length} requirement(s)`,
       filename: path.basename(doc.fileName),

--- a/extension/src/single-product-preview.ts
+++ b/extension/src/single-product-preview.ts
@@ -78,6 +78,7 @@ export class SingleProductPreview {
 
     if (!productId) {
       this.panel.webview.html = complianceShell({
+        notation: 'Product compliance',
         title: 'Single-product view',
         themeId, refreshCommand: REFRESH_COMMAND, themeCommand: 'transitrixStudio.changeTheme',
         bodyHtml: `<div class="cmp-empty">This file has no <code>id</code> — open a <code>notation: product</code> file.</div>`,
@@ -95,6 +96,7 @@ export class SingleProductPreview {
     const confidence = scoreComplianceView(viewRequirements, viewAssertions, todayIso());
 
     this.panel.webview.html = complianceShell({
+      notation: 'Product compliance',
       title: productName,
       subtitle: `${productId} · ${view.requirements.length} requirement(s) asserted`,
       filename: path.basename(doc.fileName),


### PR DESCRIPTION
## Summary

All notation previews and compliance/report dashboards now share `buildDiagramFrame` as their single HTML shell. Before this PR, five compliance views used a separate `complianceShell` function and two report views (`compliance-matrix`, `coverage-metric`) maintained entirely custom HTML shells — each with their own toolbar CSS, button styles, and structural conventions. The chrome (toolbar, buttons, error/warning blocks, title area) now comes from one source of truth.

### What changed

- **`diagram-frame.ts`** — Added `refreshCommand` (renders a `Refresh` button in the toolbar for views that don't export diagrams) and `confidenceLine` (renders a §11.6 data-quality line inside `frame-header`) options. Toolbar label now omits the colon separator when `filename` is empty (workspace-wide views).

- **`compliance-render.ts`** — `complianceShell` delegates entirely to `buildDiagramFrame`. Dropped its own `#cmp-toolbar` / `.cmp-btn` CSS block; kept badge, tree, deadline, and gap-section styles. `confidenceLineHtml` returns a block `<div>` for correct placement in `frame-header`. `ComplianceShellOptions` gains an optional `notation` field.

- **`compliance-matrix-preview.ts`** — Migrated from a custom HTML shell to `buildDiagramFrame`. Filter row moves to `interactive.controlsPanel`, the products × requirements summary goes to `frame-header` title, and the nonce'd script goes to `interactive.controlsScript`. Dropped duplicated toolbar CSS.

- **`coverage-metric-preview.ts`** — Migrated from a custom HTML shell to `buildDiagramFrame`. Dropped duplicated toolbar CSS.

- **`single-law-preview.ts`, `single-product-preview.ts`, `gap-dashboard-preview.ts`, `requirement-trace-preview.ts`** — Added `notation` label to all `complianceShell` calls (`'Law'`, `'Product compliance'`, `'Gap dashboard'`, `'Requirement trace'`).

- **`preview.ts`** (BPMN bpmn.io viewer) — Aligned `.toolbar-btn` to the standard ghost style (no blue primary background) so the Save .png button matches the rest of the extension's toolbar buttons.

### What's left for a follow-up

`compliance-impact-preview.ts` already uses `#toolbar`/`.toolbar-btn` with identical CSS (visual parity achieved), but still manually assembles its HTML rather than calling `buildDiagramFrame`. Migrating that complex interactive view is a separate effort.

## Test plan

- [ ] TypeScript compile clean (`npm run compile:extension` — zero errors)
- [ ] Test suite: 445 passed, 3 pre-existing failures in `cli-migrate.test.ts` (methodology version fixture mismatch, unrelated to this PR)
- [ ] Open a `.law.transitrix.yaml` file → Law compliance preview shows unified toolbar with `Law: filename.yaml` label, frame-header with law name, Refresh + Theme… buttons matching diagram preview style
- [ ] Open compliance matrix view → shows unified toolbar with `Compliance matrix` label, summary in frame-header, filter row, Refresh + Theme…
- [ ] Open a `.coverage-metric.transitrix.yaml` → unified toolbar with `Coverage metric: filename.yaml`, Refresh + Theme…
- [ ] BPMN preview `.bpmn.transitrix.yaml` → Save .png button now ghost style (no blue background), consistent with other toolbar buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)
