### PR TITLE
fix(diagrams): strip test fixtures and source maps from published npm package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- **`@transitrix/diagrams` 1.8.6 → 1.8.7** — the published npm package no longer includes test fixtures (`__tests__/`, `*.test.ts(x)`) or stray source maps in `dist/` or `src/`; package size roughly halved. No runtime behavior change.
+
 ## [3.0.5] — 2026-07-11
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -7789,7 +7789,7 @@
     },
     "packages/diagrams": {
       "name": "@transitrix/diagrams",
-      "version": "1.8.6",
+      "version": "1.8.7",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",
@@ -31,7 +31,12 @@
   },
   "files": [
     "dist",
-    "src"
+    "src",
+    "!src/**/__tests__",
+    "!src/**/*.test.ts",
+    "!src/**/*.test.tsx",
+    "!src/**/*.js.map",
+    "!src/**/*.d.ts.map"
   ],
   "scripts": {
     "build": "tsc -p .",

--- a/packages/diagrams/tsconfig.json
+++ b/packages/diagrams/tsconfig.json
@@ -11,5 +11,6 @@
     "skipLibCheck": true,
     "isolatedModules": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/**/__tests__/**", "src/**/*.test.ts", "src/**/*.test.tsx"]
 }


### PR DESCRIPTION
## Summary

- `packages/diagrams/tsconfig.json` now excludes `__tests__/` and `*.test.ts(x)` from the `tsc` build, so `dist/` no longer contains compiled test files (previously every `npm run build --workspace packages/diagrams` shipped 82 compiled test files into `dist/`).
- `packages/diagrams/package.json` `files` field negates `__tests__/`, `*.test.ts(x)`, and stray `*.js.map` / `*.d.ts.map` out of the raw `src/` that ships in the tarball.
- Bumps `@transitrix/diagrams` 1.8.6 → 1.8.7 (packaging-only, no runtime change) and adds a changelog note.

## Why

Auditing `@transitrix/diagrams`'s publish path (already live on npm, already using real semver, already wired into `npm-publish.yml` on GitHub Release) turned up that the published tarball included its full test suite and orphaned source maps. `npm pack --dry-run` before/after:

| | Before | After |
|---|---|---|
| package size | 808.8 kB | 384.8 kB |
| unpacked size | 3.7 MB | 1.6 MB |
| total files | 759 | 481 |

## Not changed (already correct, verified during this pass)

- `private` was never `true` on `packages/diagrams/package.json` — already publishable.
- Publish target is npm public (`npm publish --access public` in `.github/workflows/npm-publish.yml`, triggered on GitHub Release) — already implemented.
- Both the VS Code extension and `@transitrix/cli` intentionally bundle `@transitrix/diagrams` **source** at build time via esbuild rather than depending on the published package (see the comment block in `scripts/build-cli-package.mjs`) — this is a deliberate architecture decision, not a workspace-path leftover, so left as-is.
- `@transitrix/cli`'s own `npm pack --dry-run` is already clean (9 files, no tests/maps).

## Test plan

- [x] `npm run build --workspace packages/diagrams` — clean build, `dist/` has zero test/map files
- [x] `npm run test --workspace packages/diagrams` — 82 files / 1308 tests pass unaffected
- [x] `npm run compile` (root) — clean
- [x] `npm pack --dry-run --workspace packages/diagrams` — confirmed no test/map entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)