### PR TITLE
feat(cli): emit resolved element/relation records from validate --scope=repo

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -72,7 +72,7 @@ transitrix <input.yaml> <output.bpmn> [--no-metrics] [--no-validate]
 transitrix serve [--port 8765] [--host 127.0.0.1]
 transitrix metrics <input.yaml> [--json]
 transitrix validate <input.yaml> [--json]
-transitrix validate --scope=repo [--root <dir>] [--json]
+transitrix validate --scope=repo [--root <dir>] [--json] [--include-model]
 transitrix export-compliance [--format md|pdf] [--scope law:<ID>|product:<ID>|gap] [--output <path>] [--root <dir>]
 ```
 
@@ -81,7 +81,7 @@ transitrix export-compliance [--format md|pdf] [--scope law:<ID>|product:<ID>|ga
 | *(default)* / `compile` | YAML → BPMN 2.0 XML with computed layout; prints layout-quality metrics and validation findings. Exit 1 on validation errors. |
 | `serve` | Local web UI (run `npm run ui:build` once beforehand). |
 | `metrics` | Layout-quality metrics only (`--json` for CI). |
-| `validate` | Validation only, no XML output (`--json` for CI). Exit 1 on errors. Default scope is a single file; `--scope=repo` runs whole-`canon/` checks (referential integrity, atomicity, id uniqueness, policy) over `--root` (default cwd) — see [validation.md](validation.md#validation-scope-file-vs-repo). |
+| `validate` | Validation only, no XML output (`--json` for CI). Exit 1 on errors. Default scope is a single file; `--scope=repo` runs whole-`canon/` checks (referential integrity, atomicity, id uniqueness, policy) over `--root` (default cwd) — see [validation.md](validation.md#validation-scope-file-vs-repo). `--include-model` (with `--json`) also emits the resolved `canon/elements/**`/`canon/relations/**` records it parsed — see [validation.md](validation.md#resolved-model-output---include-model-669). |
 | `export-compliance` | Markdown or PDF report of the compliance views (matrix by default; `law:` / `product:` / `gap` scopes). Scans `--root` (default cwd). PDF needs WeasyPrint on PATH (`pipx install weasyprint`). |
 
 Flags: `--no-metrics` suppresses the metrics report on compile; `--no-validate`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -81,7 +81,7 @@ transitrix export-compliance [--format md|pdf] [--scope law:<ID>|product:<ID>|ga
 | *(default)* / `compile` | YAML → BPMN 2.0 XML with computed layout; prints layout-quality metrics and validation findings. Exit 1 on validation errors. |
 | `serve` | Local web UI (run `npm run ui:build` once beforehand). |
 | `metrics` | Layout-quality metrics only (`--json` for CI). |
-| `validate` | Validation only, no XML output (`--json` for CI). Exit 1 on errors. Default scope is a single file; `--scope=repo` runs whole-`canon/` checks (referential integrity, atomicity, id uniqueness, policy) over `--root` (default cwd) — see [validation.md](validation.md#validation-scope-file-vs-repo). `--include-model` (with `--json`) also emits the resolved `canon/elements/**`/`canon/relations/**` records it parsed — see [validation.md](validation.md#resolved-model-output---include-model-669). |
+| `validate` | Validation only, no XML output (`--json` for CI). Exit 1 on errors. Default scope is a single file; `--scope=repo` runs whole-`canon/` checks (referential integrity, atomicity, id uniqueness, policy) over `--root` (default cwd) — see [validation.md](validation.md#validation-scope-file-vs-repo). `--include-model` (with `--json`) also emits the resolved `canon/elements/**`/`canon/relations/**` records it parsed — see [validation.md](validation.md#resolved-model-output---include-model). |
 | `export-compliance` | Markdown or PDF report of the compliance views (matrix by default; `law:` / `product:` / `gap` scopes). Scans `--root` (default cwd). PDF needs WeasyPrint on PATH (`pipx install weasyprint`). |
 
 Flags: `--no-metrics` suppresses the metrics report on compile; `--no-validate`

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -70,14 +70,14 @@ $ transitrix validate --scope=repo --root organizations/acme_corp
 The richer `target`/`category` finding taxonomy is intentionally **not** adopted
 yet (deferred per the ADR until a consumer needs it).
 
-### Resolved model output (`--include-model`, #669)
+### Resolved model output (`--include-model`)
 
 `transitrix validate --scope=repo --json --include-model` adds a `model` key
 alongside the findings — the resolved `canon/elements/**` and
 `canon/relations/**` records the repo-scope walk already parsed, for a
 non-JS consumer (e.g. DSM's Go backend) that wants the parsed model without
 re-implementing the notation schema. Off by default — `--json` without
-`--include-model` keeps the pre-#669 output shape unchanged.
+`--include-model` keeps the existing output shape unchanged.
 
 ```json
 {

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -70,6 +70,61 @@ $ transitrix validate --scope=repo --root organizations/acme_corp
 The richer `target`/`category` finding taxonomy is intentionally **not** adopted
 yet (deferred per the ADR until a consumer needs it).
 
+### Resolved model output (`--include-model`, #669)
+
+`transitrix validate --scope=repo --json --include-model` adds a `model` key
+alongside the findings — the resolved `canon/elements/**` and
+`canon/relations/**` records the repo-scope walk already parsed, for a
+non-JS consumer (e.g. DSM's Go backend) that wants the parsed model without
+re-implementing the notation schema. Off by default — `--json` without
+`--include-model` keeps the pre-#669 output shape unchanged.
+
+```json
+{
+  "scope": "repo",
+  "root": "organizations/acme_corp",
+  "valid": true,
+  "findings": [],
+  "views": { "valid": true, "findings": [] },
+  "codex": { "valid": true, "findings": [] },
+  "compliance": { "valid": true, "findings": [] },
+  "skipped": [],
+  "model": {
+    "elements": [
+      {
+        "id": "DRIVER-COMP-1",
+        "name": "Support response time",
+        "notation": "driver",
+        "type": "internal",
+        "layer": "motivation",
+        "sourceFile": "canon/elements/01_motivation/factors/DRIVER-COMP-1.yaml"
+      }
+    ],
+    "relations": [
+      {
+        "id": "REL-EMP-PERSON-OPS-1",
+        "kind": "employment",
+        "source": "ACTOR-PERSON-1",
+        "target": "ACTOR-OPS-1",
+        "sourceFile": "canon/relations/REL-EMP-PERSON-OPS-1.yaml"
+      }
+    ]
+  }
+}
+```
+
+- **Elements** — `id`, `name` (`''` if absent), `notation` (the element TYPE's
+  short name, e.g. `driver`, `goal`, `capability`), `type` (per-TYPE subtype,
+  omitted when the doc has none), `layer` (from the doc's `layer` field, else
+  derived from the `canon/elements/<NN>_<layer>/…` folder — omitted if
+  neither is present), `sourceFile` (path relative to `--root`).
+- **Relations** — `id` (`''` if the doc has none), `kind` (the relation's
+  `type` field, omitted when absent), `source`/`target` (resolved `from`/`to`,
+  or the legacy `source`/`target` keys). A relation is only emitted once both
+  endpoints resolve to a non-empty id — an endpoint that fails to resolve is
+  already surfaced as a referential-integrity finding above; this projection
+  does not duplicate that as a half-resolved record.
+
 ## Rule Categories
 
 Rules are organized by element category using stable ID prefixes:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -27,6 +27,7 @@ npx @transitrix/cli --help
 transitrix compile <input>.yaml <output>.bpmn   # YAML → BPMN 2.0 XML
 transitrix validate <input>.yaml                # per-file validation
 transitrix validate --scope=repo                # whole-repo canon checks
+transitrix validate --scope=repo --json --include-model  # + resolved elements/relations
 transitrix metrics <input>.yaml [--json]        # layout-quality metrics
 transitrix export-compliance [--format md|pdf]  # compliance report
 transitrix serve [--port 8765]                  # local web UI

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.8.11",
+  "version": "1.8.12",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",

--- a/packages/diagrams/src/repo-validate/__tests__/resolve-model.test.ts
+++ b/packages/diagrams/src/repo-validate/__tests__/resolve-model.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from 'vitest';
+import { resolveRepoModel } from '../resolve-model.js';
+import type { RepoDoc, RepoModelInput } from '../types.js';
+
+function el(path: string, data: Record<string, unknown> | null, parseError?: string): RepoDoc {
+  return { path, data, parseError };
+}
+
+describe('resolveRepoModel — elements', () => {
+  it('resolves id/name/notation/type/layer/sourceFile from an admitted element', () => {
+    const model: RepoModelInput = {
+      elements: [
+        el('canon/elements/01_motivation/factors/DRIVER-COMP-1.yaml', {
+          notation: 'driver',
+          id: 'DRIVER-COMP-1',
+          name: 'Support response time',
+          type: 'internal',
+        }),
+      ],
+      relations: [],
+    };
+    const { elements } = resolveRepoModel(model);
+    expect(elements).toEqual([
+      {
+        id: 'DRIVER-COMP-1',
+        name: 'Support response time',
+        notation: 'driver',
+        type: 'internal',
+        layer: 'motivation',
+        sourceFile: 'canon/elements/01_motivation/factors/DRIVER-COMP-1.yaml',
+      },
+    ]);
+  });
+
+  it('prefers an explicit `layer` field over the folder-derived one', () => {
+    const model: RepoModelInput = {
+      elements: [
+        el('canon/elements/02_business/capabilities/CAPABILITY-V1.yaml', {
+          notation: 'capability',
+          id: 'CAPABILITY-V1',
+          name: 'Order management',
+          layer: 'business-explicit',
+        }),
+      ],
+      relations: [],
+    };
+    expect(resolveRepoModel(model).elements[0].layer).toBe('business-explicit');
+  });
+
+  it('omits `type` when the doc has none', () => {
+    const model: RepoModelInput = {
+      elements: [el('canon/elements/01_motivation/goals/GOAL-OPS-1.yaml', { notation: 'goal', id: 'GOAL-OPS-1', name: 'Ops goal' })],
+      relations: [],
+    };
+    expect(resolveRepoModel(model).elements[0].type).toBeUndefined();
+  });
+
+  it('defaults `name` to an empty string when absent', () => {
+    const model: RepoModelInput = {
+      elements: [el('canon/elements/01_motivation/goals/GOAL-NONAME.yaml', { notation: 'goal', id: 'GOAL-NONAME' })],
+      relations: [],
+    };
+    expect(resolveRepoModel(model).elements[0].name).toBe('');
+  });
+
+  it('skips a sidecar doc with no top-level id', () => {
+    const model: RepoModelInput = {
+      elements: [
+        el('canon/elements/02_business/capabilities/CAPABILITY-V1.history.yaml', {
+          target: 'CAPABILITY-V1',
+          attribute_versions: [],
+        }),
+      ],
+      relations: [],
+    };
+    expect(resolveRepoModel(model).elements).toEqual([]);
+  });
+
+  it('skips a doc that failed to parse (null data)', () => {
+    const model: RepoModelInput = {
+      elements: [el('canon/elements/broken.yaml', null, 'bad indentation')],
+      relations: [],
+    };
+    expect(resolveRepoModel(model).elements).toEqual([]);
+  });
+
+  it('leaves `layer` undefined when the path has no `<NN>_<layer>` folder segment', () => {
+    const model: RepoModelInput = {
+      elements: [el('canon/elements/flat.yaml', { notation: 'goal', id: 'GOAL-FLAT', name: 'Flat' })],
+      relations: [],
+    };
+    expect(resolveRepoModel(model).elements[0].layer).toBeUndefined();
+  });
+});
+
+describe('resolveRepoModel — relations', () => {
+  it('resolves id/kind/source/target/sourceFile from a canonical from/to relation', () => {
+    const model: RepoModelInput = {
+      elements: [],
+      relations: [
+        el('canon/relations/REL-EMP-PERSON-OPS-1.yaml', {
+          notation: 'relation',
+          id: 'REL-EMP-PERSON-OPS-1',
+          type: 'employment',
+          from: 'ACTOR-PERSON-1',
+          to: 'ACTOR-OPS-1',
+        }),
+      ],
+    };
+    expect(resolveRepoModel(model).relations).toEqual([
+      {
+        id: 'REL-EMP-PERSON-OPS-1',
+        kind: 'employment',
+        source: 'ACTOR-PERSON-1',
+        target: 'ACTOR-OPS-1',
+        sourceFile: 'canon/relations/REL-EMP-PERSON-OPS-1.yaml',
+      },
+    ]);
+  });
+
+  it('accepts the legacy source/target endpoint keys', () => {
+    const model: RepoModelInput = {
+      elements: [],
+      relations: [el('canon/relations/REL-ST.yaml', { id: 'REL-ST', source: 'A-1', target: 'B-1' })],
+    };
+    const rec = resolveRepoModel(model).relations[0];
+    expect(rec.source).toBe('A-1');
+    expect(rec.target).toBe('B-1');
+  });
+
+  it('resolves `{ id }` object endpoints', () => {
+    const model: RepoModelInput = {
+      elements: [],
+      relations: [el('canon/relations/REL-OBJ.yaml', { id: 'REL-OBJ', from: { id: 'A-1' }, to: { id: 'B-1' } })],
+    };
+    const rec = resolveRepoModel(model).relations[0];
+    expect(rec.source).toBe('A-1');
+    expect(rec.target).toBe('B-1');
+  });
+
+  it('omits a relation whose `from` endpoint does not resolve', () => {
+    const model: RepoModelInput = {
+      elements: [],
+      relations: [el('canon/relations/REL-BAD.yaml', { id: 'REL-BAD', to: 'B-1' })],
+    };
+    expect(resolveRepoModel(model).relations).toEqual([]);
+  });
+
+  it('omits a relation whose `to` endpoint does not resolve', () => {
+    const model: RepoModelInput = {
+      elements: [],
+      relations: [el('canon/relations/REL-BAD.yaml', { id: 'REL-BAD', from: 'A-1' })],
+    };
+    expect(resolveRepoModel(model).relations).toEqual([]);
+  });
+
+  it('defaults `id` to an empty string when the relation doc has none, but still resolves', () => {
+    const model: RepoModelInput = {
+      elements: [],
+      relations: [el('canon/relations/no-id.yaml', { from: 'A-1', to: 'B-1' })],
+    };
+    const rec = resolveRepoModel(model).relations[0];
+    expect(rec.id).toBe('');
+    expect(rec.source).toBe('A-1');
+  });
+
+  it('omits `kind` when the relation doc has no `type`', () => {
+    const model: RepoModelInput = {
+      elements: [],
+      relations: [el('canon/relations/no-type.yaml', { id: 'REL-NT', from: 'A-1', to: 'B-1' })],
+    };
+    expect(resolveRepoModel(model).relations[0].kind).toBeUndefined();
+  });
+
+  it('skips a relation doc that failed to parse (null data)', () => {
+    const model: RepoModelInput = {
+      elements: [],
+      relations: [el('canon/relations/broken.yaml', null, 'bad indentation')],
+    };
+    expect(resolveRepoModel(model).relations).toEqual([]);
+  });
+});

--- a/packages/diagrams/src/repo-validate/index.ts
+++ b/packages/diagrams/src/repo-validate/index.ts
@@ -1,2 +1,3 @@
 export { validateRepoModel } from './validate-repo.js';
-export type { RepoDoc, RepoFinding, RepoModelInput } from './types.js';
+export { resolveRepoModel } from './resolve-model.js';
+export type { RepoDoc, RepoFinding, RepoModelInput, ResolvedElementRecord, ResolvedRelationRecord, ResolvedRepoModel } from './types.js';

--- a/packages/diagrams/src/repo-validate/resolve-model.ts
+++ b/packages/diagrams/src/repo-validate/resolve-model.ts
@@ -1,9 +1,8 @@
-// Resolved element/relation records for `validate --scope=repo --json --include-model`
-// (vkgeorgia/strategy#669). A non-JS consumer (DSM's Go backend) needs the
-// canon model this CLI already parses without re-implementing the notation
-// schema — this is a pure projection over the same `RepoModelInput` the
-// repo-scope validator consumes, not a second parse pass, so the two never
-// drift out of sync.
+// Resolved element/relation records for `validate --scope=repo --json --include-model`.
+// A non-JS consumer (DSM's Go backend) needs the canon model this CLI already
+// parses without re-implementing the notation schema — this is a pure
+// projection over the same `RepoModelInput` the repo-scope validator
+// consumes, not a second parse pass, so the two never drift out of sync.
 
 import { docId, endpointId } from './validate-repo.js';
 import type {

--- a/packages/diagrams/src/repo-validate/resolve-model.ts
+++ b/packages/diagrams/src/repo-validate/resolve-model.ts
@@ -1,0 +1,79 @@
+// Resolved element/relation records for `validate --scope=repo --json --include-model`
+// (vkgeorgia/strategy#669). A non-JS consumer (DSM's Go backend) needs the
+// canon model this CLI already parses without re-implementing the notation
+// schema — this is a pure projection over the same `RepoModelInput` the
+// repo-scope validator consumes, not a second parse pass, so the two never
+// drift out of sync.
+
+import { docId, endpointId } from './validate-repo.js';
+import type {
+  RepoDoc,
+  RepoModelInput,
+  ResolvedElementRecord,
+  ResolvedRelationRecord,
+  ResolvedRepoModel,
+} from './types.js';
+
+/** Matches the `<NN>_<layer>` folder segment under `canon/elements/`, e.g.
+ *  `01_motivation` -> `motivation` (ELEMENT_PRIMITIVES.md §2/§6). */
+const LAYER_FOLDER_RE = /^\d+_(.+)$/;
+
+function readString(data: Record<string, unknown>, key: string): string | undefined {
+  const v = data[key];
+  return typeof v === 'string' && v.length > 0 ? v : undefined;
+}
+
+/** Derive `layer` from the `canon/elements/<NN>_<layer>/…` folder segment when
+ *  the doc has no explicit `layer` field — the folder is authoritative
+ *  (ELEMENT_PRIMITIVES.md §3, `ELEM-003`). */
+function layerFromPath(path: string): string | undefined {
+  const segs = path.split('/');
+  const layerSeg = segs[2]; // canon / elements / <NN>_<layer> / …
+  if (!layerSeg) return undefined;
+  const m = LAYER_FOLDER_RE.exec(layerSeg);
+  return m ? m[1] : undefined;
+}
+
+function resolveElement(doc: RepoDoc): ResolvedElementRecord | null {
+  const id = docId(doc);
+  if (!id || !doc.data) return null;
+  return {
+    id,
+    name: readString(doc.data, 'name') ?? '',
+    notation: readString(doc.data, 'notation') ?? '',
+    type: readString(doc.data, 'type'),
+    layer: readString(doc.data, 'layer') ?? layerFromPath(doc.path),
+    sourceFile: doc.path,
+  };
+}
+
+function resolveRelation(doc: RepoDoc): ResolvedRelationRecord | null {
+  if (!doc.data) return null;
+  const source = endpointId(doc.data['from']) ?? endpointId(doc.data['source']);
+  const target = endpointId(doc.data['to']) ?? endpointId(doc.data['target']);
+  if (!source || !target) return null;
+  return {
+    id: docId(doc) ?? '',
+    kind: readString(doc.data, 'type'),
+    source,
+    target,
+    sourceFile: doc.path,
+  };
+}
+
+/** Project a loaded canon model into the resolved element/relation records a
+ *  non-JS consumer can read directly, without depending on this repo's YAML
+ *  parsing internals. Pure: no IO. */
+export function resolveRepoModel(input: RepoModelInput): ResolvedRepoModel {
+  const elements: ResolvedElementRecord[] = [];
+  for (const doc of input.elements) {
+    const rec = resolveElement(doc);
+    if (rec) elements.push(rec);
+  }
+  const relations: ResolvedRelationRecord[] = [];
+  for (const doc of input.relations) {
+    const rec = resolveRelation(doc);
+    if (rec) relations.push(rec);
+  }
+  return { elements, relations };
+}

--- a/packages/diagrams/src/repo-validate/types.ts
+++ b/packages/diagrams/src/repo-validate/types.ts
@@ -49,7 +49,7 @@ export interface RepoModelInput {
 }
 
 /** One resolved canon element, projected from a `RepoDoc` for a non-JS
- *  consumer (vkgeorgia/strategy#669 — DSM's Go importer). Mirrors the fields
+ *  consumer (DSM's Go importer). Mirrors the fields
  *  DSM's `methodology_element` table already persists (`ElementID`, `Name`,
  *  `ElementType`, `Layer`, `Notation`, `SourceFile`), minus DB-internal
  *  concerns (row id, timestamps). */
@@ -68,7 +68,7 @@ export interface ResolvedElementRecord {
   sourceFile: string;
 }
 
-/** One resolved canon relation, projected from a `RepoDoc` (#669). Only
+/** One resolved canon relation, projected from a `RepoDoc`. Only
  *  emitted when both endpoints resolve to a non-empty id — an endpoint that
  *  fails to resolve is already surfaced as a referential-integrity finding by
  *  `validateRepoModel`; this projection does not duplicate that as a
@@ -86,7 +86,7 @@ export interface ResolvedRelationRecord {
   sourceFile: string;
 }
 
-/** The resolved element/relation records for a repo-scope run (#669) —
+/** The resolved element/relation records for a repo-scope run —
  *  the shape `transitrix validate --scope=repo --json --include-model` adds
  *  alongside the validation findings. */
 export interface ResolvedRepoModel {

--- a/packages/diagrams/src/repo-validate/types.ts
+++ b/packages/diagrams/src/repo-validate/types.ts
@@ -47,3 +47,49 @@ export interface RepoModelInput {
   /** Documents found under `canon/relations/**`. */
   relations: RepoDoc[];
 }
+
+/** One resolved canon element, projected from a `RepoDoc` for a non-JS
+ *  consumer (vkgeorgia/strategy#669 — DSM's Go importer). Mirrors the fields
+ *  DSM's `methodology_element` table already persists (`ElementID`, `Name`,
+ *  `ElementType`, `Layer`, `Notation`, `SourceFile`), minus DB-internal
+ *  concerns (row id, timestamps). */
+export interface ResolvedElementRecord {
+  /** Canonical id, e.g. `DRIVER-COMP-1`. */
+  id: string;
+  /** `name` field; `''` when absent (should not happen for an admitted element). */
+  name: string;
+  /** The element TYPE's short name — the doc's `notation` field, e.g. `driver`, `goal`, `capability`. */
+  notation: string;
+  /** Subtype from the TYPE's controlled vocabulary (ELEMENT_PRIMITIVES.md §3), e.g. `internal`/`external` for DRIVER. Omitted when the doc has none. */
+  type?: string;
+  /** `motivation` / `business` / `application` / `technology` / `implementation`. Read from the doc's `layer` field when present, else derived from the `canon/elements/<NN>_<layer>/…` folder. */
+  layer?: string;
+  /** Source file path, relative to the scanned root. */
+  sourceFile: string;
+}
+
+/** One resolved canon relation, projected from a `RepoDoc` (#669). Only
+ *  emitted when both endpoints resolve to a non-empty id — an endpoint that
+ *  fails to resolve is already surfaced as a referential-integrity finding by
+ *  `validateRepoModel`; this projection does not duplicate that as a
+ *  half-resolved record. */
+export interface ResolvedRelationRecord {
+  /** Canonical id, e.g. `REL-EMP-PERSON-OPS-1`. `''` when the relation doc has no `id`. */
+  id: string;
+  /** The relation's `type` field, e.g. `employment`, `realizes`. Omitted when the doc has none. */
+  kind?: string;
+  /** Resolved `from` (or legacy `source`) endpoint id. */
+  source: string;
+  /** Resolved `to` (or legacy `target`) endpoint id. */
+  target: string;
+  /** Source file path, relative to the scanned root. */
+  sourceFile: string;
+}
+
+/** The resolved element/relation records for a repo-scope run (#669) —
+ *  the shape `transitrix validate --scope=repo --json --include-model` adds
+ *  alongside the validation findings. */
+export interface ResolvedRepoModel {
+  elements: ResolvedElementRecord[];
+  relations: ResolvedRelationRecord[];
+}

--- a/packages/diagrams/src/repo-validate/validate-repo.ts
+++ b/packages/diagrams/src/repo-validate/validate-repo.ts
@@ -33,15 +33,16 @@ const PScope: RepoFinding['scope'] = 'repo';
 /** Statuses that, per lint.py's policy check, require an owner. */
 const OWNER_REQUIRED_STATUSES = new Set(['Active', 'Production']);
 
-function isRecord(v: unknown): v is Record<string, unknown> {
+export function isRecord(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null && !Array.isArray(v);
 }
 
 /** Read a string `id` from a parsed doc, or `null` if absent/non-string.
  *  Mirrors lint.py, which only treats a doc as an element/relation when it has
  *  a top-level `id` (sidecars such as versioned-attribute files have no `id`
- *  and are ignored). */
-function docId(doc: RepoDoc): string | null {
+ *  and are ignored). Exported for reuse by `resolve-model.ts`, which needs the
+ *  same id/endpoint reading rules to stay in lockstep with this validator. */
+export function docId(doc: RepoDoc): string | null {
   if (!doc.data) return null;
   const id = doc.data['id'];
   return typeof id === 'string' && id.length > 0 ? id : null;
@@ -49,7 +50,7 @@ function docId(doc: RepoDoc): string | null {
 
 /** Resolve a relation endpoint, which may be a bare id string or a `{ id }`
  *  mapping (lint.py accepts both). Returns the id string or `null`. */
-function endpointId(value: unknown): string | null {
+export function endpointId(value: unknown): string | null {
   if (typeof value === 'string') return value.length > 0 ? value : null;
   if (isRecord(value)) {
     const id = value['id'];

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -328,10 +328,10 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
   if (scope === 'repo') {
     const repoRoot = root ?? process.cwd();
     const result = runRepoValidate(repoRoot);
-    // --include-model (vkgeorgia/strategy#669): also emit the resolved
-    // element/relation records the canon walk already parsed, for a non-JS
-    // consumer (DSM) that wants the model without a second parser. Opt-in so
-    // the default --scope=repo output shape is unchanged for existing callers.
+    // --include-model: also emit the resolved element/relation records the
+    // canon walk already parsed, for a non-JS consumer (DSM) that wants the
+    // model without a second parser. Opt-in so the default --scope=repo
+    // output shape is unchanged for existing callers.
     const includeModel = argv.includes('--include-model');
     const model = includeModel ? buildRepoModel(repoRoot) : undefined;
     reportRepoFindings(repoRoot, result, useJson, model);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,7 +17,7 @@ import type { ValidationReport, ValidationFinding } from './validator-types.js';
 import { parseYamlToIr } from './parser.js';
 import { validateProcess } from './validator.js';
 import type { ProcessIr } from './ir.js';
-import { runRepoValidate, reportRepoFindings, repoScopeHasErrors } from './repo-validate.js';
+import { runRepoValidate, reportRepoFindings, repoScopeHasErrors, buildRepoModel } from './repo-validate.js';
 import {
   isFileValidatableNotation,
   loadNotationYaml,
@@ -56,7 +56,7 @@ function printUsage(): void {
        transitrix metrics [--ext=.bpmn.transitrix.yaml] <input.yaml> [--json]
        transitrix validate <input.yaml> [--json]
        transitrix validate [--ext=.bpmn.transitrix.yaml] <input.yaml> [--json]
-       transitrix validate --scope=repo [--root <dir>] [--json]
+       transitrix validate --scope=repo [--root <dir>] [--json] [--include-model]
        transitrix export-compliance [--format md|pdf] [--scope law:<ID>|product:<ID>|gap] [--output <path>] [--root <dir>]
        transitrix migrate [--from X.Y] [--to X.Y] [--dry-run] [--recipes <dir>] [target-dir]
 
@@ -69,7 +69,8 @@ function printUsage(): void {
               activities, activity-card, process-blueprint, blocks) routed by its
               notation: field — the same checks the Studio preview shows.
               --scope=repo runs whole-canon checks (referential integrity,
-              atomicity, id uniqueness, policy).
+              atomicity, id uniqueness, policy). --include-model (with --json)
+              also emits the resolved element/relation records it parsed.
   export-compliance — Markdown or PDF report of the compliance views (matrix by
               default; law:/product:/gap scopes). Scans --root (default cwd) for
               requirement/assertion/product/codex canon. PDF rendering requires
@@ -304,7 +305,7 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
 
   if (wantsHelp) {
     console.error(`usage: transitrix validate <input.yaml> [--json]                 (file scope, default)`);
-    console.error(`       transitrix validate --scope=repo [--root <dir>] [--json]`);
+    console.error(`       transitrix validate --scope=repo [--root <dir>] [--json] [--include-model]`);
     console.error('');
     console.error('file scope — single-file structural/semantic validation (default).');
     console.error('             BPMN, or any diagram notation routed by its notation: field');
@@ -315,6 +316,10 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
     console.error('             Canonical notation extensions are accepted without --ext.');
     console.error('repo scope — whole-canon checks (referential integrity, atomicity,');
     console.error('             id uniqueness, policy) over <root> (default: cwd).');
+    console.error('             --include-model (with --json) also emits the resolved');
+    console.error('             canon/elements/** and canon/relations/** records it parsed,');
+    console.error('             as { model: { elements: [...], relations: [...] } } — for a');
+    console.error('             non-JS consumer of the parsed model. Off by default.');
     console.error('Exits with code 1 if any findings.');
     process.exit(0);
   }
@@ -323,7 +328,13 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
   if (scope === 'repo') {
     const repoRoot = root ?? process.cwd();
     const result = runRepoValidate(repoRoot);
-    reportRepoFindings(repoRoot, result, useJson);
+    // --include-model (vkgeorgia/strategy#669): also emit the resolved
+    // element/relation records the canon walk already parsed, for a non-JS
+    // consumer (DSM) that wants the model without a second parser. Opt-in so
+    // the default --scope=repo output shape is unchanged for existing callers.
+    const includeModel = argv.includes('--include-model');
+    const model = includeModel ? buildRepoModel(repoRoot) : undefined;
+    reportRepoFindings(repoRoot, result, useJson, model);
     if (repoScopeHasErrors(result)) {
       process.exit(1);
     }

--- a/src/repo-validate.ts
+++ b/src/repo-validate.ts
@@ -598,7 +598,7 @@ export function runRepoValidate(root: string): RepoScopeResult {
 }
 
 /** Load the canon model under `root` and resolve it into the element/relation
- *  records a non-JS consumer can read (vkgeorgia/strategy#669) — the output
+ *  records a non-JS consumer can read — the output
  *  `validate --scope=repo --json --include-model` adds alongside findings.
  *  Reuses `loadRepoModel`, the same walk `runRepoValidate` uses for its canon
  *  cross-reference checks, so the two never see a different model. */
@@ -619,7 +619,7 @@ export function repoScopeHasErrors(result: RepoScopeResult): boolean {
 
 /** Print the repo-scope result (human or JSON). Returns nothing; the caller sets
  *  the exit code via repoScopeHasErrors(). `model` is set only when the caller
- *  passed `--include-model` (#669) — omitted from the JSON entirely otherwise,
+ *  passed `--include-model` — omitted from the JSON entirely otherwise,
  *  so the default output shape is unchanged for existing consumers. */
 export function reportRepoFindings(
   root: string,

--- a/src/repo-validate.ts
+++ b/src/repo-validate.ts
@@ -16,9 +16,11 @@ import yaml from 'js-yaml';
 import { coerceDatesToIsoStrings } from '@transitrix/diagrams/yaml-normalize.js';
 import {
   validateRepoModel,
+  resolveRepoModel,
   type RepoDoc,
   type RepoFinding,
   type RepoModelInput,
+  type ResolvedRepoModel,
 } from '@transitrix/diagrams/repo-validate';
 import {
   buildComplianceScan,
@@ -595,6 +597,15 @@ export function runRepoValidate(root: string): RepoScopeResult {
   return { canon, views, codex, compliance, skipped };
 }
 
+/** Load the canon model under `root` and resolve it into the element/relation
+ *  records a non-JS consumer can read (vkgeorgia/strategy#669) — the output
+ *  `validate --scope=repo --json --include-model` adds alongside findings.
+ *  Reuses `loadRepoModel`, the same walk `runRepoValidate` uses for its canon
+ *  cross-reference checks, so the two never see a different model. */
+export function buildRepoModel(root: string): ResolvedRepoModel {
+  return resolveRepoModel(loadRepoModel(root));
+}
+
 /** True when the run has a blocking finding — a canon finding or a view error.
  *  View warnings and skipped files do not fail the run. */
 export function repoScopeHasErrors(result: RepoScopeResult): boolean {
@@ -607,8 +618,15 @@ export function repoScopeHasErrors(result: RepoScopeResult): boolean {
 }
 
 /** Print the repo-scope result (human or JSON). Returns nothing; the caller sets
- *  the exit code via repoScopeHasErrors(). */
-export function reportRepoFindings(root: string, result: RepoScopeResult, useJson: boolean): void {
+ *  the exit code via repoScopeHasErrors(). `model` is set only when the caller
+ *  passed `--include-model` (#669) — omitted from the JSON entirely otherwise,
+ *  so the default output shape is unchanged for existing consumers. */
+export function reportRepoFindings(
+  root: string,
+  result: RepoScopeResult,
+  useJson: boolean,
+  model?: ResolvedRepoModel,
+): void {
   const { canon, views, codex, compliance, skipped } = result;
   const viewErrors = views.filter((v) => v.severity === 'error');
   const viewWarnings = views.filter((v) => v.severity === 'warning');
@@ -634,6 +652,7 @@ export function reportRepoFindings(root: string, result: RepoScopeResult, useJso
           codex: { valid: codexErrors.length === 0, findings: codex },
           compliance: { valid: complianceErrors.length === 0, findings: compliance },
           skipped,
+          ...(model ? { model } : {}),
         },
         null,
         2,
@@ -644,6 +663,9 @@ export function reportRepoFindings(root: string, result: RepoScopeResult, useJso
 
   if (valid && skipped.length === 0) {
     console.log(`✓ ${root} — repo-scope validation passed`);
+    if (model) {
+      console.log(`  Resolved model: ${model.elements.length} element(s), ${model.relations.length} relation(s)`);
+    }
     console.log();
     return;
   }
@@ -748,6 +770,11 @@ export function reportRepoFindings(root: string, result: RepoScopeResult, useJso
   }
   if (parts.length > 0) {
     console.log(`Repo-scope validation: ${parts.join(', ')}`);
+    console.log();
+  }
+
+  if (model) {
+    console.log(`Resolved model: ${model.elements.length} element(s), ${model.relations.length} relation(s)`);
     console.log();
   }
 }

--- a/tests/cli-repo-validate-model.test.ts
+++ b/tests/cli-repo-validate-model.test.ts
@@ -1,0 +1,72 @@
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+import { describe, it, expect } from 'vitest'
+
+// Spawns the built CLI (dist/cli.js — produced by the `pretest` build step),
+// same pattern as cli.test.ts.
+const cliPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'dist', 'cli.js')
+const acmeCorpRoot = join(dirname(fileURLToPath(import.meta.url)), '..', 'organizations', 'acme_corp')
+
+function runCli(args: string[]): { status: number; stdout: string; stderr: string } {
+  const r = spawnSync(process.execPath, [cliPath, ...args], { encoding: 'utf8' })
+  return { status: r.status ?? 1, stdout: r.stdout ?? '', stderr: r.stderr ?? '' }
+}
+
+// vkgeorgia/strategy#669 — `validate --scope=repo --json --include-model` also
+// emits the resolved canon/elements/** and canon/relations/** records, for a
+// non-JS consumer (DSM's Go importer) that wants the parsed model without
+// re-implementing the notation schema.
+describe('CLI validate --scope=repo --include-model (#669)', () => {
+  it('omits the `model` key by default (existing --json consumers unaffected)', () => {
+    const { stdout } = runCli(['validate', '--scope=repo', '--root', acmeCorpRoot, '--json'])
+    const output = JSON.parse(stdout)
+    expect('model' in output).toBe(false)
+  })
+
+  it('emits resolved element and relation records with --include-model', () => {
+    const { stdout } = runCli(['validate', '--scope=repo', '--root', acmeCorpRoot, '--json', '--include-model'])
+    const output = JSON.parse(stdout)
+    expect(Array.isArray(output.model.elements)).toBe(true)
+    expect(Array.isArray(output.model.relations)).toBe(true)
+    expect(output.model.elements.length).toBeGreaterThan(0)
+    expect(output.model.relations.length).toBeGreaterThan(0)
+
+    const driver = output.model.elements.find((e: { id: string }) => e.id === 'DRIVER-COMP-1')
+    expect(driver).toMatchObject({
+      id: 'DRIVER-COMP-1',
+      name: 'Support response time',
+      notation: 'driver',
+      type: 'internal',
+      layer: 'motivation',
+    })
+    expect(driver.sourceFile).toMatch(/canon\/elements\/01_motivation\/factors\/DRIVER-COMP-1\.yaml$/)
+
+    const relation = output.model.relations.find((r: { id: string }) => r.id === 'REL-EMP-PERSON-OPS-1')
+    expect(relation).toMatchObject({
+      id: 'REL-EMP-PERSON-OPS-1',
+      kind: 'employment',
+      source: 'ACTOR-PERSON-1',
+      target: 'ACTOR-OPS-1',
+    })
+  })
+
+  it('every relation record resolves to non-empty source/target ids', () => {
+    const { stdout } = runCli(['validate', '--scope=repo', '--root', acmeCorpRoot, '--json', '--include-model'])
+    const output = JSON.parse(stdout)
+    for (const r of output.model.relations) {
+      expect(typeof r.source).toBe('string')
+      expect(r.source.length).toBeGreaterThan(0)
+      expect(typeof r.target).toBe('string')
+      expect(r.target.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('--include-model without --json does not error (flag is a no-op outside JSON mode)', () => {
+    const { status } = runCli(['validate', '--scope=repo', '--root', acmeCorpRoot, '--include-model'])
+    // acme_corp has pre-existing compliance findings unrelated to this flag —
+    // only assert the process ran and did not crash on the new flag.
+    expect([0, 1]).toContain(status)
+  })
+})

--- a/tests/cli-repo-validate-model.test.ts
+++ b/tests/cli-repo-validate-model.test.ts
@@ -14,11 +14,11 @@ function runCli(args: string[]): { status: number; stdout: string; stderr: strin
   return { status: r.status ?? 1, stdout: r.stdout ?? '', stderr: r.stderr ?? '' }
 }
 
-// vkgeorgia/strategy#669 — `validate --scope=repo --json --include-model` also
-// emits the resolved canon/elements/** and canon/relations/** records, for a
-// non-JS consumer (DSM's Go importer) that wants the parsed model without
-// re-implementing the notation schema.
-describe('CLI validate --scope=repo --include-model (#669)', () => {
+// `validate --scope=repo --json --include-model` emits the resolved
+// canon/elements/** and canon/relations/** records, for a non-JS consumer
+// (DSM's Go importer) that wants the parsed model without re-implementing
+// the notation schema.
+describe('CLI validate --scope=repo --include-model', () => {
   it('omits the `model` key by default (existing --json consumers unaffected)', () => {
     const { stdout } = runCli(['validate', '--scope=repo', '--root', acmeCorpRoot, '--json'])
     const output = JSON.parse(stdout)


### PR DESCRIPTION
## Summary
- `transitrix validate --scope=repo --json --include-model` adds a `model: { elements, relations }` key with the resolved canon/elements/** and canon/relations/** records (id/name/notation/type/layer per element; id/kind/source/target per relation) — for a non-JS consumer (DSM's Go backend) that wants the parsed model without re-implementing the notation schema.
- Opt-in flag; the existing `--scope=repo --json` output shape is unchanged for current consumers when `--include-model` is omitted.
- Reuses the same `RepoModelInput` walk `runRepoValidate` already does for canon cross-reference checks — a pure projection, not a second parse pass.
- Documented in `docs/cli.md` / `docs/validation.md` / `packages/cli/README.md`.

## Test plan
- [x] `npm run build`
- [x] `npm test` — 458 passing; 3 pre-existing failures in `tests/cli-migrate.test.ts` unrelated to this change (sibling `methodology` repo migration-recipe drift, reproduces identically on the pre-change commit)
- [x] New coverage: `packages/diagrams/src/repo-validate/__tests__/resolve-model.test.ts`, `tests/cli-repo-validate-model.test.ts`