### PR TITLE
feat(blocks): render the grid: root matrix subset

### DIFF
--- a/extension/src/blocks-preview.ts
+++ b/extension/src/blocks-preview.ts
@@ -5,14 +5,17 @@ import { buildDiagramFrame, type ThemeId, OPEN_THEME_COMMAND } from './diagram-f
 import { TITLE_BLOCK_H, titleBlockSvg, todayIso } from './svg-title-block.js';
 import { StaticSvgPreview } from './static-preview.js';
 import {
-  validateNestedBlocks,
+  validateBlocks,
   layoutNestedBlocks,
+  layoutGrid,
   iterateBlocks,
   type BlocksFile,
   type BlocksLayout,
+  type GridFile,
+  type GridLayout,
 } from '@transitrix/diagrams/blocks';
 import { coerceDatesToIsoStrings } from '@transitrix/diagrams/yaml-normalize.js';
-import { renderBlocksLayoutSvg } from '@transitrix/diagrams/webview/render-blocks.js';
+import { renderBlocksLayoutSvg, renderGridLayoutSvg } from '@transitrix/diagrams/webview/render-blocks.js';
 import { readBlocksLeafSize } from './node-size-config.js';
 
 
@@ -39,6 +42,22 @@ function layoutToSvg(
   return renderBlocksLayoutSvg(layout, { topInset: titleH, title: titleSvg });
 }
 
+/**
+ * Matrix subset (§4a) counterpart to {@link layoutToSvg} — same VS Code title
+ * block, delegating body emission to {@link renderGridLayoutSvg}.
+ */
+function gridLayoutToSvg(
+  layout: GridLayout,
+  filename?: string,
+  date?: string,
+  version?: string,
+): string {
+  const showTitle = filename != null && date != null;
+  const titleH = showTitle ? TITLE_BLOCK_H : 0;
+  const titleSvg = showTitle ? titleBlockSvg('Nested Blocks', filename!, date!, PAD, PAD, version) : '';
+  return renderGridLayoutSvg(layout, { topInset: titleH, title: titleSvg });
+}
+
 export class BlocksPreview extends StaticSvgPreview {
   readonly panelTitle = 'Blocks Preview';
   protected readonly viewType = 'blocksPreview';
@@ -58,13 +77,23 @@ export class BlocksPreview extends StaticSvgPreview {
 
     try {
       const parsed = coerceDatesToIsoStrings(yaml.load(yamlText) as unknown);
-      const v = validateNestedBlocks(parsed);
+      const raw = (parsed && typeof parsed === 'object' ? parsed : {}) as Record<string, unknown>;
+      const hasGrid = raw['grid'] !== undefined && raw['grid'] !== null;
+
+      const v = validateBlocks(parsed);
       warnings = v.warnings.map((w) => `${w.code}: ${w.message}`);
       if (!v.valid) {
         errorMsg = v.errors.map((e) => `${e.code}: ${e.message}`).join('\n');
+      } else if (hasGrid) {
+        // Matrix subset (08-blocks.md §4a) — single-layer rectangular grid,
+        // e.g. a RACI matrix. Layers/arbitrary shapes/sub-grids belong to the
+        // still-in-design layered-grid superset and are not handled here.
+        const file = parsed as GridFile;
+        const docDate = (typeof raw['generated_at'] === 'string' ? raw['generated_at'] : undefined) ?? todayIso();
+        const layout = layoutGrid(file);
+        svgContent = gridLayoutToSvg(layout, filename, docDate);
       } else {
         const file = parsed as BlocksFile;
-        const raw = (parsed && typeof parsed === 'object' ? parsed : {}) as Record<string, unknown>;
         const nb =
           (file as unknown as { nested_blocks?: { version?: unknown; date?: unknown } })
             .nested_blocks ?? {};

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.8.16",
+  "version": "1.8.17",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",

--- a/packages/diagrams/src/blocks/__tests__/layout.test.ts
+++ b/packages/diagrams/src/blocks/__tests__/layout.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { layoutNestedBlocks, iterateBlocks } from '../layout.js';
-import type { BlocksFile, LaidOutBlock } from '../types.js';
+import { layoutNestedBlocks, layoutGrid, iterateBlocks } from '../layout.js';
+import type { BlocksFile, GridFile, LaidOutBlock } from '../types.js';
 
 function findById(layout: ReturnType<typeof layoutNestedBlocks>, id: string): LaidOutBlock | undefined {
   for (const b of iterateBlocks(layout)) {
@@ -165,5 +165,84 @@ describe('layoutNestedBlocks', () => {
     expect(layout.blocks).toHaveLength(0);
     expect(layout.bounds.width).toBe(0);
     expect(layout.bounds.height).toBe(0);
+  });
+});
+
+// Matrix subset (08-blocks.md §4a) — modelled on the real RACI template
+// (methodology `templates/raci/raci.blocks.transitrix.yaml`).
+const RACI_GRID: GridFile = {
+  notation: 'blocks',
+  spec_version: '0.1',
+  grid: {
+    columns: [
+      { id: 'ROLE-PRODUCT', name: 'Product Owner' },
+      { id: 'ROLE-LEAD-ARCH', name: 'Lead Architect' },
+      { id: 'ROLE-REVIEW-BOARD', name: 'Architecture Review Board' },
+    ],
+    rows: [
+      {
+        id: 'ACT-PROPOSE',
+        name: 'Propose a change',
+        assign: { 'ROLE-PRODUCT': 'A', 'ROLE-LEAD-ARCH': 'C', 'ROLE-REVIEW-BOARD': 'I' },
+      },
+      {
+        id: 'ACT-DECIDE',
+        name: 'Approve / reject',
+        assign: { 'ROLE-REVIEW-BOARD': 'A', 'ROLE-LEAD-ARCH': 'R' },
+      },
+    ],
+  },
+};
+
+describe('layoutGrid', () => {
+  it('positions the row-header column at x=0 and the first data column right after it', () => {
+    const layout = layoutGrid(RACI_GRID);
+    expect(layout.columns[0].x).toBe(layout.rowHeaderWidth);
+  });
+
+  it('positions the column-header row at y=0 and the first data row right below it', () => {
+    const layout = layoutGrid(RACI_GRID);
+    expect(layout.rows[0].y).toBe(layout.headerHeight);
+  });
+
+  it('lays out one cell per (row, column) pair, including blank cells', () => {
+    const layout = layoutGrid(RACI_GRID);
+    expect(layout.cells).toHaveLength(RACI_GRID.grid.rows.length * RACI_GRID.grid.columns.length);
+    const blank = layout.cells.find((c) => c.rowId === 'ACT-DECIDE' && c.colId === 'ROLE-PRODUCT');
+    expect(blank?.value).toBeUndefined();
+  });
+
+  it('carries the assign value through to the matching cell', () => {
+    const layout = layoutGrid(RACI_GRID);
+    const cell = layout.cells.find((c) => c.rowId === 'ACT-PROPOSE' && c.colId === 'ROLE-PRODUCT');
+    expect(cell?.value).toBe('A');
+  });
+
+  it('bounds cover the full row-header + columns width and header + rows height', () => {
+    const layout = layoutGrid(RACI_GRID);
+    const lastCol = layout.columns[layout.columns.length - 1];
+    const lastRow = layout.rows[layout.rows.length - 1];
+    expect(layout.bounds.width).toBe(lastCol.x + lastCol.width);
+    expect(layout.bounds.height).toBe(lastRow.y + lastRow.height);
+  });
+
+  it('honours custom layout options', () => {
+    const layout = layoutGrid(RACI_GRID, { columnWidth: 100, rowHeight: 30, rowHeaderWidth: 150, headerHeight: 40 });
+    expect(layout.rowHeaderWidth).toBe(150);
+    expect(layout.headerHeight).toBe(40);
+    expect(layout.columns[0].width).toBe(100);
+    expect(layout.rows[0].height).toBe(30);
+  });
+
+  it('handles an empty grid gracefully (returns zero-size bounds)', () => {
+    const layout = layoutGrid({
+      notation: 'blocks',
+      // Schema-wise this is invalid (BL-021/BL-022), but the layout function
+      // still needs to be defensive — validation runs separately.
+      grid: { columns: [], rows: [] },
+    });
+    expect(layout.columns).toHaveLength(0);
+    expect(layout.rows).toHaveLength(0);
+    expect(layout.cells).toHaveLength(0);
   });
 });

--- a/packages/diagrams/src/blocks/index.ts
+++ b/packages/diagrams/src/blocks/index.ts
@@ -9,6 +9,11 @@ export type {
   GridRow,
   GridHeader,
   GridFile,
+  GridLayoutOptions,
+  LaidOutGridColumn,
+  LaidOutGridRow,
+  LaidOutGridCell,
+  GridLayout,
 } from './types.js';
 
 export { validateNestedBlocks, validateGrid, validateBlocks, isWellFormedBlock } from './validate.js';
@@ -21,6 +26,6 @@ export type {
   ValidateBlocksOptions,
 } from './validate.js';
 
-export { layoutNestedBlocks, iterateBlocks } from './layout.js';
+export { layoutNestedBlocks, layoutGrid, iterateBlocks } from './layout.js';
 
 export { GRID_TEMPLATE_RULES } from './templates/index.js';

--- a/packages/diagrams/src/blocks/layout.ts
+++ b/packages/diagrams/src/blocks/layout.ts
@@ -3,7 +3,13 @@ import type {
   BlocksFile,
   BlocksLayout,
   BlocksLayoutOptions,
+  GridFile,
+  GridLayout,
+  GridLayoutOptions,
   LaidOutBlock,
+  LaidOutGridCell,
+  LaidOutGridColumn,
+  LaidOutGridRow,
 } from './types.js';
 import { ENTITY_NODE_SIZE } from '../node-size-presets.js';
 
@@ -14,6 +20,13 @@ const DEFAULTS: Required<BlocksLayoutOptions> = {
   headerHeight: 32,
   childGap: 12,
   topLevelGap: 24,
+};
+
+const GRID_DEFAULTS: Required<GridLayoutOptions> = {
+  columnWidth: 130,
+  rowHeight: 44,
+  rowHeaderWidth: 200,
+  headerHeight: 56,
 };
 
 interface MeasuredBlock {
@@ -184,4 +197,61 @@ export function* iterateBlocks(layout: BlocksLayout): Iterable<LaidOutBlock> {
     for (const c of b.children) yield* walk(c);
   }
   for (const b of layout.blocks) yield* walk(b);
+}
+
+/**
+ * Matrix subset (08-blocks.md §4a): lay out a `grid:` root document as a
+ * single-layer rectangular table — a row-header column, a column-header row,
+ * and one cell per `(row, column)` pair. Assumes the document is already
+ * well-formed ({@link validateGrid}); callers validate first.
+ */
+export function layoutGrid(file: GridFile, options?: GridLayoutOptions): GridLayout {
+  const opts = { ...GRID_DEFAULTS, ...(options ?? {}) };
+  const grid = file?.grid;
+  const rawColumns = Array.isArray(grid?.columns) ? grid.columns : [];
+  const rawRows = Array.isArray(grid?.rows) ? grid.rows : [];
+
+  const columns: LaidOutGridColumn[] = rawColumns.map((c, i) => ({
+    id: c.id,
+    name: c.name,
+    x: opts.rowHeaderWidth + i * opts.columnWidth,
+    width: opts.columnWidth,
+  }));
+
+  const rows: LaidOutGridRow[] = rawRows.map((r, i) => ({
+    id: r.id,
+    name: r.name,
+    y: opts.headerHeight + i * opts.rowHeight,
+    height: opts.rowHeight,
+  }));
+
+  const cells: LaidOutGridCell[] = [];
+  for (let ri = 0; ri < rawRows.length; ri++) {
+    const row = rawRows[ri];
+    for (let ci = 0; ci < rawColumns.length; ci++) {
+      const col = rawColumns[ci];
+      const raw = row.assign?.[col.id];
+      cells.push({
+        rowId: row.id,
+        colId: col.id,
+        x: columns[ci].x,
+        y: rows[ri].y,
+        width: opts.columnWidth,
+        height: opts.rowHeight,
+        value: raw === undefined ? undefined : String(raw),
+      });
+    }
+  }
+
+  const width = opts.rowHeaderWidth + rawColumns.length * opts.columnWidth;
+  const height = opts.headerHeight + rawRows.length * opts.rowHeight;
+
+  return {
+    bounds: { x: 0, y: 0, width, height },
+    rowHeaderWidth: opts.rowHeaderWidth,
+    headerHeight: opts.headerHeight,
+    columns,
+    rows,
+    cells,
+  };
 }

--- a/packages/diagrams/src/blocks/types.ts
+++ b/packages/diagrams/src/blocks/types.ts
@@ -43,6 +43,51 @@ export interface GridFile {
   grid: GridHeader;
 }
 
+export interface GridLayoutOptions {
+  /** Width of each data column (px). */
+  columnWidth?: number;
+  /** Height of each data row (px). */
+  rowHeight?: number;
+  /** Width of the row-header column carrying each row's name (px). */
+  rowHeaderWidth?: number;
+  /** Height of the column-header row carrying each column's name (px). */
+  headerHeight?: number;
+}
+
+export interface LaidOutGridColumn {
+  id: string;
+  name: string;
+  x: number;
+  width: number;
+}
+
+export interface LaidOutGridRow {
+  id: string;
+  name: string;
+  y: number;
+  height: number;
+}
+
+export interface LaidOutGridCell {
+  rowId: string;
+  colId: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  /** The cell's `assign` value, stringified; omitted (blank) when unassigned. */
+  value?: string;
+}
+
+export interface GridLayout {
+  bounds: LayoutBounds;
+  rowHeaderWidth: number;
+  headerHeight: number;
+  columns: LaidOutGridColumn[];
+  rows: LaidOutGridRow[];
+  cells: LaidOutGridCell[];
+}
+
 export interface BlocksLayoutOptions {
   /** Width of a leaf block (a block with no children). */
   leafWidth?: number;

--- a/packages/diagrams/src/webview/__tests__/render-blocks.test.ts
+++ b/packages/diagrams/src/webview/__tests__/render-blocks.test.ts
@@ -8,8 +8,8 @@
  */
 import { describe, expect, it } from 'vitest';
 
-import type { BlocksFile } from '../../blocks/types.js';
-import { renderBlocksSvg } from '../render-blocks.js';
+import type { BlocksFile, GridFile } from '../../blocks/types.js';
+import { renderBlocksSvg, renderGridSvg } from '../render-blocks.js';
 import { CHAR_W_PRIMARY as CHAR_W, CHAR_W_ID, TEXT_MARGIN_X } from '../entity-text-layout.js';
 import { ENTITY_NODE_SIZE } from '../../node-size-presets.js';
 
@@ -202,5 +202,66 @@ describe('renderBlocksSvg — name/ID vertical overlap regression (follows-up on
     const lastNameBottom = Math.max(...nameY) + NAME_HALF_H;
     const firstIdTop = Math.min(...idY) - ID_HALF_H;
     expect(firstIdTop).toBeGreaterThan(lastNameBottom);
+  });
+});
+
+// Matrix subset (08-blocks.md §4a) — modelled on the real RACI template
+// (methodology `templates/raci/raci.blocks.transitrix.yaml`).
+const RACI_GRID: GridFile = {
+  notation: 'blocks',
+  spec_version: '0.1',
+  grid: {
+    columns: [
+      { id: 'ROLE-PRODUCT', name: 'Product Owner' },
+      { id: 'ROLE-LEAD-ARCH', name: 'Lead Architect' },
+      { id: 'ROLE-REVIEW-BOARD', name: 'Architecture Review Board' },
+    ],
+    rows: [
+      {
+        id: 'ACT-PROPOSE',
+        name: 'Propose a change',
+        assign: { 'ROLE-PRODUCT': 'A', 'ROLE-LEAD-ARCH': 'C', 'ROLE-REVIEW-BOARD': 'I' },
+      },
+      {
+        id: 'ACT-DECIDE',
+        name: 'Approve / reject',
+        assign: { 'ROLE-REVIEW-BOARD': 'A', 'ROLE-LEAD-ARCH': 'R' },
+      },
+    ],
+  },
+};
+
+describe('renderGridSvg — matrix subset', () => {
+  it('renders one text-header line per column and one text-primary line per row', () => {
+    const svg = renderGridSvg(RACI_GRID);
+    for (const col of RACI_GRID.grid.columns) {
+      // Column names are wrapped to up to 2 lines, so match on a fragment.
+      expect(svg).toMatch(new RegExp(`<text class="text-header"[\\s\\S]*?${col.name.split(' ')[0]}`));
+    }
+    for (const row of RACI_GRID.grid.rows) {
+      expect(svg).toMatch(new RegExp(`<text class="text-primary"[\\s\\S]*?${row.name.split(' ')[0]}`));
+    }
+  });
+
+  it('renders every non-blank assign value as text-secondary', () => {
+    const svg = renderGridSvg(RACI_GRID);
+    const values = svg.match(/<text class="text-secondary"[^>]*>([^<]*)<\/text>/g) ?? [];
+    expect(values.some((t) => t.includes('>A<'))).toBe(true);
+    expect(values.some((t) => t.includes('>R<'))).toBe(true);
+    expect(values.some((t) => t.includes('>C<'))).toBe(true);
+    expect(values.some((t) => t.includes('>I<'))).toBe(true);
+  });
+
+  it('does not emit a text-secondary element for a blank cell', () => {
+    const svg = renderGridSvg(RACI_GRID);
+    // 3 columns x 2 rows = 6 cells; only 5 are assigned (ACT-DECIDE has no
+    // ROLE-PRODUCT entry), so exactly 5 value texts should render.
+    const values = svg.match(/<text class="text-secondary"[^>]*>[^<]*<\/text>/g) ?? [];
+    expect(values).toHaveLength(5);
+  });
+
+  it('returns a zero-size svg for an empty grid', () => {
+    const svg = renderGridSvg({ notation: 'blocks', grid: { columns: [], rows: [] } });
+    expect(svg).toContain('width="0" height="0"');
   });
 });

--- a/packages/diagrams/src/webview/render-blocks.ts
+++ b/packages/diagrams/src/webview/render-blocks.ts
@@ -154,9 +154,9 @@ export function renderBlocksSvg(doc: BlocksFile, options: RenderBlocksOptions = 
 }
 
 /**
- * Matrix subset (08-blocks.md §4a) — first cut per vkgeorgia/strategy#764: a
- * single-layer rectangular `grid:` document (the RACI-style matrix case)
- * rendered as a plain HTML/CSS-table-like SVG grid. Layers, arbitrary
+ * Matrix subset (08-blocks.md §4a) — first cut: a single-layer rectangular
+ * `grid:` document (the RACI-style matrix case) rendered as a plain
+ * HTML/CSS-table-like SVG grid. Layers, arbitrary
  * (non-rectangular) cell sets, and nested sub-grids belong to the general
  * layered-grid superset, which is still in design upstream (methodology) and
  * out of scope here — see 08-blocks.md §4a / §8.

--- a/packages/diagrams/src/webview/render-blocks.ts
+++ b/packages/diagrams/src/webview/render-blocks.ts
@@ -12,14 +12,25 @@
  * the shared theme CSS embedded in a `<style>` element and a simple optional
  * title `<text>`.
  */
-import { layoutNestedBlocks } from '../blocks/layout.js';
-import type { BlocksFile, BlocksLayout, BlocksLayoutOptions, LaidOutBlock } from '../blocks/types.js';
+import { layoutNestedBlocks, layoutGrid } from '../blocks/layout.js';
+import type {
+  BlocksFile,
+  BlocksLayout,
+  BlocksLayoutOptions,
+  GridFile,
+  GridLayout,
+  GridLayoutOptions,
+  LaidOutBlock,
+} from '../blocks/types.js';
 import { parseNodeSizePreset, resolveBlocksLeafSize, type NodeSizePreset } from '../node-size-presets.js';
 import { generateSvgEmbedCss, type ThemeId } from '../theme/index.js';
 import {
+  CHAR_W_PRIMARY,
   emitCenteredTextSvg,
   layoutHeaderBlockText,
   layoutLeafBlockText,
+  maxCharsForInnerWidth,
+  wrapWords,
 } from './entity-text-layout.js';
 import { escXml } from './render-util.js';
 import { ENTITY_NODE_RX } from './notation-style.js';
@@ -140,4 +151,150 @@ export function renderBlocksSvg(doc: BlocksFile, options: RenderBlocksOptions = 
     : '';
 
   return renderBlocksLayoutSvg(layout, { title: titleSvg, embedCssTheme: 'transitrix' });
+}
+
+/**
+ * Matrix subset (08-blocks.md §4a) — first cut per vkgeorgia/strategy#764: a
+ * single-layer rectangular `grid:` document (the RACI-style matrix case)
+ * rendered as a plain HTML/CSS-table-like SVG grid. Layers, arbitrary
+ * (non-rectangular) cell sets, and nested sub-grids belong to the general
+ * layered-grid superset, which is still in design upstream (methodology) and
+ * out of scope here — see 08-blocks.md §4a / §8.
+ */
+const GRID_CELL_PAD_X = 8;
+const GRID_LINE_HEIGHT = 15;
+const GRID_EMBED_CSS = `
+.blocks-grid-border { fill: none; stroke: var(--ts-border, #cbd5e1); }`;
+
+function centeredGridCellTextSvg(
+  lines: string[],
+  cls: string,
+  cx: number,
+  cellTop: number,
+  cellHeight: number,
+): string {
+  const ls = lines.length > 0 ? lines : [''];
+  const firstY = cellTop + cellHeight / 2 - ((ls.length - 1) / 2) * GRID_LINE_HEIGHT;
+  const tspans = ls
+    .map((ln, i) => `<tspan x="${cx}" y="${firstY + i * GRID_LINE_HEIGHT}">${escXml(ln)}</tspan>`)
+    .join('');
+  return `<text class="${cls}" text-anchor="middle" dominant-baseline="central">${tspans}</text>`;
+}
+
+/**
+ * Emit the grid body (headers, cells, grid lines) at the given origin offset.
+ * Shared by the host-neutral wrapper below; VS Code's blocks preview wraps
+ * this the same way it wraps {@link renderBlocksLayoutSvg} for the tree form.
+ */
+export function renderGridBody(layout: GridLayout, ox: number, oy: number): string {
+  const tw = layout.bounds.width;
+  const th = layout.bounds.height;
+  const parts: string[] = [];
+
+  parts.push(`<rect class="diagram-node level-0" x="${ox}" y="${oy}" width="${tw}" height="${th}" stroke="none"/>`);
+
+  // Corner cell (above the row headers, left of the column headers).
+  parts.push(
+    `<rect class="diagram-node level-1" x="${ox}" y="${oy}" width="${layout.rowHeaderWidth}" height="${layout.headerHeight}" stroke="none"/>`,
+  );
+
+  for (const col of layout.columns) {
+    const x = col.x + ox;
+    parts.push(
+      `<rect class="diagram-node level-1" x="${x}" y="${oy}" width="${col.width}" height="${layout.headerHeight}" stroke="none"/>`,
+    );
+    const maxChars = maxCharsForInnerWidth(col.width - GRID_CELL_PAD_X * 2, CHAR_W_PRIMARY);
+    const lines = wrapWords(col.name, maxChars, 2);
+    parts.push(centeredGridCellTextSvg(lines, 'text-header', x + col.width / 2, oy, layout.headerHeight));
+  }
+
+  for (const row of layout.rows) {
+    const y = row.y + oy;
+    parts.push(
+      `<rect class="diagram-node level-2" x="${ox}" y="${y}" width="${layout.rowHeaderWidth}" height="${row.height}" stroke="none"/>`,
+    );
+    const maxChars = maxCharsForInnerWidth(layout.rowHeaderWidth - GRID_CELL_PAD_X * 2, CHAR_W_PRIMARY);
+    const lines = wrapWords(row.name, maxChars, 2);
+    parts.push(centeredGridCellTextSvg(lines, 'text-primary', ox + layout.rowHeaderWidth / 2, y, row.height));
+  }
+
+  for (const cell of layout.cells) {
+    if (cell.value === undefined) continue;
+    const cx = cell.x + ox + cell.width / 2;
+    const cy = cell.y + oy + cell.height / 2;
+    parts.push(
+      `<text class="text-secondary" x="${cx}" y="${cy}" text-anchor="middle" dominant-baseline="central">${escXml(cell.value)}</text>`,
+    );
+  }
+
+  const gridX1 = ox;
+  const gridX2 = ox + tw;
+  const gridY1 = oy;
+  const gridY2 = oy + th;
+
+  const headerBottomY = oy + layout.headerHeight;
+  parts.push(`<line class="diagram-edge" x1="${gridX1}" y1="${headerBottomY}" x2="${gridX2}" y2="${headerBottomY}"/>`);
+  for (const row of layout.rows) {
+    const rowBottomY = oy + row.y + row.height;
+    parts.push(`<line class="diagram-edge" x1="${gridX1}" y1="${rowBottomY}" x2="${gridX2}" y2="${rowBottomY}"/>`);
+  }
+
+  const rowHeaderLineX = ox + layout.rowHeaderWidth;
+  parts.push(`<line class="diagram-edge" x1="${rowHeaderLineX}" y1="${gridY1}" x2="${rowHeaderLineX}" y2="${gridY2}"/>`);
+  for (const col of layout.columns) {
+    const colLineX = ox + col.x + col.width;
+    parts.push(`<line class="diagram-edge" x1="${colLineX}" y1="${gridY1}" x2="${colLineX}" y2="${gridY2}"/>`);
+  }
+
+  parts.push(`<rect class="blocks-grid-border" x="${ox}" y="${oy}" width="${tw}" height="${th}"/>`);
+
+  return parts.join('\n');
+}
+
+export interface RenderGridLayoutOptions {
+  /** Extra vertical space reserved at the top of the canvas (e.g. for a title block). */
+  topInset?: number;
+  /** Raw SVG injected immediately after the opening tag — a header line or a full title block. */
+  title?: string;
+  /** When set, the theme CSS is embedded as `<style>` so the SVG is self-contained. */
+  embedCssTheme?: ThemeId;
+}
+
+/** The single grid (matrix subset) SVG emitter shared by every host. */
+export function renderGridLayoutSvg(layout: GridLayout, options: RenderGridLayoutOptions = {}): string {
+  const { topInset = 0, title = '', embedCssTheme } = options;
+
+  const w = layout.bounds.width + PAD * 2;
+  const h = layout.bounds.height + PAD * 2 + topInset;
+  const ox = PAD;
+  const oy = PAD + topInset;
+
+  const body = renderGridBody(layout, ox, oy);
+  const styleLine = embedCssTheme ? `\n<style>${generateSvgEmbedCss(embedCssTheme)}${GRID_EMBED_CSS}</style>` : '';
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">${styleLine}
+${title}
+${body}
+</svg>`;
+}
+
+export interface RenderGridOptions {
+  title?: string;
+  layoutOptions?: GridLayoutOptions;
+}
+
+/** Host-neutral grid (matrix subset) renderer (IntelliJ/UI). */
+export function renderGridSvg(doc: GridFile, options: RenderGridOptions = {}): string {
+  const { title = '', layoutOptions } = options;
+  const layout = layoutGrid(doc, layoutOptions);
+
+  if (layout.columns.length === 0 || layout.rows.length === 0) {
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="0" height="0" viewBox="0 0 0 0"></svg>`;
+  }
+
+  const titleSvg = title
+    ? `<text class="text-header" x="${PAD}" y="${PAD - 6}">${escXml(`Nested Blocks — ${title}`)}</text>`
+    : '';
+
+  return renderGridLayoutSvg(layout, { title: titleSvg, embedCssTheme: 'transitrix' });
 }


### PR DESCRIPTION
## Summary

- Adds `layoutGrid` + `renderGridSvg`/`renderGridLayoutSvg` for the `blocks` notation's matrix subset (08-blocks.md §4a) — a single-layer rectangular `grid:` root document, e.g. a RACI matrix.
- Wires the VS Code blocks preview to dispatch on `grid` vs `nested_blocks` via the existing `validateBlocks` root-dispatcher, so a grid document now renders instead of failing validation with "missing nested_blocks".
- Column/row headers wrap long labels to 2 lines; body cells show the `assign` value (blank cells render nothing); grid lines and an outer border round out the table look.

## Scope note

This covers only the first-cut suggestion already in the task: a single-layer, rectangular grid. Layers, arbitrary (non-rectangular) cell sets, and nested sub-grids are explicitly out of scope — the general layered-grid superset those need is still in design upstream, and methodology's own spec note (08-blocks.md §7 "Scope note") leaves matrix-subset rendering as "a design question for Studio to resolve," which this PR resolves for the subset that has actually landed.

No matrix-level semantic invariants (e.g. RACI's "exactly one Accountable per row") are enforced here — that's the base-vs-template split the spec already draws (§6a), and the RACI invariant already has its own `GridRule` in the CLI validator.

## Test plan

- [x] `npm --workspace packages/diagrams test` — 183 passed, including new `layoutGrid` and `renderGridSvg` tests modelled on the real RACI template (`methodology/templates/raci/raci.blocks.transitrix.yaml`)
- [x] `npm run compile:extension` — clean
- [x] `packages/diagrams/package.json` version bumped (1.8.16 → 1.8.17) per the `diagrams-version-bump` CI guard
- [ ] Manual check: open a `grid:` document in the VS Code Blocks Preview (not done — no running VS Code instance in this environment)

Do not merge without Valerii review.