### PR TITLE
chore(release): bump extension to 3.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,16 @@
 
 ## Unreleased
 
+## [3.0.7] — 2026-07-14
+
 ### Changed
 
+- **One unified Preview button, everywhere** (#395). Every notation (BPMN, Goals, DGCA/DGA, Blocks, Capability Map, Process Blueprint, PlantUML, and the rest) now shares a single "Transitrix: Open Preview" command and editor-title button carrying the monochrome Transitrix mark, instead of 20+ near-identical per-notation preview commands. Compliance Matrix and Gap Dashboard keep their own commands since they're repo-wide dashboards, not tied to one open file.
 - **`@transitrix/diagrams` 1.8.6 → 1.8.7** — the published npm package no longer includes test fixtures (`__tests__/`, `*.test.ts(x)`) or stray source maps in `dist/` or `src/`; package size roughly halved. No runtime behavior change.
+
+### Fixed
+
+- **PlantUML preview no longer fails with a CSP/WebAssembly compile error** (#396). The webview's Content-Security-Policy had no eval-class permission, so `WebAssembly.instantiate()` inside the bundled PlantUML engine couldn't compile. Added the narrow `'wasm-unsafe-eval'` token to `script-src` — permits WebAssembly compilation only, not general JS eval.
 
 ## [3.0.6] — 2026-07-13
 

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,9 +2,17 @@
 
 ## Unreleased
 
+## 3.0.7 — 2026-07-14
+
+One Preview button for every notation, and a PlantUML rendering fix.
+
 ### Changed
 
 - **One unified Preview button, everywhere.** Every notation (BPMN, Goals, DGCA/DGA, Blocks, Capability Map, Process Blueprint, PlantUML, and the rest) now shares a single "Transitrix: Open Preview" command and editor-title button carrying the monochrome Transitrix mark, instead of 20+ near-identical per-notation preview commands. Opening a supported file always shows the same, recognisable "see this rendered" affordance in the same place. Compliance Matrix and Gap Dashboard keep their own commands since they're repo-wide dashboards, not tied to one open file.
+
+### Fixed
+
+- **PlantUML preview no longer fails with a CSP/WebAssembly compile error.** The webview's Content-Security-Policy had no eval-class permission for WebAssembly, so the bundled PlantUML engine (compiled to wasm) never finished compiling and the preview stayed blank. Added the narrow `'wasm-unsafe-eval'` token to `script-src` — permits WebAssembly compilation only, not general JS eval.
 
 ## 3.0.6 — 2026-07-13
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,11 +2,14 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "Diagrams as text. Write goals, processes, capabilities, BPMN, and more as plain YAML — 17 notations, live preview in VS Code. Diffable in git. AI-friendly. Open source.",
   "license": "MIT",
   "icon": "icon.png",
-  "galleryBanner": { "color": "#004d67", "theme": "dark" },
+  "galleryBanner": {
+    "color": "#004d67",
+    "theme": "dark"
+  },
   "homepage": "https://github.com/transitrix/transitrix-studio#readme",
   "bugs": {
     "url": "https://github.com/transitrix/transitrix-studio/issues"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "transitrix-studio",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "transitrix-studio",
-      "version": "3.0.6",
+      "version": "3.0.7",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
## Summary
- Bumps `extension/package.json` and `package.json` from 3.0.6 → 3.0.7 (`node scripts/bump-extension-version.mjs`, patch), syncs `package-lock.json`.
- Finalizes `CHANGELOG.md` and `extension/CHANGELOG.md`: moves the pending Unreleased content into a dated `3.0.7` section and adds the changelog entry that was missing for the PlantUML CSP fix.

Bundles everything merged into `main` since 3.0.6:
- One unified Preview button, everywhere (#395)
- PlantUML preview: fix CSP/WebAssembly compile error (#396)
- `@transitrix/diagrams` 1.8.6 → 1.8.7 — npm package hygiene, already published (#392), changelog catch-up only

## Test plan
- [x] `npm run compile:extension` — clean.
- [x] Diff matches the established `chore/release-X.Y.Z` pattern (compared against PR #391).
- [ ] VSIX packaging (`npm run package-extension`) — not run; only on your explicit request per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)