### PR TITLE
fix(diagrams): unbox DGCA/DGA column headers, widen title-block gap

### DIFF
--- a/extension/src/svg-title-block.ts
+++ b/extension/src/svg-title-block.ts
@@ -16,7 +16,7 @@
 
 import { escXml } from '@transitrix/diagrams/webview/render-util.js';
 
-export const TITLE_BLOCK_H = 60;
+export const TITLE_BLOCK_H = 74;
 
 /**
  * Build the title <g> for embedding at (x, top) inside an SVG.

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",

--- a/packages/diagrams/src/webview/render-fgca.ts
+++ b/packages/diagrams/src/webview/render-fgca.ts
@@ -64,10 +64,7 @@ export function renderFgcaBody(
 
   const headerSvg = columns
     .map(({ col, x }) =>
-      [
-        `<rect class="diagram-node layer-${col}" x="${x}" y="${PAD}" width="${nodeWidth}" height="${HEADER_H}" rx="6"/>`,
-        `<text class="text-header" x="${x + nodeWidth / 2}" y="${PAD + HEADER_H / 2}" text-anchor="middle" dominant-baseline="central">${escXml(truncateLine(COL_LABELS[col], headerTruncate))}</text>`,
-      ].join('\n'),
+      `<text class="text-header" x="${x + nodeWidth / 2}" y="${PAD + HEADER_H / 2}" text-anchor="middle" dominant-baseline="central">${escXml(truncateLine(COL_LABELS[col], headerTruncate))}</text>`,
     )
     .join('\n');
 


### PR DESCRIPTION
## Summary

- DGCA/DGA column headers (Drivers/Goals/Changes/Actions) were rendered as filled `<rect>`s styled identically to entity nodes, making them read as meaningful boxes to the user instead of plain labels. Now rendered as bare `<text class="text-header">` — same text, same font, no box.
- Doubled the gap between the SVG title block and the diagram body (14px -> 28px) by bumping `TITLE_BLOCK_H` 60 -> 74. This constant is shared across every vector preview (DGCA/DGA, Goals, Blocks, Activity Card, Action, Process Blueprint), so the change applies uniformly.

`@transitrix/diagrams` bumped 1.8.4 -> 1.8.5 (CI version-bump gate, `render-fgca.ts` changed).

## Test plan

- [x] `tsc --noEmit` clean in both `extension` and `packages/diagrams`
- [x] `packages/diagrams` test suite: 223/223 passed
- [x] Root test suite: 445/448 passed (3 pre-existing `cli-migrate.test.ts` failures, unrelated fixture mismatch)
- [ ] Open a `.dgca.transitrix.yaml` file → column headers show as plain text, no box; entity node boxes unaffected
- [ ] Confirm wider gap between the title block and diagram body across DGCA, Goals, Blocks, Activity Card previews

🤖 Generated with [Claude Code](https://claude.com/claude-code)