### PR TITLE
chore(release): bump extension to 3.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+## [3.0.5] — 2026-07-11
+
+### Fixed
+
+- **DGCA/DGA column headers no longer render as boxes** (#387). Drivers/Goals/Changes/Actions headers were styled identically to entity nodes (filled rect, node stroke), which read as meaningful boxes rather than plain labels; now bare text, same font.
+- **Doubled the gap between the SVG title block and the diagram body** (14px → 28px), across every vector preview (#387).
+- **Long edges in the Action Network view no longer bow excessively.** A tall, narrow-column edge's curve-handle length grew unbounded with the vertical span, so its control points could overshoot each other in x and produce an exaggerated S-curve; capped the growth so only extreme spans are affected — short and medium edges are unchanged (#388).
+- **Critical path (Action Network + Gantt) now differs from the regular path by color only**, not stroke width — critical nodes/edges previously rendered with a heavier stroke than everything else (#388).
+
+### Changed
+
+- **Unified webview chrome across every notation and report/compliance preview** (#385). All previews now share a single `buildDiagramFrame` HTML shell — toolbar, buttons, error/warning blocks, title area — instead of five separate `complianceShell` duplicates and two fully custom shells (`compliance-matrix`, `coverage-metric`). No visual change intended.
+- **Marketplace gallery banner set to Transitrix petrol** (#386).
+- **`@transitrix/diagrams` 1.8.4 → 1.8.6** — unboxed DGCA/DGA headers, capped edge-curve handle length, unified critical-path stroke widths.
+
 ## [3.0.4] — 2026-07-10
 
 ### Added

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+## 3.0.5 — 2026-07-11
+
+Network-diagram edge and critical-path polish, DGCA header cleanup, and a unified preview shell under the hood.
+
+### Fixed
+
+- **DGCA/DGA column headers no longer render as boxes.** Drivers/Goals/Changes/Actions headers now render as plain text instead of a filled box styled like an entity node, so they read as labels rather than data.
+- **Doubled the gap between a diagram's title block and its body** (14px → 28px) — applies to every vector preview (Goals, DGCA/DGA, Nested Blocks, Activity Card, Action, Process Blueprint).
+- **Long edges in the Action Network view no longer bow excessively.** Tall, narrow-column edges could balloon into an exaggerated S-curve; capped the curve's control-handle growth so only the extreme cases are affected — short and medium edges are unchanged.
+- **Critical path now differs from the regular path by color only**, in both the Action Network and Gantt views — critical nodes/edges previously rendered with a heavier stroke than everything else.
+
+### Changed
+
+- Marketplace listing banner now uses the Transitrix petrol brand color.
+- Every notation preview and compliance/report dashboard now shares one HTML shell internally — no visual change, but removes several duplicated toolbar/CSS implementations.
+
 ## 3.0.4 — 2026-07-10
 
 Transitrix brand is now the default diagram theme, plus a harmonized maturity color scale.

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "Architecture-as-code for the modern enterprise. Author 17 notations — goals, processes, capabilities, BPMN, applications, more — as plain YAML, get live diagrams in VS Code. Diffable in git. AI-friendly. Open source. Built on ArchiMate 3.2 and BPMN 2.0.",
   "license": "MIT",
   "icon": "icon.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
## Summary

Release for the four PRs merged since 3.0.4:

- #385 — unified webview chrome across every notation + compliance/report preview (internal, no visual change intended)
- #386 — Marketplace gallery banner set to Transitrix petrol
- #387 — DGCA/DGA column headers no longer render as boxes; doubled the title-block-to-body gap
- #388 — Action Network long-edge curve overshoot capped; critical path (Network + Gantt) now differs by color only, not stroke width

`@transitrix/diagrams` 1.8.4 → 1.8.6 as part of #387/#388.

## Test plan

- [x] `extension/package.json` / `package.json` version bumped to 3.0.5, valid JSON
- [x] `CHANGELOG.md` / `extension/CHANGELOG.md` entries added, matching the existing format
- [ ] Valerii review + merge (no VSIX build triggered by this PR — package-extension only runs on explicit request)

🤖 Generated with [Claude Code](https://claude.com/claude-code)