### PR TITLE
chore(release): bump extension to 3.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## [3.0.6] — 2026-07-13
+
+### Added
+
+- **Live preview for `.puml` / `.plantuml` files**, powered by `@plantuml/core` — the official PlantUML engine (Arnaud Roques), compiled to JavaScript via TeaVM, MIT-licensed (#390). Runs entirely in the webview: no Java, no Graphviz binary, works in `vscode.dev` and browser-based Codespaces. Forces `!pragma layout smetana` on every render to eliminate Graphviz layout variance across machines, auto-injects the Transitrix theme when `diagrams/transitrix-theme.puml` exists in the workspace, and replaces raw PlantUML error text with a titled, hinted friendly error card. Same editor UX as every other Transitrix notation preview (editor title icon, auto-open on file focus, refresh on save).
+
 ## [3.0.5] — 2026-07-11
 
 ### Fixed

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+## 3.0.6 — 2026-07-13
+
+PlantUML live preview, bundled and themed.
+
+### Added
+
+- **`.puml` / `.plantuml` files now get a live preview**, same as every other Transitrix notation. Powered by the official PlantUML engine compiled to JavaScript (no Java, no Graphviz install — works in `vscode.dev` and browser-based Codespaces too). Layout is pinned to Smetana so diagrams render identically across machines. If your workspace has `diagrams/transitrix-theme.puml`, it's applied automatically. Syntax errors show as a friendly, titled card instead of raw engine output.
+
 ## 3.0.5 — 2026-07-11
 
 Network-diagram edge and critical-path polish, DGCA header cleanup, and a unified preview shell under the hood.

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "Architecture-as-code for the modern enterprise. Author 17 notations — goals, processes, capabilities, BPMN, applications, more — as plain YAML, get live diagrams in VS Code. Diffable in git. AI-friendly. Open source. Built on ArchiMate 3.2 and BPMN 2.0.",
   "license": "MIT",
   "icon": "icon.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "transitrix-studio",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "transitrix-studio",
-      "version": "3.0.5",
+      "version": "3.0.6",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
## Summary

- Bumps `extension/package.json` and root `package.json` to `3.0.6`
- Adds changelog entries (root `CHANGELOG.md` + `extension/CHANGELOG.md`) for the PlantUML live preview shipped in #390

## Why now

#390 (PlantUML preview via `@plantuml/core`) merged into `main` on 2026-07-12 but hasn't shipped in a release yet — latest published release is still v3.0.5. This bump is the release vehicle for it.

## Test plan

- [x] `npm run compile:extension` — type-checks clean
- [x] `npm run verify-extension-packaging` — OK
- [ ] Marketplace publish on merge (per existing release process)

🤖 Generated with [Claude Code](https://claude.com/claude-code)