### PR TITLE
docs(extension): reframe marketplace listing as a standalone diagram tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Text-first BPMN authoring: write your process as structured YAML, compile to val
 
 Transitrix Studio brings **text-first diagram authoring** to VS Code. Instead of dragging shapes in a GUI editor, you write YAML — structured, diffable, reviewable in pull requests. The compiler produces BPMN 2.0 XML with computed layout coordinates using the ELK (Eclipse Layout Kernel) engine.
 
-Studio previews the full Transitrix notation kit — **13 diagram notations** plus compliance views and canon artefacts (assertion / requirement). See [`extension/README.md`](extension/README.md) for the authoritative per-format list shipping in the VSIX, and the methodology repo for the notation specs themselves: [github.com/transitrix/methodology](https://github.com/transitrix/methodology).
+Studio previews the full Transitrix notation kit — **13 diagram notations** plus compliance and traceability views (assertion / requirement). See [`extension/README.md`](extension/README.md) for the authoritative per-format list shipping in the VSIX, and the methodology repo for the notation specs themselves: [github.com/transitrix/methodology](https://github.com/transitrix/methodology).
 
 > **Legacy identifiers.** The pre-rename `cervin` name is fully retired in extension **3.0+** and CLI **2.0+**. Use canonical `*.<short-name>.transitrix.yaml` suffixes (e.g. `*.bpmn.transitrix.yaml` for BPMN).
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -1,19 +1,19 @@
 # Transitrix Studio
 
-**Architecture-as-code for the modern enterprise.** Describe your organisation — goals, processes, capabilities, applications, BPMN flows — in plain YAML, and Transitrix Studio renders live diagrams inside VS Code. Review architectural changes like pull requests. Diff them. Version them. Hand them to an AI that actually reads YAML.
+**Diagrams as text, in your editor.** Write a diagram in a plain YAML file, and Transitrix Studio renders it live, right beside your code. No drag-and-drop canvas, no proprietary file format — just text you can diff, review in a pull request, and hand to an AI that reads it natively.
 
 ![Process landscape preview — YAML on the left, rendered diagram on the right](https://raw.githubusercontent.com/transitrix/transitrix-studio/main/extension/docs/preview.png)
 
-## Why text-native architecture?
+## Why text-native diagrams?
 
 Diagrams hidden in proprietary binary files don't survive contact with version control. They are hard to diff, hard to review, hard to merge. They drift from the truth they once described.
 
 Transitrix flips that:
 
-- **Your architecture lives in YAML files** — readable in any editor, diffable in git, reviewable in pull requests.
-- **Diagrams are derived, not authored** — never out of sync with the source of truth.
-- **AI works with it natively** — your assistant can read, edit, and reason about the entire enterprise model without leaving the repo.
-- **Built on open standards** — ArchiMate 3.2, BPMN 2.0, CMM. Your investment survives any single tool.
+- **The diagram lives in a YAML file** — readable in any editor, diffable in git, reviewable in pull requests.
+- **The picture is derived, not authored** — edit the text, save, and the diagram updates itself. Never out of sync.
+- **AI works with it natively** — your assistant can read, edit, and reason about the diagram's source without a plugin or export step.
+- **Built on open standards** — ArchiMate 3.2, BPMN 2.0, CMM. Your files aren't locked to this extension.
 
 ## 17 notations, one extension
 
@@ -44,13 +44,24 @@ The preview opens automatically when a recognised file becomes the active editor
 
 Transitrix and Mermaid are **complementary, not competing**. Use **Mermaid** for general-purpose diagrams — flowcharts, sequence diagrams, ER, Gantt. Use **Transitrix** for the structured enterprise notations Mermaid doesn't cover. Together: nearly 30 notations at your fingertips, both free and open source.
 
-## Get started in 60 seconds
+## Get started in 3 steps
 
 1. **Install this extension** — search for **Transitrix Studio** in the Extensions panel of VS Code, Cursor, VSCodium, or Windsurf.
-2. **Clone the starter repo:** `git clone https://github.com/transitrix/methodology`
-3. **Open any `.transitrix.yaml` file** under `notations/examples/` — preview opens automatically.
+2. **Create a file** ending in one of the recognised suffixes, e.g. `app.blocks.transitrix.yaml`:
 
-Recognised BPMN file suffixes are configurable in **Settings → Transitrix Studio**.
+   ```yaml
+   notation: blocks
+   nested_blocks:
+     id: BLOCKS-DEMO-1
+     name: "My app"
+     blocks:
+       - { id: FRONTEND, name: "Frontend" }
+       - { id: BACKEND, name: "Backend" }
+   ```
+
+3. **Save it.** The preview panel opens automatically beside the file and shows two connected boxes, "Frontend" and "Backend", inside a "My app" container — and re-renders on every save from then on.
+
+Every notation in the table above follows the same pattern: `*.<notation>.transitrix.yaml` in, live diagram out. Recognised suffixes are configurable in **Settings → Transitrix Studio**.
 
 > **Editors:** the extension ships to the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=transitrix.transitrix-studio) (VS Code) and to the [Open VSX Registry](https://open-vsx.org/extension/transitrix/transitrix-studio) (Cursor, VSCodium, Windsurf). The artefact is identical; pick whichever Extensions panel ships with your editor. **JetBrains IDEs** (IntelliJ IDEA and the rest) have a companion **Transitrix Studio** plugin — install it from **Settings → Plugins → Marketplace** and search for *Transitrix Studio*.
 
@@ -70,11 +81,14 @@ Configure under **Settings → Transitrix Studio**. The canonical keys are `tran
 | `transitrix.nodeSize.processBlueprint` | `normal` | Cell/column sizing preset for Process Blueprint (pairs with existing column-width slider). |
 | `transitrix.nodeSize.capabilityMap` | `normal` | Node size preset for Capability Map tree preview. |
 
+## Doing this for a whole system, not one diagram?
+
+Studio renders one file at a time — no repository, no setup beyond installing it. If you want to model an entire organization's goals, processes, and capabilities as one connected, version-controlled model instead of separate diagrams, that's a different job with its own quick start: **[set up an architecture repository →](https://github.com/transitrix/methodology)**
+
 ## Learn more
 
 - 🌐 **Site** — [transitrix.com](https://transitrix.com)
-- 📖 **Methodology canon** — [github.com/transitrix/methodology](https://github.com/transitrix/methodology)
 - 🧰 **Source & issues** — [github.com/transitrix/transitrix-studio](https://github.com/transitrix/transitrix-studio)
-- 📚 **Glossary** — see [`glossary.md`](https://github.com/transitrix/transitrix-studio/blob/main/glossary.md) in the repo root for domain terminology
+- 📚 **Glossary** — see [`glossary.md`](https://github.com/transitrix/transitrix-studio/blob/main/glossary.md) in the repo root for the notation terms used above
 
 Open source. MIT licensed. Built by [Valerii Korobeinikov](https://github.com/transitrix).

--- a/extension/package.json
+++ b/extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
   "version": "3.0.5",
-  "description": "Architecture-as-code for the modern enterprise. Author 17 notations — goals, processes, capabilities, BPMN, applications, more — as plain YAML, get live diagrams in VS Code. Diffable in git. AI-friendly. Open source. Built on ArchiMate 3.2 and BPMN 2.0.",
+  "description": "Diagrams as text. Write goals, processes, capabilities, BPMN, and more as plain YAML — 17 notations, live preview in VS Code. Diffable in git. AI-friendly. Open source.",
   "license": "MIT",
   "icon": "icon.png",
   "galleryBanner": { "color": "#004d67", "theme": "dark" },


### PR DESCRIPTION
## Summary

Implements the Track-A checklist from the two-track onboarding ADR (hub epic #576):

- **Reframed headline/intro** in `extension/README.md` (the file `vsce` packages as the VS Code Marketplace / Open VSX listing) around one concept — *diagrams are text*. Removed "architecture-as-code for the modern enterprise" / "describe your organisation" framing and all methodology/canon/architecture-repository/adopter vocabulary from the headline and intro.
- **3-step quickstart** (install → create a `.transitrix.yaml` file → save and see it render live), replacing the old step 2 that told newcomers to `git clone` the methodology starter repo mid-flow. Includes an inline 8-line working example (`notation: blocks`, two boxes) — validated with `transitrix validate` before committing.
- **Exactly one A→B bridge**, placed after the quickstart at the success moment: *"Doing this for a whole system, not one diagram? → set up an architecture repository"*, linking to the methodology repo's own quick start. The old second methodology link (in the former "Learn more" list) is gone — there is now exactly one link to `transitrix/methodology` in the file.
- `extension/package.json` `description` (the Marketplace search-results subtitle) reframed the same way.
- Root `README.md`: dropped the one literal "canon artefacts" phrase. Left the rest of the root README as-is — it documents CLI/repo-layout for contributors, not marketplace-facing copy, and isn't what a Marketplace visitor sees.

## Acceptance criteria (from the hub issue)

- [x] A newcomer following the extension README reaches a rendered diagram without encountering "methodology", "canon", or "architecture repository" before the bridge.
- [x] Exactly one A→B link exists in `extension/README.md`.
- [x] Marketplace listing text (`extension/README.md` + `package.json` description) is clean of the banned vocabulary.

## Note

Did not generate a new rendered screenshot specifically for the quickstart's 8-line example — reuses the existing hero image (`extension/docs/preview.png`) at the top of the README instead. A dedicated quickstart screenshot ties into the already-deferred "replace the hero preview" work; happy to pick that up separately if wanted.

## Test plan

- [x] `npm run verify-extension-packaging` — OK
- [x] Quickstart example validated: `transitrix validate demo.blocks.transitrix.yaml` → `valid: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)