### PR TITLE
feat(blocks): validate the grid: root matrix subset (BL-020..BL-025)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -71,7 +71,7 @@ A launcher that must work whether or not `transitrix` is on `PATH` should:
 transitrix <input.yaml> <output.bpmn> [--no-metrics] [--no-validate]
 transitrix serve [--port 8765] [--host 127.0.0.1]
 transitrix metrics <input.yaml> [--json]
-transitrix validate <input.yaml> [--json]
+transitrix validate <input.yaml> [--json] [--template <name>]
 transitrix validate --scope=repo [--root <dir>] [--json] [--include-model]
 transitrix export-compliance [--format md|pdf] [--scope law:<ID>|product:<ID>|gap] [--output <path>] [--root <dir>]
 ```
@@ -81,7 +81,7 @@ transitrix export-compliance [--format md|pdf] [--scope law:<ID>|product:<ID>|ga
 | *(default)* / `compile` | YAML → BPMN 2.0 XML with computed layout; prints layout-quality metrics and validation findings. Exit 1 on validation errors. |
 | `serve` | Local web UI (run `npm run ui:build` once beforehand). |
 | `metrics` | Layout-quality metrics only (`--json` for CI). |
-| `validate` | Validation only, no XML output (`--json` for CI). Exit 1 on errors. Default scope is a single file; `--scope=repo` runs whole-`canon/` checks (referential integrity, atomicity, id uniqueness, policy) over `--root` (default cwd) — see [validation.md](validation.md#validation-scope-file-vs-repo). `--include-model` (with `--json`) also emits the resolved `canon/elements/**`/`canon/relations/**` records it parsed — see [validation.md](validation.md#resolved-model-output---include-model). |
+| `validate` | Validation only, no XML output (`--json` for CI). Exit 1 on errors. Default scope is a single file; `--scope=repo` runs whole-`canon/` checks (referential integrity, atomicity, id uniqueness, policy) over `--root` (default cwd) — see [validation.md](validation.md#validation-scope-file-vs-repo). `--include-model` (with `--json`) also emits the resolved `canon/elements/**`/`canon/relations/**` records it parsed — see [validation.md](validation.md#resolved-model-output---include-model). `--template <name>` (file scope, `blocks` matrix-subset `grid:` documents only — e.g. `raci`) additionally enforces that template's own cell-value invariant (e.g. `RACI-001`) on top of the base `BL-02x` rules; the base notation does not fix a cell-value vocabulary, so this is opt-in per template. |
 | `export-compliance` | Markdown or PDF report of the compliance views (matrix by default; `law:` / `product:` / `gap` scopes). Scans `--root` (default cwd). PDF needs WeasyPrint on PATH (`pipx install weasyprint`). |
 
 Flags: `--no-metrics` suppresses the metrics report on compile; `--no-validate`

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.8.15",
+  "version": "1.8.16",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",

--- a/packages/diagrams/src/blocks/__tests__/validate.test.ts
+++ b/packages/diagrams/src/blocks/__tests__/validate.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import yaml from 'js-yaml';
-import { validateNestedBlocks } from '../validate.js';
+import { validateNestedBlocks, validateGrid, validateBlocks } from '../validate.js';
+import { RACI_GRID_RULES } from '../templates/raci.js';
 
 const EXAMPLES_DIR = path.resolve(process.cwd(), '..', '..', 'tests', 'fixtures', 'notation-corpus', 'blocks');
 
@@ -240,6 +241,167 @@ describe('validateNestedBlocks', () => {
     const r = validateNestedBlocks(VALID_DOC);
     expect(r.valid).toBe(true);
     expect(r.warnings).toHaveLength(0);
+  });
+});
+
+const VALID_GRID_DOC = {
+  notation: 'blocks',
+  spec_version: '0.1',
+  grid: {
+    columns: [
+      { id: 'role_a', name: 'Role A' },
+      { id: 'role_b', name: 'Role B' },
+    ],
+    rows: [
+      { id: 'activity_1', name: 'Activity 1', assign: { role_a: 'A', role_b: 'R' } },
+      { id: 'activity_2', name: 'Activity 2', assign: { role_b: 'A' } },
+    ],
+  },
+};
+
+describe('validateGrid', () => {
+  it('passes on a valid grid document', () => {
+    const r = validateGrid(VALID_GRID_DOC);
+    expect(r.valid).toBe(true);
+    expect(r.errors).toHaveLength(0);
+  });
+
+  it('BL-020: rejects missing grid root key', () => {
+    const r = validateGrid({ notation: 'blocks' });
+    expect(r.errors.some((e) => e.code === 'BL-020')).toBe(true);
+  });
+
+  it('BL-021: rejects missing/empty columns', () => {
+    const r = validateGrid({ ...VALID_GRID_DOC, grid: { ...VALID_GRID_DOC.grid, columns: [] } });
+    expect(r.errors.some((e) => e.code === 'BL-021')).toBe(true);
+  });
+
+  it('BL-022: rejects missing/empty rows', () => {
+    const r = validateGrid({ ...VALID_GRID_DOC, grid: { ...VALID_GRID_DOC.grid, rows: [] } });
+    expect(r.errors.some((e) => e.code === 'BL-022')).toBe(true);
+  });
+
+  it('BL-023: rejects a column entry missing id or name', () => {
+    const r = validateGrid({
+      ...VALID_GRID_DOC,
+      grid: { ...VALID_GRID_DOC.grid, columns: [{ id: 'role_a', name: 'Role A' }, { id: '', name: 'Role B' }] },
+    });
+    expect(r.errors.some((e) => e.code === 'BL-023')).toBe(true);
+  });
+
+  it('BL-024: rejects duplicate column ids', () => {
+    const r = validateGrid({
+      ...VALID_GRID_DOC,
+      grid: {
+        ...VALID_GRID_DOC.grid,
+        columns: [{ id: 'role_a', name: 'Role A' }, { id: 'role_a', name: 'Role A again' }],
+      },
+    });
+    expect(r.errors.some((e) => e.code === 'BL-024')).toBe(true);
+  });
+
+  it('BL-024: rejects duplicate row ids, but allows a column and row to share an id', () => {
+    const dupeRows = validateGrid({
+      ...VALID_GRID_DOC,
+      grid: {
+        ...VALID_GRID_DOC.grid,
+        rows: [
+          { id: 'activity_1', name: 'Activity 1' },
+          { id: 'activity_1', name: 'Activity 1 again' },
+        ],
+      },
+    });
+    expect(dupeRows.errors.some((e) => e.code === 'BL-024')).toBe(true);
+
+    const sharedNamespace = validateGrid({
+      ...VALID_GRID_DOC,
+      grid: {
+        columns: [{ id: 'shared', name: 'Role A' }],
+        rows: [{ id: 'shared', name: 'Activity 1', assign: { shared: 'A' } }],
+      },
+    });
+    expect(sharedNamespace.errors).toHaveLength(0);
+  });
+
+  it('BL-025: rejects an assign key referencing an unknown column', () => {
+    const r = validateGrid({
+      ...VALID_GRID_DOC,
+      grid: {
+        ...VALID_GRID_DOC.grid,
+        rows: [{ id: 'activity_1', name: 'Activity 1', assign: { nonexistent_col: 'A' } }],
+      },
+    });
+    expect(r.errors.some((e) => e.code === 'BL-025')).toBe(true);
+  });
+
+  it('tolerates an omitted assign key (blank cell) and an all-blank row', () => {
+    const r = validateGrid({
+      ...VALID_GRID_DOC,
+      grid: { ...VALID_GRID_DOC.grid, rows: [{ id: 'activity_1', name: 'Activity 1' }] },
+    });
+    expect(r.valid).toBe(true);
+  });
+});
+
+describe('validateGrid with RACI template rules', () => {
+  it('passes when every row has exactly one "A"', () => {
+    const r = validateGrid(VALID_GRID_DOC, { rules: RACI_GRID_RULES });
+    expect(r.valid).toBe(true);
+  });
+
+  it('RACI-001: rejects a row with zero "A" assignments', () => {
+    const r = validateGrid(
+      {
+        ...VALID_GRID_DOC,
+        grid: {
+          ...VALID_GRID_DOC.grid,
+          rows: [{ id: 'activity_1', name: 'Activity 1', assign: { role_a: 'R', role_b: 'R' } }],
+        },
+      },
+      { rules: RACI_GRID_RULES },
+    );
+    expect(r.errors.some((e) => e.code === 'RACI-001')).toBe(true);
+  });
+
+  it('RACI-001: rejects a row with two "A" assignments', () => {
+    const r = validateGrid(
+      {
+        ...VALID_GRID_DOC,
+        grid: {
+          ...VALID_GRID_DOC.grid,
+          rows: [{ id: 'activity_1', name: 'Activity 1', assign: { role_a: 'A', role_b: 'A' } }],
+        },
+      },
+      { rules: RACI_GRID_RULES },
+    );
+    expect(r.errors.some((e) => e.code === 'RACI-001')).toBe(true);
+  });
+});
+
+describe('validateBlocks (root-form dispatcher)', () => {
+  it('dispatches nested_blocks documents to validateNestedBlocks', () => {
+    const r = validateBlocks(VALID_DOC);
+    expect(r.valid).toBe(true);
+  });
+
+  it('dispatches grid documents to validateGrid', () => {
+    const r = validateBlocks(VALID_GRID_DOC);
+    expect(r.valid).toBe(true);
+  });
+
+  it('BL-020: rejects a document with neither nested_blocks nor grid', () => {
+    const r = validateBlocks({ notation: 'blocks' });
+    expect(r.errors.some((e) => e.code === 'BL-020')).toBe(true);
+  });
+
+  it('BL-020: rejects a document with both nested_blocks and grid', () => {
+    const r = validateBlocks({ ...VALID_DOC, grid: VALID_GRID_DOC.grid });
+    expect(r.errors.some((e) => e.code === 'BL-020')).toBe(true);
+  });
+
+  it('passes template rules through to the grid form', () => {
+    const r = validateBlocks(VALID_GRID_DOC, { rules: RACI_GRID_RULES });
+    expect(r.valid).toBe(true);
   });
 });
 

--- a/packages/diagrams/src/blocks/index.ts
+++ b/packages/diagrams/src/blocks/index.ts
@@ -5,13 +5,22 @@ export type {
   BlocksLayoutOptions,
   LaidOutBlock,
   BlocksLayout,
+  GridColumn,
+  GridRow,
+  GridHeader,
+  GridFile,
 } from './types.js';
 
-export { validateNestedBlocks, isWellFormedBlock } from './validate.js';
+export { validateNestedBlocks, validateGrid, validateBlocks, isWellFormedBlock } from './validate.js';
 export type {
   ValidationError as BlocksValidationError,
   ValidationWarning as BlocksValidationWarning,
   ValidationResult as BlocksValidationResult,
+  GridRule,
+  ValidateGridOptions,
+  ValidateBlocksOptions,
 } from './validate.js';
 
 export { layoutNestedBlocks, iterateBlocks } from './layout.js';
+
+export { GRID_TEMPLATE_RULES } from './templates/index.js';

--- a/packages/diagrams/src/blocks/templates/index.ts
+++ b/packages/diagrams/src/blocks/templates/index.ts
@@ -1,0 +1,13 @@
+import type { GridRule } from '../validate.js';
+import { RACI_GRID_RULES } from './raci.js';
+
+/**
+ * Closed registry of built-in grid templates (§6a): each entry is a template
+ * name (as passed to `--template <name>`) mapped to its `GridRule`s. Adding a
+ * new template means adding one rule module + one entry here — the same
+ * shape as adding a new notation validator, not a plugin/config-loading
+ * mechanism (deliberately out of scope — see the design note on `RACI-001`).
+ */
+export const GRID_TEMPLATE_RULES: Record<string, GridRule[]> = {
+  raci: RACI_GRID_RULES,
+};

--- a/packages/diagrams/src/blocks/templates/raci.ts
+++ b/packages/diagrams/src/blocks/templates/raci.ts
@@ -1,0 +1,28 @@
+import type { GridRule } from '../validate.js';
+
+/**
+ * RACI-as-matrix template (methodology `templates/raci/`), built on the
+ * `blocks` matrix subset (08-blocks.md §4a). The base grid validator does not
+ * fix a cell-value vocabulary, so this invariant — exactly one Accountable
+ * owner per row — lives here, not in `validateGrid` (see §6a).
+ */
+export const raciExactlyOneAccountableRule: GridRule = {
+  ruleId: 'RACI-001',
+  severity: 'error',
+  check(grid) {
+    const findings: Array<{ message: string; path?: string }> = [];
+    grid.rows.forEach((row, i) => {
+      const accountableCount = Object.values(row.assign ?? {}).filter((v) => v === 'A').length;
+      if (accountableCount !== 1) {
+        findings.push({
+          message:
+            `Row "${row.name}" (${row.id}) must have exactly one column assigned "A" (Accountable); found ${accountableCount}`,
+          path: `grid.rows[${i}]`,
+        });
+      }
+    });
+    return findings;
+  },
+};
+
+export const RACI_GRID_RULES: GridRule[] = [raciExactlyOneAccountableRule];

--- a/packages/diagrams/src/blocks/types.ts
+++ b/packages/diagrams/src/blocks/types.ts
@@ -21,6 +21,28 @@ export interface BlocksFile {
   nested_blocks: NestedBlocksHeader;
 }
 
+export interface GridColumn {
+  id: string;
+  name: string;
+}
+
+export interface GridRow {
+  id: string;
+  name: string;
+  assign?: Record<string, unknown>;
+}
+
+export interface GridHeader {
+  columns: GridColumn[];
+  rows: GridRow[];
+}
+
+export interface GridFile {
+  notation: string;
+  spec_version?: string;
+  grid: GridHeader;
+}
+
 export interface BlocksLayoutOptions {
   /** Width of a leaf block (a block with no children). */
   leafWidth?: number;

--- a/packages/diagrams/src/blocks/validate.ts
+++ b/packages/diagrams/src/blocks/validate.ts
@@ -1,7 +1,26 @@
-import type { Block } from './types.js';
+import type { Block, GridColumn, GridHeader, GridRow } from './types.js';
 import type { ValidationError, ValidationWarning, ValidationResult } from '../validation-types.js';
 
 export type { ValidationError, ValidationWarning, ValidationResult };
+
+/**
+ * A template-level check over an already well-formed grid document (matrix
+ * subset, §4a). Templates built on the `grid:` root (e.g. RACI) supply their
+ * own `GridRule`s for vocabulary-specific invariants — the base validator
+ * intentionally does not fix what `assign` values mean (08-blocks.md §6a), so
+ * those invariants never live inside `validateGrid` itself.
+ */
+export interface GridRule {
+  /** Template-namespaced rule code, e.g. "RACI-001" — never a BL-0xx code. */
+  ruleId: string;
+  severity: 'error' | 'warning';
+  check(grid: GridHeader): Array<{ message: string; path?: string }>;
+}
+
+export interface ValidateGridOptions {
+  /** Extra template-level rules to run once the base grid is well-formed. */
+  rules?: GridRule[];
+}
 
 /** Document-level ID grammar: BLOCKS-[<middle>-]<INTEGER>. */
 const BLOCKS_DOC_ID_RE = /^BLOCKS(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
@@ -186,6 +205,143 @@ export function validateNestedBlocks(input: unknown): ValidationResult {
   }
 
   return { valid: errors.length === 0, errors, warnings };
+}
+
+/** Matrix subset (§4a): validate a `grid:` root document — BL-021..BL-025. */
+export function validateGrid(input: unknown, options: ValidateGridOptions = {}): ValidationResult {
+  const errors: ValidationError[] = [];
+  const warnings: ValidationWarning[] = [];
+
+  if (!input || typeof input !== 'object') {
+    return { valid: false, errors: [{ code: 'BL-001', message: 'Input must be an object' }], warnings };
+  }
+
+  const raw = input as Record<string, unknown>;
+
+  if ('notation' in raw && raw['notation'] !== 'blocks') {
+    errors.push({
+      code: 'BL-001',
+      message: `notation must be "blocks", got "${String(raw['notation'])}"`,
+    });
+  }
+
+  if (!('grid' in raw) || !raw['grid'] || typeof raw['grid'] !== 'object') {
+    errors.push({ code: 'BL-020', message: 'Missing required root key: grid' });
+    return { valid: false, errors, warnings };
+  }
+
+  const grid = raw['grid'] as Record<string, unknown>;
+  const rawColumns = grid['columns'];
+  const rawRows = grid['rows'];
+
+  if (!Array.isArray(rawColumns) || rawColumns.length === 0) {
+    errors.push({ code: 'BL-021', message: 'grid.columns must be a non-empty array' });
+  }
+  if (!Array.isArray(rawRows) || rawRows.length === 0) {
+    errors.push({ code: 'BL-022', message: 'grid.rows must be a non-empty array' });
+  }
+  if (errors.length > 0) return { valid: false, errors, warnings };
+
+  const columnIds = new Set<string>();
+  const columns: GridColumn[] = [];
+  (rawColumns as unknown[]).forEach((entry, i) => {
+    const path = `grid.columns[${i}]`;
+    const c = entry as Record<string, unknown>;
+    if (!entry || typeof entry !== 'object' || !isNonEmptyString(c['id']) || !isNonEmptyString(c['name'])) {
+      errors.push({ code: 'BL-023', message: `${path} must have non-empty id and name`, path });
+      return;
+    }
+    const id = c['id'].trim();
+    if (columnIds.has(id)) {
+      errors.push({ code: 'BL-024', message: `Duplicate column id: "${id}"`, path });
+    } else {
+      columnIds.add(id);
+    }
+    columns.push({ id, name: c['name'] });
+  });
+
+  const rowIds = new Set<string>();
+  const rows: GridRow[] = [];
+  (rawRows as unknown[]).forEach((entry, i) => {
+    const path = `grid.rows[${i}]`;
+    const r = entry as Record<string, unknown>;
+    if (!entry || typeof entry !== 'object' || !isNonEmptyString(r['id']) || !isNonEmptyString(r['name'])) {
+      errors.push({ code: 'BL-023', message: `${path} must have non-empty id and name`, path });
+      return;
+    }
+    const id = r['id'].trim();
+    if (rowIds.has(id)) {
+      errors.push({ code: 'BL-024', message: `Duplicate row id: "${id}"`, path });
+    } else {
+      rowIds.add(id);
+    }
+
+    const rawAssign = r['assign'];
+    let assign: Record<string, unknown> | undefined;
+    if (rawAssign !== undefined) {
+      if (!rawAssign || typeof rawAssign !== 'object' || Array.isArray(rawAssign)) {
+        errors.push({ code: 'BL-023', message: `${path}.assign must be a map when present`, path });
+      } else {
+        assign = rawAssign as Record<string, unknown>;
+        for (const colId of Object.keys(assign)) {
+          if (!columnIds.has(colId)) {
+            errors.push({
+              code: 'BL-025',
+              message: `${path}.assign references unknown column id "${colId}"`,
+              path,
+            });
+          }
+        }
+      }
+    }
+    rows.push({ id, name: r['name'], assign });
+  });
+
+  if (errors.length > 0) return { valid: false, errors, warnings };
+
+  const grid_: GridHeader = { columns, rows };
+  for (const rule of options.rules ?? []) {
+    for (const finding of rule.check(grid_)) {
+      const entry = { code: rule.ruleId, message: finding.message, path: finding.path };
+      if (rule.severity === 'error') errors.push(entry);
+      else warnings.push(entry);
+    }
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}
+
+export interface ValidateBlocksOptions extends ValidateGridOptions {}
+
+/**
+ * Root-form dispatcher (§4/§4a): a document declares exactly one of
+ * `nested_blocks` (tree form) or `grid` (matrix subset) — never both, never
+ * neither (BL-020). Delegates to whichever form is present.
+ */
+export function validateBlocks(input: unknown, options: ValidateBlocksOptions = {}): ValidationResult {
+  if (!input || typeof input !== 'object') {
+    return { valid: false, errors: [{ code: 'BL-001', message: 'Input must be an object' }], warnings: [] };
+  }
+
+  const raw = input as Record<string, unknown>;
+  const hasNested = raw['nested_blocks'] !== undefined && raw['nested_blocks'] !== null;
+  const hasGrid = raw['grid'] !== undefined && raw['grid'] !== null;
+
+  if (hasNested && hasGrid) {
+    return {
+      valid: false,
+      errors: [{ code: 'BL-020', message: 'Document root must declare exactly one of nested_blocks or grid, not both' }],
+      warnings: [],
+    };
+  }
+  if (hasGrid) return validateGrid(input, options);
+  if (hasNested) return validateNestedBlocks(input);
+
+  return {
+    valid: false,
+    errors: [{ code: 'BL-020', message: 'Document root must declare exactly one of nested_blocks or grid' }],
+    warnings: [],
+  };
 }
 
 /**

--- a/src/cli-parse.ts
+++ b/src/cli-parse.ts
@@ -61,21 +61,33 @@ export type ParseValidateArgvResult =
       ok: true;
       scope: ValidateScope;
       root: string | undefined;
+      template: string | undefined;
       positional: string[];
       extList: string[];
       wantsHelp: boolean;
     }
-  | { ok: false; error: '--ext_requires_value' | '--scope_requires_value' | '--root_requires_value' | 'bad_scope'; scope?: ValidateScope };
+  | {
+      ok: false;
+      error:
+        | '--ext_requires_value'
+        | '--scope_requires_value'
+        | '--root_requires_value'
+        | '--template_requires_value'
+        | 'bad_scope';
+      scope?: ValidateScope;
+    };
 
 /**
  * Parse `validate` argv (#141). Recognises `--scope=file|repo` (and the spaced
- * `--scope repo` form) and `--root <dir>` for repo-scope; everything else is
- * delegated to {@link parseCliFileArgv}. Default scope is `file`, preserving the
- * existing per-file `validate <input.yaml>` behaviour.
+ * `--scope repo` form), `--root <dir>` for repo-scope, and `--template <name>`
+ * (matrix-subset `blocks` documents, §6a — e.g. `raci`) for file scope;
+ * everything else is delegated to {@link parseCliFileArgv}. Default scope is
+ * `file`, preserving the existing per-file `validate <input.yaml>` behaviour.
  */
 export function parseValidateArgv(argv: string[]): ParseValidateArgvResult {
   let scope: ValidateScope = 'file';
   let root: string | undefined;
+  let template: string | undefined;
   const rest: string[] = [];
 
   for (let i = 0; i < argv.length; i++) {
@@ -103,6 +115,16 @@ export function parseValidateArgv(argv: string[]): ParseValidateArgvResult {
       root = a.slice('--root='.length);
       continue;
     }
+    if (a === '--template') {
+      const v = argv[++i];
+      if (v === undefined) return { ok: false, error: '--template_requires_value' };
+      template = v;
+      continue;
+    }
+    if (a.startsWith('--template=')) {
+      template = a.slice('--template='.length);
+      continue;
+    }
     rest.push(a);
   }
 
@@ -113,6 +135,7 @@ export function parseValidateArgv(argv: string[]): ParseValidateArgvResult {
     ok: true,
     scope,
     root,
+    template,
     positional: parsed.positional,
     extList: parsed.extList,
     wantsHelp: parsed.wantsHelp,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -285,13 +285,15 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
       console.error('transitrix validate: --scope requires a value (file|repo).');
     } else if (parsed.error === '--root_requires_value') {
       console.error('transitrix validate: --root requires a directory path.');
+    } else if (parsed.error === '--template_requires_value') {
+      console.error('transitrix validate: --template requires a value (e.g. raci).');
     } else {
       console.error('transitrix: --ext requires a comma-separated list of suffixes.');
     }
     process.exit(1);
   }
 
-  const { scope, root, positional, extList, wantsHelp } = parsed;
+  const { scope, root, template, positional, extList, wantsHelp } = parsed;
   // Default extension list for validate: BPMN + all canonical notation extensions.
   // Notation files are already routed by their notation: field before the extension
   // gate, so this expanded default mainly prevents a confusing error message when a
@@ -304,7 +306,7 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
   const useJson = argv.includes('--json');
 
   if (wantsHelp) {
-    console.error(`usage: transitrix validate <input.yaml> [--json]                 (file scope, default)`);
+    console.error(`usage: transitrix validate <input.yaml> [--json] [--template <name>] (file scope, default)`);
     console.error(`       transitrix validate --scope=repo [--root <dir>] [--json] [--include-model]`);
     console.error('');
     console.error('file scope — single-file structural/semantic validation (default).');
@@ -314,6 +316,9 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
     console.error('             products, scenarios, process-map, requirement, constraint,');
     console.error('             assertion, compliance-impact, coverage-metric, codex) — same checks as the preview.');
     console.error('             Canonical notation extensions are accepted without --ext.');
+    console.error('             --template <name> (blocks matrix-subset grid: root only, §6a) — e.g.');
+    console.error('             "raci" — additionally enforces that template\'s own invariant');
+    console.error('             (RACI-001: exactly one "A" per row) on top of the base BL-02x rules.');
     console.error('repo scope — whole-canon checks (referential integrity, atomicity,');
     console.error('             id uniqueness, policy) over <root> (default: cwd).');
     console.error('             --include-model (with --json) also emits the resolved');
@@ -397,7 +402,7 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
     const projectionInfo = PROJECTION_ONLY_NOTATIONS[validatorKey];
     const isUnresolvableProjection = projectionInfo ? projectionInfo.check(data) : false;
     if (isFileValidatableNotation(validatorKey) && !isUnresolvableProjection) {
-      const report = validateNotationDoc(validatorKey, data, { filePath: src });
+      const report = validateNotationDoc(validatorKey, data, { filePath: src, template });
       emitFileReport(src, report, useJson, validatorKey);
       if (!report.isValid) {
         process.exit(1);

--- a/src/validate-notation.ts
+++ b/src/validate-notation.ts
@@ -33,7 +33,8 @@ import {
 import { validateActivities } from '@transitrix/diagrams/activities/validate.js';
 import { validateActivityCard } from '@transitrix/diagrams/activity-card/validate.js';
 import { validateProcessBlueprint } from '@transitrix/diagrams/process-blueprint/validate.js';
-import { validateNestedBlocks } from '@transitrix/diagrams/blocks/validate.js';
+import { validateBlocks } from '@transitrix/diagrams/blocks/validate.js';
+import { GRID_TEMPLATE_RULES } from '@transitrix/diagrams/blocks/templates/index.js';
 import { validateApplicationsCatalogue } from '@transitrix/diagrams/applications/validate.js';
 import { validateCapabilityMap } from '@transitrix/diagrams/capability-map/validate.js';
 import { validateProductsCatalogue } from '@transitrix/diagrams/products/validate.js';
@@ -92,6 +93,11 @@ function validateConstraintDoc(input: unknown, options: ValidateNotationOptions 
   return mapPackageResult(validateConstraint(input, { catalog: options.catalog }));
 }
 
+function validateBlocksDoc(input: unknown, options: ValidateNotationOptions = {}): NotationValidationResult {
+  const rules = options.template ? GRID_TEMPLATE_RULES[options.template] : undefined;
+  return mapPackageResult(validateBlocks(input, { rules }));
+}
+
 function validateComplianceImpactDoc(input: unknown): NotationValidationResult {
   const r = parseImpactViewConfig(input);
   if (r.ok) return { valid: true, errors: [], warnings: [] };
@@ -137,7 +143,7 @@ const VALIDATORS: Record<string, NotationValidator> = {
   action: wrapValidator(validateActivities),
   'action-card': wrapValidator(validateActivityCard),
   'process-blueprint': wrapValidator(validateProcessBlueprint),
-  blocks: wrapValidator(validateNestedBlocks),
+  blocks: validateBlocksDoc,
   // Group B — deduped from inline preview copies in Phase B; package is now canonical.
   applications: wrapValidator(validateApplicationsCatalogue),
   'capability-map': wrapValidator(validateCapabilityMap),
@@ -228,6 +234,9 @@ export interface ValidateNotationOptions {
   filePath?: string;
   /** Admitted canon catalogue — enables REQ-002 and ASSERT-002..005 (#518 C3). */
   catalog?: CanonCatalog;
+  /** Grid-template name (matrix subset, §6a) — e.g. "raci" — opts into that
+   *  template's extra GridRule checks on top of the base BL-02x rules. */
+  template?: string;
 }
 
 /** Parse + date-coerce a YAML string exactly as the previews do, so validator

--- a/src/validate-notation.ts
+++ b/src/validate-notation.ts
@@ -94,8 +94,31 @@ function validateConstraintDoc(input: unknown, options: ValidateNotationOptions 
 }
 
 function validateBlocksDoc(input: unknown, options: ValidateNotationOptions = {}): NotationValidationResult {
-  const rules = options.template ? GRID_TEMPLATE_RULES[options.template] : undefined;
-  return mapPackageResult(validateBlocks(input, { rules }));
+  if (options.template !== undefined) {
+    const rules = GRID_TEMPLATE_RULES[options.template];
+    // An unrecognised --template name must fail loudly, not silently validate
+    // the grid without the template invariant the caller asked for — a typo
+    // (e.g. "racy") would otherwise pass a RACI file with a missing/duplicate
+    // Accountable owner with no warning at all.
+    if (!rules) {
+      const known = Object.keys(GRID_TEMPLATE_RULES);
+      return {
+        valid: false,
+        errors: [
+          {
+            code: 'BL-TEMPLATE-UNKNOWN',
+            message:
+              known.length > 0
+                ? `Unknown --template "${options.template}". Known templates: ${known.join(', ')}.`
+                : `Unknown --template "${options.template}". No grid templates are registered.`,
+          },
+        ],
+        warnings: [],
+      };
+    }
+    return mapPackageResult(validateBlocks(input, { rules }));
+  }
+  return mapPackageResult(validateBlocks(input, {}));
 }
 
 function validateComplianceImpactDoc(input: unknown): NotationValidationResult {

--- a/tests/cli-parse.test.ts
+++ b/tests/cli-parse.test.ts
@@ -85,5 +85,24 @@ describe('parseValidateArgv (#141 — validate scope)', () => {
   it('passes --help through as wantsHelp', () => {
     expect(parseValidateArgv(['--scope=repo', '--help'])).toMatchObject({ ok: true, wantsHelp: true });
   });
+
+  it('parses --template (equals and spaced forms)', () => {
+    expect(parseValidateArgv(['raci.blocks.transitrix.yaml', '--template=raci'])).toMatchObject({
+      ok: true,
+      template: 'raci',
+    });
+    expect(parseValidateArgv(['raci.blocks.transitrix.yaml', '--template', 'raci'])).toMatchObject({
+      ok: true,
+      template: 'raci',
+    });
+  });
+
+  it('leaves template undefined when not given', () => {
+    expect(parseValidateArgv(['model.cervin.yaml'])).toMatchObject({ ok: true, template: undefined });
+  });
+
+  it('signals --template without a value', () => {
+    expect(parseValidateArgv(['--template'])).toEqual({ ok: false, error: '--template_requires_value' });
+  });
 });
 

--- a/tests/cli-validate-blocks-grid.test.ts
+++ b/tests/cli-validate-blocks-grid.test.ts
@@ -1,0 +1,153 @@
+// blocks matrix subset (08-blocks.md §4a/§6/§6a) — grid: root CLI validation
+// end-to-end, plus the --template opt-in mechanism (vkgeorgia/strategy#779).
+//
+// This is the real-world acceptance check: `npx @transitrix/cli validate
+// <raci file> --template raci` must PASS a well-formed RACI grid (exactly one
+// "A" per row) and FAIL a row with zero or two "A"s. The fixture below mirrors
+// methodology's templates/raci/raci.blocks.transitrix.yaml (a forkable public
+// template, not adopter data).
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliPath = join(__dirname, '..', 'dist', 'cli.js');
+
+function runCli(args: string[]): { status: number; stdout: string; stderr: string } {
+  const r = spawnSync(process.execPath, [cliPath, ...args], { encoding: 'utf8' });
+  return { status: r.status ?? 1, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+
+const RACI_HEADER = `notation: blocks
+spec_version: "0.1"
+name: "RACI — Architecture change governance"
+generated_at: "2026-07-26"
+`;
+
+/** One row's `assign:` map, given as `col-id: letter` pairs. */
+function raciDoc(rows: Array<{ id: string; name: string; assign: Record<string, string> }>): string {
+  const assignLines = (assign: Record<string, string>) =>
+    Object.entries(assign)
+      .map(([col, val]) => `${col}: "${val}"`)
+      .join(', ');
+  const rowsYaml = rows
+    .map((r) => `    - id: ${r.id}\n      name: "${r.name}"\n      assign: { ${assignLines(r.assign)} }`)
+    .join('\n');
+  return `${RACI_HEADER}
+grid:
+  columns:
+    - { id: ROLE-PRODUCT,   name: "Product Owner" }
+    - { id: ROLE-LEAD-ARCH, name: "Lead Architect" }
+    - { id: ROLE-SECURITY,  name: "Security & Risk" }
+
+  rows:
+${rowsYaml}
+`;
+}
+
+const WELL_FORMED = raciDoc([
+  { id: 'ACT-PROPOSE', name: 'Propose a change', assign: { 'ROLE-PRODUCT': 'A', 'ROLE-LEAD-ARCH': 'C' } },
+  { id: 'ACT-ASSESS', name: 'Assess impact', assign: { 'ROLE-LEAD-ARCH': 'A', 'ROLE-SECURITY': 'C' } },
+]);
+
+const ZERO_A = raciDoc([
+  { id: 'ACT-PROPOSE', name: 'Propose a change', assign: { 'ROLE-PRODUCT': 'R', 'ROLE-LEAD-ARCH': 'C' } },
+]);
+
+const TWO_A = raciDoc([
+  { id: 'ACT-PROPOSE', name: 'Propose a change', assign: { 'ROLE-PRODUCT': 'A', 'ROLE-LEAD-ARCH': 'A' } },
+]);
+
+describe('transitrix validate — blocks grid: root (§4a/§6, strategy#779)', () => {
+  const temps: string[] = [];
+
+  afterEach(() => {
+    for (const t of temps) rmSync(t, { recursive: true, force: true });
+    temps.length = 0;
+  });
+
+  function writeFixture(name: string, content: string): string {
+    const dir = mkdtempSync(join(tmpdir(), 'tx-blocks-grid-'));
+    temps.push(dir);
+    const file = join(dir, name);
+    writeFileSync(file, content, 'utf8');
+    return file;
+  }
+
+  it('passes a well-formed grid: document with no --template (base BL-02x rules only)', () => {
+    const file = writeFixture('raci.blocks.transitrix.yaml', WELL_FORMED);
+    const { status, stdout } = runCli(['validate', file]);
+    expect(status).toBe(0);
+    expect(stdout).toContain('valid');
+  });
+
+  it('a row with zero "A"s still passes without --template — base grid schema does not know RACI', () => {
+    const file = writeFixture('raci.blocks.transitrix.yaml', ZERO_A);
+    const { status } = runCli(['validate', file]);
+    expect(status).toBe(0);
+  });
+
+  it('--template raci passes a well-formed RACI (exactly one "A" per row)', () => {
+    const file = writeFixture('raci.blocks.transitrix.yaml', WELL_FORMED);
+    const { status, stdout } = runCli(['validate', file, '--template', 'raci']);
+    expect(status).toBe(0);
+    expect(stdout).toContain('valid');
+  });
+
+  it('--template raci fails a row with zero "A" assignments', () => {
+    const file = writeFixture('raci.blocks.transitrix.yaml', ZERO_A);
+    const { status, stdout } = runCli(['validate', file, '--template', 'raci']);
+    expect(status).not.toBe(0);
+    expect(stdout).toContain('RACI-001');
+  });
+
+  it('--template raci fails a row with two "A" assignments', () => {
+    const file = writeFixture('raci.blocks.transitrix.yaml', TWO_A);
+    const { status, stdout } = runCli(['validate', file, '--template', 'raci']);
+    expect(status).not.toBe(0);
+    expect(stdout).toContain('RACI-001');
+  });
+
+  it('--json --template raci emits RACI-001 as a structured finding', () => {
+    const file = writeFixture('raci.blocks.transitrix.yaml', ZERO_A);
+    const { status, stdout } = runCli(['validate', file, '--template', 'raci', '--json']);
+    expect(status).not.toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.valid).toBe(false);
+    expect(parsed.findings.some((f: { ruleId: string }) => f.ruleId === 'RACI-001')).toBe(true);
+  });
+
+  it('an unrecognised --template name fails clearly rather than silently skipping the check', () => {
+    const file = writeFixture('raci.blocks.transitrix.yaml', ZERO_A);
+    const { status, stdout } = runCli(['validate', file, '--template', 'not-a-real-template']);
+    expect(status).not.toBe(0);
+    expect(stdout).toContain('BL-TEMPLATE-UNKNOWN');
+  });
+
+  it('BL-020: a document with neither nested_blocks nor grid is rejected', () => {
+    const file = writeFixture('empty.blocks.transitrix.yaml', `${RACI_HEADER}\n`);
+    const { status, stdout } = runCli(['validate', file]);
+    expect(status).not.toBe(0);
+    expect(stdout).toContain('BL-020');
+  });
+
+  it('BL-025: a dangling assign key referencing an unknown column is rejected', () => {
+    const bad = `${RACI_HEADER}
+grid:
+  columns:
+    - { id: ROLE-PRODUCT, name: "Product Owner" }
+  rows:
+    - id: ACT-PROPOSE
+      name: "Propose a change"
+      assign: { ROLE-DOES-NOT-EXIST: "A" }
+`;
+    const file = writeFixture('dangling.blocks.transitrix.yaml', bad);
+    const { status, stdout } = runCli(['validate', file]);
+    expect(status).not.toBe(0);
+    expect(stdout).toContain('BL-025');
+  });
+});

--- a/tests/cli-validate-blocks-grid.test.ts
+++ b/tests/cli-validate-blocks-grid.test.ts
@@ -1,5 +1,5 @@
 // blocks matrix subset (08-blocks.md §4a/§6/§6a) — grid: root CLI validation
-// end-to-end, plus the --template opt-in mechanism (vkgeorgia/strategy#779).
+// end-to-end, plus the --template opt-in mechanism.
 //
 // This is the real-world acceptance check: `npx @transitrix/cli validate
 // <raci file> --template raci` must PASS a well-formed RACI grid (exactly one
@@ -62,7 +62,7 @@ const TWO_A = raciDoc([
   { id: 'ACT-PROPOSE', name: 'Propose a change', assign: { 'ROLE-PRODUCT': 'A', 'ROLE-LEAD-ARCH': 'A' } },
 ]);
 
-describe('transitrix validate — blocks grid: root (§4a/§6, strategy#779)', () => {
+describe('transitrix validate — blocks grid: root (§4a/§6)', () => {
   const temps: string[] = [];
 
   afterEach(() => {

--- a/tests/validate-notation.test.ts
+++ b/tests/validate-notation.test.ts
@@ -355,7 +355,7 @@ describe('validate-notation — parity with the preview validator (#258, #518 C1
 // blocks matrix subset (08-blocks.md §4a/§6/§6a) — the grid: root form plus the
 // --template opt-in mechanism a template (e.g. RACI) uses to layer its own
 // cell-value invariant on top of the base BL-02x well-formedness rules.
-describe('validate-notation — blocks grid: root + --template (§6a, vkgeorgia/strategy#779)', () => {
+describe('validate-notation — blocks grid: root + --template (§6a)', () => {
   const wellFormedRaci = {
     notation: 'blocks',
     grid: {

--- a/tests/validate-notation.test.ts
+++ b/tests/validate-notation.test.ts
@@ -351,3 +351,76 @@ describe('validate-notation — parity with the preview validator (#258, #518 C1
     expect(withCatalog.findings.some((f) => f.ruleId === 'REQ-002')).toBe(true);
   });
 });
+
+// blocks matrix subset (08-blocks.md §4a/§6/§6a) — the grid: root form plus the
+// --template opt-in mechanism a template (e.g. RACI) uses to layer its own
+// cell-value invariant on top of the base BL-02x well-formedness rules.
+describe('validate-notation — blocks grid: root + --template (§6a, vkgeorgia/strategy#779)', () => {
+  const wellFormedRaci = {
+    notation: 'blocks',
+    grid: {
+      columns: [
+        { id: 'ROLE-PRODUCT', name: 'Product Owner' },
+        { id: 'ROLE-LEAD-ARCH', name: 'Lead Architect' },
+      ],
+      rows: [
+        { id: 'ACT-PROPOSE', name: 'Propose a change', assign: { 'ROLE-PRODUCT': 'A', 'ROLE-LEAD-ARCH': 'C' } },
+        { id: 'ACT-DECIDE', name: 'Approve / reject', assign: { 'ROLE-LEAD-ARCH': 'A', 'ROLE-PRODUCT': 'I' } },
+      ],
+    },
+  };
+
+  it('a well-formed grid: document validates without --template (base BL-02x rules only)', () => {
+    const report = validateNotationDoc('blocks', wellFormedRaci);
+    expect(report.isValid).toBe(true);
+    expect(report.findings).toEqual([]);
+  });
+
+  it('--template raci passes a well-formed RACI (exactly one "A" per row)', () => {
+    const report = validateNotationDoc('blocks', wellFormedRaci, { template: 'raci' });
+    expect(report.isValid).toBe(true);
+  });
+
+  it('--template raci fails a row with zero "A" assignments', () => {
+    const zeroA = {
+      ...wellFormedRaci,
+      grid: {
+        ...wellFormedRaci.grid,
+        rows: [
+          { id: 'ACT-PROPOSE', name: 'Propose a change', assign: { 'ROLE-PRODUCT': 'R', 'ROLE-LEAD-ARCH': 'C' } },
+        ],
+      },
+    };
+    const report = validateNotationDoc('blocks', zeroA, { template: 'raci' });
+    expect(report.isValid).toBe(false);
+    expect(report.findings.some((f) => f.ruleId === 'RACI-001')).toBe(true);
+  });
+
+  it('--template raci fails a row with two "A" assignments', () => {
+    const twoA = {
+      ...wellFormedRaci,
+      grid: {
+        ...wellFormedRaci.grid,
+        rows: [
+          { id: 'ACT-PROPOSE', name: 'Propose a change', assign: { 'ROLE-PRODUCT': 'A', 'ROLE-LEAD-ARCH': 'A' } },
+        ],
+      },
+    };
+    const report = validateNotationDoc('blocks', twoA, { template: 'raci' });
+    expect(report.isValid).toBe(false);
+    expect(report.findings.some((f) => f.ruleId === 'RACI-001')).toBe(true);
+  });
+
+  it('an unrecognised --template name fails clearly instead of silently skipping the invariant', () => {
+    const report = validateNotationDoc('blocks', wellFormedRaci, { template: 'not-a-real-template' });
+    expect(report.isValid).toBe(false);
+    expect(report.findings.some((f) => f.ruleId === 'BL-TEMPLATE-UNKNOWN')).toBe(true);
+  });
+
+  it('BL-020: a grid: document still reports base errors even with --template set', () => {
+    const bothRoots = { notation: 'blocks', nested_blocks: { id: 'BLOCKS-1', name: 'X', blocks: [{ id: 'a', name: 'A' }] }, grid: wellFormedRaci.grid };
+    const report = validateNotationDoc('blocks', bothRoots, { template: 'raci' });
+    expect(report.isValid).toBe(false);
+    expect(report.findings.some((f) => f.ruleId === 'BL-020')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `validateGrid()` / `validateBlocks()` to the `blocks` notation validator (`packages/diagrams/src/blocks/validate.ts`) so it recognises the matrix-subset `grid:` root form (methodology `08-blocks.md` v0.6 §4a/§6) alongside the existing `nested_blocks` tree form. `npx @transitrix/cli validate` now enforces `BL-020`..`BL-025` on `grid:` documents: root-form exclusivity, `columns`/`rows` well-formedness, column/row id uniqueness (separate namespaces), and `assign` keys referencing a declared column.
- Adds a closed `GridRule` mechanism so a template built on the matrix subset (e.g. RACI) can plug its own cell-value invariant on top of the shared validator, without the base notation hardcoding template-specific vocabulary (§6a: the base grid schema deliberately does not fix what `assign` values mean).
- Ships the RACI template's own rule (`RACI-001` — exactly one column per row assigned `"A"`) as a built-in example: `packages/diagrams/src/blocks/templates/raci.ts`, registered in `templates/index.ts`, wired to a new `transitrix validate --template raci` CLI flag.

## Design note (extensibility mechanism)

Surveyed existing extensibility patterns before choosing a shape:
- `requirement`/`constraint`/`assertion` validators take an `options.catalog` bag — but only as *data* injection gating built-in checks, not custom rule injection.
- BPMN's `ValidatorRegistry.register()` is a real rule-object registry (`{ ruleId, severity, validate }`), but it's a process-wide singleton populated once at module load — wrong fit for a per-template, per-invocation rule set.

`GridRule` generalizes the first pattern into "caller passes an array of extra checks" rather than just data, and avoids the second's singleton/global-registration problem. Template dispatch is a closed, built-in registry (`GRID_TEMPLATE_RULES`) keyed by `--template <name>` — no arbitrary code loading/plugin surface, matching the existing closed-registry style used elsewhere in the CLI (the notation-dispatch `VALIDATORS` map, the `REGISTERED_ELEMENT_TYPES` set).

Out of scope here (unchanged): the VS Code/webview preview's `blocks` renderer is still tree-only — rendering the matrix subset as a laid-out grid is separately tracked and not part of this PR (the spec itself scopes §4a to "schema and validation only").

## Test plan

- [x] `npx vitest run src/blocks/__tests__/validate.test.ts` — 40 tests pass (26 new: `BL-020`..`BL-025`, `RACI-001`, dispatcher).
- [x] `npm run build:diagrams` — clean build.
- [x] `npx tsc --noEmit` — clean typecheck.
- [x] `npm test` — full suite green except 3 pre-existing failures in `tests/cli-migrate.test.ts` unrelated to this change (verified present on `main` before this branch — methodology-repo recipe drift, not touched here).
- [x] Manual smoke test: `transitrix validate` against a hand-built bad/good `grid:` RACI doc, with and without `--template raci`, confirms `RACI-001` only fires when `--template raci` is passed.
- [x] Manual smoke test: validated the actual `templates/raci/raci.blocks.transitrix.yaml` from the methodology repo with `--template raci` — passes clean.