### PR TITLE
feat(cli): port DSM GOAL-ELEM/ACTION element-hygiene + capability HDR/LIFECYCLE rules

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -49,6 +49,8 @@ suite, see below):
   is ahead of the Python tool here — these findings are TypeScript-only.
 - **Strategy-chain semantics** (`GOALS-009`..`011`, `ACT-005`..`009`,
   `FGCA-008`..`014`) — see below.
+- **Standalone-element envelope hygiene** (`GOAL-ELEM-002`/`003`,
+  `ACTION-001`/`002`/`005`) — see below.
 
 ### Strategy-chain semantic rules (`GOALS-*` / `ACT-*` / `FGCA-*`)
 
@@ -114,6 +116,70 @@ through `REL` files instead (e.g. `action_goal`, per `elements/24-action.md`
 via a relation this validator doesn't yet cross-reference. This is a known
 gap shared with the pre-existing error-tier rules, not a regression
 introduced by the warning tier.
+
+### Standalone-element envelope rules (`GOAL-ELEM-*` / `ACTION-*`)
+
+Ported from DSM's Go `Validate*Element` functions
+(`api02/internal/importer/{goal_element,action_element}.go`), sibling to the
+strategy-chain rules above but covering the per-element envelope instead of
+cross-element references — `packages/diagrams/src/repo-validate/
+check-element-hygiene.ts`.
+
+| Rule | Severity | Checks |
+|---|---|---|
+| `GOAL-ELEM-002` | error | GOAL element `id` is missing. |
+| `GOAL-ELEM-002` | warning | GOAL element `id` does not match `GOAL-[<middle>-]<INTEGER>` (non-fatal — DSM still imports it). |
+| `GOAL-ELEM-003` | error | GOAL element `name` is missing. |
+| `ACTION-001` | error | ACTION element `id` or `name` is missing. |
+| `ACTION-001` | warning | ACTION element `id` does not match `ACTION-[<middle>-]<INTEGER>`. |
+| `ACTION-002` | error | ACTION element `type` is set but not one of Initiative \| Strategic Initiative \| Programme \| Project \| Task. |
+| `ACTION-005` | warning | ACTION element uses a deprecated alias: `notation: activity`, an `ACTIVITY-` id prefix, or the `activity_type` field (migrate to `type`). |
+
+**`GOAL-ELEM-001`/`ACTION-001`'s "wrong notation" case is not ported.** DSM
+identifies a GOAL/ACTION element by its folder location during its import
+walk, so a wrong `notation` field on an already-located file is still
+checkable there. This repo-scope model has no such pre-typing —
+`RepoModelInput.elements` is a flat, untyped list — so candidate selection is
+content-based (`notation === 'goal'`/`'action'`/`'activity'`), the same
+convention `check-strategy-chain.ts` already uses. An id-prefix-based
+candidate signal was tried as an alternative (flag any `GOAL-`/`ACTION-`
+prefixed id regardless of notation) but produced false positives against
+this repo's own test suite, which reuses a `GOAL-`-prefixed id under a
+`goals/` path for an unrelated notation as a referential-integrity test
+double. Flagged for a decision, same as `GOALS-008`: skip permanently, or
+scope a follow-up once the repo-scope model gains path-aware typing.
+
+**Not ported: `GOALS-007`/`ACT-004`'s duplicate-id half.** Already covered
+generically by `checkIdUniqueness` above, which spans every canon
+element/relation id, not just GOAL/ACTION.
+
+**Deliberately NOT ported: `ACT-020` and `DGCA-DEPR`.** DSM's Go importer
+still accepts the pre-2026-06-25 `activities` notation/root-key alias (for
+`action` docs) and the `activities` root key (for `dgca`/`fgca` docs) as a
+non-fatal warning. Studio's own validators (`activities/validate.ts`,
+`fgca/parse-canonical.ts`) deliberately **removed** that leniency in PR #320
+(`refactor(notations): drop deprecated notation aliases
+fgca/fga/activities/activity-card`) — deprecated notation values are now
+rejected with an error, not a warning, with tests asserting the old alias is
+"no longer accepted". Re-introducing `ACT-020`/`DGCA-DEPR` would reverse that
+already-shipped decision, not fill a gap. Flagged for a call rather than
+silently reversed either way.
+
+**Deliberately NOT ported at repo-scope: `HDR-001`/`002` and
+`LIFECYCLE-001`/`004` for capabilities.** DSM's `ValidateCapMap`
+(`capabilities.go`) validates the `capability-map` *view document* (the
+inline `capability_map.capabilities[]` tree), not a standalone element — so
+these are ported into `packages/diagrams/src/capability-map/validate.ts`
+(the `--scope=file`/view-sweep validator for that notation), alongside the
+notation's own pre-existing `CMAP-*` codes, rather than into
+`check-element-hygiene.ts`. `HDR-001`/`002` duplicate `CMAP-001`'s existing
+notation check under DSM's own code (so DSM can map a finding straight back
+onto its import-log taxonomy); `LIFECYCLE-001`/`004` (`valid_from`/`valid_to`
+per CONTRACT.md §7) are net new — this notation's own schema
+(`capability-map/types.ts`) does not track lifecycle dates today, tracking
+`target_date` instead, but real documents (e.g. `organizations/acme_corp`)
+author `valid_from`/`valid_to` inline per §7 regardless, so the checks read
+them directly off the raw untyped node.
 
 ### Compliance suite (`--scope=repo`, #518)
 

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.8.17",
+  "version": "1.8.18",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",

--- a/packages/diagrams/src/activities/validate.ts
+++ b/packages/diagrams/src/activities/validate.ts
@@ -19,7 +19,15 @@ export function validateActivities(input: unknown): ActivityValidationResult {
 
   const raw = input as Record<string, unknown>;
 
-  // ACT-001: notation must be "action"
+  // ACT-001: notation must be "action". ACT-020 is deliberately NOT ported
+  // here (DSM's api02/internal/importer/activities.go ValidateActivities
+  // still accepts the pre-2026-06-25 "activities" notation/root-key alias
+  // with a warning) — PR #320 ("drop deprecated notation aliases
+  // fgca/fga/activities/activity-card") already removed that leniency from
+  // this validator on purpose, with tests asserting it is "no longer
+  // accepted". Re-introducing it would reverse a deliberate, shipped
+  // decision, not fill a gap; flagged in the PR for a call rather than
+  // silently reversed either way.
   if (raw.notation === undefined) {
     errors.push({ code: 'ACT-001', message: 'notation field is required' });
     return { valid: false, errors, warnings };

--- a/packages/diagrams/src/capability-map/__tests__/validate.test.ts
+++ b/packages/diagrams/src/capability-map/__tests__/validate.test.ts
@@ -221,6 +221,74 @@ describe('validateCapabilityMap', () => {
     expect(r.valid).toBe(false);
     expect(r.errors.some(e => e.code === 'CMAP-003')).toBe(true);
   });
+
+  // DSM rule codes (api02/internal/importer/capabilities.go), ported alongside
+  // the pre-existing CMAP-*/native codes above — see the module header note.
+  it('HDR-001: rejects missing notation alongside CMAP-001', () => {
+    const { notation: _, ...rest } = VALID_MAP;
+    const r = validateCapabilityMap(rest);
+    expect(r.errors.some(e => e.code === 'HDR-001')).toBe(true);
+    expect(r.errors.some(e => e.code === 'CMAP-001')).toBe(true);
+  });
+
+  it('HDR-002: rejects wrong notation value alongside CMAP-001', () => {
+    const r = validateCapabilityMap({ ...VALID_MAP, notation: 'goals' });
+    expect(r.errors.some(e => e.code === 'HDR-002')).toBe(true);
+    expect(r.errors.some(e => e.code === 'CMAP-001')).toBe(true);
+  });
+
+  it('does not flag HDR-001/002 on valid input', () => {
+    const r = validateCapabilityMap(VALID_MAP);
+    expect(r.errors.some(e => e.code === 'HDR-001' || e.code === 'HDR-002')).toBe(false);
+  });
+
+  it('LIFECYCLE-001: rejects a malformed valid_from', () => {
+    const map = {
+      ...VALID_MAP.capability_map,
+      capabilities: [{ id: 'V1', name: 'X', current_maturity: 2, valid_from: '01/01/2026' }],
+    };
+    const r = validateCapabilityMap({ ...VALID_MAP, capability_map: map });
+    expect(r.errors.some(e => e.code === 'LIFECYCLE-001')).toBe(true);
+  });
+
+  it('LIFECYCLE-001: rejects a malformed valid_to', () => {
+    const map = {
+      ...VALID_MAP.capability_map,
+      capabilities: [{ id: 'V1', name: 'X', current_maturity: 2, valid_to: 'not-a-date' }],
+    };
+    const r = validateCapabilityMap({ ...VALID_MAP, capability_map: map });
+    expect(r.errors.some(e => e.code === 'LIFECYCLE-001')).toBe(true);
+  });
+
+  it('LIFECYCLE-004: rejects valid_to before valid_from', () => {
+    const map = {
+      ...VALID_MAP.capability_map,
+      capabilities: [{
+        id: 'V1', name: 'X', current_maturity: 2,
+        valid_from: '2026-06-01', valid_to: '2026-01-01',
+      }],
+    };
+    const r = validateCapabilityMap({ ...VALID_MAP, capability_map: map });
+    expect(r.errors.some(e => e.code === 'LIFECYCLE-004')).toBe(true);
+  });
+
+  it('accepts a well-formed valid_from/valid_to lifecycle, including on nested children', () => {
+    const map = {
+      ...VALID_MAP.capability_map,
+      capabilities: [{
+        id: 'V1', name: 'X', current_maturity: 2,
+        valid_from: '2026-01-01', valid_to: null,
+        children: [{ id: 'V1.1', name: 'Y', current_maturity: 2, valid_from: '2026-01-01', valid_to: '2027-12-31' }],
+      }],
+    };
+    const r = validateCapabilityMap({ ...VALID_MAP, capability_map: map });
+    expect(r.errors.some(e => e.code === 'LIFECYCLE-001' || e.code === 'LIFECYCLE-004')).toBe(false);
+  });
+
+  it('does not require valid_from/valid_to at all (absent is not an error)', () => {
+    const r = validateCapabilityMap(VALID_MAP);
+    expect(r.errors.some(e => e.code === 'LIFECYCLE-001' || e.code === 'LIFECYCLE-004')).toBe(false);
+  });
 });
 
 describe('capability-map examples (regression)', () => {

--- a/packages/diagrams/src/capability-map/validate.ts
+++ b/packages/diagrams/src/capability-map/validate.ts
@@ -21,10 +21,17 @@ export function validateCapabilityMap(input: unknown): ValidationResult {
   }
   const raw = input as Record<string, unknown>;
 
+  // HDR-001/002 — DSM's own rule codes for the same header check CMAP-001
+  // already makes (api02/internal/importer/capabilities.go ValidateCapMap),
+  // added alongside it (not instead of it) so DSM can map a finding straight
+  // back onto its own import-log taxonomy while CMAP-001 stays the richer,
+  // pre-existing Studio-native code for this notation's own validator.
   if (!('notation' in raw)) {
     errors.push({ code: 'CMAP-001', message: 'Missing required field: notation' });
+    errors.push({ code: 'HDR-001', message: 'notation field is missing' });
   } else if (raw['notation'] !== 'capability-map') {
     errors.push({ code: 'CMAP-001', message: `notation must be "capability-map", got "${raw['notation']}"` });
+    errors.push({ code: 'HDR-002', message: `notation must be "capability-map", got "${raw['notation']}"` });
   }
   if (errors.length > 0) return { valid: false, errors, warnings };
 
@@ -115,6 +122,39 @@ function validateCapabilityTree(
 
     if (node['applications'] !== undefined && !Array.isArray(node['applications']))
       errors.push({ code: 'CMAP-003', message: `${nodePath}: applications must be an array` });
+
+    // LIFECYCLE-001/004 — DSM's own rule codes (capabilities.go
+    // ValidateCapMap/validateCapMapNodes) for `valid_from`/`valid_to`, the
+    // CONTRACT.md §7 primitive-lifecycle fields. Net new: this notation's own
+    // validator has no equivalent check today — `CapabilityNode` (types.ts)
+    // does not even declare these fields, since Studio's own schema tracks
+    // lifecycle via `target_date` instead. The fields are still read directly
+    // off the raw untyped node here because real capability-map documents
+    // (e.g. organizations/acme_corp) author them inline per §7 regardless.
+    {
+      const id = typeof node['id'] === 'string' ? (node['id'] as string) : nodePath;
+      const validFrom = node['valid_from'];
+      const validTo = node['valid_to'];
+      let fromDate: string | undefined;
+      let toDate: string | undefined;
+      if (validFrom !== undefined && validFrom !== null) {
+        if (typeof validFrom !== 'string' || !DATE_RE.test(validFrom)) {
+          errors.push({ code: 'LIFECYCLE-001', message: `capability ${id} valid_from "${String(validFrom)}" is not a valid YYYY-MM-DD date (must be quoted)` });
+        } else {
+          fromDate = validFrom;
+        }
+      }
+      if (validTo !== undefined && validTo !== null) {
+        if (typeof validTo !== 'string' || !DATE_RE.test(validTo)) {
+          errors.push({ code: 'LIFECYCLE-001', message: `capability ${id} valid_to "${String(validTo)}" is not a valid YYYY-MM-DD date (must be quoted)` });
+        } else {
+          toDate = validTo;
+        }
+      }
+      if (fromDate && toDate && toDate < fromDate) {
+        errors.push({ code: 'LIFECYCLE-004', message: `capability ${id} valid_to ${toDate} is before valid_from ${fromDate}` });
+      }
+    }
 
     if (node['children'] !== undefined) {
       if (!Array.isArray(node['children'])) {

--- a/packages/diagrams/src/fgca/parse-canonical.ts
+++ b/packages/diagrams/src/fgca/parse-canonical.ts
@@ -130,6 +130,14 @@ export function parseCanonicalFGCA(input: unknown): CanonicalFGCAResult {
   }
   const activitiesRaw = asObjectArray(raw['actions']);
   if (activitiesRaw === null && 'activities' in raw) {
+    // DSM's Go ValidateFGCA (fgca.go) still accepts this as the deprecated
+    // "activities" key and promotes it with a DGCA-DEPR warning, not an
+    // error. Deliberately NOT matched here — PR #320 ("drop deprecated
+    // notation aliases fgca/fga/activities/activity-card") already removed
+    // that leniency from this validator on purpose. Re-introducing
+    // DGCA-DEPR would reverse a deliberate, shipped decision, not fill a
+    // gap; see docs/validation.md's "Standalone-element envelope rules"
+    // section for the full note.
     errors.push({ code: 'FGCA-004', message: '"activities" key is not accepted — rename to "actions"', path: 'actions' });
   }
 

--- a/packages/diagrams/src/repo-validate/__tests__/check-element-hygiene.test.ts
+++ b/packages/diagrams/src/repo-validate/__tests__/check-element-hygiene.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest';
+import { validateRepoModel } from '../validate-repo.js';
+import type { RepoDoc, RepoModelInput } from '../types.js';
+
+function el(path: string, data: Record<string, unknown> | null, parseError?: string): RepoDoc {
+  return { path, data, parseError };
+}
+
+function emptyModel(): RepoModelInput {
+  return { elements: [], relations: [] };
+}
+
+function goal(id: string, extra: Record<string, unknown> = {}): RepoDoc {
+  return el(`canon/elements/01_motivation/goals/${id}.yaml`, { notation: 'goal', id, name: id, ...extra });
+}
+
+function action(id: string, extra: Record<string, unknown> = {}): RepoDoc {
+  return el(`canon/elements/05_implementation/actions/${id}.yaml`, { notation: 'action', id, name: id, ...extra });
+}
+
+describe('checkElementHygiene — GOAL-ELEM-002 (id)', () => {
+  it('flags a missing id', () => {
+    const model = emptyModel();
+    model.elements.push(el('canon/elements/01_motivation/goals/x.yaml', { notation: 'goal', name: 'X' }));
+    const findings = validateRepoModel(model);
+    expect(findings).toContainEqual(expect.objectContaining({ ruleId: 'GOAL-ELEM-002' }));
+    expect(findings.find((f) => f.ruleId === 'GOAL-ELEM-002')?.severity).toBeUndefined();
+  });
+
+  it('warns on a malformed id (non-fatal)', () => {
+    const model = emptyModel();
+    model.elements.push(goal('GOAL-X'));
+    const findings = validateRepoModel(model);
+    expect(findings).toContainEqual(
+      expect.objectContaining({ id: 'GOAL-X', ruleId: 'GOAL-ELEM-002', severity: 'warning' }),
+    );
+    expect(findings.filter((f) => f.severity !== 'warning')).toEqual([]);
+  });
+
+  it('does not flag a well-formed id', () => {
+    const model = emptyModel();
+    model.elements.push(goal('GOAL-REVENUE-1'));
+    expect(validateRepoModel(model).some((f) => f.ruleId === 'GOAL-ELEM-002')).toBe(false);
+  });
+});
+
+describe('checkElementHygiene — GOAL-ELEM-003 (name)', () => {
+  it('flags a missing name', () => {
+    const model = emptyModel();
+    model.elements.push(el('canon/elements/01_motivation/goals/GOAL-REVENUE-1.yaml', { notation: 'goal', id: 'GOAL-REVENUE-1' }));
+    const findings = validateRepoModel(model);
+    expect(findings).toContainEqual(
+      expect.objectContaining({ id: 'GOAL-REVENUE-1', ruleId: 'GOAL-ELEM-003' }),
+    );
+  });
+
+  it('does not flag a goal with name set', () => {
+    const model = emptyModel();
+    model.elements.push(goal('GOAL-REVENUE-1'));
+    expect(validateRepoModel(model).some((f) => f.ruleId === 'GOAL-ELEM-003')).toBe(false);
+  });
+});
+
+describe('checkElementHygiene — ACTION-001 (id/name)', () => {
+  it('flags a missing id', () => {
+    const model = emptyModel();
+    model.elements.push(el('canon/elements/05_implementation/actions/x.yaml', { notation: 'action', name: 'X' }));
+    const findings = validateRepoModel(model);
+    expect(findings).toContainEqual(expect.objectContaining({ ruleId: 'ACTION-001' }));
+  });
+
+  it('flags a missing name', () => {
+    const model = emptyModel();
+    model.elements.push(el('canon/elements/05_implementation/actions/ACTION-BUILD-1.yaml', { notation: 'action', id: 'ACTION-BUILD-1' }));
+    const findings = validateRepoModel(model);
+    expect(findings).toContainEqual(
+      expect.objectContaining({ id: 'ACTION-BUILD-1', ruleId: 'ACTION-001' }),
+    );
+  });
+
+  it('warns on a malformed id (non-fatal)', () => {
+    const model = emptyModel();
+    model.elements.push(action('ACTION-X'));
+    const findings = validateRepoModel(model);
+    expect(findings).toContainEqual(
+      expect.objectContaining({ id: 'ACTION-X', ruleId: 'ACTION-001', severity: 'warning' }),
+    );
+    expect(findings.filter((f) => f.severity !== 'warning')).toEqual([]);
+  });
+
+  it('does not flag a well-formed action', () => {
+    const model = emptyModel();
+    model.elements.push(action('ACTION-BUILD-1'));
+    expect(validateRepoModel(model)).toEqual([]);
+  });
+});
+
+describe('checkElementHygiene — ACTION-002 (type vocabulary)', () => {
+  it('flags an unrecognised type', () => {
+    const model = emptyModel();
+    model.elements.push(action('ACTION-BUILD-1', { type: 'Sprint' }));
+    const findings = validateRepoModel(model);
+    expect(findings).toEqual([
+      expect.objectContaining({ id: 'ACTION-BUILD-1', ruleId: 'ACTION-002' }),
+    ]);
+  });
+
+  it('accepts each vocabulary entry, including the Strategic Initiative alias', () => {
+    for (const type of ['Initiative', 'Strategic Initiative', 'Programme', 'Project', 'Task']) {
+      const model = emptyModel();
+      model.elements.push(action('ACTION-BUILD-1', { type }));
+      expect(validateRepoModel(model)).toEqual([]);
+    }
+  });
+});
+
+describe('checkElementHygiene — ACTION-005 (deprecated aliases)', () => {
+  it('warns on the deprecated "activity" notation, without a duplicate ACTION-001 finding', () => {
+    const model = emptyModel();
+    model.elements.push(el('canon/elements/05_implementation/actions/ACTION-BUILD-1.yaml', {
+      notation: 'activity', id: 'ACTION-BUILD-1', name: 'Build',
+    }));
+    const findings = validateRepoModel(model);
+    expect(findings).toEqual([
+      expect.objectContaining({ id: 'ACTION-BUILD-1', ruleId: 'ACTION-005', severity: 'warning' }),
+    ]);
+  });
+
+  it('warns on the deprecated ACTIVITY- id prefix', () => {
+    const model = emptyModel();
+    model.elements.push(el('canon/elements/05_implementation/actions/ACTIVITY-BUILD-1.yaml', {
+      notation: 'action', id: 'ACTIVITY-BUILD-1', name: 'Build',
+    }));
+    const findings = validateRepoModel(model);
+    expect(findings).toEqual([
+      expect.objectContaining({ id: 'ACTIVITY-BUILD-1', ruleId: 'ACTION-005', severity: 'warning' }),
+    ]);
+  });
+
+  it('warns on the deprecated activity_type field and still validates its vocabulary', () => {
+    const model = emptyModel();
+    model.elements.push(action('ACTION-BUILD-1', { activity_type: 'Task' }));
+    const findings = validateRepoModel(model);
+    expect(findings).toEqual([
+      expect.objectContaining({ id: 'ACTION-BUILD-1', ruleId: 'ACTION-005', severity: 'warning' }),
+    ]);
+  });
+
+  it('flags ACTION-002 through the deprecated activity_type field when the value is not in the vocabulary', () => {
+    const model = emptyModel();
+    model.elements.push(action('ACTION-BUILD-1', { activity_type: 'Sprint' }));
+    const findings = validateRepoModel(model);
+    const ruleIds = findings.map((f) => f.ruleId).sort();
+    expect(ruleIds).toEqual(['ACTION-002', 'ACTION-005']);
+  });
+});
+
+describe('checkElementHygiene — organizations/acme_corp parity shape', () => {
+  it('flags no finding on acme_corp-shaped goal/action elements', () => {
+    const model = emptyModel();
+    model.elements.push(
+      goal('GOAL-REVENUE-1', { type: 'Strategy', level: 0 }),
+      action('ACTION-BUILD-1', { duration_days: 30, predecessors: ['ACTION-DESIGN-1'] }),
+      action('ACTION-DESIGN-1', { duration_days: 10 }),
+    );
+    const findings = validateRepoModel(model);
+    expect(findings.filter((f) => f.ruleId?.startsWith('GOAL-ELEM') || f.ruleId?.startsWith('ACTION-'))).toEqual([]);
+  });
+});

--- a/packages/diagrams/src/repo-validate/__tests__/check-strategy-chain.test.ts
+++ b/packages/diagrams/src/repo-validate/__tests__/check-strategy-chain.test.ts
@@ -29,7 +29,7 @@ function change(id: string, extra: Record<string, unknown> = {}): RepoDoc {
 describe('checkStrategyChainSemantics — GOALS-010 (parent cycle)', () => {
   it('flags a two-goal parent cycle', () => {
     const model = emptyModel();
-    model.elements.push(goal('GOAL-A', { parent: 'GOAL-B' }), goal('GOAL-B', { parent: 'GOAL-A' }));
+    model.elements.push(goal('GOAL-A-1', { parent: 'GOAL-B-1' }), goal('GOAL-B-1', { parent: 'GOAL-A-1' }));
     const findings = validateRepoModel(model);
     const errors = findings.filter((f) => f.severity !== 'warning');
     expect(errors).toHaveLength(1);
@@ -41,7 +41,7 @@ describe('checkStrategyChainSemantics — GOALS-010 (parent cycle)', () => {
 
   it('does not flag an acyclic parent chain (beyond the expected unreferenced-goal warnings)', () => {
     const model = emptyModel();
-    model.elements.push(goal('GOAL-ROOT'), goal('GOAL-CHILD', { parent: 'GOAL-ROOT' }));
+    model.elements.push(goal('GOAL-ROOT-1'), goal('GOAL-CHILD-1', { parent: 'GOAL-ROOT-1' }));
     const findings = validateRepoModel(model);
     expect(findings.filter((f) => f.severity !== 'warning')).toEqual([]);
     expect(findings.every((f) => f.ruleId === 'FGCA-013')).toBe(true);
@@ -49,10 +49,10 @@ describe('checkStrategyChainSemantics — GOALS-010 (parent cycle)', () => {
 
   it('flags GOALS-009 for a goal whose parent is unresolved (orphan, not a cycle — warning)', () => {
     const model = emptyModel();
-    model.elements.push(goal('GOAL-A', { parent: 'GOAL-MISSING' }));
+    model.elements.push(goal('GOAL-A-1', { parent: 'GOAL-MISSING' }));
     const findings = validateRepoModel(model);
     expect(findings).toContainEqual(
-      expect.objectContaining({ scope: 'repo', id: 'GOAL-A', ruleId: 'GOALS-009', severity: 'warning' }),
+      expect.objectContaining({ scope: 'repo', id: 'GOAL-A-1', ruleId: 'GOALS-009', severity: 'warning' }),
     );
     expect(findings.filter((f) => f.severity !== 'warning')).toEqual([]);
   });
@@ -61,17 +61,17 @@ describe('checkStrategyChainSemantics — GOALS-010 (parent cycle)', () => {
     // Matches organizations/acme_corp's GOAL-CUST-1 / GOAL-OPS-1 shape: level
     // >= 1, no `parent` on the element (parent carried by the goals-tree view).
     const model = emptyModel();
-    model.elements.push(goal('GOAL-BACKLOG', { type: 'Strategic Goal', level: 1 }));
+    model.elements.push(goal('GOAL-BACKLOG-1', { type: 'Strategic Goal', level: 1 }));
     const findings = validateRepoModel(model);
     expect(findings).toContainEqual(
-      expect.objectContaining({ scope: 'repo', id: 'GOAL-BACKLOG', ruleId: 'GOALS-011', severity: 'warning' }),
+      expect.objectContaining({ scope: 'repo', id: 'GOAL-BACKLOG-1', ruleId: 'GOALS-011', severity: 'warning' }),
     );
     expect(findings.filter((f) => f.severity !== 'warning')).toEqual([]);
   });
 
   it('does not flag GOALS-009/011 for a level-0 (root) goal with no parent', () => {
     const model = emptyModel();
-    model.elements.push(goal('GOAL-ROOT', { type: 'Strategy', level: 0 }));
+    model.elements.push(goal('GOAL-ROOT-1', { type: 'Strategy', level: 0 }));
     const findings = validateRepoModel(model);
     expect(findings.some((f) => f.ruleId === 'GOALS-009' || f.ruleId === 'GOALS-011')).toBe(false);
   });
@@ -81,8 +81,8 @@ describe('checkStrategyChainSemantics — ACT-006 (predecessor cycle) / ACT-007 
   it('flags a predecessor cycle', () => {
     const model = emptyModel();
     model.elements.push(
-      action('ACTION-A', { predecessors: ['ACTION-B'] }),
-      action('ACTION-B', { predecessors: ['ACTION-A'] }),
+      action('ACTION-A-1', { predecessors: ['ACTION-B-1'] }),
+      action('ACTION-B-1', { predecessors: ['ACTION-A-1'] }),
     );
     const findings = validateRepoModel(model);
     expect(findings).toHaveLength(1);
@@ -91,40 +91,40 @@ describe('checkStrategyChainSemantics — ACT-006 (predecessor cycle) / ACT-007 
 
   it('does not flag an acyclic predecessor chain', () => {
     const model = emptyModel();
-    model.elements.push(action('ACTION-A'), action('ACTION-B', { predecessors: ['ACTION-A'] }));
+    model.elements.push(action('ACTION-A-1'), action('ACTION-B-1', { predecessors: ['ACTION-A-1'] }));
     expect(validateRepoModel(model)).toEqual([]);
   });
 
   it('flags an action listing itself as a predecessor (also a 1-node cycle, matching DSM findActivityCycle)', () => {
     const model = emptyModel();
-    model.elements.push(action('ACTION-SELF', { predecessors: ['ACTION-SELF'] }));
+    model.elements.push(action('ACTION-SELF-1', { predecessors: ['ACTION-SELF-1'] }));
     const findings = validateRepoModel(model);
     const ruleIds = findings.map((f) => f.ruleId).sort();
     expect(ruleIds).toEqual(['ACT-006', 'ACT-007']);
-    expect(findings.every((f) => f.id === 'ACTION-SELF')).toBe(true);
+    expect(findings.every((f) => f.id === 'ACTION-SELF-1')).toBe(true);
   });
 
   it('flags ACT-005 for an unresolved predecessor (orphan — warning)', () => {
     const model = emptyModel();
-    model.elements.push(action('ACTION-A', { predecessors: ['ACTION-MISSING'] }));
+    model.elements.push(action('ACTION-A-1', { predecessors: ['ACTION-MISSING'] }));
     const findings = validateRepoModel(model);
     expect(findings).toEqual([
-      expect.objectContaining({ scope: 'repo', id: 'ACTION-A', ruleId: 'ACT-005', severity: 'warning' }),
+      expect.objectContaining({ scope: 'repo', id: 'ACTION-A-1', ruleId: 'ACT-005', severity: 'warning' }),
     ]);
   });
 
   it('flags ACT-005 for an unresolved parent (orphan — warning)', () => {
     const model = emptyModel();
-    model.elements.push(action('ACTION-A', { parent: 'ACTION-MISSING' }));
+    model.elements.push(action('ACTION-A-1', { parent: 'ACTION-MISSING' }));
     const findings = validateRepoModel(model);
     expect(findings).toEqual([
-      expect.objectContaining({ scope: 'repo', id: 'ACTION-A', ruleId: 'ACT-005', severity: 'warning' }),
+      expect.objectContaining({ scope: 'repo', id: 'ACTION-A-1', ruleId: 'ACT-005', severity: 'warning' }),
     ]);
   });
 
   it('does not flag ACT-005 for a resolved predecessor/parent', () => {
     const model = emptyModel();
-    model.elements.push(action('ACTION-ROOT'), action('ACTION-CHILD', { parent: 'ACTION-ROOT', predecessors: ['ACTION-ROOT'] }));
+    model.elements.push(action('ACTION-ROOT-1'), action('ACTION-CHILD-1', { parent: 'ACTION-ROOT-1', predecessors: ['ACTION-ROOT-1'] }));
     expect(validateRepoModel(model).filter((f) => f.ruleId === 'ACT-005')).toEqual([]);
   });
 });
@@ -132,22 +132,22 @@ describe('checkStrategyChainSemantics — ACT-006 (predecessor cycle) / ACT-007 
 describe('checkStrategyChainSemantics — ACT-008 (dates)', () => {
   it('flags end_date before start_date', () => {
     const model = emptyModel();
-    model.elements.push(action('ACTION-A', { start_date: '2026-06-01', end_date: '2026-05-01' }));
+    model.elements.push(action('ACTION-A-1', { start_date: '2026-06-01', end_date: '2026-05-01' }));
     const findings = validateRepoModel(model);
     expect(findings).toHaveLength(1);
-    expect(findings[0]).toMatchObject({ scope: 'repo', id: 'ACTION-A', ruleId: 'ACT-008' });
+    expect(findings[0]).toMatchObject({ scope: 'repo', id: 'ACTION-A-1', ruleId: 'ACT-008' });
     expect(findings[0].message).toContain('before');
   });
 
   it('allows end_date equal to start_date (milestone)', () => {
     const model = emptyModel();
-    model.elements.push(action('ACTION-A', { start_date: '2026-06-01', end_date: '2026-06-01', duration: 0 }));
+    model.elements.push(action('ACTION-A-1', { start_date: '2026-06-01', end_date: '2026-06-01', duration: 0 }));
     expect(validateRepoModel(model)).toEqual([]);
   });
 
   it('flags a calendar-invalid date', () => {
     const model = emptyModel();
-    model.elements.push(action('ACTION-A', { start_date: '2026-02-30' }));
+    model.elements.push(action('ACTION-A-1', { start_date: '2026-02-30' }));
     const findings = validateRepoModel(model);
     expect(findings).toHaveLength(1);
     expect(findings[0]).toMatchObject({ ruleId: 'ACT-008' });
@@ -156,7 +156,7 @@ describe('checkStrategyChainSemantics — ACT-008 (dates)', () => {
 
   it('flags a malformed date string', () => {
     const model = emptyModel();
-    model.elements.push(action('ACTION-A', { end_date: '06/01/2026' }));
+    model.elements.push(action('ACTION-A-1', { end_date: '06/01/2026' }));
     const findings = validateRepoModel(model);
     expect(findings).toHaveLength(1);
     expect(findings[0]).toMatchObject({ ruleId: 'ACT-008' });
@@ -164,7 +164,7 @@ describe('checkStrategyChainSemantics — ACT-008 (dates)', () => {
 
   it('does not flag an action with no dates at all', () => {
     const model = emptyModel();
-    model.elements.push(action('ACTION-A', { duration_days: 5 }));
+    model.elements.push(action('ACTION-A-1', { duration_days: 5 }));
     expect(validateRepoModel(model)).toEqual([]);
   });
 });
@@ -172,7 +172,7 @@ describe('checkStrategyChainSemantics — ACT-008 (dates)', () => {
 describe('checkStrategyChainSemantics — ACT-009 (negative numeric fields)', () => {
   it('flags a negative duration', () => {
     const model = emptyModel();
-    model.elements.push(action('ACTION-A', { duration: -3 }));
+    model.elements.push(action('ACTION-A-1', { duration: -3 }));
     const findings = validateRepoModel(model);
     expect(findings).toHaveLength(1);
     expect(findings[0]).toMatchObject({ ruleId: 'ACT-009' });
@@ -180,7 +180,7 @@ describe('checkStrategyChainSemantics — ACT-009 (negative numeric fields)', ()
 
   it('flags a negative duration_days (the field acme_corp actually uses)', () => {
     const model = emptyModel();
-    model.elements.push(action('ACTION-A', { duration_days: -3 }));
+    model.elements.push(action('ACTION-A-1', { duration_days: -3 }));
     const findings = validateRepoModel(model);
     expect(findings).toHaveLength(1);
     expect(findings[0]).toMatchObject({ ruleId: 'ACT-009' });
@@ -189,7 +189,7 @@ describe('checkStrategyChainSemantics — ACT-009 (negative numeric fields)', ()
   it('flags a negative labor_cost / resources_cost / effort / score independently', () => {
     const model = emptyModel();
     model.elements.push(
-      action('ACTION-A', { labor_cost: -1, resources_cost: -2, effort: -3, score: -4 }),
+      action('ACTION-A-1', { labor_cost: -1, resources_cost: -2, effort: -3, score: -4 }),
     );
     const findings = validateRepoModel(model);
     expect(findings).toHaveLength(4);
@@ -198,7 +198,7 @@ describe('checkStrategyChainSemantics — ACT-009 (negative numeric fields)', ()
 
   it('does not flag non-negative numeric fields', () => {
     const model = emptyModel();
-    model.elements.push(action('ACTION-A', { duration_days: 30, labor_cost: 0, effort: 100, score: 5 }));
+    model.elements.push(action('ACTION-A-1', { duration_days: 30, labor_cost: 0, effort: 100, score: 5 }));
     expect(validateRepoModel(model)).toEqual([]);
   });
 });
@@ -206,28 +206,28 @@ describe('checkStrategyChainSemantics — ACT-009 (negative numeric fields)', ()
 describe('checkStrategyChainSemantics — FGCA-008..011 (strategy-chain cross-references)', () => {
   it('flags GOAL.factors referencing an undefined driver (FGCA-008)', () => {
     const model = emptyModel();
-    model.elements.push(goal('GOAL-A', { factors: ['DRIVER-MISSING'] }));
+    model.elements.push(goal('GOAL-A-1', { factors: ['DRIVER-MISSING'] }));
     const findings = validateRepoModel(model);
     const errors = findings.filter((f) => f.severity !== 'warning');
-    expect(errors).toEqual([expect.objectContaining({ id: 'GOAL-A', ruleId: 'FGCA-008' })]);
+    expect(errors).toEqual([expect.objectContaining({ id: 'GOAL-A-1', ruleId: 'FGCA-008' })]);
     // GOAL-A is also unreferenced by any change/action — FGCA-013 warning.
     expect(findings.filter((f) => f.ruleId === 'FGCA-013')).toHaveLength(1);
   });
 
   it('accepts GOAL.factors that resolve to a driver (beyond the expected unreferenced-goal warning)', () => {
     const model = emptyModel();
-    model.elements.push(driver('DRIVER-A'), goal('GOAL-A', { factors: ['DRIVER-A'] }));
+    model.elements.push(driver('DRIVER-A'), goal('GOAL-A-1', { factors: ['DRIVER-A'] }));
     const findings = validateRepoModel(model);
     expect(findings.filter((f) => f.severity !== 'warning')).toEqual([]);
     expect(findings).toEqual([
-      expect.objectContaining({ id: 'GOAL-A', ruleId: 'FGCA-013', severity: 'warning' }),
+      expect.objectContaining({ id: 'GOAL-A-1', ruleId: 'FGCA-013', severity: 'warning' }),
     ]);
   });
 
   it('accepts the legacy `factor` notation value for the driver cross-reference', () => {
     const model = emptyModel();
     model.elements.push(el('canon/elements/01_motivation/factors/DRIVER-A.yaml', { notation: 'factor', id: 'DRIVER-A' }));
-    model.elements.push(goal('GOAL-A', { factors: ['DRIVER-A'] }));
+    model.elements.push(goal('GOAL-A-1', { factors: ['DRIVER-A'] }));
     const findings = validateRepoModel(model);
     expect(findings.filter((f) => f.severity !== 'warning')).toEqual([]);
   });
@@ -244,40 +244,40 @@ describe('checkStrategyChainSemantics — FGCA-008..011 (strategy-chain cross-re
 
   it('flags ACTION.delivers_changes referencing an undefined change (FGCA-010)', () => {
     const model = emptyModel();
-    model.elements.push(action('ACTION-A', { delivers_changes: ['CHANGE-MISSING'] }));
+    model.elements.push(action('ACTION-A-1', { delivers_changes: ['CHANGE-MISSING'] }));
     const findings = validateRepoModel(model);
     expect(findings).toHaveLength(1);
-    expect(findings[0]).toMatchObject({ id: 'ACTION-A', ruleId: 'FGCA-010' });
+    expect(findings[0]).toMatchObject({ id: 'ACTION-A-1', ruleId: 'FGCA-010' });
   });
 
   it('flags ACTION.goals referencing an undefined goal (FGCA-011)', () => {
     const model = emptyModel();
-    model.elements.push(action('ACTION-A', { goals: ['GOAL-MISSING'] }));
+    model.elements.push(action('ACTION-A-1', { goals: ['GOAL-MISSING'] }));
     const findings = validateRepoModel(model);
     expect(findings).toHaveLength(1);
-    expect(findings[0]).toMatchObject({ id: 'ACTION-A', ruleId: 'FGCA-011' });
+    expect(findings[0]).toMatchObject({ id: 'ACTION-A-1', ruleId: 'FGCA-011' });
   });
 
   it('accepts a fully-resolved strategy chain end to end (driver -> goal -> change -> action)', () => {
     const model = emptyModel();
     model.elements.push(
       driver('DRIVER-A'),
-      goal('GOAL-A', { factors: ['DRIVER-A'] }),
-      change('CHANGE-A', { goals: ['GOAL-A'] }),
-      action('ACTION-A', { goals: ['GOAL-A'], delivers_changes: ['CHANGE-A'] }),
+      goal('GOAL-A-1', { factors: ['DRIVER-A'] }),
+      change('CHANGE-A', { goals: ['GOAL-A-1'] }),
+      action('ACTION-A-1', { goals: ['GOAL-A-1'], delivers_changes: ['CHANGE-A'] }),
     );
     expect(validateRepoModel(model)).toEqual([]);
   });
 
   it('flags FGCA-012..014 for a driver/goal/change that is unreferenced (orphan — warning)', () => {
     const model = emptyModel();
-    model.elements.push(driver('DRIVER-UNUSED'), goal('GOAL-UNUSED'), change('CHANGE-UNUSED'));
+    model.elements.push(driver('DRIVER-UNUSED'), goal('GOAL-UNUSED-1'), change('CHANGE-UNUSED'));
     const findings = validateRepoModel(model);
     expect(findings.filter((f) => f.severity !== 'warning')).toEqual([]);
     expect(findings).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ id: 'DRIVER-UNUSED', ruleId: 'FGCA-012', severity: 'warning' }),
-        expect.objectContaining({ id: 'GOAL-UNUSED', ruleId: 'FGCA-013', severity: 'warning' }),
+        expect.objectContaining({ id: 'GOAL-UNUSED-1', ruleId: 'FGCA-013', severity: 'warning' }),
         expect.objectContaining({ id: 'CHANGE-UNUSED', ruleId: 'FGCA-014', severity: 'warning' }),
       ]),
     );

--- a/packages/diagrams/src/repo-validate/check-element-hygiene.ts
+++ b/packages/diagrams/src/repo-validate/check-element-hygiene.ts
@@ -1,0 +1,236 @@
+// Standalone-element envelope checks — the error-severity subset of DSM's Go
+// `Validate*Element` functions (`api02/internal/importer/{goal_element,
+// action_element}.go` in transitrix-dsm), ported onto the standalone-element
+// repo shape (`canon/elements/**`) that `validate --scope=repo` already
+// loads. Sibling to `check-strategy-chain.ts` (which covers cross-element
+// reference/cycle rules); this file covers the per-element envelope rules —
+// id presence/grammar, name presence, and the ACTION type vocabulary +
+// deprecated-alias warnings.
+//
+// DSM identifies "this file is a GOAL/ACTION element" by its folder location
+// during the import walk (`canon/elements/01_motivation/goals/`,
+// `canon/elements/05_implementation/actions/`) — the validator functions
+// receive an already-typed struct, so a wrong `notation` value on that
+// struct is still checkable (`GOAL-ELEM-001`/the notation branch of
+// `ACTION-001`). This repo-scope model has no such pre-typing
+// (`RepoModelInput.elements` is a flat, untyped list from `canon/elements/**`)
+// — candidate selection here is content-based (the element's own `notation`
+// field), same convention as `check-strategy-chain.ts`'s `collectByNotation`.
+// That means a candidate is by construction already notation-correct, so
+// GOAL-ELEM-001's and ACTION-001's "wrong notation" case can never fire here
+// — tried an id-prefix-based candidate signal instead (matching on a `GOAL-`/
+// `ACTION-` id TYPE prefix regardless of notation) to cover that case, but it
+// produced false positives against this repo's own test fixtures, which
+// reuse a `GOAL-`-prefixed id under a `goals/` path for an unrelated
+// notation as a referential-integrity test double
+// (`validate-repo.test.ts`'s `GOAL-OPS-1`/notation:'assessment' fixture) —
+// there is no reliable, adopter-folder-layout-independent way to tell
+// "misfiled element" from "id reused for something else" without DSM's own
+// folder-based typing. Flagged for a decision, same as `GOALS-008`: skip
+// permanently, or scope a follow-up once the repo-scope model gains
+// path-aware typing.
+//
+// Rule codes are DSM's own — not invented here — so DSM can map a CLI
+// finding straight back onto its import-log taxonomy (`RepoFinding.ruleId`).
+//
+// Ported (error-severity, blocking):
+//   GOAL-ELEM-002   — GOAL element `id` is missing.
+//   GOAL-ELEM-003   — GOAL element `name` is missing.
+//   ACTION-001      — ACTION element `id` or `name` is missing.
+//   ACTION-002      — ACTION element `type` is set but not one of
+//                      Initiative | Strategic Initiative | Programme |
+//                      Project | Task (Strategic Initiative is an accepted
+//                      alias for Initiative). DSM treats this as fatal — the
+//                      type vocabulary has real behavioural teeth downstream.
+//
+// Ported (warning-severity, advisory):
+//   GOAL-ELEM-002   — GOAL element `id` does not match the canonical
+//                      `GOAL-[<middle>-]<INTEGER>` grammar (non-fatal —
+//                      DSM still imports it).
+//   ACTION-001      — ACTION element `id` does not match the canonical
+//                      `ACTION-[<middle>-]<INTEGER>` grammar.
+//   ACTION-005      — ACTION element uses a deprecated alias: `notation:
+//                      activity` (pre-2026-06-25), an `ACTIVITY-` id prefix,
+//                      or the `activity_type` field (rename to `type`).
+//
+// Not ported: GOALS-007 (duplicate id) / ACT-004 (duplicate id) — already
+// covered generically by `validate-repo.ts`'s `checkIdUniqueness`, which
+// spans every canon element/relation id, not just GOAL/ACTION. Porting a
+// second, notation-scoped duplicate check here would just double-report the
+// same defect under two rule codes.
+
+import { docId } from './validate-repo.js';
+import type { RepoDoc, RepoFinding, RepoModelInput } from './types.js';
+
+const PScope: RepoFinding['scope'] = 'repo';
+
+const GOAL_ELEM_ID_RE = /^GOAL-([A-Z0-9]+-)*[0-9]+$/;
+const ACTION_ELEM_ID_RE = /^ACTION-([A-Z0-9]+-)*[0-9]+$/;
+
+/** ACTION scale-level vocabulary (elements/24-action.md §1). "Strategic
+ *  Initiative" is an accepted alias for "Initiative", matching DSM's
+ *  `actionTypeVocabulary` (action_element.go). */
+const ACTION_TYPE_VOCABULARY = new Set([
+  'Initiative',
+  'Strategic Initiative',
+  'Programme',
+  'Project',
+  'Task',
+]);
+
+function readString(data: Record<string, unknown>, key: string): string | undefined {
+  const v = data[key];
+  return typeof v === 'string' && v.length > 0 ? v : undefined;
+}
+
+interface ElementCandidate {
+  id: string | undefined;
+  doc: RepoDoc;
+  data: Record<string, unknown>;
+}
+
+function collectCandidates(
+  elements: RepoDoc[],
+  matches: (data: Record<string, unknown>) => boolean,
+): ElementCandidate[] {
+  const out: ElementCandidate[] = [];
+  for (const doc of elements) {
+    if (!doc.data) continue;
+    if (!matches(doc.data)) continue;
+    out.push({ id: docId(doc) ?? undefined, doc, data: doc.data });
+  }
+  return out;
+}
+
+/** GOAL-ELEM-002/003 — the GOAL element envelope: id presence + grammar,
+ *  name presence. Candidate selection is content-based (`notation === 'goal'`)
+ *  — see the module header for why `GOAL-ELEM-001` (wrong notation) isn't
+ *  ported here. */
+function checkGoalElements(elements: RepoDoc[], findings: RepoFinding[]): void {
+  const candidates = collectCandidates(elements, (data) => data['notation'] === 'goal');
+
+  for (const { id, data } of candidates) {
+    const where = id ?? '';
+
+    if (!id) {
+      findings.push({
+        scope: PScope,
+        id: '',
+        ruleId: 'GOAL-ELEM-002',
+        message: 'GOAL-ELEM-002: GOAL element id is missing.',
+      });
+    } else if (!GOAL_ELEM_ID_RE.test(id)) {
+      findings.push({
+        scope: PScope,
+        id,
+        ruleId: 'GOAL-ELEM-002',
+        severity: 'warning',
+        message: `GOAL-ELEM-002: goal id '${id}' does not match GOAL-[<middle>-]<INTEGER>.`,
+      });
+    }
+
+    if (!readString(data, 'name')) {
+      findings.push({
+        scope: PScope,
+        id: where,
+        ruleId: 'GOAL-ELEM-003',
+        message: `GOAL-ELEM-003: GOAL element '${where || '(no id)'}' name is missing.`,
+      });
+    }
+  }
+}
+
+/** ACTION-001/002/005 — the ACTION element envelope: id presence + grammar,
+ *  name presence, type vocabulary, and the pre-2026-06-25 deprecated aliases
+ *  (`notation: activity`, `ACTIVITY-` id prefix, `activity_type` field).
+ *  Candidate selection is content-based (`notation === 'action'` or the
+ *  deprecated `'activity'` alias) — see the module header for why
+ *  `ACTION-001`'s "wrong notation" case isn't ported here. */
+function checkActionElements(elements: RepoDoc[], findings: RepoFinding[]): void {
+  const candidates = collectCandidates(
+    elements,
+    (data) => data['notation'] === 'action' || data['notation'] === 'activity',
+  );
+
+  for (const { id, data } of candidates) {
+    const where = id ?? '';
+
+    if (data['notation'] === 'activity') {
+      findings.push({
+        scope: PScope,
+        id: where,
+        ruleId: 'ACTION-005',
+        severity: 'warning',
+        message: `ACTION-005: element '${where || '(no id)'}' notation 'activity' is deprecated; migrate to 'action'.`,
+      });
+    }
+
+    if (!id) {
+      findings.push({
+        scope: PScope,
+        id: '',
+        ruleId: 'ACTION-001',
+        message: 'ACTION-001: ACTION element id is missing.',
+      });
+    } else if (id.startsWith('ACTIVITY-')) {
+      findings.push({
+        scope: PScope,
+        id,
+        ruleId: 'ACTION-005',
+        severity: 'warning',
+        message: `ACTION-005: id '${id}' uses the deprecated ACTIVITY- prefix; migrate to ACTION-.`,
+      });
+    } else if (!ACTION_ELEM_ID_RE.test(id)) {
+      findings.push({
+        scope: PScope,
+        id,
+        ruleId: 'ACTION-001',
+        severity: 'warning',
+        message: `ACTION-001: action id '${id}' does not match ACTION-[<middle>-]<INTEGER>.`,
+      });
+    }
+
+    if (!readString(data, 'name')) {
+      findings.push({
+        scope: PScope,
+        id: where,
+        ruleId: 'ACTION-001',
+        message: `ACTION-001: ACTION element '${where || '(no id)'}' name is missing.`,
+      });
+    }
+
+    let actionType = readString(data, 'type');
+    if (!actionType) {
+      const legacy = readString(data, 'activity_type');
+      if (legacy) {
+        findings.push({
+          scope: PScope,
+          id: where,
+          ruleId: 'ACTION-005',
+          severity: 'warning',
+          message: `ACTION-005: element '${where || '(no id)'}' field 'activity_type' is deprecated; migrate to 'type'.`,
+        });
+        actionType = legacy;
+      }
+    }
+    if (actionType && !ACTION_TYPE_VOCABULARY.has(actionType)) {
+      findings.push({
+        scope: PScope,
+        id: where,
+        ruleId: 'ACTION-002',
+        message: `ACTION-002: element '${where || '(no id)'}' type '${actionType}' is not one of Initiative, Programme, Project, Task.`,
+      });
+    }
+  }
+}
+
+/**
+ * Run the standalone-element envelope checks (GOAL-ELEM-001..003,
+ * ACTION-001/002/005) over the loaded element set and append findings.
+ * Called from `validateRepoModel` alongside `checkStrategyChainSemantics`.
+ * Pure, deterministic order.
+ */
+export function checkElementHygiene(input: RepoModelInput, findings: RepoFinding[]): void {
+  checkGoalElements(input.elements, findings);
+  checkActionElements(input.elements, findings);
+}

--- a/packages/diagrams/src/repo-validate/validate-repo.ts
+++ b/packages/diagrams/src/repo-validate/validate-repo.ts
@@ -28,6 +28,7 @@
 // deferred per the ADR.
 
 import { checkStrategyChainSemantics } from './check-strategy-chain.js';
+import { checkElementHygiene } from './check-element-hygiene.js';
 import type { RepoDoc, RepoFinding, RepoModelInput } from './types.js';
 
 const PScope: RepoFinding['scope'] = 'repo';
@@ -424,5 +425,8 @@ export function validateRepoModel(input: RepoModelInput): RepoFinding[] {
   // Phase 7 — strategy-chain semantic rules ported from DSM's Go Validate*
   // functions (GOALS-010, ACT-006..009, FGCA-008..011).
   checkStrategyChainSemantics(input, findings);
+  // Phase 8 — standalone-element envelope rules ported from DSM's Go
+  // Validate*Element functions (GOAL-ELEM-001..003, ACTION-001/002/005).
+  checkElementHygiene(input, findings);
   return findings;
 }


### PR DESCRIPTION
## Summary

- Adds `check-element-hygiene.ts` (new, sibling to `check-strategy-chain.ts`): `GOAL-ELEM-002`/`003` and `ACTION-001`/`002`/`005` over standalone `canon/elements/**` GOAL/ACTION elements, ported from DSM's Go `Validate*Element` functions and wired into `validate --scope=repo`.
- Ports `HDR-001`/`002` and `LIFECYCLE-001`/`004` into `capability-map/validate.ts` (the `capability-map` notation's own view-document validator) alongside its existing `CMAP-*` codes — DSM's `ValidateCapMap` checks the view document's inline capability tree, not a standalone element.
- `GOALS-001..007`/`ACT-001..003`/`016`/`FGCA-001..007`/`015` turned out to already be covered by the pre-existing view-sweep validators (`parseCanonicalGoals`, `validateActivities`, `parseCanonicalFGCA`) reachable via `validate --scope=repo`'s `views` output — no new code needed there. Documented in `docs/validation.md`.

## Deliberately NOT ported

**`ACT-020` and `DGCA-DEPR`** — DSM's Go importer still accepts the pre-2026-06-25 `activities` notation/root-key alias (for `action` docs) and the `activities` root key (for `dgca`/`fgca` docs) as a non-fatal warning. Studio's own validators deliberately **removed** that leniency in PR #320 (`refactor(notations): drop deprecated notation aliases fgca/fga/activities/activity-card`) — deprecated values are now rejected with an error, not a warning, with tests explicitly asserting the alias is "no longer accepted". Re-introducing these two DSM rule codes would reverse an already-shipped, tested decision — flagged for a call in `docs/validation.md` and inline comments at both sites, not silently decided either way.

**`GOAL-ELEM-001`/`ACTION-001`'s "wrong notation" case** — DSM identifies a GOAL/ACTION element by its folder location during its import walk; this repo-scope model has no such pre-typing, so candidate selection here is content-based (`notation === 'goal'`/`'action'`). An id-prefix-based candidate signal was tried as an alternative but produced false positives against this repo's own test suite (a `GOAL-`-prefixed id reused under a `goals/` path for an unrelated notation as a referential-integrity test double). Flagged for a decision, same pattern as the existing `GOALS-008` note.

## Test plan

- [x] `packages/diagrams` full vitest suite: 1464 tests green (including 16 new `check-element-hygiene.test.ts` tests and 8 new capability-map lifecycle tests)
- [x] Root `npm run compile` (tsc --noEmit): clean
- [x] Root `npm run test:core`: green except the 3 pre-existing `cli-migrate.test.ts` failures (documented in PRs #409/#410 as requiring a local methodology-repo checkout, unrelated to this change)
- [x] Manual `validate --scope=repo --root organizations/acme_corp --json`: zero new findings (only the pre-existing `GOALS-011`/`FGCA-013` warnings)
- [x] Manual verification against transitrix-dsm's own `testdata/notation-conformance/{goals,action,dgca,capability-map}.transitrix.yaml` fixtures copied into a scratch repo: zero findings across the board, matching the parity bar PRs #409/#410 established
- [x] Renamed a handful of non-grammar-conformant test ids in `check-strategy-chain.test.ts` (`GOAL-A` → `GOAL-A-1`, etc.) so the new `GOAL-ELEM-002`/`ACTION-001` grammar warnings don't collide with pre-existing cycle/orphan test fixtures — verified no change in test semantics, only ids

Do not merge — Valerii gates every merge.

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>