### PR TITLE
chore(release): bump extension to 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [3.1.0] — 2026-07-27
+
 ### Added
 
 - **`validate --scope=repo --json --include-model` emits the resolved element/relation model** (#406, #407). Opt-in flag adds a `model: { elements, relations }` key — id/name/notation/type/layer per element, id/kind/source/target per relation — reusing the same canon walk the repo-scope validator already does, for a non-JS consumer (DSM's Go backend) that wants the parsed model without re-implementing the notation schema. #407 adds a `data` field carrying the complete parsed element document alongside the minimal projection, so callers can read notation-specific fields (a goal's `level`/`parent`, an action's scheduling fields, …) without an engine schema change. Existing `--scope=repo --json` output is unchanged when `--include-model` is omitted.
@@ -14,6 +16,7 @@
 
 ### Packages
 
+- **Transitrix Studio extension** 3.0.9 → 3.1.0
 - **`@transitrix/cli`** 2.0.1 → 2.1.0 (#408, enables `--include-model` from #407) → 2.2.0 (#411 — the `grid:` validator and the `--template raci` flag).
 - **`@transitrix/diagrams`** 1.8.11 → 1.8.18 — grid-matrix rendering (#413) and the repo-validate rule additions above (#409, #410, #414).
 

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+## 3.1.0 — 2026-07-27
+
+Blocks gains a matrix form (RACI-style tables), `transitrix validate --scope=repo` now distinguishes errors from warnings and covers more of the methodology's rule set, and `--include-model` gives tooling a parsed view of your repo without re-implementing the notation schema.
+
+### Added
+
+- **Blocks matrix (`grid:`) documents** — a single-layer rectangular table, e.g. a RACI chart — are now validated and rendered in the preview, alongside the existing tree (`nested_blocks`) form. `transitrix validate --template raci` additionally checks that every row has exactly one Accountable owner.
+- **`transitrix validate --scope=repo` now distinguishes errors from warnings.** Only errors fail the command; checks for orphaned goal/action parents and unreferenced drivers/goals/changes surface as warnings instead of blocking validation.
+- **More of the methodology's validation rule set is enforced**, including goal/action element hygiene, capability map header/lifecycle rules, and additional strategy-chain checks (parent-chain cycles, dangling cross-references, invalid action dates/ordering).
+- **`transitrix validate --scope=repo --json --include-model` emits the parsed repo model** (elements and relations) for tools that want to consume Transitrix data without re-implementing the notation schema.
+
 ## 3.0.9 — 2026-07-17
 
 Action Schedule, DGCA, and Goals Tree can now be shared across documents (canon-projection form), plus several correctness fixes for `transitrix validate`.

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "3.0.9",
+  "version": "3.1.0",
   "description": "Diagrams as text. Write goals, processes, capabilities, BPMN, and more as plain YAML — 17 notations, live preview in VS Code. Diffable in git. AI-friendly. Open source.",
   "license": "MIT",
   "icon": "icon.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "transitrix-studio",
-  "version": "3.0.9",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "transitrix-studio",
-      "version": "3.0.9",
+      "version": "3.1.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -7771,7 +7771,7 @@
     },
     "packages/cli": {
       "name": "@transitrix/cli",
-      "version": "2.0.1",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",
@@ -7789,7 +7789,7 @@
     },
     "packages/diagrams": {
       "name": "@transitrix/diagrams",
-      "version": "1.8.11",
+      "version": "1.8.18",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "3.0.9",
+  "version": "3.1.0",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
## Why

`CHANGELOG.md`'s `Unreleased` section (filled in by #416) covers eight merged PRs since v3.0.9 — repo-scope `--include-model`, error/warning severity + more strategy-chain rules, the `blocks` `grid:` matrix form (validate + render), and ported DSM element-hygiene/capability-lifecycle rules — with no version behind it yet.

## What this does

- `extension/package.json` + `package.json`: `3.0.9` → `3.1.0` (via `npm run bump-extension-version -- set 3.1.0`).
- `CHANGELOG.md`: closes `Unreleased` as `## [3.1.0] — 2026-07-27`, opens a fresh empty `Unreleased`.
- `extension/CHANGELOG.md`: adds the adopter-facing `3.1.0` entry (narrative summary, matching the existing style).
- `package-lock.json`: version bump only (`npm install --package-lock-only`) — this also catches up the `packages/cli` (2.0.1 → 2.2.0) and `packages/diagrams` (1.8.11 → 1.8.18) lockfile entries, which had drifted out of sync with their own `package.json` versions across the standalone bumps in #408 and #413/#414.
- `extension/package-lock.json` untouched — gitignored since TX-204.

`@transitrix/cli` and `@transitrix/diagrams` are not bumped here — both are already at their released npm versions (2.2.0 / 1.8.18) from prior standalone publishes.

## Test plan

- [x] `npm run compile` (build:diagrams + root tsc --noEmit) — clean

## After merge

Cutting the GitHub Release (tag `v3.1.0`) triggers `npm — publish packages` (idempotent, already-published versions skip) plus the VS Code / Open VSX / JetBrains marketplace publishes. Leaving that step to Valerii.