### PR TITLE
fix(extension): mount PlantUML preview on the shared preview shell

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -615,6 +615,12 @@
         "icon": "$(save)"
       },
       {
+        "command": "transitrixStudio.savePumlAsSvg",
+        "title": "Transitrix: Save PlantUML diagram as SVG",
+        "category": "Transitrix",
+        "icon": "$(save)"
+      },
+      {
         "command": "transitrixStudio.exportActionTreeAsMarkdown",
         "title": "Transitrix: Export action tree as Markdown",
         "category": "Transitrix",
@@ -680,6 +686,16 @@
       {
         "command": "transitrixStudio.copyDGAAsPng",
         "title": "Transitrix: Copy DGA diagram as PNG",
+        "category": "Transitrix"
+      },
+      {
+        "command": "transitrixStudio.savePumlAsPng",
+        "title": "Transitrix: Save PlantUML diagram as PNG",
+        "category": "Transitrix"
+      },
+      {
+        "command": "transitrixStudio.copyPumlAsPng",
+        "title": "Transitrix: Copy PlantUML diagram as PNG",
         "category": "Transitrix"
       },
       {
@@ -831,6 +847,16 @@
         {
           "when": "activeWebviewPanelId == dgaPreview",
           "command": "transitrixStudio.saveDGAAsSvg",
+          "group": "navigation@-9"
+        },
+        {
+          "when": "resourceFilename =~ /\\.(puml|plantuml)$/",
+          "command": "transitrixStudio.savePumlAsSvg",
+          "group": "navigation@-9"
+        },
+        {
+          "when": "activeWebviewPanelId == transitrixPumlPreview",
+          "command": "transitrixStudio.savePumlAsSvg",
           "group": "navigation@-9"
         },
         {

--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -165,9 +165,9 @@ export interface DiagramFrameOpts {
     extraScripts?: Array<{ src: string; module?: boolean }>;
     /**
      * Widens the CSP for a wasm-based rendering engine running in the
-     * webview (vkgeorgia/strategy#597 — PlantUML preview): appends
-     * `'wasm-unsafe-eval'` to `script-src` and adds `img-src data: blob:;`.
-     * Omit for previews that don't run wasm.
+     * webview (the PlantUML preview): appends `'wasm-unsafe-eval'` to
+     * `script-src` and adds `img-src data: blob:;`. Omit for previews that
+     * don't run wasm.
      */
     allowWasmRendering?: boolean;
   };

--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -154,6 +154,22 @@ export interface DiagramFrameOpts {
      * actions. Pass '' / omit when the preview has no toolbar control.
      */
     viewToggleHtml?: string;
+    /**
+     * Extra `<script>` tags appended after the controls script — for previews
+     * whose rendering engine loads external files (e.g. the PlantUML wasm
+     * client). Each renders as `<script nonce="…" [type="module"] src="…">`;
+     * a CSP nonce covers external-`src` script elements the same as inline
+     * ones, so no `script-src` host-listing is needed. Omit for previews with
+     * no extra scripts (the four spacing/curvature/scope previews).
+     */
+    extraScripts?: Array<{ src: string; module?: boolean }>;
+    /**
+     * Widens the CSP for a wasm-based rendering engine running in the
+     * webview (vkgeorgia/strategy#597 — PlantUML preview): appends
+     * `'wasm-unsafe-eval'` to `script-src` and adds `img-src data: blob:;`.
+     * Omit for previews that don't run wasm.
+     */
+    allowWasmRendering?: boolean;
   };
   /**
    * When present, injects snapshot capture + timeline UI into the frame.
@@ -568,13 +584,20 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
   // Interactive previews (vkgeorgia/strategy#75/#76/#77 PR2) opt into a strict
   // nonce-based CSP and the in-preview control panel. Static previews keep the
   // script-less CSP unchanged — the only diff in their output is none.
+  const wasmScriptSrc = interactive?.allowWasmRendering ? " 'wasm-unsafe-eval'" : '';
+  const wasmImgSrc = interactive?.allowWasmRendering ? ' img-src data: blob:;' : '';
   const csp = interactive
-    ? `default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${interactive.nonce}';`
+    ? `default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${interactive.nonce}'${wasmScriptSrc};${wasmImgSrc}`
     : `default-src 'none'; style-src 'unsafe-inline';`;
   const controlsCss = interactive ? CONTROLS_PANEL_CSS : '';
   const snapshotCss = snapshotUi ? SNAPSHOT_TOOLBAR_CSS : '';
   const controlsPanel = interactive ? interactive.controlsPanel : '';
   const controlsScript = interactive ? interactive.controlsScript : '';
+  const extraScriptTags = interactive?.extraScripts
+    ? interactive.extraScripts
+        .map(s => `<script nonce="${interactive.nonce}"${s.module ? ' type="module"' : ''} src="${escXml(s.src)}"></script>`)
+        .join('\n  ')
+    : '';
 
   // Timeline strip and info box — rendered below the controls panel when snapshotUi present.
   const timelineStrip = snapshotUi?.timelineStrip ?? '';
@@ -620,6 +643,7 @@ ${extraStyles}
     ${canvasContent}
   </div>
   ${controlsScript}
+  ${extraScriptTags}
 </body>
 </html>`;
 }

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -387,8 +387,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     vscode.commands.registerCommand('transitrixStudio.copyDGCAAsPng', () => dgcaPreview.copyAsPng()),
     vscode.commands.registerCommand('transitrixStudio.saveDGAAsPng', () => dgaPreview.saveAsPng()),
     vscode.commands.registerCommand('transitrixStudio.copyDGAAsPng', () => dgaPreview.copyAsPng()),
-    // PlantUML export — same shared-shell contract as the notations above
-    // (vkgeorgia/strategy#597), even though rendering happens webview-side.
+    // PlantUML export — same shared-shell contract as the notations above,
+    // even though rendering happens webview-side.
     vscode.commands.registerCommand('transitrixStudio.savePumlAsSvg', () => plantumlPreview.saveAsSvg()),
     vscode.commands.registerCommand('transitrixStudio.savePumlAsPng', () => plantumlPreview.saveAsPng()),
     vscode.commands.registerCommand('transitrixStudio.copyPumlAsPng', () => plantumlPreview.copyAsPng()),

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -387,6 +387,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     vscode.commands.registerCommand('transitrixStudio.copyDGCAAsPng', () => dgcaPreview.copyAsPng()),
     vscode.commands.registerCommand('transitrixStudio.saveDGAAsPng', () => dgaPreview.saveAsPng()),
     vscode.commands.registerCommand('transitrixStudio.copyDGAAsPng', () => dgaPreview.copyAsPng()),
+    // PlantUML export — same shared-shell contract as the notations above
+    // (vkgeorgia/strategy#597), even though rendering happens webview-side.
+    vscode.commands.registerCommand('transitrixStudio.savePumlAsSvg', () => plantumlPreview.saveAsSvg()),
+    vscode.commands.registerCommand('transitrixStudio.savePumlAsPng', () => plantumlPreview.saveAsPng()),
+    vscode.commands.registerCommand('transitrixStudio.copyPumlAsPng', () => plantumlPreview.copyAsPng()),
     vscode.commands.registerCommand('transitrixStudio.saveActivitiesAsPng', () => actionPreview.saveAsPng()),
     vscode.commands.registerCommand('transitrixStudio.copyActivitiesAsPng', () => actionPreview.copyAsPng()),
     vscode.commands.registerCommand('transitrixStudio.exportActionTreeAsMarkdown', () => actionPreview.exportTreeAsMarkdown()),
@@ -486,6 +491,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       void processBlueprintPreview.refreshConfig();
       void capabilityMapPreview.refreshConfig();
       if (isThemeChange) {
+        void plantumlPreview.refreshConfig();
         void activityCardPreview.refreshConfig();
         void applicationsPreview.refreshConfig();
         void productsPreview.refreshConfig();

--- a/extension/src/plantuml-preview.ts
+++ b/extension/src/plantuml-preview.ts
@@ -1,11 +1,18 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
+import { buildDiagramFrame, prepareSvgForExport, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
+import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
+import { genNonce } from './preview-controls.js';
 
 /** Detects `.puml` files (also accepts `.plantuml`). */
 export function isPumlFile(doc: vscode.TextDocument): boolean {
   const n = doc.fileName;
   return n.endsWith('.puml') || n.endsWith('.plantuml');
 }
+
+const SAVE_SVG_COMMAND = 'transitrixStudio.savePumlAsSvg';
+const SAVE_PNG_COMMAND = 'transitrixStudio.savePumlAsPng';
+const COPY_PNG_COMMAND = 'transitrixStudio.copyPumlAsPng';
 
 /**
  * PlantUML `.puml` / `.plantuml` file preview powered by @plantuml/core
@@ -16,13 +23,28 @@ export function isPumlFile(doc: vscode.TextDocument): boolean {
  * source (Smetana pragma + optional Transitrix theme injection) and delivers
  * it over postMessage. The webview signals readiness and the host flushes
  * any pending source.
+ *
+ * The chrome (toolbar, save/copy/zoom/theme, title toggle) is the shared
+ * `buildDiagramFrame` shell (vkgeorgia/strategy#597) — only the canvas
+ * scaffold (loading/error/output divs) and the wasm engine's own script tags
+ * are PlantUML-specific. Since rendering happens webview-side and
+ * asynchronously, the rendered SVG is pushed back to the host via a
+ * `rendered` postMessage so Save/Copy can read it synchronously, the same
+ * way every other preview reads its host-held `lastSvg`.
  */
 export class PlantUMLPreview {
   readonly panelTitle = 'PlantUML Preview';
   private panel: vscode.WebviewPanel | undefined;
   private trackedUri: string | undefined;
   private webviewReady = false;
-  private pendingSource: string | undefined;
+  private pendingSource: { source: string; seq: number } | undefined;
+  private lastSvg = '';
+  // Bumped on every sendDocument() call and echoed back by the webview in its
+  // `rendered` message. The wasm render is async and multiple can be
+  // in-flight at once (e.g. switching the tracked file mid-render) — without
+  // this, a slow render for a since-superseded source could resolve last and
+  // overwrite `lastSvg` (and the canvas) with the wrong file's diagram.
+  private renderSeq = 0;
 
   constructor(private readonly extensionUri: vscode.Uri) {}
 
@@ -48,6 +70,7 @@ export class PlantUMLPreview {
           enableScripts: true,
           retainContextWhenHidden: true,
           localResourceRoots: [mediaDir],
+          enableCommandUris: [SAVE_SVG_COMMAND, SAVE_PNG_COMMAND, COPY_PNG_COMMAND, OPEN_THEME_COMMAND],
         },
       );
 
@@ -55,9 +78,12 @@ export class PlantUMLPreview {
         if (isReadyMessage(msg)) {
           this.webviewReady = true;
           if (this.pendingSource !== undefined) {
-            void this.panel?.webview.postMessage({ type: 'render', source: this.pendingSource });
+            void this.panel?.webview.postMessage({ type: 'render', source: this.pendingSource.source, seq: this.pendingSource.seq });
             this.pendingSource = undefined;
           }
+        } else if (isRenderedMessage(msg)) {
+          // Ignore a stale render that lost the race against a newer one.
+          if (msg.seq === this.renderSeq) this.lastSvg = msg.svg;
         }
       });
 
@@ -66,9 +92,10 @@ export class PlantUMLPreview {
         this.trackedUri = undefined;
         this.webviewReady = false;
         this.pendingSource = undefined;
+        this.lastSvg = '';
       });
 
-      this.panel.webview.html = buildHtml(this.panel.webview, mediaDir);
+      this.panel.webview.html = this.buildFrameHtml(this.panel.webview, mediaDir, path.basename(doc.fileName));
     }
 
     await this.sendDocument(doc);
@@ -79,14 +106,114 @@ export class PlantUMLPreview {
     await this.sendDocument(doc);
   }
 
+  /** Re-render the tracked document — used when the theme setting changes.
+   *  Rebuilds the whole frame (the new theme is baked into the served HTML),
+   *  so the wasm engine re-initialises the same way it does on first open. */
+  async refreshConfig(): Promise<void> {
+    if (!this.panel || !this.trackedUri) return;
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.parse(this.trackedUri));
+    const mediaDir = vscode.Uri.joinPath(this.extensionUri, 'media', 'plantuml');
+    this.webviewReady = false;
+    this.pendingSource = undefined;
+    this.panel.webview.html = this.buildFrameHtml(this.panel.webview, mediaDir, path.basename(doc.fileName));
+    await this.sendDocument(doc);
+  }
+
   private async sendDocument(doc: vscode.TextDocument): Promise<void> {
     if (!this.panel) return;
+    this.renderSeq += 1;
+    const seq = this.renderSeq;
+    // The in-flight source no longer matches whatever SVG the webview last
+    // rendered — clear it so an export mid-refresh can't hand back stale
+    // (or a different file's) content. The webview pushes a fresh one back
+    // once it finishes rendering.
+    this.lastSvg = '';
     const source = await prepareSource(doc);
+    // A newer sendDocument() call ran while prepareSource() was awaiting —
+    // this one is already stale, don't send it.
+    if (seq !== this.renderSeq) return;
     if (this.webviewReady) {
-      void this.panel.webview.postMessage({ type: 'render', source });
+      void this.panel.webview.postMessage({ type: 'render', source, seq });
     } else {
-      this.pendingSource = source;
+      this.pendingSource = { source, seq };
     }
+  }
+
+  private pngTarget(): { rawSvg: string | undefined; themeId: ThemeId; emptyMessage: string } {
+    return {
+      rawSvg: this.lastSvg || undefined,
+      themeId: vscode.workspace.getConfiguration('transitrix').get<ThemeId>('theme', 'transitrix'),
+      emptyMessage: 'No diagram rendered yet. Open a .puml/.plantuml file with valid PlantUML source first.',
+    };
+  }
+
+  saveAsPng(): Promise<void> {
+    return savePngFromSvg({ ...this.pngTarget(), sourceUri: this.sourceUri(), stripExt: /\.(puml|plantuml)$/ });
+  }
+
+  copyAsPng(): Promise<void> {
+    return copyPngFromSvg(this.pngTarget());
+  }
+
+  async saveAsSvg(): Promise<void> {
+    if (!this.lastSvg) {
+      vscode.window.showWarningMessage('No diagram rendered yet. Open a .puml/.plantuml file with valid PlantUML source first.');
+      return;
+    }
+    const sourceUri = this.sourceUri();
+    const stem = sourceUri
+      ? path.basename(sourceUri.fsPath).replace(/\.(puml|plantuml)$/, '')
+      : 'diagram';
+    const defaultUri = sourceUri
+      ? vscode.Uri.file(path.join(path.dirname(sourceUri.fsPath), `${stem}.svg`))
+      : vscode.Uri.file(`${stem}.svg`);
+    const target = await vscode.window.showSaveDialog({ defaultUri, filters: { 'SVG Image': ['svg'] } });
+    if (!target) return;
+    const themeId = vscode.workspace.getConfiguration('transitrix').get<ThemeId>('theme', 'transitrix');
+    const svg = prepareSvgForExport(this.lastSvg, themeId);
+    await vscode.workspace.fs.writeFile(target, Buffer.from(svg, 'utf-8'));
+    vscode.window.showInformationMessage(`Saved: ${path.basename(target.fsPath)}`);
+  }
+
+  private sourceUri(): vscode.Uri | undefined {
+    return this.trackedUri ? vscode.Uri.parse(this.trackedUri) : undefined;
+  }
+
+  private buildFrameHtml(webview: vscode.Webview, mediaDir: vscode.Uri, filename: string): string {
+    const vizUri = webview.asWebviewUri(vscode.Uri.joinPath(mediaDir, 'viz-global.js'));
+    const clientUri = webview.asWebviewUri(vscode.Uri.joinPath(mediaDir, 'plantuml-client.js'));
+    const themeId = vscode.workspace.getConfiguration('transitrix').get<ThemeId>('theme', 'transitrix');
+    const nonce = genNonce();
+
+    const bodyContent = `<div id="puml-loading">Rendering diagram…</div>
+    <div id="puml-error">
+      <div id="puml-error-title"></div>
+      <pre id="puml-error-body"></pre>
+      <div id="puml-error-hint"></div>
+    </div>
+    <div id="puml-output"></div>`;
+
+    return buildDiagramFrame({
+      filename,
+      notation: 'PlantUML',
+      bodyContent,
+      themeId,
+      extraStyles: PUML_EXTRA_STYLES,
+      saveSvgCommand: SAVE_SVG_COMMAND,
+      savePngCommand: SAVE_PNG_COMMAND,
+      copyPngCommand: COPY_PNG_COMMAND,
+      themeCommand: OPEN_THEME_COMMAND,
+      interactive: {
+        nonce,
+        controlsPanel: '',
+        controlsScript: '',
+        extraScripts: [
+          { src: vizUri.toString() },
+          { src: clientUri.toString(), module: true },
+        ],
+        allowWasmRendering: true,
+      },
+    });
   }
 }
 
@@ -94,6 +221,16 @@ export class PlantUMLPreview {
 
 function isReadyMessage(msg: unknown): boolean {
   return typeof msg === 'object' && msg !== null && (msg as Record<string, unknown>).type === 'ready';
+}
+
+function isRenderedMessage(msg: unknown): msg is { type: 'rendered'; svg: string; seq: number } {
+  return (
+    typeof msg === 'object' &&
+    msg !== null &&
+    (msg as Record<string, unknown>).type === 'rendered' &&
+    typeof (msg as Record<string, unknown>).svg === 'string' &&
+    typeof (msg as Record<string, unknown>).seq === 'number'
+  );
 }
 
 /**
@@ -150,98 +287,39 @@ async function readWorkspaceTheme(): Promise<string | undefined> {
   return undefined;
 }
 
-function escHtml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+/** Loading/error card styling for the PlantUML canvas scaffold. The toolbar,
+ *  toggle, zoom, and save/theme controls come from the shared frame CSS. */
+const PUML_EXTRA_STYLES = `
+#puml-loading {
+  display: none;
+  padding: 16px;
+  font-size: 12px;
+  color: var(--vscode-descriptionForeground, #64748b);
 }
-
-function buildHtml(webview: vscode.Webview, mediaDir: vscode.Uri): string {
-  const cspSource = webview.cspSource;
-  const vizUri = webview.asWebviewUri(vscode.Uri.joinPath(mediaDir, 'viz-global.js'));
-  const clientUri = webview.asWebviewUri(vscode.Uri.joinPath(mediaDir, 'plantuml-client.js'));
-
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8"/>
-  <meta http-equiv="Content-Security-Policy"
-    content="default-src 'none'; style-src 'unsafe-inline'; script-src ${escHtml(cspSource)} 'wasm-unsafe-eval'; img-src data: blob:;">
-  <style>
-    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-    html, body { width: 100%; height: 100%; overflow: hidden; }
-    body {
-      display: flex; flex-direction: column;
-      background: var(--vscode-editor-background, #fff);
-      color: var(--vscode-editor-foreground, #000);
-      font-family: var(--vscode-font-family, system-ui, sans-serif);
-      font-size: var(--vscode-font-size, 13px);
-    }
-    #puml-toolbar {
-      flex-shrink: 0;
-      padding: 6px 12px;
-      border-bottom: 1px solid var(--vscode-panel-border, #e2e8f0);
-      font-size: 11px;
-      color: var(--vscode-descriptionForeground, #64748b);
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-    #puml-loading {
-      display: none;
-      padding: 16px;
-      font-size: 12px;
-      color: var(--vscode-descriptionForeground, #64748b);
-    }
-    #puml-error {
-      display: none;
-      margin: 12px 16px;
-      border: 1px solid var(--vscode-inputValidation-errorBorder, #b91c1c);
-      border-radius: 6px;
-    }
-    #puml-error-title {
-      padding: 8px 12px;
-      font-size: 12px;
-      font-weight: 600;
-      color: var(--vscode-errorForeground, #b91c1c);
-    }
-    #puml-error-body {
-      padding: 0 12px 8px;
-      font-size: 11px;
-      color: var(--vscode-errorForeground, #b91c1c);
-      white-space: pre-wrap;
-      font-family: var(--vscode-editor-font-family, monospace);
-      max-height: 200px;
-      overflow-y: auto;
-    }
-    #puml-error-hint {
-      padding: 0 12px 10px;
-      font-size: 11px;
-      color: var(--vscode-descriptionForeground, #64748b);
-    }
-    #puml-output {
-      flex: 1;
-      overflow: auto;
-      padding: 16px;
-    }
-    #puml-output svg {
-      max-width: 100%;
-      height: auto;
-    }
-  </style>
-</head>
-<body>
-  <div id="puml-toolbar">PlantUML Preview — loading engine…</div>
-  <div id="puml-loading">Rendering diagram…</div>
-  <div id="puml-error">
-    <div id="puml-error-title"></div>
-    <pre id="puml-error-body"></pre>
-    <div id="puml-error-hint"></div>
-  </div>
-  <div id="puml-output"></div>
-
-  <!-- Graphviz layout engine — must load before plantuml.js -->
-  <script src="${escHtml(vizUri.toString())}"></script>
-  <!-- PlantUML client module (statically imports plantuml.js from same dir) -->
-  <script type="module" src="${escHtml(clientUri.toString())}"></script>
-</body>
-</html>`;
+#puml-error {
+  display: none;
+  margin: 12px 16px;
+  border: 1px solid var(--vscode-inputValidation-errorBorder, #b91c1c);
+  border-radius: 6px;
 }
+#puml-error-title {
+  padding: 8px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--vscode-errorForeground, #b91c1c);
+}
+#puml-error-body {
+  padding: 0 12px 8px;
+  font-size: 11px;
+  color: var(--vscode-errorForeground, #b91c1c);
+  white-space: pre-wrap;
+  font-family: var(--vscode-editor-font-family, monospace);
+  max-height: 200px;
+  overflow-y: auto;
+}
+#puml-error-hint {
+  padding: 0 12px 10px;
+  font-size: 11px;
+  color: var(--vscode-descriptionForeground, #64748b);
+}
+`;

--- a/extension/src/plantuml-preview.ts
+++ b/extension/src/plantuml-preview.ts
@@ -25,12 +25,12 @@ const COPY_PNG_COMMAND = 'transitrixStudio.copyPumlAsPng';
  * any pending source.
  *
  * The chrome (toolbar, save/copy/zoom/theme, title toggle) is the shared
- * `buildDiagramFrame` shell (vkgeorgia/strategy#597) — only the canvas
- * scaffold (loading/error/output divs) and the wasm engine's own script tags
- * are PlantUML-specific. Since rendering happens webview-side and
- * asynchronously, the rendered SVG is pushed back to the host via a
- * `rendered` postMessage so Save/Copy can read it synchronously, the same
- * way every other preview reads its host-held `lastSvg`.
+ * `buildDiagramFrame` shell — only the canvas scaffold (loading/error/output
+ * divs) and the wasm engine's own script tags are PlantUML-specific. Since
+ * rendering happens webview-side and asynchronously, the rendered SVG is
+ * pushed back to the host via a `rendered` postMessage so Save/Copy can read
+ * it synchronously, the same way every other preview reads its host-held
+ * `lastSvg`.
  */
 export class PlantUMLPreview {
   readonly panelTitle = 'PlantUML Preview';

--- a/scripts/build-plantuml-assets.mjs
+++ b/scripts/build-plantuml-assets.mjs
@@ -61,7 +61,15 @@ function humanizeError(raw) {
   return { title: 'Diagram error', hint: '' };
 }
 
-function renderDiagram(source) {
+// Tracks the most recently requested render. renderToString is async and the
+// host can send a newer 'render' before an older one resolves (e.g. the user
+// switches the tracked file mid-render) — a stale callback firing after a
+// newer one would overwrite the canvas and the host's exported SVG with the
+// wrong diagram, so late callbacks for a superseded seq are dropped.
+let latestSeq = 0;
+
+function renderDiagram(source, seq) {
+  latestSeq = seq;
   const loadingEl = document.getElementById('puml-loading');
   const errorCard = document.getElementById('puml-error');
   const errorTitle = document.getElementById('puml-error-title');
@@ -76,16 +84,25 @@ function renderDiagram(source) {
   renderToString(
     source.split('\\n'),
     (svg) => {
+      if (seq !== latestSeq) return;
       outputEl.innerHTML = svg;
       loadingEl.style.display = 'none';
+      // Push the rendered SVG back to the host so Save/Copy can read it
+      // synchronously — rendering happens here in the webview (wasm engine),
+      // never host-side, so this is the only way the host ever sees it.
+      vscode.postMessage({ type: 'rendered', svg: svg, seq: seq });
     },
     (err) => {
+      if (seq !== latestSeq) return;
       const { title, hint } = humanizeError(err);
       errorTitle.textContent = title;
       errorBody.textContent = typeof err === 'string' ? err : String(err ?? '');
       errorHint.textContent = hint;
       errorCard.style.display = 'block';
       loadingEl.style.display = 'none';
+      // Clear the host's held SVG — the last successful render no longer
+      // matches what's on screen (the error card replaced it).
+      vscode.postMessage({ type: 'rendered', svg: '', seq: seq });
     },
   );
 }
@@ -93,7 +110,7 @@ function renderDiagram(source) {
 window.addEventListener('message', (event) => {
   const msg = event.data;
   if (msg?.type === 'render') {
-    renderDiagram(msg.source);
+    renderDiagram(msg.source, msg.seq);
   }
 });
 

--- a/tests/diagram-frame.test.ts
+++ b/tests/diagram-frame.test.ts
@@ -118,9 +118,9 @@ describe('buildDiagramFrame warnings strip', () => {
   });
 });
 
-// vkgeorgia/strategy#597 — the PlantUML preview needs to load its wasm
-// rendering engine as external <script> files inside the frame's strict
-// nonce CSP, rather than re-implementing a bespoke toolbar/CSP.
+// The PlantUML preview needs to load its wasm rendering engine as external
+// <script> files inside the frame's strict nonce CSP, rather than
+// re-implementing a bespoke toolbar/CSP.
 describe('buildDiagramFrame interactive.extraScripts / allowWasmRendering', () => {
   const interactiveBase = { nonce: 'test-nonce', controlsPanel: '', controlsScript: '' };
 

--- a/tests/diagram-frame.test.ts
+++ b/tests/diagram-frame.test.ts
@@ -117,3 +117,48 @@ describe('buildDiagramFrame warnings strip', () => {
     expect(html).toContain('&lt;script&gt;x&lt;/script&gt;');
   });
 });
+
+// vkgeorgia/strategy#597 — the PlantUML preview needs to load its wasm
+// rendering engine as external <script> files inside the frame's strict
+// nonce CSP, rather than re-implementing a bespoke toolbar/CSP.
+describe('buildDiagramFrame interactive.extraScripts / allowWasmRendering', () => {
+  const interactiveBase = { nonce: 'test-nonce', controlsPanel: '', controlsScript: '' };
+
+  it('renders extra script tags nonce\'d, in order, module flag respected', () => {
+    const html = buildDiagramFrame({
+      ...base,
+      bodyContent: '<div id="puml-output"></div>',
+      interactive: {
+        ...interactiveBase,
+        extraScripts: [
+          { src: 'https://example.invalid/viz-global.js' },
+          { src: 'https://example.invalid/plantuml-client.js', module: true },
+        ],
+      },
+    });
+    expect(html).toContain('<script nonce="test-nonce" src="https://example.invalid/viz-global.js"></script>');
+    expect(html).toContain('<script nonce="test-nonce" type="module" src="https://example.invalid/plantuml-client.js"></script>');
+    const vizIdx = html.indexOf('viz-global.js');
+    const clientIdx = html.indexOf('plantuml-client.js');
+    expect(vizIdx).toBeGreaterThan(-1);
+    expect(clientIdx).toBeGreaterThan(vizIdx);
+  });
+
+  it('emits no extra script tags when extraScripts is omitted', () => {
+    const html = buildDiagramFrame({ ...base, interactive: { ...interactiveBase } });
+    expect(html).not.toContain('<script nonce="test-nonce" src=');
+  });
+
+  it('widens the CSP for wasm-unsafe-eval and img-src when allowWasmRendering is true', () => {
+    const html = buildDiagramFrame({ ...base, interactive: { ...interactiveBase, allowWasmRendering: true } });
+    expect(html).toContain(`script-src 'nonce-test-nonce' 'wasm-unsafe-eval';`);
+    expect(html).toContain('img-src data: blob:;');
+  });
+
+  it('keeps the strict CSP unchanged when allowWasmRendering is omitted', () => {
+    const html = buildDiagramFrame({ ...base, interactive: { ...interactiveBase } });
+    expect(html).toContain(`script-src 'nonce-test-nonce';`);
+    expect(html).not.toContain('wasm-unsafe-eval');
+    expect(html).not.toContain('img-src data: blob:');
+  });
+});


### PR DESCRIPTION
## Summary
- PUML preview now uses the shared `buildDiagramFrame` shell (toolbar, zoom, Save .svg/.png, Copy image, Theme selector, title toggle) instead of a bespoke webview with no export affordance at all.
- Extends `DiagramFrameOpts.interactive` with two additive, opt-in fields (`extraScripts`, `allowWasmRendering`) so a wasm-based renderer can load its external script files inside the shell's strict nonce CSP — no existing preview is affected.
- Rendering still happens asynchronously inside the webview (wasm PlantUML engine, unlike every other notation which renders host-side); the rendered SVG is now pushed back to the host via a sequenced `postMessage` so Save/Copy/Theme work the same way they do everywhere else, and a stale render for a since-superseded file can't silently overwrite a newer one.
- Exported PNGs get a real background for free (existing shared `rasterizeSvgToPng` default), and the Theme… selector now drives a real Transitrix theme rather than whatever VS Code color theme happens to be active — resolving the "is this Dark theme or just transparency" ambiguity in the previous implementation.

## Test plan
- [x] `npm run build` (repo-wide typecheck) passes
- [x] `npx vitest run` — all green except 3 pre-existing failures in `tests/cli-migrate.test.ts` unrelated to this change (confirmed identical on `main`)
- [x] New `tests/diagram-frame.test.ts` cases cover the new `extraScripts`/`allowWasmRendering` options (nonce applied to external script tags, CSP widened only when opted in)
- [x] Verified empirically (headless Chrome) that a nonce'd `<script type="module">` loading external files can statically `import` a sibling module with no nonce of its own, under a nonce-only CSP with no `'strict-dynamic'` — confirms the CSP approach works for PlantUML's module-based wasm client
- [ ] Manual: open a `.puml` file in the Extension Development Host, confirm the shared toolbar order (zoom · Save .svg/.png · Copy image · Theme… · Title), that Save/Copy/export produce the correct diagram, and that an exported PNG under the light theme has a solid background — not done from this environment (no VS Code UI access here); please verify before merge

## Notes
Also discovered while researching this: the BPMN preview (`extension/src/preview.ts`) is *also* not on the shared shell — its own bespoke toolbar with only a "Save .png" button. Out of scope for this PR; worth a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)