### PR TITLE
fix(diagrams): sync blocks BL-006 TYPE registry with IDS_AND_REFERENCES.md §3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7789,7 +7789,7 @@
     },
     "packages/diagrams": {
       "name": "@transitrix/diagrams",
-      "version": "1.8.19",
+      "version": "1.8.20",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.8.19",
+  "version": "1.8.20",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",

--- a/packages/diagrams/src/blocks/__tests__/validate.test.ts
+++ b/packages/diagrams/src/blocks/__tests__/validate.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import yaml from 'js-yaml';
-import { validateNestedBlocks, validateGrid, validateBlocks } from '../validate.js';
+import { validateNestedBlocks, validateGrid, validateBlocks, REGISTERED_ELEMENT_TYPES } from '../validate.js';
 import { RACI_GRID_RULES } from '../templates/raci.js';
 
 const EXAMPLES_DIR = path.resolve(process.cwd(), '..', '..', 'tests', 'fixtures', 'notation-corpus', 'blocks');
@@ -165,6 +165,78 @@ describe('validateNestedBlocks', () => {
       },
     });
     expect(r.errors.some((e) => e.code === 'BL-006')).toBe(false);
+  });
+
+  it('BL-006: matches the current IDS_AND_REFERENCES.md §3.1 registry exactly (+ VERIFICATION, §3.7) — fails on drift', () => {
+    // Hardcoded against the spec, not re-derived from the module under test —
+    // if methodology adds/retires a TYPE and this file isn't updated to match,
+    // this assertion is what catches it (see validate.ts's own doc comment).
+    expect(REGISTERED_ELEMENT_TYPES).toEqual(
+      new Set([
+        'DRIVER',
+        'FACTOR',
+        'GOAL',
+        'CHANGE',
+        'ACTION',
+        'ACTIVITY',
+        'CAPABILITY',
+        'PROCESS',
+        'STEP',
+        'PRODUCT',
+        'APPLICATION',
+        'INTEGRATION',
+        'ROLE',
+        'ACTOR',
+        'LOCATION',
+        'BUSINESS_SERVICE',
+        'SCENARIO',
+        'EQUIPMENT',
+        'NODE',
+        'TECHNOLOGY_SERVICE',
+        'BUSINESS_OBJECT',
+        'RULE',
+        'REGISTRY',
+        'CONSTRAINT',
+        'REQUIREMENT',
+        'STAKEHOLDER',
+        'ASSESSMENT',
+        'HAZARD',
+        'RISK_CONTROL',
+        'TARGET_STATE',
+        'REL',
+        'MILESTONE',
+        'VERIFICATION',
+      ]),
+    );
+  });
+
+  it('BL-006: accepts the newly-covered ISO 14971 chain TYPEs (HAZARD, RISK_CONTROL, REQUIREMENT, VERIFICATION)', () => {
+    const r = validateNestedBlocks({
+      ...VALID_DOC,
+      nested_blocks: {
+        ...VALID_DOC.nested_blocks,
+        blocks: [
+          { id: 'HAZARD-BATTERY-1', name: 'Battery overheat' },
+          { id: 'RISK_CONTROL-FUSE-1', name: 'Thermal fuse' },
+          { id: 'REQUIREMENT-IEC-1', name: 'IEC 60601 clause 4' },
+          { id: 'VERIFICATION-BENCH-1', name: 'Bench test protocol' },
+        ],
+      },
+    });
+    expect(r.errors.some((e) => e.code === 'BL-006')).toBe(false);
+  });
+
+  it('BL-006: rejects TYPE prefixes retired/removed from canon (UNIT, EMPLOYEE, ISSUE) and STAGE (never canonical)', () => {
+    for (const id of ['UNIT-HR-1', 'EMPLOYEE-HR-1', 'ISSUE-BUG-1', 'STAGE-PHASE-1']) {
+      const r = validateNestedBlocks({
+        ...VALID_DOC,
+        nested_blocks: {
+          ...VALID_DOC.nested_blocks,
+          blocks: [{ id, name: 'X' }],
+        },
+      });
+      expect(r.errors.some((e) => e.code === 'BL-006')).toBe(true);
+    }
   });
 
   it('BL-006: accepts free-form local labels (APPLICATION_LAYER, frontend, my-thing)', () => {

--- a/packages/diagrams/src/blocks/validate.ts
+++ b/packages/diagrams/src/blocks/validate.ts
@@ -45,23 +45,55 @@ const CANONICAL_ID_RE = /^[A-Z][A-Z0-9_]*(-[A-Z0-9][A-Z0-9_]*)+-\d+$/;
  */
 const CAPABILITY_ID_RE = /^CAPABILITY-[VH]\d+(\.\d+){0,2}$/;
 
-/** Element-level TYPE registry — IDS_AND_REFERENCES.md §3.1. */
-const REGISTERED_ELEMENT_TYPES = new Set<string>([
+/**
+ * Element-level TYPE registry — IDS_AND_REFERENCES.md §3.1, plus
+ * `VERIFICATION` (§3.7): block diagrams cross-reference the full
+ * hazard → risk-control → requirement → verification chain, and
+ * `VERIFICATION` is the terminal link in that chain.
+ *
+ * `FACTOR` and `ACTIVITY` are kept alongside their canonical replacements
+ * `DRIVER` and `ACTION` — both still-valid grandfathered/deprecated aliases
+ * per §3.1 and §6, not yet forced to migrate.
+ *
+ * `UNIT`/`EMPLOYEE` (replaced by `ACTOR`, removed from canon 2026-05-29) and
+ * `ISSUE` (retired 2026-06-07, no replacement TYPE — see methodology
+ * `docs/decisions/2026-06-07-retire-model-issue-type.md`) are deliberately
+ * not carried forward. `STAGE` was never a canonical TYPE.
+ */
+export const REGISTERED_ELEMENT_TYPES = new Set<string>([
+  'DRIVER',
   'FACTOR',
   'GOAL',
   'CHANGE',
+  'ACTION',
   'ACTIVITY',
   'CAPABILITY',
   'PROCESS',
+  'STEP',
   'PRODUCT',
   'APPLICATION',
   'INTEGRATION',
   'ROLE',
-  'UNIT',
-  'EMPLOYEE',
+  'ACTOR',
+  'LOCATION',
+  'BUSINESS_SERVICE',
   'SCENARIO',
-  'ISSUE',
-  'STAGE',
+  'EQUIPMENT',
+  'NODE',
+  'TECHNOLOGY_SERVICE',
+  'BUSINESS_OBJECT',
+  'RULE',
+  'REGISTRY',
+  'CONSTRAINT',
+  'REQUIREMENT',
+  'STAKEHOLDER',
+  'ASSESSMENT',
+  'HAZARD',
+  'RISK_CONTROL',
+  'TARGET_STATE',
+  'REL',
+  'MILESTONE',
+  'VERIFICATION',
 ]);
 
 /**


### PR DESCRIPTION
## Summary

`REGISTERED_ELEMENT_TYPES` in `packages/diagrams/src/blocks/validate.ts` (the TYPE allowlist behind the blocks-diagram `BL-006` check) was a stale, hand-maintained copy of methodology's element-level TYPE registry (`IDS_AND_REFERENCES.md` §3.1). It still accepted `UNIT`/`EMPLOYEE` (removed from canon 2026-05-29, replaced by `ACTOR`) and `ISSUE` (retired 2026-06-07, no replacement TYPE), while rejecting current canonical TYPEs — reported by an adopter for `HAZARD`, `RISK_CONTROL`, `REQUIREMENT`, `VERIFICATION` specifically, but the drift was wider.

- `REGISTERED_ELEMENT_TYPES` now matches §3.1 exactly, keeping both members of each still-valid alias pair (`FACTOR`/`DRIVER`, `ACTIVITY`/`ACTION`), plus `VERIFICATION` (§3.7) — the terminal link in the hazard → risk-control → requirement → verification chain these block diagrams need to reference end to end.
- Dropped `UNIT`, `EMPLOYEE`, `ISSUE` (all retired from canon) and `STAGE` (never a canonical TYPE — no trace of it anywhere in methodology's history).
- Exported `REGISTERED_ELEMENT_TYPES` and added a test asserting it against a hardcoded expected set, so the next time methodology adds/retires a TYPE without this file being updated, CI fails instead of silently drifting again.
- Added coverage for the newly-accepted ISO 14971 chain TYPEs and for rejection of the four dropped TYPEs.
- No change to `BL-006`'s free-form-local-label path or to `BL-005`.
- Bumps `@transitrix/diagrams` to 1.8.20 per the version-bump CI guard.

## Test plan

- [x] `npx vitest run src/blocks/__tests__/validate.test.ts` — 43/43 pass
- [x] Full `packages/diagrams` suite — 1472/1472 pass
- [x] New hardcoded expected-set test would fail if the registry drifts from §3.1 again

🤖 Generated with [Claude Code](https://claude.com/claude-code)