### PR TITLE
fix(diagrams): rewrite dist relative imports to be fully-specified ESM

### DIFF
--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.8.7",
+  "version": "1.8.8",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",
@@ -40,6 +40,7 @@
   ],
   "scripts": {
     "build": "tsc -p .",
+    "postbuild": "node scripts/fix-esm-extensions.mjs",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/packages/diagrams/scripts/fix-esm-extensions.mjs
+++ b/packages/diagrams/scripts/fix-esm-extensions.mjs
@@ -1,0 +1,32 @@
+// postbuild step: tsc (moduleResolution "bundler") emits relative import/export
+// specifiers exactly as written in src/ — which is extensionless barrel-style
+// (`from "./capability-map/index"`). That's fine for bundler consumers but
+// fails Node's strict ESM resolution (this package declares "type": "module"),
+// which is what a plain `import`/CRA-webpack build enforces. Rewrite the
+// compiled dist/**/*.js in place so every relative specifier is fully
+// specified, without touching src/ or the tsconfig moduleResolution mode.
+import { readdirSync, statSync, readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, extname } from "node:path";
+
+const DIST_DIR = join(dirname(fileURLToPath(import.meta.url)), "..", "dist");
+const SPECIFIER_RE = /((?:from|import)\s*\(?\s*['"])(\.\.?\/[^'"]+)(['"])/g;
+const HAS_EXTENSION_RE = /\.(js|mjs|cjs|json)$/;
+
+function fixFile(path) {
+  const src = readFileSync(path, "utf8");
+  const fixed = src.replace(SPECIFIER_RE, (match, pre, spec, post) =>
+    HAS_EXTENSION_RE.test(spec) ? match : `${pre}${spec}.js${post}`
+  );
+  if (fixed !== src) writeFileSync(path, fixed, "utf8");
+}
+
+function walk(dir) {
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) walk(path);
+    else if (extname(path) === ".js") fixFile(path);
+  }
+}
+
+walk(DIST_DIR);


### PR DESCRIPTION
## Summary

- `packages/diagrams`'s `tsc -p .` (moduleResolution `"bundler"`) emits `src/`'s barrel-style extensionless relative imports (e.g. `from "./capability-map/index"`) verbatim into `dist/`. That resolves fine for bundler consumers using loose resolution, but the package declares `"type": "module"`, and a strict Node/webpack ESM consumer (e.g. Create React App/webpack in DSM) rejects it: `Module not found: Error: Can't resolve './capability-map/index'`.
- Confirmed this is present in every published version through the current latest (1.8.7) by downloading the npm tarballs directly and grepping `dist/index.js`.
- This is what's blocking transitrix-dsm PR #119 (M3 — consume `@transitrix/diagrams`): its `frontend-tests` job fails at `Build (type-check)` with exactly this error.

## Fix

Added `packages/diagrams/scripts/fix-esm-extensions.mjs`, wired as a `postbuild` step, that rewrites every relative `import`/`export`/dynamic-`import()` specifier in the compiled `dist/**/*.js` to be fully-specified (adds `.js` if missing). Chose this over either (a) hand-editing the ~56 extensionless specifiers across `src/` or (b) switching the whole package to `moduleResolution: "NodeNext"`, since both are broader changes to a shared package with other consumers (the Studio extension itself), and this fix is scoped to the actual defect (the published dist output) without touching source or the type-check mode.

Bumped `1.8.7` → `1.8.8` so a new npm version exists once released.

## Verification

- `npm run build` in `packages/diagrams` → `grep` across `dist/**/*.js` for extensionless relative specifiers: 0 remaining (was 1 in `index.js` alone, more elsewhere e.g. `fgca/index.js`).
- `npm test` (vitest) in `packages/diagrams`: 82 files / 1308 tests, all passing — no behavior change, dist-only rewrite.

## Follow-up (out of scope for this PR)

1. Merge this PR, then cut a GitHub Release to trigger `.github/workflows/npm-publish.yml` and actually publish `1.8.8` to npm.
2. transitrix-dsm's `package-lock.json` has `@transitrix/diagrams` pinned at `1.6.0` (predates this fix) despite the `^1.6.0` range in `package.json` — `npm ci` always installs the locked `1.6.0`. DSM needs a dependency-bump PR once `1.8.8` is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)