### PR TITLE
chore(release): bump extension to 3.0.9, @transitrix/cli to 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Unreleased
 
+## [3.0.9] — 2026-07-17
+
+### Added
+
+- **Canon-projection support for Action Schedule, DGCA, and Goals Tree** (#401, #402, #403). A `view_config`-only document (no inline element data — the methodology's Full-tier projection form) now resolves correctly against `canon/elements/**` in the VS Code preview and `transitrix validate --scope=repo`; single-file `transitrix validate <file>` (which has no canon context to resolve against) now gives a clear "run --scope=repo instead" notice rather than a raw schema error. DGCA's own single-file/repo-scope CLI paths never ran this resolution at all before #402 — confirmed broken against methodology's own official example (`notations/examples/dgca/strategy-2026.dgca.transitrix.yaml`), not just adopter files.
+
+### Fixed
+
+- **DGCA canon-projection documents authored with the canonical `notation: action`** silently resolved to zero actions — the resolver only recognized the deprecated `notation: activity` alias (#404).
+- **`transitrix validate --scope=repo` silently ignored `view_config.scope.valid_at`** for any canon element with an unquoted date field — js-yaml parses those as native `Date` objects, which the date-window filter's string check treated as absent, so a lapsed element stayed included with no error (#404).
+- **Goals Tree's synthesized level table could disagree between the CLI and the VS Code preview** for identical canon content, since it depended on unsorted directory-enumeration order; level is now computed deterministically from the parent-chain structure instead (#404).
+- **Action Schedule's `scope.goals` filter never consulted `action_goal` relations**, only the transitional inline `goals[]` field, unlike the sibling DGCA resolver (#404).
+- **`transitrix validate --scope=repo` walked the canon tree twice** on any repo with at least one canon-projection document (#404).
+
+### Packages
+
+- **Transitrix Studio extension** 3.0.8 → 3.0.9
+- **`@transitrix/diagrams`** 1.8.8 → 1.8.11 — new `activities/resolver.ts` + `goals/resolver.ts`, `notation: action` alias fix in `fgca/resolver.ts`, new shared `canon-resolver-utils.ts`
+- **`@transitrix/cli`** 2.0.0 → 2.0.1 — the `transitrix validate` fixes above ship here
+
 ## [3.0.8] — 2026-07-15
 
 ### Fixed

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+## 3.0.9 — 2026-07-17
+
+Action Schedule, DGCA, and Goals Tree can now be shared across documents (canon-projection form), plus several correctness fixes for `transitrix validate`.
+
+### Added
+
+- **Action Schedule, DGCA, and Goals Tree now support the "shared across documents" authoring form.** Once an action, driver/goal/change, or goal is promoted to a standalone file under `canon/elements/`, a view document can reference it via `view_config` instead of repeating its data inline — the preview and `transitrix validate --scope=repo` resolve it correctly. Previously this only worked for DGCA's preview; the CLI never resolved it for DGCA at all, and Action Schedule / Goals Tree had no support for it anywhere.
+
+### Fixed
+
+- **DGCA views could silently show zero actions** when the underlying action elements used the current file format instead of an older, deprecated one.
+- **`transitrix validate --scope=repo` could silently miss a "not valid on this date" filter** for canon elements whose dates weren't quoted in the YAML — a very easy mistake to make and not obvious from the file.
+- **Goals Tree level numbers could come out differently** between the editor preview and the command line for the exact same files.
+- **Action Schedule's goal-based filtering** now also honors goal links recorded as a first-class relation, not just the older inline field.
+
 ## 3.0.8 — 2026-07-15
 
 PlantUML preview gets the same save/export/theme controls as every other notation.

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "description": "Diagrams as text. Write goals, processes, capabilities, BPMN, and more as plain YAML — 17 notations, live preview in VS Code. Diffable in git. AI-friendly. Open source.",
   "license": "MIT",
   "icon": "icon.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "transitrix-studio",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "transitrix-studio",
-      "version": "3.0.8",
+      "version": "3.0.9",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -7771,7 +7771,7 @@
     },
     "packages/cli": {
       "name": "@transitrix/cli",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",
@@ -7789,7 +7789,7 @@
     },
     "packages/diagrams": {
       "name": "@transitrix/diagrams",
-      "version": "1.8.7",
+      "version": "1.8.11",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/cli",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "description": "Transitrix CLI — compile, validate, and report on Transitrix diagrams (BPMN, Goals, DGCA, …) from any shell or CI pipeline.",
   "license": "MIT",


### PR DESCRIPTION
## What's changed

### Added

- **Canon-projection support for Action Schedule, DGCA, and Goals Tree** (#401, #402, #403). A `view_config`-only document (no inline element data — the methodology's Full-tier projection form) now resolves correctly against `canon/elements/**` in the VS Code preview and `transitrix validate --scope=repo`; single-file `transitrix validate <file>` gives a clear "run --scope=repo instead" notice rather than a raw schema error. DGCA's own single-file/repo-scope CLI paths never ran this resolution at all before #402 — confirmed broken against methodology's own official example, not just adopter files.

### Fixed

- **DGCA canon-projection documents authored with the canonical `notation: action`** silently resolved to zero actions (#404).
- **`transitrix validate --scope=repo` silently ignored `view_config.scope.valid_at`** for any canon element with an unquoted date field (#404).
- **Goals Tree's synthesized level table could disagree between the CLI and the VS Code preview** for identical canon content (#404).
- **Action Schedule's `scope.goals` filter never consulted `action_goal` relations** (#404).
- **`transitrix validate --scope=repo` walked the canon tree twice** on repos with canon-projection documents (#404).

### Packages

- **Transitrix Studio extension** 3.0.8 → 3.0.9
- **`@transitrix/diagrams`** 1.8.8 → 1.8.11 (already published at 1.8.8; version bump lands in this changelog now)
- **`@transitrix/cli`** 2.0.0 → 2.0.1 — the `transitrix validate` fixes above ship here

## Test plan

- [x] `package.json` / `extension/package.json` / `packages/cli/package.json` / `package-lock.json` versions bumped consistently (via `scripts/bump-extension-version.mjs` + `npm install --package-lock-only`)
- [x] `CHANGELOG.md` / `extension/CHANGELOG.md` updated
- [x] JSON validity checked on every touched package.json + package-lock.json
- [x] `npm run compile` — clean after the bump

## Publishing

This PR only bumps versions and changelogs — it does not publish anything. Merging it does not trigger the VS Code Marketplace / Open VSX / JetBrains / npm publish workflows; those fire on a **GitHub Release** being created (a separate, deliberate step). Once this merges, creating the release is Valerii's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)