### PR TITLE
fix: single-entity-file regexes false-matching BPMN/view files

### DIFF
--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -107,15 +107,15 @@ function isComplianceImpactFile(doc: vscode.TextDocument): boolean {
 }
 
 function isSingleLawFile(doc: vscode.TextDocument): boolean {
-  return /^(LAW|REGULATION|POLICY|INTERNAL_STANDARD)-.*\.ya?ml$/i.test(path.basename(doc.fileName));
+  return /^(LAW|REGULATION|POLICY|INTERNAL_STANDARD)-[^.]*\.ya?ml$/.test(path.basename(doc.fileName));
 }
 
 function isSingleProductFile(doc: vscode.TextDocument): boolean {
-  return /^PRODUCT-.*\.ya?ml$/i.test(path.basename(doc.fileName));
+  return /^PRODUCT-[^.]*\.ya?ml$/.test(path.basename(doc.fileName));
 }
 
 function isRequirementTraceFile(doc: vscode.TextDocument): boolean {
-  return /^(REQUIREMENT|CONSTRAINT)-.*\.ya?ml$/i.test(path.basename(doc.fileName));
+  return /^(REQUIREMENT|CONSTRAINT)-[^.]*\.ya?ml$/.test(path.basename(doc.fileName));
 }
 
 function probeDocNotation(doc: vscode.TextDocument): string | undefined {


### PR DESCRIPTION
## Summary
- Auto-preview picked the wrong renderer for files like `product-management-cycle.bpmn.transitrix.yaml`: opened the single-product compliance view (which then errored with "This file has no id") instead of the BPMN preview.
- Root cause: `isSingleProductFile`'s regex (`/^PRODUCT-.*\.ya?ml$/i`) is checked before the generic BPMN fallback in the auto-preview dispatcher. The case-insensitive flag plus an unanchored `.*` let it match any lowercase `product-`-prefixed filename, including ones with additional dotted suffixes.
- Tightened `isSingleProductFile`, and the two sibling checks that shared the exact same pattern (`isSingleLawFile`, `isRequirementTraceFile`), so they only match the intended single-entity filename shape (uppercase prefix, no dots before `.yaml`) and can no longer collide with multi-suffix view filenames.

## Test plan
- [x] `npm run compile:extension` — clean
- [x] `npm test` — 445/448 passing; the 3 failures are pre-existing on `main` (unrelated `cli-migrate` fixture drift against a newer methodology version), reproduced independently of this change
- [x] Verified the exact reported repro (`product-management-cycle.bpmn.transitrix.yaml`) no longer matches `isSingleProductFile`, while real single-entity fixtures (`PRODUCT-ECOMM-1.yaml`, `LAW-GDPR-1.yaml`, `REQUIREMENT-AUDIT-LOG-RETENTION-1.yaml`, `CONSTRAINT-GDPR-RESIDENCY-1.yaml`, `INTERNAL_STANDARD-coding-conventions-1.yaml`) still match

🤖 Generated with [Claude Code](https://claude.com/claude-code)