### PR TITLE
chore(extension): set Marketplace galleryBanner to Transitrix petrol

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -6,6 +6,7 @@
   "description": "Architecture-as-code for the modern enterprise. Author 17 notations — goals, processes, capabilities, BPMN, applications, more — as plain YAML, get live diagrams in VS Code. Diffable in git. AI-friendly. Open source. Built on ArchiMate 3.2 and BPMN 2.0.",
   "license": "MIT",
   "icon": "icon.png",
+  "galleryBanner": { "color": "#004d67", "theme": "dark" },
   "homepage": "https://github.com/transitrix/transitrix-studio#readme",
   "bugs": {
     "url": "https://github.com/transitrix/transitrix-studio/issues"


### PR DESCRIPTION
## Summary

- Adds `"galleryBanner": { "color": "#004d67", "theme": "dark" }` to `extension/package.json`
- Uses the canonical Transitrix Petrol brand colour per `brand/transitrix_brand.md`
- Last remaining item of the Marketplace banner set (strategy #502)

## Test plan

- [ ] Verify `extension/package.json` contains the new `galleryBanner` field
- [ ] After VSIX build and publish, confirm the Marketplace listing banner renders in petrol/dark

🤖 Generated with [Claude Code](https://claude.com/claude-code)