### PR TITLE
chore(release): bump extension to 3.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## [3.0.8] — 2026-07-15
+
+### Fixed
+
+- **PlantUML preview now uses the shared preview shell** (#399). Save/Copy as SVG and PNG, the zoom control, the Theme… selector, and the title toggle — previously missing entirely, so there was no way to get a rendered PlantUML diagram out of Studio — now work the same way they do for every other notation. Exported PNGs get a real background instead of inheriting whatever VS Code color theme happens to be active.
+- **`@transitrix/diagrams` 1.8.7 → 1.8.8** — the published npm package's compiled `dist/` output now uses fully-specified ESM import/export specifiers (e.g. `./index.js` instead of `./index`), fixing `Module not found` errors for consumers under strict Node/webpack ESM resolution. No runtime behavior change for existing bundler-based consumers.
+
 ## [3.0.7] — 2026-07-14
 
 ### Changed

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+## 3.0.8 — 2026-07-15
+
+PlantUML preview gets the same save/export/theme controls as every other notation.
+
+### Fixed
+
+- **PlantUML preview now has Save/Copy as SVG and PNG, zoom, a theme switcher, and a title toggle** — the same toolbar every other notation preview has. Previously there was no way to get a rendered `.puml`/`.plantuml` diagram out of Studio at all. Exported PNGs now always have a solid background instead of picking up whatever VS Code color theme happens to be active.
+
 ## 3.0.7 — 2026-07-14
 
 One Preview button for every notation, and a PlantUML rendering fix.

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "description": "Diagrams as text. Write goals, processes, capabilities, BPMN, and more as plain YAML — 17 notations, live preview in VS Code. Diffable in git. AI-friendly. Open source.",
   "license": "MIT",
   "icon": "icon.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "transitrix-studio",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "transitrix-studio",
-      "version": "3.0.7",
+      "version": "3.0.8",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
## What's changed

### Fixed

- **PlantUML preview now uses the shared preview shell** (#399). Save/Copy as SVG and PNG, the zoom control, the Theme… selector, and the title toggle — previously missing entirely — now work the same way they do for every other notation. Exported PNGs get a real background instead of inheriting whatever VS Code color theme happens to be active.
- **`@transitrix/diagrams` 1.8.7 → 1.8.8** — compiled `dist/` output now uses fully-specified ESM import/export specifiers, fixing `Module not found` errors under strict Node/webpack ESM resolution. No runtime behavior change.

### Packages

- **Transitrix Studio extension** 3.0.7 → 3.0.8
- **`@transitrix/diagrams`** unchanged at 1.8.8 (already published; version bump lands in this changelog now)
- **`@transitrix/cli`** unchanged at 2.0.0

## Test plan

- [x] `package.json` / `extension/package.json` / `package-lock.json` versions bumped consistently
- [x] `CHANGELOG.md` / `extension/CHANGELOG.md` updated
- [x] JSON validity checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)