### PR TITLE
fix(diagrams,extension,cli): resolve Action Schedule canon-projection form

### DIFF
--- a/extension/src/action-preview.ts
+++ b/extension/src/action-preview.ts
@@ -10,6 +10,8 @@ import {
   computeCpm,
   computeGanttLayout,
   isGanttUnavailable,
+  resolveAction,
+  isActionViewDoc,
   type Activity,
   type ActivityDoc,
   type ActivitiesLayout,
@@ -18,6 +20,7 @@ import {
   type GanttResult,
 } from '@transitrix/diagrams/activities';
 import { coerceDatesToIsoStrings } from '@transitrix/diagrams/yaml-normalize.js';
+import { loadCanon, findCanonRoot, isUnderCanon, type CanonDocs } from './canon-loader.js';
 import { DEFAULT_EDGE_CURVATURE } from '@transitrix/diagrams/edge-path.js';
 import { renderActivitiesNetworkBody, ACTIVITIES_NETWORK_DEFS } from '@transitrix/diagrams/webview/render-activities.js';
 import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
@@ -817,12 +820,40 @@ export class ActionPreview {
     await this.pushDocument(doc);
   }
 
-  private async pushDocument(doc: vscode.TextDocument): Promise<void> {
-    if (!this.panel) return;
-    this.panel.webview.html = this.buildHtml(doc.getText(), path.basename(doc.fileName));
+  /** Re-render the tracked document when a sibling canon element/relation saves.
+   *  Only relevant for projection-form documents (view_config-only) — inline
+   *  documents are self-contained and never read canon/. */
+  async refreshIfSiblingSaved(doc: vscode.TextDocument): Promise<void> {
+    if (!this.panel || !this.trackedUri) return;
+    if (!doc.fileName.endsWith('.yaml')) return;
+    const viewUri = vscode.Uri.parse(this.trackedUri);
+    const canonRoot = findCanonRoot(viewUri);
+    if (!canonRoot) return;
+    if (!isUnderCanon(canonRoot, doc.uri)) return;
+    const viewDoc = await vscode.workspace.openTextDocument(viewUri);
+    await this.pushDocument(viewDoc);
   }
 
-  private buildHtml(yamlText: string, filename: string): string {
+  private async pushDocument(doc: vscode.TextDocument): Promise<void> {
+    if (!this.panel) return;
+    const yamlText = doc.getText();
+    // Canon-projection form (07-action.md §4): view_config present, no inline
+    // actions[]. Load canon/elements/** lazily — only projection-form documents
+    // need it; inline documents (the default, self-contained form) skip the
+    // filesystem walk and never see a "no canon root" warning.
+    let sources: CanonDocs = { elements: [], relations: [], warnings: [] };
+    try {
+      const parsed = coerceDatesToIsoStrings(yaml.load(yamlText) as unknown);
+      if (isActionViewDoc(parsed)) {
+        sources = await loadCanon(doc.uri);
+      }
+    } catch {
+      // Parse errors are handled (and reported) again inside buildHtml.
+    }
+    this.panel.webview.html = this.buildHtml(yamlText, path.basename(doc.fileName), sources);
+  }
+
+  private buildHtml(yamlText: string, filename: string, sources: CanonDocs): string {
     let bodyContent = '';
     let errorMsg = '';
     let warnings: string[] = [];
@@ -843,13 +874,16 @@ export class ActionPreview {
       const docDate = (typeof raw['generated_at'] === 'string' ? raw['generated_at'] : undefined)
         ?? (typeof raw['date'] === 'string' ? raw['date'] : undefined)
         ?? todayIso();
-      const v = validateActivities(parsed);
-      warnings = v.warnings.map(w => `${w.code}: ${w.message}`);
+      const isView = isActionViewDoc(parsed);
+      const input = isView ? resolveAction(parsed, sources) : parsed;
+      if (isView) warnings.push(...sources.warnings);
+      const v = validateActivities(input);
+      warnings.push(...v.warnings.map(w => `${w.code}: ${w.message}`));
       if (!v.valid) {
         errorMsg = v.errors.map(e => `${e.code}: ${e.message}`).join('\n');
       } else {
         const nodeSize = readActionNodeSize();
-        const views = buildActivityViews(parsed as ActivityDoc, { horizontalGap: spacing.horizontalGap, verticalGap: spacing.verticalGap, nodeWidth: nodeSize.width, nodeHeight: nodeSize.height }, curvature, entryCurvature, filename, docDate, docVersion);
+        const views = buildActivityViews(input as ActivityDoc, { horizontalGap: spacing.horizontalGap, verticalGap: spacing.verticalGap, nodeWidth: nodeSize.width, nodeHeight: nodeSize.height }, curvature, entryCurvature, filename, docDate, docVersion);
         bodyContent = buildCanvasContent(views);
         this.lastNetworkSvg = views.networkSvg;
         this.lastGanttSvg = views.ganttSvg;

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -514,6 +514,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       void activityCardPreview.refreshIfSiblingSaved(doc);
       void actionsTreePreview.refreshIfSiblingSaved(doc);
       void dgcaPreview.refreshIfSiblingSaved(doc);
+      void actionPreview.refreshIfSiblingSaved(doc);
       // Compliance views are repo-wide: re-scan the open ones whenever a canon
       // artefact (by filename convention) is saved. No-op when no panel is open.
       if (/^(PRODUCT|REQUIREMENT|CONSTRAINT|ASSERTION|LAW|REGULATION|POLICY|INTERNAL_STANDARD)-.*\.ya?ml$/.test(path.basename(doc.fileName))) {

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.8.8",
+  "version": "1.8.9",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",

--- a/packages/diagrams/src/activities/__tests__/resolver.test.ts
+++ b/packages/diagrams/src/activities/__tests__/resolver.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect } from 'vitest';
+import { resolveAction, isActionViewDoc } from '../resolver.js';
+import { validateActivities } from '../validate.js';
+
+// ── Inline canon element store (WBS: Initiative → Programme → Project → Task) ─
+
+const ELEMENTS = [
+  {
+    notation: 'action', id: 'ACTION-PLATFORM-LAUNCH-1', name: 'Platform Launch 2026',
+    type: 'Initiative', goals: ['GOAL-CUST-001'], valid_from: '2026-01-01', valid_to: null,
+  },
+  {
+    notation: 'action', id: 'ACTION-PLATFORM-REQ-1', name: 'Requirements analysis',
+    type: 'Task', parent: 'ACTION-PLATFORM-LAUNCH-1', duration: 5, goals: ['GOAL-CUST-001'],
+    valid_from: '2026-01-01', valid_to: null,
+  },
+  {
+    notation: 'action', id: 'ACTION-PLATFORM-ARCH-1', name: 'Architecture design',
+    type: 'Task', parent: 'ACTION-PLATFORM-LAUNCH-1', duration: 8,
+    predecessors: ['ACTION-PLATFORM-REQ-1'], goals: ['GOAL-CUST-001'],
+    valid_from: '2026-01-01', valid_to: null,
+  },
+  {
+    // Deprecated alias — notation: activity, field: activity_type.
+    notation: 'activity', id: 'ACTIVITY-LEGACY-1', name: 'Legacy migration step',
+    activity_type: 'Task', parent: 'ACTION-PLATFORM-LAUNCH-1', duration: 3,
+  },
+  {
+    notation: 'action', id: 'ACTION-GDPR-1', name: 'GDPR Remediation',
+    type: 'Programme', goals: ['GOAL-COMPLIANCE-001'], valid_from: '2026-01-01', valid_to: null,
+  },
+  {
+    notation: 'action', id: 'ACTION-GDPR-AUDIT-1', name: 'Data audit',
+    type: 'Task', parent: 'ACTION-GDPR-1', duration: 10,
+    valid_from: '2026-06-01', valid_to: '2026-06-30',
+  },
+];
+
+const SOURCES = { elements: ELEMENTS };
+
+const VIEW_DOC = {
+  notation: 'action',
+  id: 'ACTION_SCHED-PLATFORM-2026-1',
+  name: 'Platform Launch 2026',
+  spec_version: '0.1',
+  view_config: {
+    scope: { root_action: 'ACTION-PLATFORM-LAUNCH-1' },
+    schedule: {
+      start_date: '2026-06-01',
+      calendar: { working_days: ['mon', 'tue', 'wed', 'thu', 'fri'], hours_per_day: 8 },
+    },
+  },
+};
+
+// ── isActionViewDoc ────────────────────────────────────────────────────────
+
+describe('isActionViewDoc', () => {
+  it('returns true for a view_config-based doc', () => {
+    expect(isActionViewDoc(VIEW_DOC)).toBe(true);
+  });
+
+  it('returns false for an inline doc with an actions[] array', () => {
+    expect(isActionViewDoc({ notation: 'action', actions: [] })).toBe(false);
+  });
+
+  it('returns false for non-objects', () => {
+    expect(isActionViewDoc(null)).toBe(false);
+    expect(isActionViewDoc('string')).toBe(false);
+    expect(isActionViewDoc(42)).toBe(false);
+  });
+});
+
+// ── resolveAction — root_action scoping ───────────────────────────────────
+
+describe('resolveAction — scope.root_action', () => {
+  it('includes the root action and its transitive descendants only', () => {
+    const doc = resolveAction(VIEW_DOC, SOURCES);
+    const ids = (doc['actions'] as Array<{ id: string }>).map((a) => a.id).sort();
+    expect(ids).toEqual([
+      'ACTION-PLATFORM-ARCH-1',
+      'ACTION-PLATFORM-LAUNCH-1',
+      'ACTION-PLATFORM-REQ-1',
+      'ACTIVITY-LEGACY-1',
+    ]);
+    expect(ids).not.toContain('ACTION-GDPR-1');
+    expect(ids).not.toContain('ACTION-GDPR-AUDIT-1');
+  });
+
+  it('accepts legacy notation: activity elements as ACTION descendants', () => {
+    const doc = resolveAction(VIEW_DOC, SOURCES);
+    const legacy = (doc['actions'] as Array<Record<string, unknown>>).find((a) => a.id === 'ACTIVITY-LEGACY-1');
+    expect(legacy).toBeDefined();
+    expect(legacy?.['activity_type']).toBe('Task');
+  });
+
+  it('maps the canonical element `type` field to the internal `activity_type` field', () => {
+    const doc = resolveAction(VIEW_DOC, SOURCES);
+    const root = (doc['actions'] as Array<Record<string, unknown>>).find((a) => a.id === 'ACTION-PLATFORM-LAUNCH-1');
+    expect(root?.['activity_type']).toBe('Initiative');
+    expect(root?.['type']).toBeUndefined();
+  });
+
+  it('drops the admission/lifecycle envelope fields not used by validateActivities', () => {
+    const doc = resolveAction(VIEW_DOC, SOURCES);
+    const root = (doc['actions'] as Array<Record<string, unknown>>).find((a) => a.id === 'ACTION-PLATFORM-LAUNCH-1');
+    expect(root?.['zone']).toBeUndefined();
+    expect(root?.['valid_from']).toBeUndefined();
+    expect(root?.['valid_to']).toBeUndefined();
+  });
+
+  it('returns an empty actions[] when root_action does not resolve', () => {
+    const viewDoc = { ...VIEW_DOC, view_config: { scope: { root_action: 'ACTION-NONEXISTENT-1' } } };
+    const doc = resolveAction(viewDoc, SOURCES);
+    expect((doc['actions'] as unknown[]).length).toBe(0);
+  });
+
+  it('carries schedule.start_date and calendar onto the resolved project block', () => {
+    const doc = resolveAction(VIEW_DOC, SOURCES);
+    expect(doc['project']).toEqual({
+      start_date: '2026-06-01',
+      calendar: { working_days: ['mon', 'tue', 'wed', 'thu', 'fri'], hours_per_day: 8 },
+    });
+  });
+
+  it('carries view doc metadata (id, title from name, spec_version)', () => {
+    const doc = resolveAction(VIEW_DOC, SOURCES);
+    expect(doc['notation']).toBe('action');
+    expect(doc['id']).toBe('ACTION_SCHED-PLATFORM-2026-1');
+    expect(doc['title']).toBe('Platform Launch 2026');
+    expect(doc['spec_version']).toBe('0.1');
+  });
+
+  it('produces a document that passes validateActivities', () => {
+    const doc = resolveAction(VIEW_DOC, SOURCES);
+    const v = validateActivities(doc);
+    expect(v.valid).toBe(true);
+    expect(v.errors).toEqual([]);
+  });
+});
+
+// ── resolveAction — scope.goals ───────────────────────────────────────────
+
+describe('resolveAction — scope.goals', () => {
+  it('narrows to actions linked to at least one listed goal, ignoring hierarchy', () => {
+    const viewDoc = { ...VIEW_DOC, view_config: { scope: { goals: ['GOAL-COMPLIANCE-001'] } } };
+    const doc = resolveAction(viewDoc, SOURCES);
+    const ids = (doc['actions'] as Array<{ id: string }>).map((a) => a.id);
+    expect(ids).toEqual(['ACTION-GDPR-1']);
+  });
+});
+
+// ── resolveAction — scope.type_filter ─────────────────────────────────────
+
+describe('resolveAction — scope.type_filter', () => {
+  it('narrows the full catalogue to actions of a listed type', () => {
+    const viewDoc = { ...VIEW_DOC, view_config: { scope: { type_filter: ['Programme'] } } };
+    const doc = resolveAction(viewDoc, SOURCES);
+    const ids = (doc['actions'] as Array<{ id: string }>).map((a) => a.id);
+    expect(ids).toEqual(['ACTION-GDPR-1']);
+  });
+
+  it('composes with root_action — intersection, not union', () => {
+    const viewDoc = {
+      ...VIEW_DOC,
+      view_config: { scope: { root_action: 'ACTION-PLATFORM-LAUNCH-1', type_filter: ['Task'] } },
+    };
+    const doc = resolveAction(viewDoc, SOURCES);
+    const ids = (doc['actions'] as Array<{ id: string }>).map((a) => a.id).sort();
+    expect(ids).toEqual(['ACTION-PLATFORM-ARCH-1', 'ACTION-PLATFORM-REQ-1', 'ACTIVITY-LEGACY-1']);
+  });
+});
+
+// ── resolveAction — scope.valid_at ────────────────────────────────────────
+
+describe('resolveAction — scope.valid_at', () => {
+  it('excludes actions outside their [valid_from, valid_to] window', () => {
+    const viewDoc = {
+      ...VIEW_DOC,
+      view_config: { scope: { root_action: 'ACTION-GDPR-1', valid_at: '2026-07-15' } },
+    };
+    const doc = resolveAction(viewDoc, SOURCES);
+    const ids = (doc['actions'] as Array<{ id: string }>).map((a) => a.id).sort();
+    // ACTION-GDPR-AUDIT-1's window (2026-06-01..2026-06-30) has already closed by 2026-07-15.
+    expect(ids).toEqual(['ACTION-GDPR-1']);
+  });
+
+  it('keeps actions with no valid_from tracked (permissive default)', () => {
+    const viewDoc = {
+      notation: 'action', id: 'X', name: 'X',
+      view_config: { scope: { valid_at: '2026-07-15' } },
+    };
+    const untracked = { notation: 'action', id: 'ACTION-UNTRACKED-1', name: 'Untracked' };
+    const doc = resolveAction(viewDoc, { elements: [...ELEMENTS, untracked] });
+    const ids = (doc['actions'] as Array<{ id: string }>).map((a) => a.id);
+    expect(ids).toContain('ACTION-UNTRACKED-1');
+  });
+});
+
+// ── resolveAction — empty / degenerate inputs ─────────────────────────────
+
+describe('resolveAction — empty sources', () => {
+  it('returns empty actions[] when canon has no elements', () => {
+    const doc = resolveAction(VIEW_DOC, { elements: [] });
+    expect((doc['actions'] as unknown[]).length).toBe(0);
+  });
+
+  it('returns an empty inline document for a non-object viewDoc', () => {
+    const doc = resolveAction(null, SOURCES);
+    expect(doc).toEqual({ notation: 'action', actions: [] });
+  });
+
+  it('includes the full catalogue when scope is entirely omitted', () => {
+    const viewDoc = { notation: 'action', id: 'X', name: 'X', view_config: {} };
+    const doc = resolveAction(viewDoc, SOURCES);
+    expect((doc['actions'] as unknown[]).length).toBe(ELEMENTS.length);
+  });
+});

--- a/packages/diagrams/src/activities/index.ts
+++ b/packages/diagrams/src/activities/index.ts
@@ -26,3 +26,5 @@ export { validateActivities } from './validate.js';
 export { computeCpm } from './cpm.js';
 export { layoutActivities } from './layout.js';
 export { computeGanttLayout, isGanttUnavailable } from './gantt.js';
+export { resolveAction, isActionViewDoc } from './resolver.js';
+export type { ActionViewConfig, ActionCanonSources } from './resolver.js';

--- a/packages/diagrams/src/activities/resolver.ts
+++ b/packages/diagrams/src/activities/resolver.ts
@@ -1,0 +1,212 @@
+/**
+ * Action Schedule canon resolver — assembles a flat canonical Action document
+ * from a view_config projection and a canon element store (methodology
+ * `notations/views/07-action.md` §4 "Projection form (Full tier —
+ * post-promotion)"). Mirrors `fgca/resolver.ts`'s `resolveFGCA`/`isFGCAViewDoc`
+ * pattern for the `action` notation.
+ *
+ * Output shape matches the flat inline form `validateActivities` expects:
+ * top-level `project` block + `actions[]`, with ACTION element fields carried
+ * through unchanged except `type` → `activity_type` (the internal Activity
+ * field name; `type` is the canonical element field per elements/24-action.md
+ * §2). Filesystem-free — callable from unit tests without vscode.
+ */
+
+export interface ActionViewConfig {
+  scope?: {
+    root_action?: string;
+    goals?: string[];
+    type_filter?: string[];
+    valid_at?: string | null;
+  };
+  schedule?: {
+    start_date?: string;
+    calendar?: {
+      working_days?: string[];
+      hours_per_day?: number;
+      holidays?: string[];
+    };
+  };
+  display?: {
+    view?: 'network' | 'gantt' | 'both';
+    depth?: number | null;
+    collapsed?: string[];
+  };
+}
+
+export interface ActionCanonSources {
+  elements: unknown[];
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === 'object' && !Array.isArray(v);
+}
+
+function str(v: unknown): string | undefined {
+  return typeof v === 'string' && v.trim().length > 0 ? v : undefined;
+}
+
+function strArray(v: unknown): string[] {
+  if (!Array.isArray(v)) return [];
+  return v.filter((x): x is string => typeof x === 'string' && x.trim().length > 0);
+}
+
+/** ACTION elements by id. `notation: action` is canonical; `notation: activity`
+ *  is the deprecated pre-2026-06-25 alias (elements/24-action.md §"Deprecated
+ *  alias") — accepted the same way `collectByNotation` callers elsewhere do. */
+function collectActionElements(docs: unknown[]): Map<string, Record<string, unknown>> {
+  const out = new Map<string, Record<string, unknown>>();
+  for (const doc of docs) {
+    if (!isObject(doc)) continue;
+    const notation = str(doc['notation']);
+    if (notation !== 'action' && notation !== 'activity') continue;
+    const id = str(doc['id']);
+    if (!id) continue;
+    if (!out.has(id)) out.set(id, doc); // first definition wins
+  }
+  return out;
+}
+
+/**
+ * Returns true when the parsed view document uses the canon-projection form
+ * (`view_config` key present, no inline `actions[]`). Used by the preview and
+ * CLI to decide whether to run the resolver or fall back to direct
+ * `validateActivities` on the inline document.
+ */
+export function isActionViewDoc(parsed: unknown): boolean {
+  if (!isObject(parsed)) return false;
+  return 'view_config' in parsed && !('actions' in parsed);
+}
+
+/** `rootId` and every element reachable by following `parent` links downward
+ *  (Initiative → Programme → Project → Task, elements/24-action.md §1). */
+function descendantsOf(rootId: string, all: Map<string, Record<string, unknown>>): Set<string> {
+  const childrenByParent = new Map<string, string[]>();
+  for (const [id, el] of all) {
+    const parent = str(el['parent']);
+    if (!parent) continue;
+    const list = childrenByParent.get(parent) ?? [];
+    list.push(id);
+    childrenByParent.set(parent, list);
+  }
+  const result = new Set<string>();
+  const queue: string[] = [rootId];
+  while (queue.length > 0) {
+    const id = queue.shift()!;
+    if (result.has(id)) continue;
+    result.add(id);
+    for (const child of childrenByParent.get(id) ?? []) queue.push(child);
+  }
+  return result;
+}
+
+/**
+ * Assemble a flat canonical Action document from the canon ACTION element
+ * store, filtered by the view document's `view_config.scope`. The return
+ * value is ready to pass to `validateActivities`.
+ */
+export function resolveAction(
+  viewDoc: unknown,
+  sources: ActionCanonSources,
+): Record<string, unknown> {
+  if (!isObject(viewDoc)) {
+    return { notation: 'action', actions: [] };
+  }
+
+  const vc = isObject(viewDoc['view_config']) ? viewDoc['view_config'] : {};
+  const scope = isObject(vc['scope']) ? vc['scope'] : {};
+  const schedule = isObject(vc['schedule']) ? vc['schedule'] : {};
+
+  const allActions = collectActionElements(sources.elements);
+
+  // 1. Scope by root_action (this action + its descendants), or the full
+  // catalogue when omitted (§5.1: "Omit to include elements from the full
+  // catalogue (or use goals/type_filter for other scoping)").
+  const rootAction = str(scope['root_action']);
+  let candidateIds: Set<string>;
+  if (rootAction) {
+    candidateIds = allActions.has(rootAction) ? descendantsOf(rootAction, allActions) : new Set();
+  } else {
+    candidateIds = new Set(allActions.keys());
+  }
+
+  // 2. Narrow by goals — only actions linked to at least one listed GOAL.
+  const goalsFilter = strArray(scope['goals']);
+  if (goalsFilter.length > 0) {
+    candidateIds = new Set(
+      [...candidateIds].filter((id) => strArray(allActions.get(id)?.['goals']).some((g) => goalsFilter.includes(g))),
+    );
+  }
+
+  // 3. Narrow by type_filter — only actions of a listed type.
+  const typeFilter = strArray(scope['type_filter']);
+  if (typeFilter.length > 0) {
+    candidateIds = new Set(
+      [...candidateIds].filter((id) => {
+        const el = allActions.get(id);
+        const t = str(el?.['type']) ?? str(el?.['activity_type']);
+        return t !== undefined && typeFilter.includes(t);
+      }),
+    );
+  }
+
+  // 4. Narrow by valid_at — only actions in effect on that date. Actions with
+  // no valid_from are not lifecycle-tracked and are kept (permissive default,
+  // matching the resolver's general "missing = not excluded" stance).
+  const validAt = str(scope['valid_at']);
+  if (validAt) {
+    candidateIds = new Set(
+      [...candidateIds].filter((id) => {
+        const el = allActions.get(id);
+        const from = str(el?.['valid_from']);
+        const to = str(el?.['valid_to']);
+        if (from && validAt < from) return false;
+        if (to && validAt > to) return false;
+        return true;
+      }),
+    );
+  }
+
+  // Element fields map onto Activity fields unchanged, except the canonical
+  // `type` (elements/24-action.md §2) which becomes the internal `activity_type`
+  // (types.ts `Activity.activity_type`) — the admission/lifecycle envelope
+  // fields (zone, admitted_*, gate_checks, valid_from/valid_to) are dropped,
+  // they carry no schedule/render meaning for `validateActivities`.
+  const selectedActions = [...candidateIds].map((id) => {
+    const el = allActions.get(id)!;
+    const {
+      notation: _notation,
+      zone: _zone,
+      admitted_at: _admittedAt,
+      admitted_by: _admittedBy,
+      gate_checks: _gateChecks,
+      valid_from: _validFrom,
+      valid_to: _validTo,
+      type,
+      activity_type,
+      ...rest
+    } = el;
+    const resolvedType = type ?? activity_type;
+    return {
+      ...rest,
+      id,
+      ...(resolvedType !== undefined ? { activity_type: resolvedType } : {}),
+    };
+  });
+
+  const project: Record<string, unknown> = {};
+  const startDate = str(schedule['start_date']);
+  if (startDate) project['start_date'] = startDate;
+  if (isObject(schedule['calendar'])) project['calendar'] = schedule['calendar'];
+
+  const out: Record<string, unknown> = {
+    notation: 'action',
+    id: viewDoc['id'],
+    title: viewDoc['name'],
+    spec_version: viewDoc['spec_version'],
+    description: viewDoc['description'],
+    actions: selectedActions,
+  };
+  if (Object.keys(project).length > 0) out['project'] = project;
+  return out;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,6 +27,7 @@ import {
   resolveValidatorKey,
 } from './validate-notation.js';
 import { handleExportComplianceCommand } from './export-compliance.js';
+import { isActionViewDoc } from '@transitrix/diagrams/activities';
 
 function printUsage(): void {
   console.error(`Transitrix Studio CLI — usage:
@@ -360,7 +361,12 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
 
   const validatorKey = resolveValidatorKey(data) ?? inferNotationFromFilename(src);
   if (validatorKey && validatorKey !== 'bpmn') {
-    if (isFileValidatableNotation(validatorKey)) {
+    // Canon-projection form (07-action.md §4): view_config present, no inline
+    // actions[]. Single-file scope has no canon/elements/** to resolve
+    // against (unlike --scope=repo, which does) — surface a clear notice
+    // instead of a confusing SCHEMA_INVALID from validating the unresolved doc.
+    const isUnresolvableProjection = validatorKey === 'action' && isActionViewDoc(data);
+    if (isFileValidatableNotation(validatorKey) && !isUnresolvableProjection) {
       const report = validateNotationDoc(validatorKey, data, { filePath: src });
       emitFileReport(src, report, useJson, validatorKey);
       if (!report.isValid) {
@@ -368,10 +374,15 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
       }
       return;
     }
-    // Recognised notation, but no file-scope CLI validator yet.
-    const notice =
-      `notation "${validatorKey}" is not yet validated by the CLI — check it in ` +
-      `the Transitrix Studio preview, or run whole-canon checks with --scope=repo.`;
+    // Recognised notation, but no file-scope CLI validator yet — or (for
+    // `action`) a projection-form document this single-file scope has no
+    // canon context to resolve.
+    const notice = isUnresolvableProjection
+      ? `"${src}" is a canon-projection Action Schedule (view_config, no inline actions[]) — ` +
+        `single-file validation has no canon/elements/** context to resolve it against. ` +
+        `Run whole-canon checks with --scope=repo, or check it in the Transitrix Studio preview.`
+      : `notation "${validatorKey}" is not yet validated by the CLI — check it in ` +
+        `the Transitrix Studio preview, or run whole-canon checks with --scope=repo.`;
     if (useJson) {
       console.log(
         JSON.stringify({ valid: null, notation: validatorKey, covered: false, message: notice }, null, 2),

--- a/src/repo-validate.ts
+++ b/src/repo-validate.ts
@@ -32,6 +32,7 @@ import {
   type ComplianceScanResult,
   type ScannedYamlDoc,
 } from '@transitrix/diagrams/compliance';
+import { resolveAction, isActionViewDoc } from '@transitrix/diagrams/activities';
 import {
   validateNotationDoc,
   isFileValidatableNotation,
@@ -208,6 +209,10 @@ export function runViewValidate(
 } {
   const findings: ViewFinding[] = [];
   const skipped: Array<{ file: string; notation: string }> = [];
+  // Lazily loaded canon ACTION elements for projection-form resolution
+  // (07-action.md §4) — computed at most once per run, only when a
+  // projection-form action document is actually encountered.
+  let actionElements: unknown[] | undefined;
   for (const doc of loadViewDocs(root)) {
     let data: unknown;
     try {
@@ -255,6 +260,18 @@ export function runViewValidate(
     if (!isFileValidatableNotation(notation)) {
       skipped.push({ file: doc.path, notation });
       continue;
+    }
+
+    // Canon-projection form (07-action.md §4): view_config present, no inline
+    // actions[] — resolve against canon/elements/** before validating, the
+    // same way the VS Code preview does (action-preview.ts).
+    if (notation === 'action' && isActionViewDoc(data)) {
+      if (!actionElements) {
+        actionElements = loadRepoModel(root).elements
+          .map((d) => d.data)
+          .filter((d): d is Record<string, unknown> => d != null);
+      }
+      data = resolveAction(data, { elements: actionElements });
     }
 
     const validateOpts = { catalog: ctx?.catalog };

--- a/tests/repo-validate-views.test.ts
+++ b/tests/repo-validate-views.test.ts
@@ -140,10 +140,10 @@ describe('repo-scope views sweep — clean tree passes (#258)', () => {
   });
 });
 
-// vkgeorgia/strategy#619: a canon-projection Action Schedule (view_config,
-// no inline actions[]) used to fail every repo-scope validate run with
-// `SCHEMA_INVALID: actions must be an array` — the validator only understood
-// the inline form. `runViewValidate` now resolves the projection against
+// A canon-projection Action Schedule (view_config, no inline actions[]) used
+// to fail every repo-scope validate run with `SCHEMA_INVALID: actions must
+// be an array` — the validator only understood the inline form.
+// `runViewValidate` now resolves the projection against
 // canon/elements/05_implementation/actions/** first (mirroring how the DGCA
 // preview resolves its own view_config projections).
 describe('repo-scope views sweep — action canon-projection form (#619)', () => {

--- a/tests/repo-validate-views.test.ts
+++ b/tests/repo-validate-views.test.ts
@@ -139,3 +139,52 @@ describe('repo-scope views sweep — clean tree passes (#258)', () => {
     expect(result.skipped.some((s) => s.notation === 'compliance-impact')).toBe(false);
   });
 });
+
+// vkgeorgia/strategy#619: a canon-projection Action Schedule (view_config,
+// no inline actions[]) used to fail every repo-scope validate run with
+// `SCHEMA_INVALID: actions must be an array` — the validator only understood
+// the inline form. `runViewValidate` now resolves the projection against
+// canon/elements/05_implementation/actions/** first (mirroring how the DGCA
+// preview resolves its own view_config projections).
+describe('repo-scope views sweep — action canon-projection form (#619)', () => {
+  let root: string;
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), 'tx-views-action-projection-'));
+    write(
+      root,
+      'canon/elements/05_implementation/actions/ACTION-GDPR-COMPLIANCE-1.yaml',
+      'notation: action\nid: ACTION-GDPR-COMPLIANCE-1\nname: GDPR Compliance\ntype: Programme\n',
+    );
+    write(
+      root,
+      'canon/elements/05_implementation/actions/ACTION-GDPR-AUDIT-1.yaml',
+      'notation: action\nid: ACTION-GDPR-AUDIT-1\nname: Data audit\ntype: Task\nparent: ACTION-GDPR-COMPLIANCE-1\nduration: 10\n',
+    );
+    write(
+      root,
+      'canon/views/action/gdpr-remediation.action.transitrix.yaml',
+      [
+        'notation: action',
+        'spec_version: "0.1"',
+        'id: ACTION_SCHED-GDPR-1',
+        'name: GDPR Remediation',
+        'view_config:',
+        '  scope:',
+        '    root_action: ACTION-GDPR-COMPLIANCE-1',
+      ].join('\n'),
+    );
+  });
+
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('resolves the projection and validates clean, instead of SCHEMA_INVALID', () => {
+    const { findings, skipped } = runViewValidate(root);
+    expect(skipped.some((s) => s.notation === 'action')).toBe(false);
+    const actionFindings = findings.filter((f) => f.notation === 'action');
+    expect(actionFindings.filter((f) => f.severity === 'error')).toEqual([]);
+    expect(actionFindings.some((f) => f.message.includes('actions must be an array'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`validateActivities` (the `action` notation validator) only understood the inline `actions[]` authoring form. A spec-valid **projection-form** Action Schedule document (`view_config` only, no inline `actions[]` — `notations/views/07-action.md` §4) failed everywhere it was validated, with a confusing `SCHEMA_INVALID: actions must be an array`:

- the VS Code Action preview,
- `transitrix validate --scope=repo`,
- single-file `transitrix validate <file>`.

This mirrors the DGCA preview's existing `view_config` resolution pattern (`fgca/resolver.ts` → `isFGCAViewDoc` / `resolveFGCA`) for the `action` notation, and wires it into every place that validates an Action Schedule document.

- **`packages/diagrams/src/activities/resolver.ts`** (new) — `isActionViewDoc` / `resolveAction`. Assembles a flat `actions[]` document from canon `ACTION` elements (`canon/elements/05_implementation/actions/**`), filtered by `view_config.scope` (`root_action` + transitive descendants via `parent`, `goals`, `type_filter`, `valid_at`). Pure/filesystem-free, unit tested (19 cases).
- **`extension/src/action-preview.ts`** — resolves the projection against `canon/elements/**` before calling `validateActivities`, same as `dgca-preview.ts`. Canon is loaded lazily, only for projection-form documents, so inline documents (the default, self-contained form) stay untouched and never see a spurious "no canon root" warning. Also wires `refreshIfSiblingSaved` so editing a referenced canon element re-renders an open Action preview (parity with DGCA/Actions-Tree/Action-Card).
- **`src/repo-validate.ts`** — `runViewValidate` resolves `action` projections against `canon/elements/**` (loaded once, lazily, only when a projection-form doc is encountered) before validating. Covered by a new integration test in `tests/repo-validate-views.test.ts`.
- **`src/cli.ts`** — single-file `transitrix validate <file>` has no canon context to resolve against (unlike `--scope=repo`), so a projection-form document now gets a clear notice pointing at `--scope=repo` / the Studio preview, instead of the misleading `SCHEMA_INVALID`.

Note: DGCA's own single-file CLI path (`transitrix validate <file>` without `--scope=repo`) has the same "no canon context" gap for `view_config` documents — pre-existing, out of scope here since this PR is scoped to the `action` notation.

## Test plan

- [x] `npm run compile` (root, builds `@transitrix/diagrams` first) — clean
- [x] `npm run compile:extension` — clean
- [x] `npm run test:diagrams` — 1327/1327 passing, including 19 new resolver tests
- [x] `npx vitest run tests/repo-validate-views.test.ts tests/repo-validate-codex.test.ts tests/repo-validate-compliance.test.ts` — 25/25 passing, including new action-projection integration test
- [x] `npm run test:core` — same as `main` (3 pre-existing failures in `tests/cli-migrate.test.ts`, unrelated to this change — they depend on drift in the local sibling `../methodology` clone, confirmed failing identically on `main`)
- [x] Manual smoke test: hand-built `canon/elements/05_implementation/actions/**` + a `view_config`-only `.action.transitrix.yaml` file
  - `transitrix validate <file>` → clear "run --scope=repo" notice (was `SCHEMA_INVALID`)
  - `transitrix validate --scope=repo --json` → `valid: true`, resolves both elements, only the expected ACT-011/013/019 warnings (missing duration/dates on the fixture — correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)