### PR TITLE
chore(release): bump extension to 3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+## [3.1.1] — 2026-07-27
+
+### Fixed
+
+- **Network/PSND view could draw a skip edge as a straight line directly through an intermediate node** (#418). When a multi-predecessor activity's nearer predecessor and an in-between column shared the same row, the straight-tangent cubic connecting them degenerated into a flat horizontal line crossing that node's box. Skip edges now detect the collision and arc above the obstacle instead, growing the canvas's top padding so the arc is never clipped. Shared by the webview renderer and the VS Code extension preview (`renderActivitiesNetworkBody`).
+
+### Packages
+
+- **`@transitrix/diagrams`** 1.8.18 → 1.8.19 — the skip-edge routing fix above.
+
 ## [3.1.0] — 2026-07-27
 
 ### Added

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+## 3.1.1 — 2026-07-27
+
+A Network/PSND view rendering fix: an activity dependency line could be drawn straight through an unrelated node instead of around it.
+
+### Fixed
+
+- **Network/PSND view no longer draws a dependency line through an unrelated activity box.** When an activity depended on two predecessors from different columns, the line from the nearer one could cross directly over a node sitting in between if it shared the same row. That line now arcs above the node instead.
+
 ## 3.1.0 — 2026-07-27
 
 Blocks gains a matrix form (RACI-style tables), `transitrix validate --scope=repo` now distinguishes errors from warnings and covers more of the methodology's rule set, and `--include-model` gives tooling a parsed view of your repo without re-implementing the notation schema.

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Diagrams as text. Write goals, processes, capabilities, BPMN, and more as plain YAML — 17 notations, live preview in VS Code. Diffable in git. AI-friendly. Open source.",
   "license": "MIT",
   "icon": "icon.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "transitrix-studio",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "transitrix-studio",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -7789,7 +7789,7 @@
     },
     "packages/diagrams": {
       "name": "@transitrix/diagrams",
-      "version": "1.8.18",
+      "version": "1.8.19",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
## Why

`CHANGELOG.md`'s `Unreleased` section covers #418 (Network/PSND skip-edge routing fix) with no version behind it yet.

## What this does

- `extension/package.json` + `package.json`: `3.1.0` → `3.1.1` (via `npm run bump-extension-version -- set 3.1.1`).
- `CHANGELOG.md`: closes `Unreleased` as `## [3.1.1] — 2026-07-27`, opens a fresh empty `Unreleased`.
- `extension/CHANGELOG.md`: adds the adopter-facing `3.1.1` entry (narrative summary, matching the existing style).
- `package-lock.json`: version bump only (`npm install --package-lock-only`) — also catches up the `packages/diagrams` (1.8.18 → 1.8.19) lockfile entry.

`@transitrix/cli` is not bumped here — already at its released npm version (2.2.0) from a prior standalone publish.

## Test plan

- [x] `npm run compile` (build:diagrams + root tsc --noEmit) — clean

## After merge

Cutting the GitHub Release (tag `v3.1.1`) triggers `npm — publish packages` (idempotent, already-published versions skip) plus the VS Code / Open VSX / JetBrains marketplace publishes. Leaving that step to Valerii.

🤖 Generated with [Claude Code](https://claude.com/claude-code)