### PR TITLE
fix(diagrams,extension): rein in edge-curve overshoot, unify critical-path stroke widths

### DIFF
--- a/extension/src/action-preview.ts
+++ b/extension/src/action-preview.ts
@@ -640,16 +640,16 @@ function buildCanvasContent(views: ActivityViews): string {
 /** Diagram-class CSS used both in the webview and in saved .svg exports. */
 const ACTIVITIES_DIAGRAM_CSS = `
   .act-node { fill: var(--ts-layer-activity, #d4edda); stroke: var(--ts-node-stroke, #004d67); stroke-width: 1; }
-  .critical-node { fill: var(--ts-brand-orange-tint, #ffeee5); stroke: var(--ts-brand-orange, #ff4d00); stroke-width: 2.5; }
+  .critical-node { fill: var(--ts-brand-orange-tint, #ffeee5); stroke: var(--ts-brand-orange, #ff4d00); stroke-width: 1; }
   .milestone-node { fill: #ecfeff; stroke: var(--ts-text-muted, #64748b); stroke-dasharray: 4 2; }
-  .critical-edge { stroke: var(--ts-brand-orange, #ff4d00); stroke-width: 2; }
+  .critical-edge { stroke: var(--ts-brand-orange, #ff4d00); stroke-width: 1.5; }
   .arrow-fill-critical { fill: var(--ts-brand-orange, #ff4d00); }
 
   .gantt-header { fill: var(--ts-bg-subtle, #f1f5f9); stroke: var(--ts-border, #cbd5e1); stroke-width: 1; }
   .gantt-grid { stroke: var(--ts-border, #cbd5e1); stroke-width: 1; opacity: 0.5; }
   .gantt-row-alt { fill: var(--ts-bg-subtle, #f8fafc); opacity: 0.5; }
   .gantt-bar { fill: var(--ts-bg-surface, #dbeafe); stroke: var(--ts-border, #60a5fa); stroke-width: 1; }
-  .gantt-bar.critical-bar { fill: var(--ts-brand-orange-tint, #ffeee5); stroke: var(--ts-brand-orange, #ff4d00); stroke-width: 1.5; }
+  .gantt-bar.critical-bar { fill: var(--ts-brand-orange-tint, #ffeee5); stroke: var(--ts-brand-orange, #ff4d00); stroke-width: 1; }
   .gantt-phase { fill: var(--ts-text-muted, #475569); opacity: 0.85; }
   .gantt-milestone { fill: var(--ts-text, #0f172a); }
   .gantt-milestone.critical-bar { fill: var(--ts-brand-orange, #ff4d00); }

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",

--- a/packages/diagrams/src/__tests__/edge-path.test.ts
+++ b/packages/diagrams/src/__tests__/edge-path.test.ts
@@ -55,4 +55,13 @@ describe('horizontalCubicEdgePath', () => {
       horizontalCubicEdgePath(0, 0, 40, 0, 0.5, 0.5),
     );
   });
+
+  it('caps the handle for a tall edge with a narrow column gap, instead of overshooting the target', () => {
+    // A network-view edge spanning several rows (|dy|=500) with a typical
+    // adjacent-column gap (dx=80): uncapped, |dy|*0.8=400 would push the exit
+    // control point 320px past the target's x, producing an exaggerated
+    // S-bow. Capped at 160, the control points stay close to the endpoints.
+    const d = horizontalCubicEdgePath(0, 0, 80, 500, 1);
+    expect(d).toBe('M0,0 C160,0 -80,500 80,500');
+  });
 });

--- a/packages/diagrams/src/edge-path.ts
+++ b/packages/diagrams/src/edge-path.ts
@@ -17,6 +17,16 @@ export const EDGE_MIN_HANDLE = 64;
 const DX_FACTOR = 0.5;
 const DY_FACTOR = 0.8;
 
+/**
+ * Ceiling on each span factor's contribution. Uncapped, a tall edge with a
+ * narrow column gap (large dy, small dx — the common case in a many-row
+ * network view) grows a handle far past the endpoints' actual x-distance;
+ * the two control points then overshoot each other, producing an
+ * exaggerated S-bow instead of a gentle curve. Capping keeps typical spans
+ * (within the existing historical range) untouched while reining in outliers.
+ */
+const MAX_HANDLE = 160;
+
 /** Multiplier applied to the base handle length. 1 = historical appearance. */
 export const DEFAULT_EDGE_CURVATURE = 1;
 
@@ -43,7 +53,11 @@ export function horizontalCubicEdgePath(
 ): string {
   const dx = tx - sx;
   const dy = ty - sy;
-  const baseHandle = Math.max(EDGE_MIN_HANDLE, Math.abs(dx) * DX_FACTOR, Math.abs(dy) * DY_FACTOR);
+  const baseHandle = Math.max(
+    EDGE_MIN_HANDLE,
+    Math.min(Math.abs(dx) * DX_FACTOR, MAX_HANDLE),
+    Math.min(Math.abs(dy) * DY_FACTOR, MAX_HANDLE),
+  );
   const exitHandle = baseHandle * curvature;
   const entryHandle = baseHandle * (entryCurvature ?? curvature);
   return `M${sx},${sy} C${sx + exitHandle},${sy} ${tx - entryHandle},${ty} ${tx},${ty}`;

--- a/packages/diagrams/src/webview/render-activities.ts
+++ b/packages/diagrams/src/webview/render-activities.ts
@@ -39,9 +39,9 @@ const N_PAD = 24;
  */
 export const ACTIVITIES_NETWORK_CSS = `
   .act-node { fill: var(--ts-layer-activity, #d4edda); stroke: var(--ts-node-stroke, #004d67); stroke-width: 1; }
-  .critical-node { fill: var(--ts-brand-orange-tint, #ffeee5); stroke: var(--ts-brand-orange, #ff4d00); stroke-width: 2.5; }
+  .critical-node { fill: var(--ts-brand-orange-tint, #ffeee5); stroke: var(--ts-brand-orange, #ff4d00); stroke-width: 1; }
   .milestone-node { fill: #ecfeff; stroke: var(--ts-text-muted, #64748b); stroke-dasharray: 4 2; }
-  .critical-edge { stroke: var(--ts-brand-orange, #ff4d00); stroke-width: 2; }
+  .critical-edge { stroke: var(--ts-brand-orange, #ff4d00); stroke-width: 1.5; }
   .arrow-fill-critical { fill: var(--ts-brand-orange, #ff4d00); }
 `;
 


### PR DESCRIPTION
## Summary

Three related issues in the Action-diagram Network view, all rooted in the shared curved-edge geometry / critical-path CSS:

1. **Arrow looks disconnected from its incoming line.** The arrowhead itself sits at a correct 90° entry (guaranteed by construction — the cubic Bezier's control point always shares the target's Y), but the curve just before it could still be visibly steep, making the flatten-out at the very end look like an abrupt flick rather than a smooth approach.
2. **The longest edge bows excessively.** `horizontalCubicEdgePath` (`edge-path.ts`) grows its control-handle length linearly and unbounded with the vertical span (`|dy| * 0.8`). In the network view's common case — tall row-span, narrow column gap (~80px) — this pushes both control points well past each other's x-position, producing a dramatic S-curve.
3. **Critical-path nodes/edges are thicker than regular ones.** Per earlier feedback, critical path should differ by color only. Found `stroke-width: 2.5` (nodes, vs. 1 normally) and `stroke-width: 2` (edges, vs. 1.5 normally) — duplicated in two places (`packages/diagrams`' shared CSS and the extension's own copy for the VS Code webview), which is why an earlier fix attempt silently didn't stick — only one copy ever got touched.

## Fix

- `packages/diagrams/src/edge-path.ts`: cap each span factor's contribution to the handle length at 160px (`MAX_HANDLE`). Verified against the exact network-layout parameters (80px column gap, common row heights): a 3-row-tall edge's overshoot past the target/source x drops from ~170px to ~80px. Short/medium edges (within the existing locked test range) are pixel-identical — all 1308 existing `packages/diagrams` tests pass unchanged; added one new test for the capped case.
- `packages/diagrams/src/webview/render-activities.ts` **and** `extension/src/action-preview.ts`: both copies of the critical-path CSS now match the regular stroke-width (`.critical-node` 1, `.critical-edge` 1.5, `.gantt-bar.critical-bar` 1) — color is the only remaining differentiator.

`@transitrix/diagrams` bumped 1.8.5 -> 1.8.6 (CI version-bump gate).

## Test plan

- [x] `tsc --noEmit` clean in both `extension` and `packages/diagrams`
- [x] `packages/diagrams` full test suite: 1308/1308 passed (incl. new edge-path cap test)
- [x] Root test suite: 445/448 passed (3 pre-existing `cli-migrate.test.ts` failures, unrelated fixture mismatch)
- [x] Manually rendered a network scenario matching the reported layout (multi-row, narrow column gap) and confirmed the long edge's control-point overshoot is reduced ~53%
- [ ] Open an `.action.transitrix.yaml` file with a multi-predecessor network → Network view: longest edge visibly less bowed, critical-path nodes/edges same thickness as regular ones (color only), arrow entries read as a continuous curve rather than a disconnected flick

🤖 Generated with [Claude Code](https://claude.com/claude-code)