### PR TITLE
fix(diagrams): route Network/PSND skip edges around intermediate nodes

### DIFF
--- a/extension/src/action-preview.ts
+++ b/extension/src/action-preview.ts
@@ -22,7 +22,7 @@ import {
 import { coerceDatesToIsoStrings } from '@transitrix/diagrams/yaml-normalize.js';
 import { loadCanon, findCanonRoot, isUnderCanon, type CanonDocs } from './canon-loader.js';
 import { DEFAULT_EDGE_CURVATURE } from '@transitrix/diagrams/edge-path.js';
-import { renderActivitiesNetworkBody, ACTIVITIES_NETWORK_DEFS } from '@transitrix/diagrams/webview/render-activities.js';
+import { renderActivitiesNetworkBody, ACTIVITIES_NETWORK_DEFS, computeNetworkTopPad } from '@transitrix/diagrams/webview/render-activities.js';
 import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
 import { readSpacing, readCurvature, readEntryCurvature, applyControlMessage, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND } from './spacing-config.js';
 import { readActionNodeSize, readNodeSizePreset } from './node-size-config.js';
@@ -82,10 +82,12 @@ function networkSvg(doc: ActivityDoc, gaps: ActivitiesLayoutOptions = {}, curvat
   const showTitle = heading != null && filename != null && date != null;
   const titleH = showTitle ? (TITLE_BLOCK_H + (actionName ? ACTIVITY_ACTION_NAME_H : 0)) : 0;
   const cpm = computeCpm(doc.activities ?? []);
+  const oyBase = -layout.bounds.y + N_PAD + titleH;
+  const topPad = computeNetworkTopPad(layout, oyBase);
   const W = layout.bounds.width + N_PAD * 2;
-  const H = layout.bounds.height + N_PAD * 2 + titleH;
+  const H = layout.bounds.height + N_PAD * 2 + titleH + topPad;
   const ox = -layout.bounds.x + N_PAD;
-  const oy = -layout.bounds.y + N_PAD + titleH;
+  const oy = oyBase + topPad;
 
   const body = renderActivitiesNetworkBody(layout, cpm, ox, oy, curvature, entryCurvature);
 

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.8.18",
+  "version": "1.8.19",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",

--- a/packages/diagrams/src/__tests__/edge-path.test.ts
+++ b/packages/diagrams/src/__tests__/edge-path.test.ts
@@ -89,7 +89,7 @@ describe('bowedCubicEdgePath', () => {
     expect(Number(m![4])).toBe(20);
   });
 
-  it('clears a same-row obstacle sitting on the direct sy=ty line (vkgeorgia/strategy — arrow through node)', () => {
+  it('clears a same-row obstacle sitting on the direct sy=ty line (arrow drawn through the node)', () => {
     // Reproduces the SDS-workflow scenario: A-001 (col 0) -> A-003 (col 2),
     // with A-002 (col 1) occupying the same row in between.
     const sx = 274, sy = 138, tx = 752, ty = 138; // A-001 right edge -> A-003 left edge

--- a/packages/diagrams/src/__tests__/edge-path.test.ts
+++ b/packages/diagrams/src/__tests__/edge-path.test.ts
@@ -1,5 +1,19 @@
 import { describe, it, expect } from 'vitest';
-import { horizontalCubicEdgePath, EDGE_MIN_HANDLE } from '../edge-path.js';
+import { horizontalCubicEdgePath, bowedCubicEdgePath, EDGE_MIN_HANDLE } from '../edge-path.js';
+
+/** Point at parameter `t` on cubic `P0 C P1 P2 P3` (`d` in `M.. C..`/coords form). */
+function cubicPointAt(
+  p0: [number, number],
+  p1: [number, number],
+  p2: [number, number],
+  p3: [number, number],
+  t: number,
+): [number, number] {
+  const u = 1 - t;
+  const x = u ** 3 * p0[0] + 3 * u ** 2 * t * p1[0] + 3 * u * t ** 2 * p2[0] + t ** 3 * p3[0];
+  const y = u ** 3 * p0[1] + 3 * u ** 2 * t * p1[1] + 3 * u * t ** 2 * p2[1] + t ** 3 * p3[1];
+  return [x, y];
+}
 
 describe('horizontalCubicEdgePath', () => {
   // A short horizontal edge: |dx|=40 < EDGE_MIN_HANDLE*2, |dy|=0, so the
@@ -63,5 +77,38 @@ describe('horizontalCubicEdgePath', () => {
     // S-bow. Capped at 160, the control points stay close to the endpoints.
     const d = horizontalCubicEdgePath(0, 0, 80, 500, 1);
     expect(d).toBe('M0,0 C160,0 -80,500 80,500');
+  });
+});
+
+describe('bowedCubicEdgePath', () => {
+  it('both control points target bowY, not the endpoints\' own Y', () => {
+    const d = bowedCubicEdgePath(0, 100, 400, 100, 20, 1);
+    const m = d.match(/^M0,100 C(-?[\d.]+),(-?[\d.]+) (-?[\d.]+),(-?[\d.]+) 400,100$/);
+    expect(m).not.toBeNull();
+    expect(Number(m![2])).toBe(20);
+    expect(Number(m![4])).toBe(20);
+  });
+
+  it('clears a same-row obstacle sitting on the direct sy=ty line (vkgeorgia/strategy — arrow through node)', () => {
+    // Reproduces the SDS-workflow scenario: A-001 (col 0) -> A-003 (col 2),
+    // with A-002 (col 1) occupying the same row in between.
+    const sx = 274, sy = 138, tx = 752, ty = 138; // A-001 right edge -> A-003 left edge
+    const obstacle = { x: 388, y: 98, width: 250, height: 80 }; // A-002's box
+    const clearance = obstacle.height; // matches render-activities.ts's bowY()
+    const bowYAt = obstacle.y - clearance;
+    const d = bowedCubicEdgePath(sx, sy, tx, ty, bowYAt, 1);
+    const m = d.match(/^M([\d.]+),([\d.]+) C([\d.-]+),([\d.-]+) ([\d.-]+),([\d.-]+) ([\d.]+),([\d.]+)$/);
+    expect(m).not.toBeNull();
+    const [, x0, y0, x1, y1, x2, y2, x3, y3] = m!.map(Number);
+    // Sample densely; wherever the curve's x falls inside the obstacle's
+    // horizontal span, its y must be above (numerically less than) the box's
+    // top edge — i.e. the arc clears over the node instead of crossing it.
+    for (let i = 0; i <= 100; i++) {
+      const t = i / 100;
+      const [x, y] = cubicPointAt([x0, y0], [x1, y1], [x2, y2], [x3, y3], t);
+      if (x >= obstacle.x && x <= obstacle.x + obstacle.width) {
+        expect(y).toBeLessThan(obstacle.y);
+      }
+    }
   });
 });

--- a/packages/diagrams/src/edge-path.ts
+++ b/packages/diagrams/src/edge-path.ts
@@ -62,3 +62,30 @@ export function horizontalCubicEdgePath(
   const entryHandle = baseHandle * (entryCurvature ?? curvature);
   return `M${sx},${sy} C${sx + exitHandle},${sy} ${tx - entryHandle},${ty} ${tx},${ty}`;
 }
+
+/**
+ * Builds the SVG `d` for a "skip" edge that must arc over an intermediate
+ * node sitting on the direct (sx,sy)→(tx,ty) line — e.g. a Network/PSND view
+ * where a multi-predecessor activity's nearer predecessor shares a row with
+ * one of the columns in between (vkgeorgia/strategy — "arrow goes straight
+ * through the node"). Both control points target `bowY` instead of each
+ * endpoint's own Y, producing a hump that departs/arrives at an angle rather
+ * than the flat horizontal tangent of `horizontalCubicEdgePath`.
+ *
+ * A cubic's actual apex only reaches part-way from an endpoint Y to the
+ * control-point Y (75% at the midpoint for a fully symmetric sy=ty curve),
+ * so callers must pick `bowY` well past the obstacle for the apex to clear
+ * it — see `render-activities.ts`'s `blockingNodes`/`bowY` for the margin.
+ */
+export function bowedCubicEdgePath(
+  sx: number,
+  sy: number,
+  tx: number,
+  ty: number,
+  bowY: number,
+  curvature: number = DEFAULT_EDGE_CURVATURE,
+): string {
+  const dx = tx - sx;
+  const handle = Math.max(EDGE_MIN_HANDLE, Math.min(Math.abs(dx) * DX_FACTOR, MAX_HANDLE)) * curvature;
+  return `M${sx},${sy} C${sx + handle},${bowY} ${tx - handle},${bowY} ${tx},${ty}`;
+}

--- a/packages/diagrams/src/edge-path.ts
+++ b/packages/diagrams/src/edge-path.ts
@@ -67,8 +67,8 @@ export function horizontalCubicEdgePath(
  * Builds the SVG `d` for a "skip" edge that must arc over an intermediate
  * node sitting on the direct (sx,sy)→(tx,ty) line — e.g. a Network/PSND view
  * where a multi-predecessor activity's nearer predecessor shares a row with
- * one of the columns in between (vkgeorgia/strategy — "arrow goes straight
- * through the node"). Both control points target `bowY` instead of each
+ * one of the columns in between, so the direct line would be drawn straight
+ * through that node. Both control points target `bowY` instead of each
  * endpoint's own Y, producing a hump that departs/arrives at an angle rather
  * than the flat horizontal tangent of `horizontalCubicEdgePath`.
  *

--- a/packages/diagrams/src/webview/__tests__/render-activities.test.ts
+++ b/packages/diagrams/src/webview/__tests__/render-activities.test.ts
@@ -9,6 +9,20 @@ import { describe, it, expect } from 'vitest';
 import { renderActivitiesSvg } from '../render-activities.js';
 import type { ActivityDoc } from '../../activities/types.js';
 
+/** Point at parameter `t` on cubic `P0 C P1 P2 P3`. */
+function cubicPointAt(
+  p0: [number, number],
+  p1: [number, number],
+  p2: [number, number],
+  p3: [number, number],
+  t: number,
+): [number, number] {
+  const u = 1 - t;
+  const x = u ** 3 * p0[0] + 3 * u ** 2 * t * p1[0] + 3 * u * t ** 2 * p2[0] + t ** 3 * p3[0];
+  const y = u ** 3 * p0[1] + 3 * u ** 2 * t * p1[1] + 3 * u * t ** 2 * p2[1] + t ** 3 * p3[1];
+  return [x, y];
+}
+
 const BASE_DOC: ActivityDoc = {
   notation: 'action',
   activities: [
@@ -96,5 +110,71 @@ describe('renderActivitiesSvg — project-node suppression (#421)', () => {
     const svg = renderActivitiesSvg(doc);
     expect(svg).toContain('A1');
     expect(svg).toContain('A2');
+  });
+});
+
+describe('renderActivitiesSvg — skip-edge arcs over an intermediate node', () => {
+  // Reproduces the reported bug: A-003 depends on both A-001 and A-002, so
+  // A-001 lands two columns before A-003 while A-002 (one column ahead of
+  // A-001) shares A-003's row — the direct A-001->A-003 edge used to draw a
+  // straight line right across A-002's box.
+  const doc: ActivityDoc = {
+    notation: 'action',
+    activities: [
+      { id: 'A-001', name: 'Build REQUIREMENT baseline', duration: 3 },
+      { id: 'A-002', name: 'Model HAZARD and RISK_CONTROL', duration: 2, predecessors: ['A-001'] },
+      { id: 'A-003', name: 'Define VERIFICATION protocols', duration: 3, predecessors: ['A-001', 'A-002'] },
+    ],
+  };
+
+  it('routes the A-001->A-003 edge above A-002 instead of through it', () => {
+    const svg = renderActivitiesSvg(doc);
+    // A-002's node rect: parse its x/y/width/height from the emitted SVG.
+    const nodeMatch = svg.match(/<rect class="[^"]*" x="([\d.]+)" y="([\d.]+)" width="([\d.]+)" height="([\d.]+)"[^>]*\/>\s*<text[^>]*>Model HAZARD/);
+    expect(nodeMatch).not.toBeNull();
+    const [, nx, ny, nw] = nodeMatch!.map(Number);
+    const obstacle = { x: nx, y: ny, width: nw };
+
+    // Every cubic edge path in the SVG; find the one spanning A-001's column
+    // to A-003's column (i.e. one whose x-range covers the obstacle's).
+    const paths = [...svg.matchAll(/<path d="M([\d.]+),([\d.]+) C([\d.-]+),([\d.-]+) ([\d.-]+),([\d.-]+) ([\d.]+),([\d.]+)"/g)]
+      .map((m) => m.slice(1).map(Number) as [number, number, number, number, number, number, number, number]);
+    const skipEdge = paths.find(([x0, , , , , , x3]) => x0 < obstacle.x && x3 > obstacle.x + obstacle.width);
+    expect(skipEdge).toBeDefined();
+    const [x0, y0, x1, y1, x2, y2, x3, y3] = skipEdge!;
+
+    for (let i = 0; i <= 100; i++) {
+      const t = i / 100;
+      const [x, y] = cubicPointAt([x0, y0], [x1, y1], [x2, y2], [x3, y3], t);
+      if (x >= obstacle.x && x <= obstacle.x + obstacle.width) {
+        expect(y).toBeLessThan(obstacle.y);
+      }
+    }
+  });
+
+  it('grows the canvas so the bow never draws above y=0 (would otherwise be clipped)', () => {
+    // The blocking node sits in the topmost (and only) row, so a naive bow
+    // would need to rise above the SVG's own y=0 — the canvas must grow to
+    // absorb that instead of letting the arc get clipped by the viewBox.
+    const svg = renderActivitiesSvg(doc);
+    const paths = [...svg.matchAll(/<path d="M([\d.]+),([\d.]+) C([\d.-]+),([\d.-]+) ([\d.-]+),([\d.-]+) ([\d.]+),([\d.]+)"/g)]
+      .map((m) => m.slice(1).map(Number) as [number, number, number, number, number, number, number, number]);
+    for (const [, , , y1, , y2] of paths) {
+      expect(y1).toBeGreaterThanOrEqual(0);
+      expect(y2).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it('leaves non-colliding edges as a plain horizontal-tangent curve', () => {
+    const svg = renderActivitiesSvg(doc);
+    // A-001->A-002 (adjacent columns, nothing in between) keeps the
+    // historical flat-tangent shape: both control points share their
+    // endpoint's own Y. Locate it as the shortest-span edge.
+    const paths = [...svg.matchAll(/<path d="M([\d.]+),([\d.]+) C([\d.-]+),([\d.-]+) ([\d.-]+),([\d.-]+) ([\d.]+),([\d.]+)"/g)]
+      .map((mm) => mm.slice(1).map(Number) as [number, number, number, number, number, number, number, number]);
+    const adjacentEdge = paths.reduce((shortest, p) => (p[6] - p[0] < shortest[6] - shortest[0] ? p : shortest));
+    const [x0, y0, , y1, , y2, , y3] = adjacentEdge;
+    expect(y1).toBe(y0);
+    expect(y2).toBe(y3);
   });
 });

--- a/packages/diagrams/src/webview/render-activities.ts
+++ b/packages/diagrams/src/webview/render-activities.ts
@@ -23,7 +23,7 @@ import type {
   ActivitiesLayout,
   ActivitiesLayoutOptions,
 } from '../activities/types.js';
-import { horizontalCubicEdgePath, DEFAULT_EDGE_CURVATURE } from '../edge-path.js';
+import { horizontalCubicEdgePath, bowedCubicEdgePath, DEFAULT_EDGE_CURVATURE } from '../edge-path.js';
 import { parseNodeSizePreset, resolveActionNodeSize, type NodeSizePreset } from '../node-size-presets.js';
 import { generateSvgEmbedCss } from '../theme/index.js';
 import { emitCenteredTextSvg, layoutCenteredEntityText } from './entity-text-layout.js';
@@ -54,6 +54,72 @@ export const ACTIVITIES_NETWORK_DEFS = `<defs>
     <path d="M0,0 L0,6 L8,3 z" class="arrow-fill-critical"/>
   </marker>
 </defs>`;
+
+type ActivityLayoutNode = ActivitiesLayout['nodes'][number];
+
+/**
+ * Nodes horizontally between `source` and `target` (a "skip" edge passes over
+ * their column) whose vertical span overlaps the edge's Y band. A
+ * straight-tangent cubic (`horizontalCubicEdgePath`) stays within
+ * [min(sourceCenterY,targetCenterY), max(...)] by convex hull, so any such
+ * node sits directly on the edge's path — the "arrow goes straight through
+ * the node" bug reported against a linear PSND chain where a multi-predecessor
+ * activity's nearer predecessor shares a row with an intermediate column.
+ */
+function blockingNodes(
+  nodes: ActivityLayoutNode[],
+  source: ActivityLayoutNode,
+  target: ActivityLayoutNode,
+): ActivityLayoutNode[] {
+  const sCenterY = source.y + source.height / 2;
+  const tCenterY = target.y + target.height / 2;
+  const loY = Math.min(sCenterY, tCenterY);
+  const hiY = Math.max(sCenterY, tCenterY);
+  const sRight = source.x + source.width;
+  const tLeft = target.x;
+  return nodes.filter((n) => {
+    if (n.id === source.id || n.id === target.id) return false;
+    if (n.x + n.width <= sRight || n.x >= tLeft) return false; // not between the two columns
+    return n.y < hiY && n.y + n.height > loY; // vertical overlap with the edge's band
+  });
+}
+
+/**
+ * Pre-offset bow-control-point Y for a skip edge arcing over `blockers`: one
+ * full node-height of clearance above the topmost blocker's top edge. A
+ * cubic's apex only reaches part-way toward its control point (see
+ * `bowedCubicEdgePath` doc), so this generous margin is what actually keeps
+ * the visible curve clear of the box — verified numerically in
+ * `render-activities.test.ts`.
+ */
+function bowY(blockers: ActivityLayoutNode[]): number {
+  const topY = Math.min(...blockers.map((n) => n.y));
+  const clearance = Math.max(...blockers.map((n) => n.height));
+  return topY - clearance;
+}
+
+/**
+ * Extra top padding (px) a network-view canvas must add so skip-edge bows
+ * (see `blockingNodes`/`bowY` above) never draw above the SVG's y=0 and get
+ * clipped. `oyBase` is the canvas's Y offset *before* this padding — the
+ * historical `-bounds.y + N_PAD + titleH` both hosts compute — since a bow
+ * near the topmost row can reach above the diagram's own node bounds.
+ * Callers add the returned value to both `oyBase` and the canvas height.
+ */
+export function computeNetworkTopPad(layout: ActivitiesLayout, oyBase: number): number {
+  const nodeMap = new Map(layout.nodes.map((n) => [n.id, n]));
+  let pad = 0;
+  for (const e of layout.edges) {
+    const s = nodeMap.get(e.sourceId);
+    const t = nodeMap.get(e.targetId);
+    if (!s || !t) continue;
+    const blockers = blockingNodes(layout.nodes, s, t);
+    if (blockers.length === 0) continue;
+    const shortfall = -(oyBase + bowY(blockers));
+    if (shortfall > pad) pad = shortfall;
+  }
+  return pad;
+}
 
 function activityNodeSvg(
   n: ActivitiesLayout['nodes'][number],
@@ -119,7 +185,11 @@ export function renderActivitiesNetworkBody(
       const ty = t.y + oy + t.height / 2;
       const cls = e.isCritical ? 'diagram-edge critical-edge' : 'diagram-edge';
       const marker = `url(#${e.isCritical ? 'arrow-crit' : 'arrow'})`;
-      return `<path d="${horizontalCubicEdgePath(sx, sy, tx, ty, curvature, entryCurvature)}" class="${cls}" marker-end="${marker}"/>`;
+      const blockers = blockingNodes(layout.nodes, s, t);
+      const d = blockers.length > 0
+        ? bowedCubicEdgePath(sx, sy, tx, ty, bowY(blockers) + oy, curvature)
+        : horizontalCubicEdgePath(sx, sy, tx, ty, curvature, entryCurvature);
+      return `<path d="${d}" class="${cls}" marker-end="${marker}"/>`;
     })
     .join('\n');
 
@@ -207,10 +277,12 @@ export function renderActivitiesSvg(doc: ActivityDoc, options: RenderActivitiesO
 
   const cpm = computeCpm(renderDoc.activities ?? []);
   const titleH = title ? 24 : 0;
+  const oyBase = -layout.bounds.y + N_PAD + titleH;
+  const topPad = computeNetworkTopPad(layout, oyBase);
   const w = layout.bounds.width + N_PAD * 2;
-  const h = layout.bounds.height + N_PAD * 2 + titleH;
+  const h = layout.bounds.height + N_PAD * 2 + titleH + topPad;
   const ox = -layout.bounds.x + N_PAD;
-  const oy = -layout.bounds.y + N_PAD + titleH;
+  const oy = oyBase + topPad;
 
   const body = renderActivitiesNetworkBody(layout, cpm, ox, oy, curvature, entryCurvature);
 


### PR DESCRIPTION
## Summary
- The Network/PSND view could draw an edge as a straight line directly across an intermediate node's box: when a multi-predecessor activity's nearer predecessor lands in the same row as a column in between (e.g. `A -> C` skipping over `B`, where `B` sits in the same row), the straight-tangent cubic Bézier degenerates to a flat horizontal line through `B`.
- Added `bowedCubicEdgePath` (edge-path.ts) and `blockingNodes`/`bowY`/`computeNetworkTopPad` (render-activities.ts) to detect this case and arc the edge above the obstacle instead, growing the canvas's top padding so the arc is never clipped by the viewBox.
- Wired the same top-padding calc into the VS Code extension's `networkSvg` (action-preview.ts), since both hosts share `renderActivitiesNetworkBody`.

## Test plan
- [x] New unit tests in `edge-path.test.ts` numerically sample the bowed cubic to confirm it clears a same-row obstacle
- [x] New unit tests in `render-activities.test.ts` reproduce the reported scenario end-to-end and assert the emitted SVG's skip edge clears the node, non-colliding edges are unchanged, and the canvas never draws negative-Y content
- [x] Full `packages/diagrams` suite passes (1469 tests)
- [x] `extension` package typechecks clean after rebuilding `packages/diagrams`

🤖 Generated with [Claude Code](https://claude.com/claude-code)