### PR TITLE
feat(cli): add RepoFinding.severity, port DSM's warn-severity strategy-chain rules

### DIFF
--- a/.github/workflows/metrics-regression.yml
+++ b/.github/workflows/metrics-regression.yml
@@ -66,6 +66,7 @@ jobs:
 
       - name: Post metrics comment
         if: github.event_name == 'pull_request' && always()
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -31,8 +31,10 @@ runtime. It scans `<root>/canon/elements/**` (elements) and
 `{ scope, id, message }`. Any finding exits non-zero — the CI gate.
 
 Repo-scope checks (parity reference: the `acme_corp` worked example, which
-passes with zero findings from the checks below — it does still carry
-pre-existing findings from the separate compliance suite, see below):
+passes with zero **error**-severity findings from the checks below — it does
+carry `GOALS-011`/`FGCA-013` **warnings** from the strategy-chain rules
+described below, plus pre-existing findings from the separate compliance
+suite, see below):
 
 - **YAML syntax** — an unparseable canon file is reported and graph checks are skipped.
 - **ID uniqueness** — the same `id` defined in more than one file.
@@ -45,8 +47,8 @@ pre-existing findings from the separate compliance suite, see below):
   (TECHNOLOGY_SERVICE.node → NODE) and `INT-002` (INTEGRATION interface
   endpoints → APPLICATION). lint.py ships this phase as a no-op stub; Studio
   is ahead of the Python tool here — these findings are TypeScript-only.
-- **Strategy-chain semantics** (`GOALS-010`, `ACT-006`..`009`, `FGCA-008`..`011`)
-  — see below.
+- **Strategy-chain semantics** (`GOALS-009`..`011`, `ACT-005`..`009`,
+  `FGCA-008`..`014`) — see below.
 
 ### Strategy-chain semantic rules (`GOALS-*` / `ACT-*` / `FGCA-*`)
 
@@ -57,43 +59,61 @@ shape (`canon/elements/01_motivation/goals/`, `canon/elements/
 factors/`), so DSM can shell out to this CLI instead of maintaining its own
 copy of these checks. Each finding carries the DSM rule code as
 `RepoFinding.ruleId`, so DSM can map a CLI finding back onto its existing
-import-log taxonomy.
+import-log taxonomy, plus a `severity` (`'error'` | `'warning'`) matching
+DSM's own `Issue.Severity` classification for that rule.
 
-| Rule | Checks |
-|---|---|
-| `GOALS-010` | A GOAL element's `parent` chain contains a cycle. |
-| `ACT-006` | An ACTION element's `predecessors` graph contains a cycle. |
-| `ACT-007` | An ACTION element lists itself in its own `predecessors`. |
-| `ACT-008` | An ACTION element's `start_date`/`end_date` is not a valid `YYYY-MM-DD` date, or `end_date` is before `start_date` (equal is allowed — e.g. a milestone). |
-| `ACT-009` | An ACTION element's `duration` (or the `duration_days` alias), `labor_cost`, `resources_cost`, `effort`, or `score` is negative. |
-| `FGCA-008` | A GOAL's `factors` references a DRIVER id that does not resolve to a DRIVER element. |
-| `FGCA-009` | A CHANGE's `goals` references a GOAL id that does not resolve to a GOAL element. |
-| `FGCA-010` | An ACTION's `delivers_changes` references a CHANGE id that does not resolve to a CHANGE element. |
-| `FGCA-011` | An ACTION's `goals` references a GOAL id that does not resolve to a GOAL element. |
+| Rule | Severity | Checks |
+|---|---|---|
+| `GOALS-009` | warning | A GOAL's `parent` is set but does not resolve to a known GOAL (orphan). |
+| `GOALS-010` | error | A GOAL element's `parent` chain contains a cycle. |
+| `GOALS-011` | warning | A GOAL has no `parent` and `level` >= 1 (backlog — untethered from the tree until attached). |
+| `ACT-005` | warning | An ACTION's `predecessors` entry, or its `parent`, does not resolve to a known ACTION (orphan). |
+| `ACT-006` | error | An ACTION element's `predecessors` graph contains a cycle. |
+| `ACT-007` | error | An ACTION element lists itself in its own `predecessors`. |
+| `ACT-008` | error | An ACTION element's `start_date`/`end_date` is not a valid `YYYY-MM-DD` date, or `end_date` is before `start_date` (equal is allowed — e.g. a milestone). |
+| `ACT-009` | error | An ACTION element's `duration` (or the `duration_days` alias), `labor_cost`, `resources_cost`, `effort`, or `score` is negative. |
+| `FGCA-008` | error | A GOAL's `factors` references a DRIVER id that does not resolve to a DRIVER element. |
+| `FGCA-009` | error | A CHANGE's `goals` references a GOAL id that does not resolve to a GOAL element. |
+| `FGCA-010` | error | An ACTION's `delivers_changes` references a CHANGE id that does not resolve to a CHANGE element. |
+| `FGCA-011` | error | An ACTION's `goals` references a GOAL id that does not resolve to a GOAL element. |
+| `FGCA-012` | warning | A DRIVER is not referenced by any GOAL's `factors` (unreferenced). |
+| `FGCA-013` | warning | A GOAL is not referenced by any CHANGE's or ACTION's `goals` (unreferenced). |
+| `FGCA-014` | warning | A CHANGE is not referenced by any ACTION's `delivers_changes` (unreferenced). |
 
-**Only DSM's error-severity rules are ported.** DSM's own taxonomy splits
-every rule error\|warn; `RepoFinding` has no severity field yet (the richer
-finding taxonomy stays deferred — see below), and every existing repo-scope
-finding is implicitly blocking (`validate --scope=repo` exits non-zero on any
-finding). DSM's warn-severity rules are deliberately **not** implemented here:
+**`GOALS-008` is the one DSM rule still not ported, at either severity.** Both
+of its cases ("type not declared in `goal_types`" and "level doesn't match
+the type's declared level") need the `goal_types[]` catalogue, which lives on
+the goals-tree *view* (`canon/views/goals/**`, `notations/views/04-goals.md`
+§5.2) — a zone this validator's `RepoModelInput` does not load (only
+`canon/elements/**` and `canon/relations/**`). There is no standalone-element
+data this rule could run against without the validator growing a third input
+zone. Flagged for a decision: skip permanently, or scope a follow-up that
+loads the goals-tree catalogue into the repo-scope model.
 
-- `GOALS-009`/`GOALS-011` (orphan / missing parent) and `ACT-005` (orphan
-  predecessor/parent) flag a normal state, not a bug, once adapted to the
-  standalone-element shape: a GOAL's `parent` is v0.x-transitional
-  (`ELEMENT_PRIMITIVES.md` §7.2 — its canonical home is a `goal_parent` REL
-  file or the goals-tree view's inline `parent`, not the element itself).
-  `organizations/acme_corp`'s own `GOAL-CUST-1`/`GOAL-OPS-1` are exactly this
-  shape (level 1, no `parent` on the element) — flagging that would fail this
-  repo's own reference fixture for doing nothing wrong.
-- `GOALS-008`'s error case ("type not declared in `goal_types`") needs a
-  catalogue this repo shape doesn't carry — `goal_types[]` lives on the
-  goals-tree view, not on the GOAL element — so it isn't portable here.
-- `FGCA-012`/`013`/`014` (unreferenced driver/goal/change) are
-  advisory-by-design in DSM ("import anyway, record the warning") — same
-  reasoning as the orphan-parent rules above.
+**Why the warning tier exists at all.** `RepoFinding` grew an optional
+`severity` field (`'error'` | `'warning'`, defaulting to `'error'` when
+omitted) precisely so DSM's warn-severity rules could be ported without
+becoming blocking findings — every finding that predates this field (the
+structural checks above, plus the error-tier strategy-chain rules and
+`TSVC-003`/`INT-002`) has no `severity` set and stays implicitly blocking;
+`validate --scope=repo` only exits non-zero on an error-severity finding.
 
-Promoting these to repo-scope findings is future work, gated on `RepoFinding`
-growing a severity field.
+**Expect warning-tier noise on `parent`-light repos, by design.** GOAL's
+`parent` field is v0.x-transitional (`ELEMENT_PRIMITIVES.md` §7.2 — its
+canonical home is a `goal_parent` REL file or the goals-tree view's inline
+`parent`, not the element itself), so most standalone GOAL elements
+legitimately omit it. `organizations/acme_corp`'s own `GOAL-CUST-1`/
+`GOAL-OPS-1`/`GOAL-EU-1` are exactly this shape (level 1, no `parent` on the
+element) and do surface `GOALS-011` warnings. That is accepted, not a defect:
+warnings are advisory and non-blocking, unlike the error tier this repo held
+the line on when these rules were first scoped. Similarly, `FGCA-012`..`014`
+read only the inline `factors`/`goals`/`delivers_changes` arrays (the same
+fields `FGCA-008`..`011` already read) — a repo wiring the strategy chain
+through `REL` files instead (e.g. `action_goal`, per `elements/24-action.md`
+§3) will see `FGCA-013`/`014` warnings on elements that are, in fact, wired
+via a relation this validator doesn't yet cross-reference. This is a known
+gap shared with the pre-existing error-tier rules, not a regression
+introduced by the warning tier.
 
 ### Compliance suite (`--scope=repo`, #518)
 
@@ -122,11 +142,13 @@ $ transitrix validate --scope=repo --root organizations/acme_corp
 ✓ organizations/acme_corp — repo-scope validation passed
 ```
 
-The richer `target`/`category`/severity finding taxonomy is intentionally
-**not** adopted yet (deferred per the ADR until a consumer needs it). One
-field, `ruleId`, is now un-frozen — a stable code on findings that have one
-(see the strategy-chain rules above, plus `TSVC-003`/`INT-002`) — for DSM to
-map findings onto its own rule taxonomy; `target`/`category`/severity stay out.
+The richer `target`/`category` finding taxonomy is intentionally **not**
+adopted yet (deferred per the ADR until a consumer needs it). Two fields are
+un-frozen: `ruleId` — a stable code on findings that have one (see the
+strategy-chain rules above, plus `TSVC-003`/`INT-002`) — and `severity`
+(`'error'` | `'warning'`, omitted meaning `'error'`) — needed so DSM's
+warn-severity strategy-chain rules could be ported without becoming blocking
+findings. `target`/`category` stay out.
 
 ### Resolved model output (`--include-model`)
 

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.8.14",
+  "version": "1.8.15",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",

--- a/packages/diagrams/src/repo-validate/__tests__/check-strategy-chain.test.ts
+++ b/packages/diagrams/src/repo-validate/__tests__/check-strategy-chain.test.ts
@@ -31,29 +31,49 @@ describe('checkStrategyChainSemantics — GOALS-010 (parent cycle)', () => {
     const model = emptyModel();
     model.elements.push(goal('GOAL-A', { parent: 'GOAL-B' }), goal('GOAL-B', { parent: 'GOAL-A' }));
     const findings = validateRepoModel(model);
-    expect(findings).toHaveLength(1);
-    expect(findings[0]).toMatchObject({ scope: 'repo', ruleId: 'GOALS-010' });
-    expect(findings[0].message).toContain('cycle');
+    const errors = findings.filter((f) => f.severity !== 'warning');
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({ scope: 'repo', ruleId: 'GOALS-010' });
+    expect(errors[0].message).toContain('cycle');
+    // Both goals are unreferenced by any change/action — FGCA-013 warnings.
+    expect(findings.filter((f) => f.ruleId === 'FGCA-013')).toHaveLength(2);
   });
 
-  it('does not flag an acyclic parent chain', () => {
+  it('does not flag an acyclic parent chain (beyond the expected unreferenced-goal warnings)', () => {
     const model = emptyModel();
     model.elements.push(goal('GOAL-ROOT'), goal('GOAL-CHILD', { parent: 'GOAL-ROOT' }));
-    expect(validateRepoModel(model)).toEqual([]);
+    const findings = validateRepoModel(model);
+    expect(findings.filter((f) => f.severity !== 'warning')).toEqual([]);
+    expect(findings.every((f) => f.ruleId === 'FGCA-013')).toBe(true);
   });
 
-  it('does not flag a goal whose parent is unresolved (orphan, not a cycle — GOALS-009 deferred)', () => {
+  it('flags GOALS-009 for a goal whose parent is unresolved (orphan, not a cycle — warning)', () => {
     const model = emptyModel();
     model.elements.push(goal('GOAL-A', { parent: 'GOAL-MISSING' }));
-    expect(validateRepoModel(model)).toEqual([]);
+    const findings = validateRepoModel(model);
+    expect(findings).toContainEqual(
+      expect.objectContaining({ scope: 'repo', id: 'GOAL-A', ruleId: 'GOALS-009', severity: 'warning' }),
+    );
+    expect(findings.filter((f) => f.severity !== 'warning')).toEqual([]);
   });
 
-  it('does not flag a goal with no parent at all (v0.x transitional — GOALS-011 deferred)', () => {
+  it('flags GOALS-011 for a level >= 1 goal with no parent at all (backlog — warning)', () => {
     // Matches organizations/acme_corp's GOAL-CUST-1 / GOAL-OPS-1 shape: level
     // >= 1, no `parent` on the element (parent carried by the goals-tree view).
     const model = emptyModel();
     model.elements.push(goal('GOAL-BACKLOG', { type: 'Strategic Goal', level: 1 }));
-    expect(validateRepoModel(model)).toEqual([]);
+    const findings = validateRepoModel(model);
+    expect(findings).toContainEqual(
+      expect.objectContaining({ scope: 'repo', id: 'GOAL-BACKLOG', ruleId: 'GOALS-011', severity: 'warning' }),
+    );
+    expect(findings.filter((f) => f.severity !== 'warning')).toEqual([]);
+  });
+
+  it('does not flag GOALS-009/011 for a level-0 (root) goal with no parent', () => {
+    const model = emptyModel();
+    model.elements.push(goal('GOAL-ROOT', { type: 'Strategy', level: 0 }));
+    const findings = validateRepoModel(model);
+    expect(findings.some((f) => f.ruleId === 'GOALS-009' || f.ruleId === 'GOALS-011')).toBe(false);
   });
 });
 
@@ -84,10 +104,28 @@ describe('checkStrategyChainSemantics — ACT-006 (predecessor cycle) / ACT-007 
     expect(findings.every((f) => f.id === 'ACTION-SELF')).toBe(true);
   });
 
-  it('does not flag an unresolved predecessor (orphan — ACT-005 deferred)', () => {
+  it('flags ACT-005 for an unresolved predecessor (orphan — warning)', () => {
     const model = emptyModel();
     model.elements.push(action('ACTION-A', { predecessors: ['ACTION-MISSING'] }));
-    expect(validateRepoModel(model)).toEqual([]);
+    const findings = validateRepoModel(model);
+    expect(findings).toEqual([
+      expect.objectContaining({ scope: 'repo', id: 'ACTION-A', ruleId: 'ACT-005', severity: 'warning' }),
+    ]);
+  });
+
+  it('flags ACT-005 for an unresolved parent (orphan — warning)', () => {
+    const model = emptyModel();
+    model.elements.push(action('ACTION-A', { parent: 'ACTION-MISSING' }));
+    const findings = validateRepoModel(model);
+    expect(findings).toEqual([
+      expect.objectContaining({ scope: 'repo', id: 'ACTION-A', ruleId: 'ACT-005', severity: 'warning' }),
+    ]);
+  });
+
+  it('does not flag ACT-005 for a resolved predecessor/parent', () => {
+    const model = emptyModel();
+    model.elements.push(action('ACTION-ROOT'), action('ACTION-CHILD', { parent: 'ACTION-ROOT', predecessors: ['ACTION-ROOT'] }));
+    expect(validateRepoModel(model).filter((f) => f.ruleId === 'ACT-005')).toEqual([]);
   });
 });
 
@@ -170,29 +208,38 @@ describe('checkStrategyChainSemantics — FGCA-008..011 (strategy-chain cross-re
     const model = emptyModel();
     model.elements.push(goal('GOAL-A', { factors: ['DRIVER-MISSING'] }));
     const findings = validateRepoModel(model);
-    expect(findings).toHaveLength(1);
-    expect(findings[0]).toMatchObject({ id: 'GOAL-A', ruleId: 'FGCA-008' });
+    const errors = findings.filter((f) => f.severity !== 'warning');
+    expect(errors).toEqual([expect.objectContaining({ id: 'GOAL-A', ruleId: 'FGCA-008' })]);
+    // GOAL-A is also unreferenced by any change/action — FGCA-013 warning.
+    expect(findings.filter((f) => f.ruleId === 'FGCA-013')).toHaveLength(1);
   });
 
-  it('accepts GOAL.factors that resolve to a driver', () => {
+  it('accepts GOAL.factors that resolve to a driver (beyond the expected unreferenced-goal warning)', () => {
     const model = emptyModel();
     model.elements.push(driver('DRIVER-A'), goal('GOAL-A', { factors: ['DRIVER-A'] }));
-    expect(validateRepoModel(model)).toEqual([]);
+    const findings = validateRepoModel(model);
+    expect(findings.filter((f) => f.severity !== 'warning')).toEqual([]);
+    expect(findings).toEqual([
+      expect.objectContaining({ id: 'GOAL-A', ruleId: 'FGCA-013', severity: 'warning' }),
+    ]);
   });
 
   it('accepts the legacy `factor` notation value for the driver cross-reference', () => {
     const model = emptyModel();
     model.elements.push(el('canon/elements/01_motivation/factors/DRIVER-A.yaml', { notation: 'factor', id: 'DRIVER-A' }));
     model.elements.push(goal('GOAL-A', { factors: ['DRIVER-A'] }));
-    expect(validateRepoModel(model)).toEqual([]);
+    const findings = validateRepoModel(model);
+    expect(findings.filter((f) => f.severity !== 'warning')).toEqual([]);
   });
 
   it('flags CHANGE.goals referencing an undefined goal (FGCA-009)', () => {
     const model = emptyModel();
     model.elements.push(change('CHANGE-A', { goals: ['GOAL-MISSING'] }));
     const findings = validateRepoModel(model);
-    expect(findings).toHaveLength(1);
-    expect(findings[0]).toMatchObject({ id: 'CHANGE-A', ruleId: 'FGCA-009' });
+    const errors = findings.filter((f) => f.severity !== 'warning');
+    expect(errors).toEqual([expect.objectContaining({ id: 'CHANGE-A', ruleId: 'FGCA-009' })]);
+    // CHANGE-A is also unreferenced by any action — FGCA-014 warning.
+    expect(findings.filter((f) => f.ruleId === 'FGCA-014')).toHaveLength(1);
   });
 
   it('flags ACTION.delivers_changes referencing an undefined change (FGCA-010)', () => {
@@ -222,15 +269,24 @@ describe('checkStrategyChainSemantics — FGCA-008..011 (strategy-chain cross-re
     expect(validateRepoModel(model)).toEqual([]);
   });
 
-  it('does not flag a driver/goal/change that is unreferenced (orphan — FGCA-012..014 deferred)', () => {
+  it('flags FGCA-012..014 for a driver/goal/change that is unreferenced (orphan — warning)', () => {
     const model = emptyModel();
     model.elements.push(driver('DRIVER-UNUSED'), goal('GOAL-UNUSED'), change('CHANGE-UNUSED'));
-    expect(validateRepoModel(model)).toEqual([]);
+    const findings = validateRepoModel(model);
+    expect(findings.filter((f) => f.severity !== 'warning')).toEqual([]);
+    expect(findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'DRIVER-UNUSED', ruleId: 'FGCA-012', severity: 'warning' }),
+        expect.objectContaining({ id: 'GOAL-UNUSED', ruleId: 'FGCA-013', severity: 'warning' }),
+        expect.objectContaining({ id: 'CHANGE-UNUSED', ruleId: 'FGCA-014', severity: 'warning' }),
+      ]),
+    );
+    expect(findings).toHaveLength(3);
   });
 });
 
 describe('checkStrategyChainSemantics — organizations/acme_corp parity shape', () => {
-  it('does not flag acme_corp-shaped goals/actions/drivers/changes', () => {
+  it('flags no error-severity finding on acme_corp-shaped goals/actions/drivers/changes', () => {
     // Mirrors organizations/acme_corp's real fixture: goals with no inline
     // `parent` (carried by the goals-tree view), actions using `duration_days`
     // with `predecessors` and `delivers_changes`, drivers/changes resolving.
@@ -244,6 +300,20 @@ describe('checkStrategyChainSemantics — organizations/acme_corp parity shape',
       action('ACTION-BUILD-1', { duration_days: 30, predecessors: ['ACTION-DESIGN-1'], delivers_changes: ['CHANGE-ONBOARD-1'] }),
       action('ACTION-LAUNCH-1', { duration_days: 5, predecessors: ['ACTION-BUILD-1'], delivers_changes: ['CHANGE-ONBOARD-1'] }),
     );
-    expect(validateRepoModel(model)).toEqual([]);
+    const findings = validateRepoModel(model);
+    // No blocking findings — the ERROR-tier parity bar this fixture has always held.
+    expect(findings.filter((f) => f.severity !== 'warning')).toEqual([]);
+    // Warning tier: GOAL-OPS-1/GOAL-CUST-1 are level >= 1 with no inline
+    // `parent` (GOALS-011 — expected, ported deliberately at warning severity);
+    // GOAL-OPS-1 is not referenced by any change/action's `goals` (FGCA-013) —
+    // only GOAL-CUST-1 is (via CHANGE-ONBOARD-1.goals).
+    expect(findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'GOAL-OPS-1', ruleId: 'GOALS-011', severity: 'warning' }),
+        expect.objectContaining({ id: 'GOAL-CUST-1', ruleId: 'GOALS-011', severity: 'warning' }),
+        expect.objectContaining({ id: 'GOAL-OPS-1', ruleId: 'FGCA-013', severity: 'warning' }),
+      ]),
+    );
+    expect(findings).toHaveLength(3);
   });
 });

--- a/packages/diagrams/src/repo-validate/__tests__/validate-repo.test.ts
+++ b/packages/diagrams/src/repo-validate/__tests__/validate-repo.test.ts
@@ -12,7 +12,12 @@ function el(path: string, data: Record<string, unknown> | null, parseError?: str
 function cleanModel(): RepoModelInput {
   return {
     elements: [
-      el('canon/elements/01_motivation/goals/GOAL-OPS-1.yaml', { notation: 'goal', id: 'GOAL-OPS-1' }),
+      // notation is deliberately NOT 'goal' — this id is reused across this file
+      // as a generic relation-endpoint placeholder, unrelated to strategy-chain
+      // checks; giving it the 'goal' notation would draw it into
+      // check-strategy-chain.ts's GOALS-*/FGCA-* rules (e.g. FGCA-013,
+      // "unreferenced goal") and add unrelated noise to unrelated tests.
+      el('canon/elements/01_motivation/goals/GOAL-OPS-1.yaml', { notation: 'assessment', id: 'GOAL-OPS-1' }),
       el('canon/elements/01_motivation/assessments/ASSESSMENT-1.yaml', { notation: 'assessment', id: 'ASSESSMENT-1' }),
       el('canon/elements/02_business/capabilities/CAPABILITY-V1.yaml', { notation: 'capability', id: 'CAPABILITY-V1' }),
       // sidecar with no `id` — must be ignored (no duplicate, not an element)

--- a/packages/diagrams/src/repo-validate/check-strategy-chain.ts
+++ b/packages/diagrams/src/repo-validate/check-strategy-chain.ts
@@ -9,39 +9,37 @@
 // — not invented here — so DSM can map a CLI finding straight back onto its
 // import-log taxonomy (`RepoFinding.ruleId`).
 //
-// Scope — only DSM's ERROR-severity rules are ported. DSM's own taxonomy
-// splits every rule error|warn (`Issue.Severity` in the Go source). Porting
-// only the error half is deliberate, not an oversight:
+// Scope — DSM's full rule set is now ported except GOALS-008 (see below).
+// `RepoFinding` grew a `severity` field precisely so DSM's warn-severity
+// rules could land without becoming blocking: every finding from before that
+// field existed stays implicitly `'error'` (`types.ts`), and the six rules
+// below set `severity: 'warning'` explicitly, matching DSM's own
+// classification (`Issue.Severity` in the Go source) and its "import
+// anyway, record the warning" policy.
 //
-//   - `RepoFinding` has no severity field. The richer finding taxonomy stays
-//     "DEFERRED until a real consumer needs it" (types.ts), and every
-//     existing repo-scope check is implicitly blocking — `validate
-//     --scope=repo` exits non-zero on ANY finding (docs/validation.md). A
-//     warn-severity DSM rule surfaced here would silently become a blocking
-//     one, which is a bigger behaviour change than asked for.
-//   - Several of DSM's warn rules flag states that are normal, not bugs, once
-//     adapted to the standalone-element shape — confirmed against
-//     `organizations/acme_corp`, this repo's own parity fixture:
-//       - GOALS-009/011 (orphan / missing parent): GOAL's `parent` is
-//         declared "v0.x transitional" (methodology ELEMENT_PRIMITIVES.md
-//         §7.2) — its canonical home is a `goal_parent` REL file or the
-//         goals-tree view's inline `parent`, not the element. acme_corp's
-//         GOAL-CUST-1 / GOAL-OPS-1 are exactly this shape (level 1, no
-//         `parent` on the element, parent carried by the view per their own
-//         file comments) — flagging that as a repo-scope error would fail
-//         this repo's reference fixture for doing nothing wrong.
-//       - GOALS-008 (type/level mismatch): DSM's error case ("type not
-//         declared in goal_types") needs a catalogue this repo shape doesn't
-//         carry (`goal_types[]` lives on the goals-tree view, not on the
-//         element) — only DSM's *warning* case is even adaptable here, so
-//         under the ERROR-only policy above it is not ported.
-//       - ACT-005 (orphan predecessor/parent) and FGCA-012/013/014
-//         (unreferenced driver/goal/change) are advisory-by-design in DSM
-//         ("import anyway, record the warning") — the same reasoning as
-//         GOALS-009/011.
+// GOALS-009/011 (orphan / missing parent) are ported at warning severity even
+// though most standalone GOAL elements legitimately have no `parent` field —
+// GOAL.parent is "v0.x transitional" (ELEMENT_PRIMITIVES.md §7.2; canonical
+// home is a `goal_parent` REL file or the goals-tree view's inline `parent`).
+// `organizations/acme_corp`'s GOAL-CUST-1/GOAL-OPS-1/GOAL-EU-1 are exactly
+// this shape and do surface GOALS-011 warnings — that noise is the accepted
+// cost of a *warning* level rule (non-blocking, advisory), unlike the ERROR
+// tier this repo held the line on. This is a deliberate call, not an
+// oversight: keep the coverage rather than drop it, now that it can be
+// non-blocking.
 //
-//   Promoting these warn-severity rules to repo-scope findings is future
-//   work, gated on `RepoFinding` growing a severity field.
+// GOALS-008 (type/level mismatch) is still NOT ported, at either severity.
+// Both of DSM's cases ("type not declared in goal_types" / "level doesn't
+// match the type's declared level") need the `goal_types[]` catalogue, which
+// lives on the goals-tree *view* (`canon/views/goals/**`,
+// notations/views/04-goals.md §5.2) — a zone this validator's `RepoModelInput`
+// does not load (only `canon/elements/**` and `canon/relations/**`, per
+// `validate-repo.ts`). There is no standalone-element-shape data this rule
+// could run against without the validator growing a third input zone — a
+// bigger architectural change than adapting a predicate to data already in
+// scope, unlike every other ported rule here. This is flagged for a
+// per-rule call: skip it (status quo) or scope a follow-up that loads
+// `canon/views/goals/**`'s `goal_types[]` into the repo-scope model.
 //
 // Ported (error-severity, blocking):
 //   GOALS-010 — GOAL `parent` chain contains a cycle.
@@ -54,6 +52,17 @@
 //   FGCA-009  — CHANGE.goals references an undefined GOAL.
 //   FGCA-010  — ACTION.delivers_changes references an undefined CHANGE.
 //   FGCA-011  — ACTION.goals references an undefined GOAL.
+//
+// Ported (warning-severity, advisory):
+//   GOALS-009 — GOAL.parent is set but does not resolve to a known GOAL (orphan).
+//   GOALS-011 — GOAL has no `parent` and `level` >= 1 (backlog).
+//   ACT-005   — ACTION.predecessors entry or ACTION.parent does not resolve
+//               to a known ACTION (orphan).
+//   FGCA-012  — a DRIVER is not referenced by any GOAL.factors (unreferenced).
+//   FGCA-013  — a GOAL is not referenced by any CHANGE.goals or ACTION.goals
+//               (unreferenced).
+//   FGCA-014  — a CHANGE is not referenced by any ACTION.delivers_changes
+//               (unreferenced).
 
 import { docId } from './validate-repo.js';
 import type { RepoDoc, RepoFinding, RepoModelInput } from './types.js';
@@ -202,6 +211,39 @@ function checkGoalParentCycle(goals: ChainElement[], findings: RepoFinding[]): v
   }
 }
 
+/** GOALS-009 / GOALS-011 — GOAL `parent` resolution (warning). Mirrors DSM's
+ *  goals.go: the two are mutually exclusive per goal — a goal with no
+ *  `parent` is checked for GOALS-011 (backlog, level >= 1); a goal with a
+ *  `parent` is checked for GOALS-009 (orphan, parent unresolved) instead. */
+function checkGoalParentResolution(goals: ChainElement[], findings: RepoFinding[]): void {
+  const knownIds = new Set(goals.map((g) => g.id));
+  for (const g of goals) {
+    const parent = readString(g.data, 'parent');
+    if (!parent) {
+      const level = readFiniteNumber(g.data, 'level');
+      if (level !== undefined && level >= 1) {
+        findings.push({
+          scope: PScope,
+          id: g.id,
+          ruleId: 'GOALS-011',
+          severity: 'warning',
+          message: `GOALS-011: goal '${g.id}' (level ${level}) has no parent; treated as backlog until attached.`,
+        });
+      }
+      continue;
+    }
+    if (!knownIds.has(parent)) {
+      findings.push({
+        scope: PScope,
+        id: g.id,
+        ruleId: 'GOALS-009',
+        severity: 'warning',
+        message: `GOALS-009: goal '${g.id}' parent '${parent}' does not resolve to a known goal; treated as orphan.`,
+      });
+    }
+  }
+}
+
 /** ACT-007 — an ACTION cannot list itself as its own predecessor. */
 function checkActionSelfPredecessor(actions: ChainElement[], findings: RepoFinding[]): void {
   for (const a of actions) {
@@ -226,6 +268,36 @@ function checkActionPredecessorCycle(actions: ChainElement[], findings: RepoFind
       ruleId: 'ACT-006',
       message: `ACT-006: predecessor graph contains a cycle involving action '${cyc}'.`,
     });
+  }
+}
+
+/** ACT-005 — an ACTION `predecessors` entry or `parent` that does not resolve
+ *  to a known ACTION is an orphan reference (warning — advisory in DSM, same
+ *  as the goal-parent orphan checks above). */
+function checkActionOrphanReferences(actions: ChainElement[], findings: RepoFinding[]): void {
+  const knownIds = new Set(actions.map((a) => a.id));
+  for (const a of actions) {
+    for (const p of readStringArray(a.data, 'predecessors')) {
+      if (!knownIds.has(p)) {
+        findings.push({
+          scope: PScope,
+          id: a.id,
+          ruleId: 'ACT-005',
+          severity: 'warning',
+          message: `ACT-005: action '${a.id}' predecessor '${p}' does not resolve to a known action.`,
+        });
+      }
+    }
+    const parent = readString(a.data, 'parent');
+    if (parent && !knownIds.has(parent)) {
+      findings.push({
+        scope: PScope,
+        id: a.id,
+        ruleId: 'ACT-005',
+        severity: 'warning',
+        message: `ACT-005: action '${a.id}' parent '${parent}' does not resolve to a known action.`,
+      });
+    }
   }
 }
 
@@ -370,10 +442,73 @@ function checkStrategyChainReferences(
   }
 }
 
+/** FGCA-012..014 — a DRIVER/GOAL/CHANGE defined but never referenced
+ *  downstream in the strategy chain is unreferenced (warning — advisory in
+ *  DSM, mirroring the orphan-reference checks above). */
+function checkStrategyChainOrphans(
+  goals: ChainElement[],
+  actions: ChainElement[],
+  drivers: ChainElement[],
+  changes: ChainElement[],
+  findings: RepoFinding[],
+): void {
+  const referencedDrivers = new Set<string>();
+  for (const g of goals) {
+    for (const f of readStringArray(g.data, 'factors')) referencedDrivers.add(f);
+  }
+  for (const d of drivers) {
+    if (!referencedDrivers.has(d.id)) {
+      findings.push({
+        scope: PScope,
+        id: d.id,
+        ruleId: 'FGCA-012',
+        severity: 'warning',
+        message: `FGCA-012: driver '${d.id}' is not referenced by any goal.`,
+      });
+    }
+  }
+
+  const referencedGoals = new Set<string>();
+  for (const c of changes) {
+    for (const g of readStringArray(c.data, 'goals')) referencedGoals.add(g);
+  }
+  for (const a of actions) {
+    for (const g of readStringArray(a.data, 'goals')) referencedGoals.add(g);
+  }
+  for (const g of goals) {
+    if (!referencedGoals.has(g.id)) {
+      findings.push({
+        scope: PScope,
+        id: g.id,
+        ruleId: 'FGCA-013',
+        severity: 'warning',
+        message: `FGCA-013: goal '${g.id}' is not referenced by any change or action.`,
+      });
+    }
+  }
+
+  const referencedChanges = new Set<string>();
+  for (const a of actions) {
+    for (const c of readStringArray(a.data, 'delivers_changes')) referencedChanges.add(c);
+  }
+  for (const c of changes) {
+    if (!referencedChanges.has(c.id)) {
+      findings.push({
+        scope: PScope,
+        id: c.id,
+        ruleId: 'FGCA-014',
+        severity: 'warning',
+        message: `FGCA-014: change '${c.id}' is not referenced by any action.`,
+      });
+    }
+  }
+}
+
 /**
- * Run the strategy-chain semantic checks (GOALS-010, ACT-006..009,
- * FGCA-008..011) over the loaded element set and append findings. Called from
- * `validateRepoModel` after the structural phases. Pure, deterministic order.
+ * Run the strategy-chain semantic checks (GOALS-009..011, ACT-005..009,
+ * FGCA-008..014 except GOALS-008 — see the module header) over the loaded
+ * element set and append findings. Called from `validateRepoModel` after the
+ * structural phases. Pure, deterministic order.
  */
 export function checkStrategyChainSemantics(input: RepoModelInput, findings: RepoFinding[]): void {
   const goals = collectByNotation(input.elements, isGoalNotation);
@@ -382,9 +517,12 @@ export function checkStrategyChainSemantics(input: RepoModelInput, findings: Rep
   const changes = collectByNotation(input.elements, isChangeNotation);
 
   checkGoalParentCycle(goals, findings);
+  checkGoalParentResolution(goals, findings);
   checkActionSelfPredecessor(actions, findings);
   checkActionPredecessorCycle(actions, findings);
+  checkActionOrphanReferences(actions, findings);
   checkActionDates(actions, findings);
   checkActionNegativeNumbers(actions, findings);
   checkStrategyChainReferences(goals, actions, drivers, changes, findings);
+  checkStrategyChainOrphans(goals, actions, drivers, changes, findings);
 }

--- a/packages/diagrams/src/repo-validate/types.ts
+++ b/packages/diagrams/src/repo-validate/types.ts
@@ -18,6 +18,17 @@
 // (`docs/validation.md` § repo-scope rule list); the original structural
 // checks (syntax/uniqueness/atomicity/referential-integrity/policy) stay
 // uncoded rather than being retrofitted with invented codes.
+//
+// A second field, `severity`, is un-frozen for the same reason (vkgeorgia/
+// strategy#719): DSM's warn-severity strategy-chain rules (GOALS-009/011,
+// ACT-005, FGCA-012..014 — see check-strategy-chain.ts) are non-fatal by
+// DSM's own taxonomy ("import anyway, record the warning"); without a
+// severity field, porting them here would silently make them blocking,
+// since every existing repo-scope finding is implicitly blocking. `severity`
+// is optional and defaults to `'error'` when omitted — every finding from
+// before this field existed (syntax/uniqueness/atomicity/referential-
+// integrity/policy, plus the error-tier strategy-chain rules and
+// TSVC-003/INT-002) stays blocking with no code change at the call site.
 
 /** A single repo-scope validation finding. */
 export interface RepoFinding {
@@ -36,6 +47,13 @@ export interface RepoFinding {
    * Omitted for checks that don't yet have one.
    */
   ruleId?: string;
+  /**
+   * `'error'` (blocking) or `'warning'` (advisory). Omitted is equivalent to
+   * `'error'` — every check that predates this field never sets it and must
+   * stay blocking. Only the warn-severity strategy-chain rules set this to
+   * `'warning'` today (`docs/validation.md` § repo-scope rule list).
+   */
+  severity?: 'error' | 'warning';
 }
 
 /** A parsed canon document fed to the repo validator. IO (the filesystem walk)

--- a/packages/diagrams/src/repo-validate/types.ts
+++ b/packages/diagrams/src/repo-validate/types.ts
@@ -19,9 +19,9 @@
 // checks (syntax/uniqueness/atomicity/referential-integrity/policy) stay
 // uncoded rather than being retrofitted with invented codes.
 //
-// A second field, `severity`, is un-frozen for the same reason (vkgeorgia/
-// strategy#719): DSM's warn-severity strategy-chain rules (GOALS-009/011,
-// ACT-005, FGCA-012..014 — see check-strategy-chain.ts) are non-fatal by
+// A second field, `severity`, is un-frozen for the same reason: DSM's
+// warn-severity strategy-chain rules (GOALS-009/011, ACT-005, FGCA-012..014
+// — see check-strategy-chain.ts) are non-fatal by
 // DSM's own taxonomy ("import anyway, record the warning"); without a
 // severity field, porting them here would silently make them blocking,
 // since every existing repo-scope finding is implicitly blocking. `severity`

--- a/packages/diagrams/src/repo-validate/validate-repo.ts
+++ b/packages/diagrams/src/repo-validate/validate-repo.ts
@@ -23,8 +23,9 @@
 //   6. Policy             (phase 6) — element marked Active/Production with no
 //                                     owner.
 //
-// Findings stay `{ scope, id, message }` — no severity, no target/category
-// taxonomy (deferred per the ADR).
+// Findings stay `{ scope, id, message }` plus the two un-frozen optional
+// fields `ruleId` and `severity` — the richer target/category taxonomy stays
+// deferred per the ADR.
 
 import { checkStrategyChainSemantics } from './check-strategy-chain.js';
 import type { RepoDoc, RepoFinding, RepoModelInput } from './types.js';

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -320,7 +320,7 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
     console.error('             canon/elements/** and canon/relations/** records it parsed,');
     console.error('             as { model: { elements: [...], relations: [...] } } — for a');
     console.error('             non-JS consumer of the parsed model. Off by default.');
-    console.error('Exits with code 1 if any findings.');
+    console.error('Exits with code 1 on any error-severity finding (warnings do not fail the run).');
     process.exit(0);
   }
 

--- a/src/repo-validate.ts
+++ b/src/repo-validate.ts
@@ -606,11 +606,18 @@ export function buildRepoModel(root: string): ResolvedRepoModel {
   return resolveRepoModel(loadRepoModel(root));
 }
 
-/** True when the run has a blocking finding — a canon finding or a view error.
- *  View warnings and skipped files do not fail the run. */
+/** A canon finding blocks the run unless it explicitly opts into
+ *  `severity: 'warning'` — every finding that predates that field (and every
+ *  error-tier strategy-chain rule) has no `severity` set and stays blocking. */
+function isCanonBlocking(f: RepoFinding): boolean {
+  return f.severity !== 'warning';
+}
+
+/** True when the run has a blocking finding — a canon error or a view error.
+ *  Canon/view/codex/compliance warnings and skipped files do not fail the run. */
 export function repoScopeHasErrors(result: RepoScopeResult): boolean {
   return (
-    result.canon.length > 0
+    result.canon.some(isCanonBlocking)
     || result.views.some((v) => v.severity === 'error')
     || result.codex.some((c) => c.severity === 'error')
     || result.compliance.some((c) => c.severity === 'error')
@@ -628,6 +635,8 @@ export function reportRepoFindings(
   model?: ResolvedRepoModel,
 ): void {
   const { canon, views, codex, compliance, skipped } = result;
+  const canonErrors = canon.filter(isCanonBlocking);
+  const canonWarnings = canon.filter((c) => c.severity === 'warning');
   const viewErrors = views.filter((v) => v.severity === 'error');
   const viewWarnings = views.filter((v) => v.severity === 'warning');
   const codexErrors = codex.filter((c) => c.severity === 'error');
@@ -635,7 +644,7 @@ export function reportRepoFindings(
   const complianceErrors = compliance.filter((c) => c.severity === 'error');
   const complianceWarnings = compliance.filter((c) => c.severity === 'warning');
   const valid =
-    canon.length === 0
+    canonErrors.length === 0
     && viewErrors.length === 0
     && codexErrors.length === 0
     && complianceErrors.length === 0;
@@ -678,7 +687,8 @@ export function reportRepoFindings(
     console.log('Canon (elements / relations):');
     for (const f of canon) {
       const where = f.id ? f.id : '(file)';
-      console.log(`  \x1b[31m✗ ${where}\x1b[0m ${f.message}`);
+      const mark = f.severity === 'warning' ? `\x1b[33m⚠ ${where}\x1b[0m` : `\x1b[31m✗ ${where}\x1b[0m`;
+      console.log(`  ${mark} ${f.message}`);
     }
     console.log();
   }
@@ -739,8 +749,13 @@ export function reportRepoFindings(
   }
 
   const parts: string[] = [];
-  if (canon.length > 0) {
-    parts.push(`\x1b[31m${canon.length}\x1b[0m canon`);
+  if (canonErrors.length > 0) {
+    parts.push(`\x1b[31m${canonErrors.length}\x1b[0m canon error${canonErrors.length === 1 ? '' : 's'}`);
+  }
+  if (canonWarnings.length > 0) {
+    parts.push(
+      `\x1b[33m${canonWarnings.length}\x1b[0m canon warning${canonWarnings.length === 1 ? '' : 's'}`,
+    );
   }
   if (viewErrors.length > 0) {
     parts.push(`\x1b[31m${viewErrors.length}\x1b[0m view error${viewErrors.length === 1 ? '' : 's'}`);


### PR DESCRIPTION
## Summary

Follow-up to the strategy-chain semantics work (#409): adds an optional `severity` field (`'error' | 'warning'`, defaulting to `'error'` when omitted) to `RepoFinding`, then ports the six DSM strategy-chain rules that were previously held back because there was no way to mark them non-blocking:

- `GOALS-009` — GOAL.parent set but unresolved (orphan)
- `GOALS-011` — GOAL with no parent and level >= 1 (backlog)
- `ACT-005` — ACTION predecessor/parent unresolved (orphan)
- `FGCA-012` — DRIVER not referenced by any GOAL.factors
- `FGCA-013` — GOAL not referenced by any CHANGE/ACTION.goals
- `FGCA-014` — CHANGE not referenced by any ACTION.delivers_changes

`validate --scope=repo` now only exits non-zero on an error-severity canon finding; every pre-existing check is unaffected since it never sets `severity`.

**`GOALS-008` stays unported, at either severity.** Both of its cases ("type not declared in `goal_types`" / "level doesn't match the type's declared level") need the `goal_types[]` catalogue, which lives on the goals-tree *view* (`canon/views/goals/**`) — a zone this validator's `RepoModelInput` doesn't load (only `canon/elements/**` + `canon/relations/**`). There's no standalone-element-shape data this rule could run against without the validator growing a third input zone, which is a bigger change than adapting a predicate to data already in scope. Flagging this for a decision: skip permanently, or scope a follow-up that loads the goals-tree catalogue.

**Known gap shared with the already-merged error tier:** `FGCA-012`..`014` (like the existing `FGCA-008`..`011`) only read the inline `factors`/`goals`/`delivers_changes` arrays, not `canon/relations/**` REL-typed edges (e.g. `action_goal`). A repo wiring the strategy chain through REL files instead of inline arrays will see warnings on elements that are, in fact, wired — not a regression introduced here, but worth knowing about.

## Verification

- `organizations/acme_corp` (this repo's own worked example): zero error-severity canon findings (same parity bar as the merged error tier); 4 new warnings surface (`GOALS-011` x3, `FGCA-013` x1) — expected given GOAL's `parent` field is v0.x-transitional and most standalone GOAL elements don't set it.
- Checked semantics against `transitrix-dsm`'s conformance fixture corpus (`testdata/notation-conformance/`, referenced by `api02/cmd/conformance-report`) — every fixture there is a clean, fully-wired example with zero DSM-side warnings for the six ported rules; reasoned through each fixture by hand since the corpus is in DSM's document-form shape, not the standalone-element shape this validator loads, so there's no automated cross-check today.
- Full test suite: `packages/diagrams` (87 files / 1412 tests) and root `test:core` all green (3 pre-existing, unrelated failures in `cli-migrate.test.ts` confirmed present on `main` before this change too).

## Test plan

- [x] `npm run compile` (root + diagrams package)
- [x] `packages/diagrams` vitest suite (87 files / 1412 tests)
- [x] root `test:core` vitest suite
- [x] Manual `transitrix validate --scope=repo --root organizations/acme_corp --json` — confirms zero error-severity canon findings, 4 new warnings