### PR TITLE
chore(cli): bump @transitrix/cli to 2.1.0 for --include-model

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/cli",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "type": "module",
   "description": "Transitrix CLI — compile, validate, and report on Transitrix diagrams (BPMN, Goals, DGCA, …) from any shell or CI pipeline.",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- PR #407 shipped `validate --scope=repo --json --include-model` but merged (`a3e48d8`) without a version bump — the published npm package (`2.0.1`) still silently ignores the flag (unrecognized flags are no-ops), so no downstream consumer can rely on it yet.
- Bumps `packages/cli/package.json` 2.0.1 → 2.1.0 only (minor: new opt-in capability, no breaking change). No CHANGELOG.md entry, matching the standalone cli-bump precedent (`effd26b`, 1.1.0) — folded into the next full-release notes instead.

## Test plan
- [x] `npm run build` clean
- [x] `npm run build:cli-package` assembles clean (dist/cli.js, repo-validate.js, etc.)
- [x] `node packages/cli/dist/cli.js validate --scope=repo --root organizations/acme_corp --json --include-model` → emits `model: { elements: 57, relations: 6 }`

Follow-up (separate, npm-only): trigger `npm-publish.yml` via `workflow_dispatch` once merged to publish 2.1.0 (and catch up `@transitrix/diagrams` 1.8.13, already bumped in-repo but never published).

🤖 Generated with Claude Code