### PR TITLE
feat(cli): repo-scope validator computes strategy-chain semantic rules + un-freeze RepoFinding.ruleId

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -31,14 +31,69 @@ runtime. It scans `<root>/canon/elements/**` (elements) and
 `{ scope, id, message }`. Any finding exits non-zero — the CI gate.
 
 Repo-scope checks (parity reference: the `acme_corp` worked example, which
-passes with zero findings):
+passes with zero findings from the checks below — it does still carry
+pre-existing findings from the separate compliance suite, see below):
 
 - **YAML syntax** — an unparseable canon file is reported and graph checks are skipped.
 - **ID uniqueness** — the same `id` defined in more than one file.
 - **Atomicity** — an element file carrying an inline `relations:` section (relations belong in `canon/relations/`).
 - **Referential integrity** — a relation endpoint (`from`/`to`, or the legacy `source`/`target`) that does not resolve to a known element.
 - **Policy** — an element marked `Active`/`Production` (`metadata.status`) with no `metadata.owner`.
-- **ArchiMate layer-semantics** — *deferred* (lint.py ships this as a no-op stub; ported faithfully as a no-op until the methodology defines the rules).
+- **ArchiMate layer-semantics** — endpoint-type constraints for the relation
+  kinds with a formally-defined methodology semantics (`unit_located_at`,
+  `located_at`, `offers`, `realizes`, `hosts`, `uses`), plus `TSVC-003`
+  (TECHNOLOGY_SERVICE.node → NODE) and `INT-002` (INTEGRATION interface
+  endpoints → APPLICATION). lint.py ships this phase as a no-op stub; Studio
+  is ahead of the Python tool here — these findings are TypeScript-only.
+- **Strategy-chain semantics** (`GOALS-010`, `ACT-006`..`009`, `FGCA-008`..`011`)
+  — see below.
+
+### Strategy-chain semantic rules (`GOALS-*` / `ACT-*` / `FGCA-*`, #719)
+
+Ported from DSM's Go `Validate*` functions (`api02/internal/importer/
+{goals,activities,fgca}.go` in `transitrix-dsm`) onto the standalone-element
+shape (`canon/elements/01_motivation/goals/`, `canon/elements/
+05_implementation/{actions,changes}/`, `canon/elements/01_motivation/
+factors/`), so DSM can shell out to this CLI instead of maintaining its own
+copy of these checks (vkgeorgia/strategy#705). Each finding carries the DSM
+rule code as `RepoFinding.ruleId`, so DSM can map a CLI finding back onto its
+existing import-log taxonomy.
+
+| Rule | Checks |
+|---|---|
+| `GOALS-010` | A GOAL element's `parent` chain contains a cycle. |
+| `ACT-006` | An ACTION element's `predecessors` graph contains a cycle. |
+| `ACT-007` | An ACTION element lists itself in its own `predecessors`. |
+| `ACT-008` | An ACTION element's `start_date`/`end_date` is not a valid `YYYY-MM-DD` date, or `end_date` is before `start_date` (equal is allowed — e.g. a milestone). |
+| `ACT-009` | An ACTION element's `duration` (or the `duration_days` alias), `labor_cost`, `resources_cost`, `effort`, or `score` is negative. |
+| `FGCA-008` | A GOAL's `factors` references a DRIVER id that does not resolve to a DRIVER element. |
+| `FGCA-009` | A CHANGE's `goals` references a GOAL id that does not resolve to a GOAL element. |
+| `FGCA-010` | An ACTION's `delivers_changes` references a CHANGE id that does not resolve to a CHANGE element. |
+| `FGCA-011` | An ACTION's `goals` references a GOAL id that does not resolve to a GOAL element. |
+
+**Only DSM's error-severity rules are ported.** DSM's own taxonomy splits
+every rule error\|warn; `RepoFinding` has no severity field yet (the richer
+finding taxonomy stays deferred — see below), and every existing repo-scope
+finding is implicitly blocking (`validate --scope=repo` exits non-zero on any
+finding). DSM's warn-severity rules are deliberately **not** implemented here:
+
+- `GOALS-009`/`GOALS-011` (orphan / missing parent) and `ACT-005` (orphan
+  predecessor/parent) flag a normal state, not a bug, once adapted to the
+  standalone-element shape: a GOAL's `parent` is v0.x-transitional
+  (`ELEMENT_PRIMITIVES.md` §7.2 — its canonical home is a `goal_parent` REL
+  file or the goals-tree view's inline `parent`, not the element itself).
+  `organizations/acme_corp`'s own `GOAL-CUST-1`/`GOAL-OPS-1` are exactly this
+  shape (level 1, no `parent` on the element) — flagging that would fail this
+  repo's own reference fixture for doing nothing wrong.
+- `GOALS-008`'s error case ("type not declared in `goal_types`") needs a
+  catalogue this repo shape doesn't carry — `goal_types[]` lives on the
+  goals-tree view, not on the GOAL element — so it isn't portable here.
+- `FGCA-012`/`013`/`014` (unreferenced driver/goal/change) are
+  advisory-by-design in DSM ("import anyway, record the warning") — same
+  reasoning as the orphan-parent rules above.
+
+Promoting these to repo-scope findings is future work, gated on `RepoFinding`
+growing a severity field.
 
 ### Compliance suite (`--scope=repo`, #518)
 
@@ -67,8 +122,11 @@ $ transitrix validate --scope=repo --root organizations/acme_corp
 ✓ organizations/acme_corp — repo-scope validation passed
 ```
 
-The richer `target`/`category` finding taxonomy is intentionally **not** adopted
-yet (deferred per the ADR until a consumer needs it).
+The richer `target`/`category`/severity finding taxonomy is intentionally
+**not** adopted yet (deferred per the ADR until a consumer needs it). `#719`
+un-froze one field, `ruleId` — a stable code on findings that have one (see
+the strategy-chain rules above, plus `TSVC-003`/`INT-002`) — for DSM to map
+findings onto its own rule taxonomy; `target`/`category`/severity stay out.
 
 ### Resolved model output (`--include-model`)
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -48,16 +48,16 @@ pre-existing findings from the separate compliance suite, see below):
 - **Strategy-chain semantics** (`GOALS-010`, `ACT-006`..`009`, `FGCA-008`..`011`)
   — see below.
 
-### Strategy-chain semantic rules (`GOALS-*` / `ACT-*` / `FGCA-*`, #719)
+### Strategy-chain semantic rules (`GOALS-*` / `ACT-*` / `FGCA-*`)
 
 Ported from DSM's Go `Validate*` functions (`api02/internal/importer/
 {goals,activities,fgca}.go` in `transitrix-dsm`) onto the standalone-element
 shape (`canon/elements/01_motivation/goals/`, `canon/elements/
 05_implementation/{actions,changes}/`, `canon/elements/01_motivation/
 factors/`), so DSM can shell out to this CLI instead of maintaining its own
-copy of these checks (vkgeorgia/strategy#705). Each finding carries the DSM
-rule code as `RepoFinding.ruleId`, so DSM can map a CLI finding back onto its
-existing import-log taxonomy.
+copy of these checks. Each finding carries the DSM rule code as
+`RepoFinding.ruleId`, so DSM can map a CLI finding back onto its existing
+import-log taxonomy.
 
 | Rule | Checks |
 |---|---|
@@ -123,10 +123,10 @@ $ transitrix validate --scope=repo --root organizations/acme_corp
 ```
 
 The richer `target`/`category`/severity finding taxonomy is intentionally
-**not** adopted yet (deferred per the ADR until a consumer needs it). `#719`
-un-froze one field, `ruleId` — a stable code on findings that have one (see
-the strategy-chain rules above, plus `TSVC-003`/`INT-002`) — for DSM to map
-findings onto its own rule taxonomy; `target`/`category`/severity stay out.
+**not** adopted yet (deferred per the ADR until a consumer needs it). One
+field, `ruleId`, is now un-frozen — a stable code on findings that have one
+(see the strategy-chain rules above, plus `TSVC-003`/`INT-002`) — for DSM to
+map findings onto its own rule taxonomy; `target`/`category`/severity stay out.
 
 ### Resolved model output (`--include-model`)
 

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.8.13",
+  "version": "1.8.14",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",

--- a/packages/diagrams/src/repo-validate/__tests__/check-strategy-chain.test.ts
+++ b/packages/diagrams/src/repo-validate/__tests__/check-strategy-chain.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect } from 'vitest';
+import { validateRepoModel } from '../validate-repo.js';
+import type { RepoDoc, RepoModelInput } from '../types.js';
+
+function el(path: string, data: Record<string, unknown> | null, parseError?: string): RepoDoc {
+  return { path, data, parseError };
+}
+
+function emptyModel(): RepoModelInput {
+  return { elements: [], relations: [] };
+}
+
+function goal(id: string, extra: Record<string, unknown> = {}): RepoDoc {
+  return el(`canon/elements/01_motivation/goals/${id}.yaml`, { notation: 'goal', id, name: id, ...extra });
+}
+
+function action(id: string, extra: Record<string, unknown> = {}): RepoDoc {
+  return el(`canon/elements/05_implementation/actions/${id}.yaml`, { notation: 'action', id, name: id, ...extra });
+}
+
+function driver(id: string, extra: Record<string, unknown> = {}): RepoDoc {
+  return el(`canon/elements/01_motivation/factors/${id}.yaml`, { notation: 'driver', id, name: id, ...extra });
+}
+
+function change(id: string, extra: Record<string, unknown> = {}): RepoDoc {
+  return el(`canon/elements/05_implementation/changes/${id}.yaml`, { notation: 'change', id, name: id, ...extra });
+}
+
+describe('checkStrategyChainSemantics — GOALS-010 (parent cycle)', () => {
+  it('flags a two-goal parent cycle', () => {
+    const model = emptyModel();
+    model.elements.push(goal('GOAL-A', { parent: 'GOAL-B' }), goal('GOAL-B', { parent: 'GOAL-A' }));
+    const findings = validateRepoModel(model);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ scope: 'repo', ruleId: 'GOALS-010' });
+    expect(findings[0].message).toContain('cycle');
+  });
+
+  it('does not flag an acyclic parent chain', () => {
+    const model = emptyModel();
+    model.elements.push(goal('GOAL-ROOT'), goal('GOAL-CHILD', { parent: 'GOAL-ROOT' }));
+    expect(validateRepoModel(model)).toEqual([]);
+  });
+
+  it('does not flag a goal whose parent is unresolved (orphan, not a cycle — GOALS-009 deferred)', () => {
+    const model = emptyModel();
+    model.elements.push(goal('GOAL-A', { parent: 'GOAL-MISSING' }));
+    expect(validateRepoModel(model)).toEqual([]);
+  });
+
+  it('does not flag a goal with no parent at all (v0.x transitional — GOALS-011 deferred)', () => {
+    // Matches organizations/acme_corp's GOAL-CUST-1 / GOAL-OPS-1 shape: level
+    // >= 1, no `parent` on the element (parent carried by the goals-tree view).
+    const model = emptyModel();
+    model.elements.push(goal('GOAL-BACKLOG', { type: 'Strategic Goal', level: 1 }));
+    expect(validateRepoModel(model)).toEqual([]);
+  });
+});
+
+describe('checkStrategyChainSemantics — ACT-006 (predecessor cycle) / ACT-007 (self-predecessor)', () => {
+  it('flags a predecessor cycle', () => {
+    const model = emptyModel();
+    model.elements.push(
+      action('ACTION-A', { predecessors: ['ACTION-B'] }),
+      action('ACTION-B', { predecessors: ['ACTION-A'] }),
+    );
+    const findings = validateRepoModel(model);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ scope: 'repo', ruleId: 'ACT-006' });
+  });
+
+  it('does not flag an acyclic predecessor chain', () => {
+    const model = emptyModel();
+    model.elements.push(action('ACTION-A'), action('ACTION-B', { predecessors: ['ACTION-A'] }));
+    expect(validateRepoModel(model)).toEqual([]);
+  });
+
+  it('flags an action listing itself as a predecessor (also a 1-node cycle, matching DSM findActivityCycle)', () => {
+    const model = emptyModel();
+    model.elements.push(action('ACTION-SELF', { predecessors: ['ACTION-SELF'] }));
+    const findings = validateRepoModel(model);
+    const ruleIds = findings.map((f) => f.ruleId).sort();
+    expect(ruleIds).toEqual(['ACT-006', 'ACT-007']);
+    expect(findings.every((f) => f.id === 'ACTION-SELF')).toBe(true);
+  });
+
+  it('does not flag an unresolved predecessor (orphan — ACT-005 deferred)', () => {
+    const model = emptyModel();
+    model.elements.push(action('ACTION-A', { predecessors: ['ACTION-MISSING'] }));
+    expect(validateRepoModel(model)).toEqual([]);
+  });
+});
+
+describe('checkStrategyChainSemantics — ACT-008 (dates)', () => {
+  it('flags end_date before start_date', () => {
+    const model = emptyModel();
+    model.elements.push(action('ACTION-A', { start_date: '2026-06-01', end_date: '2026-05-01' }));
+    const findings = validateRepoModel(model);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ scope: 'repo', id: 'ACTION-A', ruleId: 'ACT-008' });
+    expect(findings[0].message).toContain('before');
+  });
+
+  it('allows end_date equal to start_date (milestone)', () => {
+    const model = emptyModel();
+    model.elements.push(action('ACTION-A', { start_date: '2026-06-01', end_date: '2026-06-01', duration: 0 }));
+    expect(validateRepoModel(model)).toEqual([]);
+  });
+
+  it('flags a calendar-invalid date', () => {
+    const model = emptyModel();
+    model.elements.push(action('ACTION-A', { start_date: '2026-02-30' }));
+    const findings = validateRepoModel(model);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ ruleId: 'ACT-008' });
+    expect(findings[0].message).toContain('not a valid');
+  });
+
+  it('flags a malformed date string', () => {
+    const model = emptyModel();
+    model.elements.push(action('ACTION-A', { end_date: '06/01/2026' }));
+    const findings = validateRepoModel(model);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ ruleId: 'ACT-008' });
+  });
+
+  it('does not flag an action with no dates at all', () => {
+    const model = emptyModel();
+    model.elements.push(action('ACTION-A', { duration_days: 5 }));
+    expect(validateRepoModel(model)).toEqual([]);
+  });
+});
+
+describe('checkStrategyChainSemantics — ACT-009 (negative numeric fields)', () => {
+  it('flags a negative duration', () => {
+    const model = emptyModel();
+    model.elements.push(action('ACTION-A', { duration: -3 }));
+    const findings = validateRepoModel(model);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ ruleId: 'ACT-009' });
+  });
+
+  it('flags a negative duration_days (the field acme_corp actually uses)', () => {
+    const model = emptyModel();
+    model.elements.push(action('ACTION-A', { duration_days: -3 }));
+    const findings = validateRepoModel(model);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ ruleId: 'ACT-009' });
+  });
+
+  it('flags a negative labor_cost / resources_cost / effort / score independently', () => {
+    const model = emptyModel();
+    model.elements.push(
+      action('ACTION-A', { labor_cost: -1, resources_cost: -2, effort: -3, score: -4 }),
+    );
+    const findings = validateRepoModel(model);
+    expect(findings).toHaveLength(4);
+    expect(findings.every((f) => f.ruleId === 'ACT-009')).toBe(true);
+  });
+
+  it('does not flag non-negative numeric fields', () => {
+    const model = emptyModel();
+    model.elements.push(action('ACTION-A', { duration_days: 30, labor_cost: 0, effort: 100, score: 5 }));
+    expect(validateRepoModel(model)).toEqual([]);
+  });
+});
+
+describe('checkStrategyChainSemantics — FGCA-008..011 (strategy-chain cross-references)', () => {
+  it('flags GOAL.factors referencing an undefined driver (FGCA-008)', () => {
+    const model = emptyModel();
+    model.elements.push(goal('GOAL-A', { factors: ['DRIVER-MISSING'] }));
+    const findings = validateRepoModel(model);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ id: 'GOAL-A', ruleId: 'FGCA-008' });
+  });
+
+  it('accepts GOAL.factors that resolve to a driver', () => {
+    const model = emptyModel();
+    model.elements.push(driver('DRIVER-A'), goal('GOAL-A', { factors: ['DRIVER-A'] }));
+    expect(validateRepoModel(model)).toEqual([]);
+  });
+
+  it('accepts the legacy `factor` notation value for the driver cross-reference', () => {
+    const model = emptyModel();
+    model.elements.push(el('canon/elements/01_motivation/factors/DRIVER-A.yaml', { notation: 'factor', id: 'DRIVER-A' }));
+    model.elements.push(goal('GOAL-A', { factors: ['DRIVER-A'] }));
+    expect(validateRepoModel(model)).toEqual([]);
+  });
+
+  it('flags CHANGE.goals referencing an undefined goal (FGCA-009)', () => {
+    const model = emptyModel();
+    model.elements.push(change('CHANGE-A', { goals: ['GOAL-MISSING'] }));
+    const findings = validateRepoModel(model);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ id: 'CHANGE-A', ruleId: 'FGCA-009' });
+  });
+
+  it('flags ACTION.delivers_changes referencing an undefined change (FGCA-010)', () => {
+    const model = emptyModel();
+    model.elements.push(action('ACTION-A', { delivers_changes: ['CHANGE-MISSING'] }));
+    const findings = validateRepoModel(model);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ id: 'ACTION-A', ruleId: 'FGCA-010' });
+  });
+
+  it('flags ACTION.goals referencing an undefined goal (FGCA-011)', () => {
+    const model = emptyModel();
+    model.elements.push(action('ACTION-A', { goals: ['GOAL-MISSING'] }));
+    const findings = validateRepoModel(model);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ id: 'ACTION-A', ruleId: 'FGCA-011' });
+  });
+
+  it('accepts a fully-resolved strategy chain end to end (driver -> goal -> change -> action)', () => {
+    const model = emptyModel();
+    model.elements.push(
+      driver('DRIVER-A'),
+      goal('GOAL-A', { factors: ['DRIVER-A'] }),
+      change('CHANGE-A', { goals: ['GOAL-A'] }),
+      action('ACTION-A', { goals: ['GOAL-A'], delivers_changes: ['CHANGE-A'] }),
+    );
+    expect(validateRepoModel(model)).toEqual([]);
+  });
+
+  it('does not flag a driver/goal/change that is unreferenced (orphan — FGCA-012..014 deferred)', () => {
+    const model = emptyModel();
+    model.elements.push(driver('DRIVER-UNUSED'), goal('GOAL-UNUSED'), change('CHANGE-UNUSED'));
+    expect(validateRepoModel(model)).toEqual([]);
+  });
+});
+
+describe('checkStrategyChainSemantics — organizations/acme_corp parity shape', () => {
+  it('does not flag acme_corp-shaped goals/actions/drivers/changes', () => {
+    // Mirrors organizations/acme_corp's real fixture: goals with no inline
+    // `parent` (carried by the goals-tree view), actions using `duration_days`
+    // with `predecessors` and `delivers_changes`, drivers/changes resolving.
+    const model = emptyModel();
+    model.elements.push(
+      driver('DRIVER-COMP-1'),
+      goal('GOAL-OPS-1', { type: 'Strategic Goal', level: 1, factors: ['DRIVER-COMP-1'] }),
+      goal('GOAL-CUST-1', { type: 'Strategic Goal', level: 1 }),
+      change('CHANGE-ONBOARD-1', { goals: ['GOAL-CUST-1'] }),
+      action('ACTION-DESIGN-1', { duration_days: 10 }),
+      action('ACTION-BUILD-1', { duration_days: 30, predecessors: ['ACTION-DESIGN-1'], delivers_changes: ['CHANGE-ONBOARD-1'] }),
+      action('ACTION-LAUNCH-1', { duration_days: 5, predecessors: ['ACTION-BUILD-1'], delivers_changes: ['CHANGE-ONBOARD-1'] }),
+    );
+    expect(validateRepoModel(model)).toEqual([]);
+  });
+});

--- a/packages/diagrams/src/repo-validate/__tests__/validate-repo.test.ts
+++ b/packages/diagrams/src/repo-validate/__tests__/validate-repo.test.ts
@@ -34,14 +34,16 @@ describe('validateRepoModel — parity / clean tree', () => {
     expect(findings.filter((f) => f.message.includes('Duplicate'))).toEqual([]);
   });
 
-  it('every finding carries the frozen { scope, id, message } shape', () => {
+  it('every finding carries { scope, id, message } plus an optional ruleId', () => {
     const model = cleanModel();
     model.relations.push(el('canon/relations/REL-BAD.yaml', { notation: 'relation', id: 'REL-BAD', from: 'NOPE', to: 'GOAL-OPS-1' }));
     const findings = validateRepoModel(model);
     expect(findings.length).toBeGreaterThan(0);
     for (const f of findings) {
-      expect(Object.keys(f).sort()).toEqual(['id', 'message', 'scope']);
+      const keys = Object.keys(f).filter((k) => k !== 'ruleId').sort();
+      expect(keys).toEqual(['id', 'message', 'scope']);
       expect(f.scope).toBe('repo');
+      if ('ruleId' in f) expect(typeof f.ruleId).toBe('string');
     }
   });
 });

--- a/packages/diagrams/src/repo-validate/check-strategy-chain.ts
+++ b/packages/diagrams/src/repo-validate/check-strategy-chain.ts
@@ -1,13 +1,13 @@
-// Strategy-chain semantic checks (vkgeorgia/strategy#719, epic #28) — the
-// error-severity subset of DSM's Go `Validate*` functions
-// (`api02/internal/importer/{goals,activities,fgca}.go` in transitrix-dsm),
-// ported onto the standalone-element repo shape (`canon/elements/**`) that
-// `validate --scope=repo` already loads, so DSM can drop those Go functions
-// per #705 without regressing the checks they enforce today.
+// Strategy-chain semantic checks — the error-severity subset of DSM's Go
+// `Validate*` functions (`api02/internal/importer/{goals,activities,fgca}.go`
+// in transitrix-dsm), ported onto the standalone-element repo shape
+// (`canon/elements/**`) that `validate --scope=repo` already loads, so DSM
+// can drop those Go functions without regressing the checks they enforce
+// today.
 //
 // Rule codes are DSM's own (`GOALS-010`, `ACT-006`..`009`, `FGCA-008`..`011`)
 // — not invented here — so DSM can map a CLI finding straight back onto its
-// import-log taxonomy (`RepoFinding.ruleId`, vkgeorgia/strategy#719).
+// import-log taxonomy (`RepoFinding.ruleId`).
 //
 // Scope — only DSM's ERROR-severity rules are ported. DSM's own taxonomy
 // splits every rule error|warn (`Issue.Severity` in the Go source). Porting
@@ -18,7 +18,7 @@
 //     existing repo-scope check is implicitly blocking — `validate
 //     --scope=repo` exits non-zero on ANY finding (docs/validation.md). A
 //     warn-severity DSM rule surfaced here would silently become a blocking
-//     one, which is a bigger behaviour change than #719 asked for.
+//     one, which is a bigger behaviour change than asked for.
 //   - Several of DSM's warn rules flag states that are normal, not bugs, once
 //     adapted to the standalone-element shape — confirmed against
 //     `organizations/acme_corp`, this repo's own parity fixture:

--- a/packages/diagrams/src/repo-validate/check-strategy-chain.ts
+++ b/packages/diagrams/src/repo-validate/check-strategy-chain.ts
@@ -1,0 +1,390 @@
+// Strategy-chain semantic checks (vkgeorgia/strategy#719, epic #28) — the
+// error-severity subset of DSM's Go `Validate*` functions
+// (`api02/internal/importer/{goals,activities,fgca}.go` in transitrix-dsm),
+// ported onto the standalone-element repo shape (`canon/elements/**`) that
+// `validate --scope=repo` already loads, so DSM can drop those Go functions
+// per #705 without regressing the checks they enforce today.
+//
+// Rule codes are DSM's own (`GOALS-010`, `ACT-006`..`009`, `FGCA-008`..`011`)
+// — not invented here — so DSM can map a CLI finding straight back onto its
+// import-log taxonomy (`RepoFinding.ruleId`, vkgeorgia/strategy#719).
+//
+// Scope — only DSM's ERROR-severity rules are ported. DSM's own taxonomy
+// splits every rule error|warn (`Issue.Severity` in the Go source). Porting
+// only the error half is deliberate, not an oversight:
+//
+//   - `RepoFinding` has no severity field. The richer finding taxonomy stays
+//     "DEFERRED until a real consumer needs it" (types.ts), and every
+//     existing repo-scope check is implicitly blocking — `validate
+//     --scope=repo` exits non-zero on ANY finding (docs/validation.md). A
+//     warn-severity DSM rule surfaced here would silently become a blocking
+//     one, which is a bigger behaviour change than #719 asked for.
+//   - Several of DSM's warn rules flag states that are normal, not bugs, once
+//     adapted to the standalone-element shape — confirmed against
+//     `organizations/acme_corp`, this repo's own parity fixture:
+//       - GOALS-009/011 (orphan / missing parent): GOAL's `parent` is
+//         declared "v0.x transitional" (methodology ELEMENT_PRIMITIVES.md
+//         §7.2) — its canonical home is a `goal_parent` REL file or the
+//         goals-tree view's inline `parent`, not the element. acme_corp's
+//         GOAL-CUST-1 / GOAL-OPS-1 are exactly this shape (level 1, no
+//         `parent` on the element, parent carried by the view per their own
+//         file comments) — flagging that as a repo-scope error would fail
+//         this repo's reference fixture for doing nothing wrong.
+//       - GOALS-008 (type/level mismatch): DSM's error case ("type not
+//         declared in goal_types") needs a catalogue this repo shape doesn't
+//         carry (`goal_types[]` lives on the goals-tree view, not on the
+//         element) — only DSM's *warning* case is even adaptable here, so
+//         under the ERROR-only policy above it is not ported.
+//       - ACT-005 (orphan predecessor/parent) and FGCA-012/013/014
+//         (unreferenced driver/goal/change) are advisory-by-design in DSM
+//         ("import anyway, record the warning") — the same reasoning as
+//         GOALS-009/011.
+//
+//   Promoting these warn-severity rules to repo-scope findings is future
+//   work, gated on `RepoFinding` growing a severity field.
+//
+// Ported (error-severity, blocking):
+//   GOALS-010 — GOAL `parent` chain contains a cycle.
+//   ACT-006   — ACTION `predecessors` graph contains a cycle.
+//   ACT-007   — ACTION lists itself as its own predecessor.
+//   ACT-008   — ACTION `start_date`/`end_date` unparseable, or end before start.
+//   ACT-009   — ACTION numeric field (`duration`/`duration_days`, `labor_cost`,
+//               `resources_cost`, `effort`, `score`) is negative.
+//   FGCA-008  — GOAL.factors references an undefined DRIVER.
+//   FGCA-009  — CHANGE.goals references an undefined GOAL.
+//   FGCA-010  — ACTION.delivers_changes references an undefined CHANGE.
+//   FGCA-011  — ACTION.goals references an undefined GOAL.
+
+import { docId } from './validate-repo.js';
+import type { RepoDoc, RepoFinding, RepoModelInput } from './types.js';
+
+const PScope: RepoFinding['scope'] = 'repo';
+
+function isGoalNotation(n: unknown): boolean {
+  return n === 'goal';
+}
+
+function isActionNotation(n: unknown): boolean {
+  // 'activity' is the deprecated pre-2026-06-25 alias (elements/24-action.md §5).
+  return n === 'action' || n === 'activity';
+}
+
+function isDriverNotation(n: unknown): boolean {
+  // 'factor' is the pre-rename notation value (Factor -> Driver rename, in progress).
+  return n === 'driver' || n === 'factor';
+}
+
+function isChangeNotation(n: unknown): boolean {
+  return n === 'change';
+}
+
+function readStringArray(data: Record<string, unknown>, key: string): string[] {
+  const v = data[key];
+  if (!Array.isArray(v)) return [];
+  return v.filter((x): x is string => typeof x === 'string' && x.length > 0);
+}
+
+function readString(data: Record<string, unknown>, key: string): string | undefined {
+  const v = data[key];
+  return typeof v === 'string' && v.length > 0 ? v : undefined;
+}
+
+function readFiniteNumber(data: Record<string, unknown>, key: string): number | undefined {
+  const v = data[key];
+  return typeof v === 'number' && Number.isFinite(v) ? v : undefined;
+}
+
+interface ChainElement {
+  id: string;
+  doc: RepoDoc;
+  data: Record<string, unknown>;
+}
+
+function collectByNotation(
+  elements: RepoDoc[],
+  matches: (notation: unknown) => boolean,
+): ChainElement[] {
+  const out: ChainElement[] = [];
+  for (const doc of elements) {
+    if (!doc.data) continue;
+    if (!matches(doc.data['notation'])) continue;
+    const id = docId(doc);
+    if (!id) continue;
+    out.push({ id, doc, data: doc.data });
+  }
+  return out;
+}
+
+/** DFS cycle detection over a single-parent edge (GOAL.parent), matching DSM's
+ *  `findCycle` (goals.go): only walks an edge to a parent that itself resolves
+ *  within the set — an edge into an unresolved (orphan) parent is not walked,
+ *  so an orphan can never be mistaken for a cycle. Returns the id where a
+ *  back-edge was hit, or `undefined` if the graph is acyclic. */
+function findParentCycle(goals: ChainElement[]): string | undefined {
+  const parentOf = new Map<string, string | undefined>();
+  const known = new Set<string>();
+  for (const g of goals) {
+    known.add(g.id);
+    parentOf.set(g.id, readString(g.data, 'parent'));
+  }
+  const UNVISITED = 0;
+  const VISITING = 1;
+  const DONE = 2;
+  const state = new Map<string, number>();
+
+  function walk(id: string): string | undefined {
+    const s = state.get(id) ?? UNVISITED;
+    if (s === DONE) return undefined;
+    if (s === VISITING) return id;
+    state.set(id, VISITING);
+    const parent = parentOf.get(id);
+    if (parent && known.has(parent)) {
+      const hit = walk(parent);
+      if (hit) return hit;
+    }
+    state.set(id, DONE);
+    return undefined;
+  }
+
+  for (const g of goals) {
+    const hit = walk(g.id);
+    if (hit) return hit;
+  }
+  return undefined;
+}
+
+/** DFS cycle detection over a multi-predecessor edge list (ACTION.predecessors),
+ *  matching DSM's `findActivityCycle` (activities.go). Unresolved predecessors
+ *  are skipped, same rationale as `findParentCycle`. */
+function findPredecessorCycle(actions: ChainElement[]): string | undefined {
+  const predsOf = new Map<string, string[]>();
+  const known = new Set<string>();
+  for (const a of actions) {
+    known.add(a.id);
+    predsOf.set(a.id, readStringArray(a.data, 'predecessors'));
+  }
+  const UNVISITED = 0;
+  const VISITING = 1;
+  const DONE = 2;
+  const state = new Map<string, number>();
+
+  function walk(id: string): string | undefined {
+    const s = state.get(id) ?? UNVISITED;
+    if (s === DONE) return undefined;
+    if (s === VISITING) return id;
+    state.set(id, VISITING);
+    for (const p of predsOf.get(id) ?? []) {
+      if (!known.has(p)) continue;
+      const hit = walk(p);
+      if (hit) return hit;
+    }
+    state.set(id, DONE);
+    return undefined;
+  }
+
+  for (const a of actions) {
+    const hit = walk(a.id);
+    if (hit) return hit;
+  }
+  return undefined;
+}
+
+/** GOALS-010 — the GOAL `parent` chain must not contain a cycle. */
+function checkGoalParentCycle(goals: ChainElement[], findings: RepoFinding[]): void {
+  const cyc = findParentCycle(goals);
+  if (cyc) {
+    findings.push({
+      scope: PScope,
+      id: cyc,
+      ruleId: 'GOALS-010',
+      message: `GOALS-010: parent chain contains a cycle involving goal '${cyc}'.`,
+    });
+  }
+}
+
+/** ACT-007 — an ACTION cannot list itself as its own predecessor. */
+function checkActionSelfPredecessor(actions: ChainElement[], findings: RepoFinding[]): void {
+  for (const a of actions) {
+    if (readStringArray(a.data, 'predecessors').includes(a.id)) {
+      findings.push({
+        scope: PScope,
+        id: a.id,
+        ruleId: 'ACT-007',
+        message: `ACT-007: action '${a.id}' lists itself as a predecessor.`,
+      });
+    }
+  }
+}
+
+/** ACT-006 — the ACTION `predecessors` graph must not contain a cycle. */
+function checkActionPredecessorCycle(actions: ChainElement[], findings: RepoFinding[]): void {
+  const cyc = findPredecessorCycle(actions);
+  if (cyc) {
+    findings.push({
+      scope: PScope,
+      id: cyc,
+      ruleId: 'ACT-006',
+      message: `ACT-006: predecessor graph contains a cycle involving action '${cyc}'.`,
+    });
+  }
+}
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/** Parse a strict ISO `YYYY-MM-DD` date, rejecting calendar-invalid dates
+ *  (e.g. `2026-02-30`) the way Go's `time.Parse(dateLayout, …)` does — a
+ *  regex match alone accepts those. Returns `undefined` when invalid. */
+function parseIsoDate(value: string): Date | undefined {
+  if (!ISO_DATE_RE.test(value)) return undefined;
+  const [y, m, d] = value.split('-').map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  if (dt.getUTCFullYear() !== y || dt.getUTCMonth() !== m - 1 || dt.getUTCDate() !== d) {
+    return undefined;
+  }
+  return dt;
+}
+
+/** ACT-008 — `start_date`/`end_date` must be valid ISO dates, and `end_date`
+ *  must not be before `start_date` (equal is allowed — e.g. a milestone). */
+function checkActionDates(actions: ChainElement[], findings: RepoFinding[]): void {
+  for (const a of actions) {
+    const startRaw = readString(a.data, 'start_date');
+    const endRaw = readString(a.data, 'end_date');
+    let start: Date | undefined;
+    let end: Date | undefined;
+
+    if (startRaw !== undefined) {
+      start = parseIsoDate(startRaw);
+      if (!start) {
+        findings.push({
+          scope: PScope,
+          id: a.id,
+          ruleId: 'ACT-008',
+          message: `ACT-008: action '${a.id}' start_date '${startRaw}' is not a valid YYYY-MM-DD date.`,
+        });
+      }
+    }
+    if (endRaw !== undefined) {
+      end = parseIsoDate(endRaw);
+      if (!end) {
+        findings.push({
+          scope: PScope,
+          id: a.id,
+          ruleId: 'ACT-008',
+          message: `ACT-008: action '${a.id}' end_date '${endRaw}' is not a valid YYYY-MM-DD date.`,
+        });
+      }
+    }
+    if (start && end && end.getTime() < start.getTime()) {
+      findings.push({
+        scope: PScope,
+        id: a.id,
+        ruleId: 'ACT-008',
+        message: `ACT-008: action '${a.id}' end_date '${endRaw}' is before start_date '${startRaw}'.`,
+      });
+    }
+  }
+}
+
+/** ACT-009 — numeric scheduling/cost fields must not be negative. `duration`
+ *  and `duration_days` are both checked — the canonical field is `duration`
+ *  (elements/24-action.md §2), but `duration_days` is an accepted alias in
+ *  this codebase's document-form validator (activities/validate.ts) and is
+ *  the field acme_corp's own ACTION elements actually use. */
+function checkActionNegativeNumbers(actions: ChainElement[], findings: RepoFinding[]): void {
+  const fields = ['duration', 'duration_days', 'labor_cost', 'resources_cost', 'effort', 'score'] as const;
+  for (const a of actions) {
+    for (const field of fields) {
+      const v = readFiniteNumber(a.data, field);
+      if (v !== undefined && v < 0) {
+        findings.push({
+          scope: PScope,
+          id: a.id,
+          ruleId: 'ACT-009',
+          message: `ACT-009: action '${a.id}' field '${field}' is negative (${v}).`,
+        });
+      }
+    }
+  }
+}
+
+/** FGCA-008..011 — inline strategy-chain cross-references must resolve within
+ *  the repo: GOAL.factors -> DRIVER, CHANGE.goals -> GOAL, ACTION.goals ->
+ *  GOAL, ACTION.delivers_changes -> CHANGE (ELEMENT_PRIMITIVES.md §7.1-§7.4). */
+function checkStrategyChainReferences(
+  goals: ChainElement[],
+  actions: ChainElement[],
+  drivers: ChainElement[],
+  changes: ChainElement[],
+  findings: RepoFinding[],
+): void {
+  const driverIds = new Set(drivers.map((d) => d.id));
+  const goalIds = new Set(goals.map((g) => g.id));
+  const changeIds = new Set(changes.map((c) => c.id));
+
+  for (const g of goals) {
+    for (const f of readStringArray(g.data, 'factors')) {
+      if (!driverIds.has(f)) {
+        findings.push({
+          scope: PScope,
+          id: g.id,
+          ruleId: 'FGCA-008',
+          message: `FGCA-008: goal '${g.id}' references undefined driver '${f}'.`,
+        });
+      }
+    }
+  }
+  for (const c of changes) {
+    for (const g of readStringArray(c.data, 'goals')) {
+      if (!goalIds.has(g)) {
+        findings.push({
+          scope: PScope,
+          id: c.id,
+          ruleId: 'FGCA-009',
+          message: `FGCA-009: change '${c.id}' references undefined goal '${g}'.`,
+        });
+      }
+    }
+  }
+  for (const a of actions) {
+    for (const c of readStringArray(a.data, 'delivers_changes')) {
+      if (!changeIds.has(c)) {
+        findings.push({
+          scope: PScope,
+          id: a.id,
+          ruleId: 'FGCA-010',
+          message: `FGCA-010: action '${a.id}' references undefined change '${c}'.`,
+        });
+      }
+    }
+    for (const g of readStringArray(a.data, 'goals')) {
+      if (!goalIds.has(g)) {
+        findings.push({
+          scope: PScope,
+          id: a.id,
+          ruleId: 'FGCA-011',
+          message: `FGCA-011: action '${a.id}' references undefined goal '${g}'.`,
+        });
+      }
+    }
+  }
+}
+
+/**
+ * Run the strategy-chain semantic checks (GOALS-010, ACT-006..009,
+ * FGCA-008..011) over the loaded element set and append findings. Called from
+ * `validateRepoModel` after the structural phases. Pure, deterministic order.
+ */
+export function checkStrategyChainSemantics(input: RepoModelInput, findings: RepoFinding[]): void {
+  const goals = collectByNotation(input.elements, isGoalNotation);
+  const actions = collectByNotation(input.elements, isActionNotation);
+  const drivers = collectByNotation(input.elements, isDriverNotation);
+  const changes = collectByNotation(input.elements, isChangeNotation);
+
+  checkGoalParentCycle(goals, findings);
+  checkActionSelfPredecessor(actions, findings);
+  checkActionPredecessorCycle(actions, findings);
+  checkActionDates(actions, findings);
+  checkActionNegativeNumbers(actions, findings);
+  checkStrategyChainReferences(goals, actions, drivers, changes, findings);
+}

--- a/packages/diagrams/src/repo-validate/types.ts
+++ b/packages/diagrams/src/repo-validate/types.ts
@@ -9,11 +9,11 @@
 //
 // The finding shape was originally frozen minimal — `{ scope, id, message }` —
 // with the richer `target` / `category` reporting taxonomy explicitly DEFERRED
-// per the ADR until a real consumer needed it. vkgeorgia/strategy#719 un-freezes
-// one field, `ruleId`: DSM (migrating off its own Go `Validate*` functions per
-// #705) needs a stable code per finding to map onto its existing import-log
-// rule taxonomy (`api02/internal/importer/{goals,activities,fgca}.go`). The
-// richer `target`/`category` taxonomy stays deferred — only `ruleId` is added.
+// per the ADR until a real consumer needed it. This un-freezes one field,
+// `ruleId`: DSM (migrating off its own Go `Validate*` functions) needs a
+// stable code per finding to map onto its existing import-log rule taxonomy
+// (`api02/internal/importer/{goals,activities,fgca}.go`). The richer
+// `target`/`category` taxonomy stays deferred — only `ruleId` is added.
 // `ruleId` is optional: only checks with a stable, documented code set it
 // (`docs/validation.md` § repo-scope rule list); the original structural
 // checks (syntax/uniqueness/atomicity/referential-integrity/policy) stay

--- a/packages/diagrams/src/repo-validate/types.ts
+++ b/packages/diagrams/src/repo-validate/types.ts
@@ -7,11 +7,19 @@
 // runtime (methodology ADR "Validation Two-Axis Model"; Studio decision
 // "Validation Runtime Convergence").
 //
-// The finding shape is deliberately minimal — `{ scope, id, message }`. The
-// richer `target` / `category` reporting taxonomy is explicitly DEFERRED per the
-// ADR until a real consumer needs it; do not add it here.
+// The finding shape was originally frozen minimal — `{ scope, id, message }` —
+// with the richer `target` / `category` reporting taxonomy explicitly DEFERRED
+// per the ADR until a real consumer needed it. vkgeorgia/strategy#719 un-freezes
+// one field, `ruleId`: DSM (migrating off its own Go `Validate*` functions per
+// #705) needs a stable code per finding to map onto its existing import-log
+// rule taxonomy (`api02/internal/importer/{goals,activities,fgca}.go`). The
+// richer `target`/`category` taxonomy stays deferred — only `ruleId` is added.
+// `ruleId` is optional: only checks with a stable, documented code set it
+// (`docs/validation.md` § repo-scope rule list); the original structural
+// checks (syntax/uniqueness/atomicity/referential-integrity/policy) stay
+// uncoded rather than being retrofitted with invented codes.
 
-/** A single repo-scope validation finding. Shape is frozen at `{ scope, id, message }`. */
+/** A single repo-scope validation finding. */
 export interface RepoFinding {
   /** Always `'repo'` — the execution axis this finding came from. */
   scope: 'repo';
@@ -22,6 +30,12 @@ export interface RepoFinding {
   id: string;
   /** Human-readable description of the violation. */
   message: string;
+  /**
+   * Stable rule code (e.g. `GOALS-010`, `ACT-006`, `FGCA-008`), for a consumer
+   * that maps findings onto its own rule taxonomy (`docs/validation.md`).
+   * Omitted for checks that don't yet have one.
+   */
+  ruleId?: string;
 }
 
 /** A parsed canon document fed to the repo validator. IO (the filesystem walk)

--- a/packages/diagrams/src/repo-validate/validate-repo.ts
+++ b/packages/diagrams/src/repo-validate/validate-repo.ts
@@ -26,6 +26,7 @@
 // Findings stay `{ scope, id, message }` — no severity, no target/category
 // taxonomy (deferred per the ADR).
 
+import { checkStrategyChainSemantics } from './check-strategy-chain.js';
 import type { RepoDoc, RepoFinding, RepoModelInput } from './types.js';
 
 const PScope: RepoFinding['scope'] = 'repo';
@@ -346,6 +347,7 @@ function checkLayerSemantics(input: RepoModelInput, findings: RepoFinding[]): vo
       findings.push({
         scope: PScope,
         id: svcId,
+        ruleId: 'TSVC-003',
         message:
           `TSVC-003: TECHNOLOGY_SERVICE '${svcId}' node '${nodeRef}' ` +
           `must resolve to a NODE element; got notation='${resolved['notation']}'.`,
@@ -369,6 +371,7 @@ function checkLayerSemantics(input: RepoModelInput, findings: RepoFinding[]): vo
         findings.push({
           scope: PScope,
           id: intId,
+          ruleId: 'INT-002',
           message:
             `INT-002: INTEGRATION '${intId}' interface_semantics endpoint '${endpointId}' ` +
             `(${field}) must resolve to an APPLICATION element; got notation='${resolved['notation']}'.`,
@@ -400,8 +403,9 @@ function checkPolicy(input: RepoModelInput, findings: RepoFinding[]): void {
 /**
  * Run all repo-scope checks over a loaded canon model and return the findings.
  * Pure: no IO, deterministic order (syntax, uniqueness, atomicity, referential,
- * semantics, policy). Reaches parity with `lint.py` on the `acme_corp` fixture
- * (zero findings on a clean tree).
+ * semantics, policy, strategy-chain). Reaches parity with `lint.py` on the
+ * `acme_corp` fixture (zero findings on a clean tree from the original
+ * lint.py-ported phases).
  */
 export function validateRepoModel(input: RepoModelInput): RepoFinding[] {
   const findings: RepoFinding[] = [];
@@ -416,5 +420,8 @@ export function validateRepoModel(input: RepoModelInput): RepoFinding[] {
   checkReferentialIntegrity(input, findings);
   checkLayerSemantics(input, findings);
   checkPolicy(input, findings);
+  // Phase 7 — strategy-chain semantic rules ported from DSM's Go Validate*
+  // functions (GOALS-010, ACT-006..009, FGCA-008..011; vkgeorgia/strategy#719).
+  checkStrategyChainSemantics(input, findings);
   return findings;
 }

--- a/packages/diagrams/src/repo-validate/validate-repo.ts
+++ b/packages/diagrams/src/repo-validate/validate-repo.ts
@@ -421,7 +421,7 @@ export function validateRepoModel(input: RepoModelInput): RepoFinding[] {
   checkLayerSemantics(input, findings);
   checkPolicy(input, findings);
   // Phase 7 — strategy-chain semantic rules ported from DSM's Go Validate*
-  // functions (GOALS-010, ACT-006..009, FGCA-008..011; vkgeorgia/strategy#719).
+  // functions (GOALS-010, ACT-006..009, FGCA-008..011).
   checkStrategyChainSemantics(input, findings);
   return findings;
 }


### PR DESCRIPTION
## Summary

- `validate --scope=repo` now computes the error-severity subset of DSM's Go `Validate*` semantic rules over the standalone strategy-chain elements (`GOAL`, `ACTION`, `DRIVER`, `CHANGE`) it already loads: `GOALS-010` (goal parent-chain cycle), `ACT-006`/`007`/`008`/`009` (action predecessor cycle, self-predecessor, date validity/order, negative numerics), `FGCA-008`..`011` (dangling strategy-chain cross-references — `GOAL.factors`→DRIVER, `CHANGE.goals`→GOAL, `ACTION.delivers_changes`→CHANGE, `ACTION.goals`→GOAL).
- `RepoFinding.ruleId` is un-frozen (now an optional field) so a downstream consumer can map a CLI finding back onto its own rule taxonomy — populated for the new strategy-chain rules plus the two pre-existing layer-semantics codes (`TSVC-003`, `INT-002`) that already had a code embedded in their message text.
- `docs/validation.md` documents the new rule table and the scope decision below.

## Scope decision — only DSM's error-severity rules are ported

DSM's own rule taxonomy splits every rule `error`|`warn`. `RepoFinding` has no severity field, and every existing repo-scope finding is implicitly blocking (`validate --scope=repo` exits non-zero on **any** finding). Porting a warn-severity rule as-is would silently promote it to a blocking one.

Several of DSM's warn-severity rules also flag a *normal* state once adapted to the standalone-element shape, not a bug — confirmed against this repo's own `organizations/acme_corp` reference fixture:

- `GOALS-009`/`GOALS-011` (orphan/missing parent) and `ACT-005` (orphan predecessor/parent): a GOAL's `parent` field is documented as v0.x-transitional (its canonical home is a `goal_parent` relation file or the goals-tree view's inline `parent`, not the element). `acme_corp`'s own `GOAL-CUST-1`/`GOAL-OPS-1` are exactly this shape — flagging them would fail this repo's own parity fixture for doing nothing wrong.
- `GOALS-008`'s error case needs a `goal_types` catalogue that lives on the goals-tree view, not on the element — not reachable from this repo shape.
- `FGCA-012`/`013`/`014` (unreferenced driver/goal/change) are advisory-by-design upstream ("import anyway, record the warning").

These are documented in `docs/validation.md` as deliberately deferred, gated on `RepoFinding` growing a severity field — not silently dropped.

## Test plan

- [x] `packages/diagrams`: full suite green (1409 tests), including a new `check-strategy-chain.test.ts` (26 tests) covering each new rule, its negative case, and the deferred-rule non-firing cases.
- [x] Root CLI: `tsc --noEmit`, `npm run lint`, and `tests/cli-repo-validate-model.test.ts` all green.
- [x] Verified zero new findings against the real `organizations/acme_corp` fixture (`node dist/cli.js validate --scope=repo --root organizations/acme_corp --json --include-model`) — no regression on the existing structural-check parity bar.
- [x] `tests/cli-migrate.test.ts` has 3 pre-existing failures on `main` unrelated to this change (requires a local methodology-repo checkout at a specific state); confirmed unaffected by re-running on a clean stash.