### PR TITLE
fix(extension): allow WebAssembly compilation in the PlantUML preview CSP

### DIFF
--- a/extension/src/plantuml-preview.ts
+++ b/extension/src/plantuml-preview.ts
@@ -167,7 +167,7 @@ function buildHtml(webview: vscode.Webview, mediaDir: vscode.Uri): string {
 <head>
   <meta charset="UTF-8"/>
   <meta http-equiv="Content-Security-Policy"
-    content="default-src 'none'; style-src 'unsafe-inline'; script-src ${escHtml(cspSource)}; img-src data: blob:;">
+    content="default-src 'none'; style-src 'unsafe-inline'; script-src ${escHtml(cspSource)} 'wasm-unsafe-eval'; img-src data: blob:;">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
     html, body { width: 100%; height: 100%; overflow: hidden; }


### PR DESCRIPTION
## Summary
- The PlantUML preview webview's CSP (`script-src 'self' https://*.vscode-cdn.net`) had no eval-class permission, so `WebAssembly.instantiate()` inside the bundled `@plantuml/core` engine failed to compile and the preview never rendered.
- Adds the narrow `'wasm-unsafe-eval'` token to `script-src` in `extension/src/plantuml-preview.ts`'s `buildHtml()` — permits WebAssembly compilation only, not general JS eval.
- Confirmed no other webview in this extension loads WebAssembly (bpmn-js and the static SVG previews are pure JS/SVG), so the fix is scoped to the PlantUML preview only.

## Test plan
- [x] `npm run compile:extension` — clean, no type errors.
- [ ] Manual: open a `.puml` file in the Extension Development Host (F5) and confirm it renders instead of showing the CSP/WebAssembly error. A ready repro file is referenced in the originating report (`communications/articles/2026-07-13-compliance-impact/impact-graph.puml` in the strategy hub). Not run by me — no GUI automation harness in this repo to drive a native VS Code window; also no existing test runner for `extension/` to add an automated regression test against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)