### PR TITLE
feat(cli): emit the full parsed element on validate --scope=repo --include-model

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -97,7 +97,20 @@ re-implementing the notation schema. Off by default — `--json` without
         "notation": "driver",
         "type": "internal",
         "layer": "motivation",
-        "sourceFile": "canon/elements/01_motivation/factors/DRIVER-COMP-1.yaml"
+        "sourceFile": "canon/elements/01_motivation/factors/DRIVER-COMP-1.yaml",
+        "data": {
+          "notation": "driver",
+          "id": "DRIVER-COMP-1",
+          "name": "Support response time",
+          "type": "internal",
+          "description": "Standing internal driver — the performance dimension of support first-response time. …",
+          "zone": "canon",
+          "admitted_at": "2026-05-29",
+          "admitted_by": "v.korobeinikov",
+          "gate_checks": { "uniqueness": "pass", "consistency": "pass", "completeness": "pass" },
+          "valid_from": "2026-05-26",
+          "valid_to": null
+        }
       }
     ],
     "relations": [
@@ -117,7 +130,15 @@ re-implementing the notation schema. Off by default — `--json` without
   short name, e.g. `driver`, `goal`, `capability`), `type` (per-TYPE subtype,
   omitted when the doc has none), `layer` (from the doc's `layer` field, else
   derived from the `canon/elements/<NN>_<layer>/…` folder — omitted if
-  neither is present), `sourceFile` (path relative to `--root`).
+  neither is present), `sourceFile` (path relative to `--root`), `data` — the
+  complete parsed element document, unfiltered (every canon-authored field the
+  file has, plus the admission/lifecycle envelope). `id`/`name`/`notation`/
+  `type`/`layer`/`sourceFile` stay a minimal, stable identity projection for
+  consumers that only need those; `data` is the faithful projection for a
+  consumer that needs a field the engine already parsed but the minimal set
+  doesn't carry (a goal's `level`/`parent`/`link`/`tags`, an action's
+  scheduling and ownership fields, …) — without the engine growing a
+  bespoke field list per consumer.
 - **Relations** — `id` (`''` if the doc has none), `kind` (the relation's
   `type` field, omitted when absent), `source`/`target` (resolved `from`/`to`,
   or the legacy `source`/`target` keys). A relation is only emitted once both

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.8.12",
+  "version": "1.8.13",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",

--- a/packages/diagrams/src/repo-validate/__tests__/resolve-model.test.ts
+++ b/packages/diagrams/src/repo-validate/__tests__/resolve-model.test.ts
@@ -8,15 +8,14 @@ function el(path: string, data: Record<string, unknown> | null, parseError?: str
 
 describe('resolveRepoModel — elements', () => {
   it('resolves id/name/notation/type/layer/sourceFile from an admitted element', () => {
+    const doc = {
+      notation: 'driver',
+      id: 'DRIVER-COMP-1',
+      name: 'Support response time',
+      type: 'internal',
+    };
     const model: RepoModelInput = {
-      elements: [
-        el('canon/elements/01_motivation/factors/DRIVER-COMP-1.yaml', {
-          notation: 'driver',
-          id: 'DRIVER-COMP-1',
-          name: 'Support response time',
-          type: 'internal',
-        }),
-      ],
+      elements: [el('canon/elements/01_motivation/factors/DRIVER-COMP-1.yaml', doc)],
       relations: [],
     };
     const { elements } = resolveRepoModel(model);
@@ -28,8 +27,30 @@ describe('resolveRepoModel — elements', () => {
         type: 'internal',
         layer: 'motivation',
         sourceFile: 'canon/elements/01_motivation/factors/DRIVER-COMP-1.yaml',
+        data: doc,
       },
     ]);
+  });
+
+  it('carries every canon-authored field on `data`, not just the minimal identity set', () => {
+    const doc = {
+      notation: 'goal',
+      id: 'GOAL-CUST-1',
+      name: 'Improve customer onboarding experience',
+      type: 'Strategic Goal',
+      level: 1,
+      parent: 'GOAL-ROOT-1',
+      description: 'Reduce time-to-value for new customers.',
+      link: 'https://wiki.example.com/onboarding',
+      tags: ['customer', 'q3'],
+      zone: 'canon',
+      admitted_at: '2026-05-29',
+    };
+    const model: RepoModelInput = {
+      elements: [el('canon/elements/01_motivation/goals/GOAL-CUST-1.yaml', doc)],
+      relations: [],
+    };
+    expect(resolveRepoModel(model).elements[0].data).toEqual(doc);
   });
 
   it('prefers an explicit `layer` field over the folder-derived one', () => {

--- a/packages/diagrams/src/repo-validate/resolve-model.ts
+++ b/packages/diagrams/src/repo-validate/resolve-model.ts
@@ -43,6 +43,7 @@ function resolveElement(doc: RepoDoc): ResolvedElementRecord | null {
     type: readString(doc.data, 'type'),
     layer: readString(doc.data, 'layer') ?? layerFromPath(doc.path),
     sourceFile: doc.path,
+    data: doc.data,
   };
 }
 

--- a/packages/diagrams/src/repo-validate/types.ts
+++ b/packages/diagrams/src/repo-validate/types.ts
@@ -49,10 +49,18 @@ export interface RepoModelInput {
 }
 
 /** One resolved canon element, projected from a `RepoDoc` for a non-JS
- *  consumer (DSM's Go importer). Mirrors the fields
- *  DSM's `methodology_element` table already persists (`ElementID`, `Name`,
- *  `ElementType`, `Layer`, `Notation`, `SourceFile`), minus DB-internal
- *  concerns (row id, timestamps). */
+ *  consumer (DSM's Go importer). The top-level fields below are a stable,
+ *  minimal identity projection — kept for backward compatibility with
+ *  consumers that only need `id`/`name`/`notation`/`type`/`layer`/`sourceFile`
+ *  (mirrors DSM's `methodology_element` table). `data` carries the complete
+ *  parsed element alongside it, so a consumer never needs an engine schema
+ *  change to read a canon-authored field the engine already parsed (a goal's
+ *  `level`/`parent`/`description`/`link`/`tags`, an action's scheduling and
+ *  ownership fields, etc.) — the engine owns each notation's field set
+ *  (ELEMENT_PRIMITIVES.md), so its output stays notation-shaped rather than
+ *  growing a bespoke field list per consumer. This is the faithful-projection
+ *  fallback: a typed per-notation shape may replace `data` later, but the
+ *  contract must not be curated down to what one consumer currently needs. */
 export interface ResolvedElementRecord {
   /** Canonical id, e.g. `DRIVER-COMP-1`. */
   id: string;
@@ -66,6 +74,11 @@ export interface ResolvedElementRecord {
   layer?: string;
   /** Source file path, relative to the scanned root. */
   sourceFile: string;
+  /** The full parsed element document — every field its author supplied,
+   *  unfiltered (including the admission/lifecycle envelope). The same
+   *  `RepoDoc.data` the repo-scope validator already consumes, so this
+   *  projection and the validation pass never see a different parse. */
+  data: Record<string, unknown>;
 }
 
 /** One resolved canon relation, projected from a `RepoDoc`. Only

--- a/tests/cli-repo-validate-model.test.ts
+++ b/tests/cli-repo-validate-model.test.ts
@@ -43,6 +43,18 @@ describe('CLI validate --scope=repo --include-model', () => {
     })
     expect(driver.sourceFile).toMatch(/canon\/elements\/01_motivation\/factors\/DRIVER-COMP-1\.yaml$/)
 
+    // `data` carries the full parsed element — canon-authored fields beyond
+    // the minimal identity set (e.g. `description`) are readable without an
+    // engine schema change.
+    expect(driver.data).toMatchObject({
+      notation: 'driver',
+      id: 'DRIVER-COMP-1',
+      name: 'Support response time',
+      type: 'internal',
+    })
+    expect(typeof driver.data.description).toBe('string')
+    expect(driver.data.description.length).toBeGreaterThan(0)
+
     const relation = output.model.relations.find((r: { id: string }) => r.id === 'REL-EMP-PERSON-OPS-1')
     expect(relation).toMatchObject({
       id: 'REL-EMP-PERSON-OPS-1',


### PR DESCRIPTION
## Summary

- `ResolvedElementRecord` (the `model.elements[]` shape `transitrix validate --scope=repo --json --include-model` emits) stayed a minimal, DSM-shaped projection — `id`/`name`/`notation`/`type`/`layer`/`sourceFile`. Every new consumer need would otherwise mean growing that one shared record field-by-field.
- Adds a `data` field carrying the **complete parsed element document**, unfiltered — the engine already parses it for the repo-scope validation pass, so this is a pure re-use, not a second parse. A consumer can now read a goal's `level`/`parent`/`description`/`link`/`tags`, an action's scheduling/ownership fields, or anything else the notation carries, without an engine schema change.
- The existing minimal fields are unchanged — fully backward-compatible for any current consumer.
- This is the faithful full-document projection (labelled interim), not a typed per-notation model — field-semantics knowledge stays consumer-side until that lands.
- No `SCHEMA_VERSION` bump — this changes the CLI's output projection, not a notation schema or validation rule.

## Test plan

- [x] `npm run compile` — clean
- [x] `npm --workspace packages/diagrams test` — 1383 tests pass
- [x] `npx vitest run tests/cli-repo-validate-model.test.ts` — new `data` assertions pass against the built CLI + `organizations/acme_corp` fixture
- [x] `npm run test:core` — no new failures (3 pre-existing failures in `cli-migrate.test.ts` are unrelated, reproduce identically on `main`)