### PR TITLE
fix(cli): resolve DGCA canon-projection form in repo-scope and single-file validate

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,6 +28,16 @@ import {
 } from './validate-notation.js';
 import { handleExportComplianceCommand } from './export-compliance.js';
 import { isActionViewDoc } from '@transitrix/diagrams/activities';
+import { isFGCAViewDoc } from '@transitrix/diagrams/fgca';
+
+/** Notations whose canon-projection form (view_config, no inline element
+ *  data) single-file `transitrix validate <file>` cannot resolve — it has no
+ *  canon/elements/** context, unlike --scope=repo. Used to swap the raw
+ *  schema error for a clear notice instead. */
+const PROJECTION_ONLY_NOTATIONS: Record<string, { check: (d: unknown) => boolean; label: string; inlineField: string }> = {
+  action: { check: isActionViewDoc, label: 'Action Schedule', inlineField: 'actions[]' },
+  dgca: { check: isFGCAViewDoc, label: 'DGCA', inlineField: 'factors/goals/changes/actions' },
+};
 
 function printUsage(): void {
   console.error(`Transitrix Studio CLI — usage:
@@ -361,11 +371,12 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
 
   const validatorKey = resolveValidatorKey(data) ?? inferNotationFromFilename(src);
   if (validatorKey && validatorKey !== 'bpmn') {
-    // Canon-projection form (07-action.md §4): view_config present, no inline
-    // actions[]. Single-file scope has no canon/elements/** to resolve
-    // against (unlike --scope=repo, which does) — surface a clear notice
-    // instead of a confusing SCHEMA_INVALID from validating the unresolved doc.
-    const isUnresolvableProjection = validatorKey === 'action' && isActionViewDoc(data);
+    // Canon-projection form: view_config present, no inline element data.
+    // Single-file scope has no canon/elements/** to resolve against (unlike
+    // --scope=repo, which does) — surface a clear notice instead of a
+    // confusing raw schema error from validating the unresolved doc.
+    const projectionInfo = PROJECTION_ONLY_NOTATIONS[validatorKey];
+    const isUnresolvableProjection = projectionInfo ? projectionInfo.check(data) : false;
     if (isFileValidatableNotation(validatorKey) && !isUnresolvableProjection) {
       const report = validateNotationDoc(validatorKey, data, { filePath: src });
       emitFileReport(src, report, useJson, validatorKey);
@@ -374,11 +385,11 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
       }
       return;
     }
-    // Recognised notation, but no file-scope CLI validator yet — or (for
-    // `action`) a projection-form document this single-file scope has no
-    // canon context to resolve.
+    // Recognised notation, but no file-scope CLI validator yet — or a
+    // projection-form document this single-file scope has no canon context
+    // to resolve.
     const notice = isUnresolvableProjection
-      ? `"${src}" is a canon-projection Action Schedule (view_config, no inline actions[]) — ` +
+      ? `"${src}" is a canon-projection ${projectionInfo.label} document (view_config, no inline ${projectionInfo.inlineField}) — ` +
         `single-file validation has no canon/elements/** context to resolve it against. ` +
         `Run whole-canon checks with --scope=repo, or check it in the Transitrix Studio preview.`
       : `notation "${validatorKey}" is not yet validated by the CLI — check it in ` +

--- a/src/repo-validate.ts
+++ b/src/repo-validate.ts
@@ -33,6 +33,7 @@ import {
   type ScannedYamlDoc,
 } from '@transitrix/diagrams/compliance';
 import { resolveAction, isActionViewDoc } from '@transitrix/diagrams/activities';
+import { resolveFGCA, isFGCAViewDoc } from '@transitrix/diagrams/fgca';
 import {
   validateNotationDoc,
   isFileValidatableNotation,
@@ -209,10 +210,21 @@ export function runViewValidate(
 } {
   const findings: ViewFinding[] = [];
   const skipped: Array<{ file: string; notation: string }> = [];
-  // Lazily loaded canon ACTION elements for projection-form resolution
-  // (07-action.md §4) — computed at most once per run, only when a
-  // projection-form action document is actually encountered.
-  let actionElements: unknown[] | undefined;
+  // Lazily loaded canon elements/relations for projection-form resolution
+  // (dgca: view_config.goals/factors/changes/activities; action: §4 of
+  // 07-action.md) — computed at most once per run, only when a
+  // projection-form document is actually encountered.
+  let canonModel: { elements: unknown[]; relations: unknown[] } | undefined;
+  function ensureCanonModel(): { elements: unknown[]; relations: unknown[] } {
+    if (!canonModel) {
+      const model = loadRepoModel(root);
+      canonModel = {
+        elements: model.elements.map((d) => d.data).filter((d): d is Record<string, unknown> => d != null),
+        relations: model.relations.map((d) => d.data).filter((d): d is Record<string, unknown> => d != null),
+      };
+    }
+    return canonModel;
+  }
   for (const doc of loadViewDocs(root)) {
     let data: unknown;
     try {
@@ -266,12 +278,18 @@ export function runViewValidate(
     // actions[] — resolve against canon/elements/** before validating, the
     // same way the VS Code preview does (action-preview.ts).
     if (notation === 'action' && isActionViewDoc(data)) {
-      if (!actionElements) {
-        actionElements = loadRepoModel(root).elements
-          .map((d) => d.data)
-          .filter((d): d is Record<string, unknown> => d != null);
-      }
-      data = resolveAction(data, { elements: actionElements });
+      data = resolveAction(data, { elements: ensureCanonModel().elements });
+    }
+
+    // Canon-projection form (02-dgca.md): view_config present, no inline
+    // factors/goals/changes/actions — resolve against canon/elements/**
+    // before validating, the same way the VS Code DGCA preview does
+    // (dgca-preview.ts). Unlike the preview, repo-scope validate never ran
+    // this resolution at all — every projection-form DGCA document failed
+    // FGCA-004 unconditionally until now.
+    if (notation === 'dgca' && isFGCAViewDoc(data)) {
+      const model = ensureCanonModel();
+      data = resolveFGCA(data, { elements: model.elements, relations: model.relations });
     }
 
     const validateOpts = { catalog: ctx?.catalog };

--- a/tests/repo-validate-views.test.ts
+++ b/tests/repo-validate-views.test.ts
@@ -188,3 +188,60 @@ describe('repo-scope views sweep — action canon-projection form (#619)', () =>
     expect(actionFindings.some((f) => f.message.includes('actions must be an array'))).toBe(false);
   });
 });
+
+// A canon-projection DGCA document (view_config, no inline
+// factors/goals/changes/actions) failed every repo-scope validate run with
+// FGCA-004 "must be an array" — `runViewValidate` never resolved DGCA
+// projections at all (only the VS Code preview did). Confirmed against
+// methodology's own official example (notations/examples/dgca/
+// strategy-2026.dgca.transitrix.yaml) before this fix.
+describe('repo-scope views sweep — dgca canon-projection form', () => {
+  let root: string;
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), 'tx-views-dgca-projection-'));
+    write(root, 'canon/elements/01_motivation/drivers/DRIVER-1.yaml', 'notation: driver\nid: DRIVER-1\nname: Market pressure\n');
+    write(
+      root,
+      'canon/elements/01_motivation/goals/GOAL-1.yaml',
+      'notation: goal\nid: GOAL-1\nname: Grow revenue\nfactors: [DRIVER-1]\n',
+    );
+    write(
+      root,
+      'canon/elements/05_implementation/changes/CHANGE-1.yaml',
+      'notation: change\nid: CHANGE-1\nname: Launch product\ngoals: [GOAL-1]\n',
+    );
+    write(
+      root,
+      'canon/elements/05_implementation/actions/ACTION-1.yaml',
+      'notation: action\nid: ACTION-1\nname: Market research\nchanges: [CHANGE-1]\n',
+    );
+    write(
+      root,
+      'canon/views/dgca/strategy.dgca.transitrix.yaml',
+      [
+        'notation: dgca',
+        'spec_version: "0.1"',
+        'id: DGCA-STRAT-1',
+        'name: Strategy chain',
+        'view_config:',
+        '  goals: { filter: all }',
+        '  factors: { surface: derived }',
+        '  changes: { surface: derived }',
+        '  activities: { surface: derived }',
+      ].join('\n'),
+    );
+  });
+
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('resolves the projection and validates clean, instead of FGCA-004', () => {
+    const { findings, skipped } = runViewValidate(root);
+    expect(skipped.some((s) => s.notation === 'dgca')).toBe(false);
+    const dgcaFindings = findings.filter((f) => f.notation === 'dgca');
+    expect(dgcaFindings.filter((f) => f.severity === 'error')).toEqual([]);
+    expect(dgcaFindings.some((f) => f.ruleId === 'FGCA-004')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- A canon-projection DGCA document (`view_config` only, no inline `factors`/`goals`/`changes`/`actions` — `notations/views/02-dgca.md`) failed every CLI validate path with `FGCA-004: … must be an array`. Only the VS Code DGCA preview (`dgca-preview.ts`) ever resolved the projection against `canon/elements/**`; the resolver (`fgca/resolver.ts`'s `isFGCAViewDoc`/`resolveFGCA`, already existing) was never wired into the CLI at all.
- Confirmed against methodology's **own official example** (`notations/examples/dgca/strategy-2026.dgca.transitrix.yaml`), not just adopter files — this ships broken in the published npm CLI (`2.0.0`) too, not just the dev build.
- Same shape of fix as #401 (Action Schedule), applied to `dgca`:
  - `src/repo-validate.ts` — `runViewValidate` resolves `dgca` projections against `canon/elements/**` before validating. Canon elements/relations are now loaded once per run and shared between the `action` and `dgca` branches (was action-only before).
  - `src/cli.ts` — single-file `transitrix validate <file>` has no canon context to resolve against (same limitation `action` already had) — generalized the "unresolvable projection" notice from action-only to a small per-notation table covering both `action` and `dgca`, instead of the raw `FGCA-004` schema error.

Not stacked on #401 — independent branch off `main`.

## Test plan

- [x] `npm run compile` — clean
- [x] `npm run test:core` — 451/454 (same 3 pre-existing failures in `tests/cli-migrate.test.ts`, unrelated — they depend on drift in the local sibling `../methodology` clone, confirmed identical on `main`)
- [x] New integration test in `tests/repo-validate-views.test.ts` (`repo-scope views sweep — dgca canon-projection form`)
- [x] Manual smoke test against methodology's actual `strategy-2026.dgca.transitrix.yaml` + its `elements/` fixtures:
  - `transitrix validate <file>` → clear "run --scope=repo" notice (was `FGCA-004` crash)
  - `transitrix validate --scope=repo --json` → `valid: true`, zero findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)