### PR TITLE
fix(compliance): map hardcoded status colors to functional --ts-status-* tokens

### DIFF
--- a/extension/src/compliance-impact-preview.ts
+++ b/extension/src/compliance-impact-preview.ts
@@ -788,14 +788,14 @@ body { padding: 0; display: flex; flex-direction: column; height: 100vh; overflo
 .ci-row-id { font-size: 11px; font-family: var(--vscode-editor-font-family, monospace); color: var(--ts-text-muted, #64748b); }
 .ci-row-name { font-weight: 600; color: var(--ts-text, #0f172a); font-size: 12px; white-space: normal; }
 .ci-sev { font-size: 10px; text-transform: uppercase; letter-spacing: 0.04em; margin-top: 2px; }
-.ci-sev-high { color: #b91c1c; } .ci-sev-medium { color: #b45309; } .ci-sev-low { color: #2563eb; }
+.ci-sev-high { color: #b91c1c; } .ci-sev-medium { color: var(--ts-status-warning-fg, #854d0e); } .ci-sev-low { color: #2563eb; }
 .ci-jur { display: inline-block; padding: 1px 5px; border-radius: 3px; font-size: 10px; color: var(--ts-text-muted, #64748b); background: var(--ts-bg-elevated, #e2e8f0); text-transform: uppercase; letter-spacing: 0.04em; margin-top: 2px; margin-right: 2px; }
 .ci-cell { width: var(--ts-col-w, 120px); height: 40px; text-align: center; vertical-align: middle; }
 .ci-badge { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 11px; font-weight: 600; }
 .ci-link { text-decoration: none; }
 .ci-gap { background: repeating-linear-gradient(-45deg, transparent, transparent 5px, var(--ts-bg-subtle, #f1f5f9) 5px, var(--ts-bg-subtle, #f1f5f9) 10px); }
-.ci-pending { background: #fef9c3; border: 1px dashed #b45309 !important; }
-.ci-badge-pending { display: inline-block; padding: 2px 6px; border-radius: 8px; font-size: 10px; font-weight: 600; color: #b45309; background: #fef9c3; }
+.ci-pending { background: var(--ts-status-warning-bg, #fef9c3); border: 1px dashed var(--ts-status-warning-fg, #854d0e) !important; }
+.ci-badge-pending { display: inline-block; padding: 2px 6px; border-radius: 8px; font-size: 10px; font-weight: 600; color: var(--ts-status-warning-fg, #854d0e); background: var(--ts-status-warning-bg, #fef9c3); }
 .ci-filtered { background: var(--ts-bg-subtle, #f8fafc); opacity: 0.35; }
 .ci-na { background: var(--ts-bg-subtle, #f1f5f9); }
 .ci-badge-na { color: var(--ts-text-muted, #64748b); background: var(--ts-bg-subtle, #f1f5f9); }
@@ -807,8 +807,8 @@ body { padding: 0; display: flex; flex-direction: column; height: 100vh; overflo
 .ci-badge-non_compliant { color: var(--ts-status-error-fg, #991b1b); background: var(--ts-status-error-bg, #fee2e2); }
 .ci-under_review { background: var(--ts-status-info-bg, #e0f2fe); }
 .ci-badge-under_review { color: var(--ts-status-info-fg, #0c4a6e); background: var(--ts-status-info-bg, #e0f2fe); }
-.ci-pending_owner { background: #f3e8ff; }
-.ci-badge-pending_owner { color: #6b21a8; background: #f3e8ff; }
+.ci-pending_owner { background: var(--ts-status-info-bg, #e0f2fe); }
+.ci-badge-pending_owner { color: var(--ts-status-info-fg, #0c4a6e); background: var(--ts-status-info-bg, #e0f2fe); }
 .ci-empty { padding: 40px 24px; color: var(--ts-text-muted, #64748b); max-width: 640px; }
 .ci-empty code { background: var(--ts-bg-subtle, #f1f5f9); padding: 1px 4px; border-radius: 3px; }
 .ci-new { box-shadow: inset 0 0 0 2px #6366f1; }

--- a/extension/src/compliance-matrix-preview.ts
+++ b/extension/src/compliance-matrix-preview.ts
@@ -323,16 +323,16 @@ const MATRIX_CSS = `
 .cm-col-jur { margin-top: 4px; display: flex; flex-wrap: wrap; gap: 3px; }
 .cm-jur-chip { display: inline-block; padding: 1px 5px; border-radius: 3px; font-size: 10px; color: var(--ts-text-muted, #64748b); background: var(--ts-bg-elevated, #e2e8f0); text-transform: uppercase; letter-spacing: 0.04em; }
 .cm-sev-high { color: #b91c1c; }
-.cm-sev-medium { color: #b45309; }
+.cm-sev-medium { color: var(--ts-status-warning-fg, #854d0e); }
 .cm-sev-low { color: #2563eb; }
 .cm-row { padding: 6px 12px; text-align: left; font-weight: 600; color: var(--ts-text, #0f172a); background: var(--ts-bg-subtle, #f1f5f9); white-space: nowrap; position: sticky; left: 0; }
-.cm-unresolved { color: #b45309; }
+.cm-unresolved { color: var(--ts-status-warning-fg, #854d0e); }
 .cm-cell { width: var(--ts-col-w, 120px); height: 38px; text-align: center; vertical-align: middle; }
 .cm-badge { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 11px; font-weight: 600; }
 .cm-cell-link { text-decoration: none; }
 .cm-gap { background-color: var(--ts-bg, #fff); background-image: repeating-linear-gradient(135deg, rgba(100,116,139,0.18) 0, rgba(100,116,139,0.18) 2px, transparent 0, transparent 50%); background-size: 8px 8px; }
-.cm-pending { background: #fef9c3; border: 1px dashed #b45309 !important; }
-.cm-badge-pending { display: inline-block; padding: 2px 6px; border-radius: 8px; font-size: 10px; font-weight: 600; color: #b45309; background: #fef9c3; }
+.cm-pending { background: var(--ts-status-warning-bg, #fef9c3); border: 1px dashed var(--ts-status-warning-fg, #854d0e) !important; }
+.cm-badge-pending { display: inline-block; padding: 2px 6px; border-radius: 8px; font-size: 10px; font-weight: 600; color: var(--ts-status-warning-fg, #854d0e); background: var(--ts-status-warning-bg, #fef9c3); }
 .cm-compliant { background: var(--ts-status-success-bg, #d1fae5); }
 .cm-compliant .cm-badge { color: var(--ts-status-success-fg, #065f46); }
 .cm-partial { background: var(--ts-status-warning-bg, #fef9c3); }
@@ -343,8 +343,8 @@ const MATRIX_CSS = `
 .cm-under_review .cm-badge { color: var(--ts-status-info-fg, #0c4a6e); }
 .cm-n_a { background-color: var(--ts-bg, #fff); background-image: repeating-linear-gradient(135deg, var(--ts-border, #cbd5e1) 0, var(--ts-border, #cbd5e1) 1.5px, transparent 0, transparent 50%); background-size: 8px 8px; }
 .cm-n_a .cm-badge { color: var(--ts-text-muted, #64748b); }
-.cm-pending_owner { background: #f3e8ff; }
-.cm-pending_owner .cm-badge { color: #6b21a8; }
+.cm-pending_owner { background: var(--ts-status-info-bg, #e0f2fe); }
+.cm-pending_owner .cm-badge { color: var(--ts-status-info-fg, #0c4a6e); }
 .cm-empty { padding: 40px 24px; color: var(--ts-text-muted, #64748b); max-width: 640px; }
 .cm-empty code { background: var(--ts-bg-subtle, #f1f5f9); padding: 1px 4px; border-radius: 3px; }
 `;

--- a/extension/src/compliance-render.ts
+++ b/extension/src/compliance-render.ts
@@ -63,7 +63,7 @@ const COMPLIANCE_CSS = `
 .cmp-non_compliant { background: var(--ts-status-error-bg, #fee2e2); color: var(--ts-status-error-fg, #991b1b); }
 .cmp-under_review { background: var(--ts-status-info-bg, #e0f2fe); color: var(--ts-status-info-fg, #0c4a6e); }
 .cmp-n_a { background: var(--ts-bg-subtle, #f1f5f9); color: var(--ts-text-muted, #64748b); }
-.cmp-pending_owner { background: #f3e8ff; color: #6b21a8; }
+.cmp-pending_owner { background: var(--ts-status-info-bg, #e0f2fe); color: var(--ts-status-info-fg, #0c4a6e); }
 
 /* Tree (single-law) */
 .cmp-req { margin: 0 0 14px; border: 1px solid var(--ts-border, #cbd5e1); border-radius: 6px; overflow: hidden; }
@@ -71,7 +71,7 @@ const COMPLIANCE_CSS = `
 .cmp-req-name { font-weight: 600; color: var(--ts-text, #0f172a); }
 .cmp-req-id { font-size: 11px; color: var(--ts-text-muted, #64748b); font-family: var(--vscode-editor-font-family, monospace); }
 .cmp-sev { font-size: 10px; text-transform: uppercase; letter-spacing: 0.04em; }
-.cmp-sev-high { color: #b91c1c; } .cmp-sev-medium { color: #b45309; } .cmp-sev-low { color: #2563eb; }
+.cmp-sev-high { color: #b91c1c; } .cmp-sev-medium { color: var(--ts-status-warning-fg, #854d0e); } .cmp-sev-low { color: #2563eb; }
 .cmp-assertions { list-style: none; margin: 0; padding: 0; }
 .cmp-assertions li { display: flex; align-items: center; gap: 8px; padding: 6px 12px 6px 24px; border-top: 1px solid var(--ts-border, #e2e8f0); font-size: 12px; }
 .cmp-assertions li .cmp-meta { color: var(--ts-text-muted, #64748b); font-size: 11px; }

--- a/extension/src/coverage-metric-preview.ts
+++ b/extension/src/coverage-metric-preview.ts
@@ -29,7 +29,7 @@ function pct(n: number): string {
 
 const RAG_LABELS: Record<RagStatus, string> = {
   green: 'Green',
-  amber: 'Amber',
+  amber: 'Warning',
   red: 'Red',
   no_data: 'No data',
 };
@@ -67,7 +67,7 @@ function buildTableHtml(matrix: CoverageMatrix): string {
   }
 
   const rows = matrix.rows.map(buildRowHtml).join('');
-  const threshLine = `Green ≥ ${pct(matrix.thresholds.green)} · Amber ≥ ${pct(matrix.thresholds.amber)}`;
+  const threshLine = `Green ≥ ${pct(matrix.thresholds.green)} · Warning ≥ ${pct(matrix.thresholds.amber)}`;
 
   return (
     '<div class="cm-wrap">' +
@@ -82,7 +82,7 @@ function buildTableHtml(matrix: CoverageMatrix): string {
     '<th class="cm-under_review" title="Requirements under review">Under review</th>' +
     '<th class="cm-gap" title="Requirements with no assertion for scoped products">Gap</th>' +
     '<th>Coverage</th>' +
-    '<th title="Coverage status against configured thresholds (green / amber / red)">Coverage Status</th>' +
+    '<th title="Coverage status against configured thresholds (green / warning / red)">Coverage Status</th>' +
     '</tr></thead>' +
     '<tbody>' +
     rows +

--- a/extension/src/requirement-trace-preview.ts
+++ b/extension/src/requirement-trace-preview.ts
@@ -257,7 +257,7 @@ const RT_CSS = `
 .rt-note { color: var(--ts-text-muted, #64748b); font-size: 12px; margin: 0; }
 .rt-note code { font-family: var(--vscode-editor-font-family, monospace); }
 .rt-jur { display: inline-block; padding: 0 6px; margin-left: 4px; border-radius: 3px; font-size: 10px; background: var(--ts-bg-subtle, #f1f5f9); color: var(--ts-text-muted, #64748b); text-transform: uppercase; letter-spacing: 0.04em; }
-.rt-dangling { color: #b45309; font-size: 11px; font-style: normal; }
+.rt-dangling { color: var(--ts-status-warning-fg, #854d0e); font-size: 11px; font-style: normal; }
 .rt-origin { display: inline-block; padding: 0 6px; margin-left: 6px; border-radius: 3px; font-size: 10px; background: var(--ts-bg-subtle, #f1f5f9); color: var(--ts-text-muted, #64748b); text-transform: uppercase; letter-spacing: 0.04em; }
 .rt-assertions { list-style: none; margin: 0; padding: 0; }
 .rt-assertion { border: 1px solid var(--ts-border, #cbd5e1); border-radius: 6px; padding: 8px 12px; margin: 0 0 8px; }


### PR DESCRIPTION
## Summary
- Replace hardcoded purple (`#f3e8ff`/`#6b21a8`) `pending_owner` colors with `--ts-status-info-*` — matches the existing precedent in `process-blueprint-preview.ts`'s `.tx-chip-status-pending-owner`, which already pairs `pending-owner` with `under-review` under the info role.
- Replace hardcoded `#b45309`-class severity-medium / pending / dangling / unresolved colors with `--ts-status-warning-*` across `compliance-render.ts`, `compliance-impact-preview.ts`, `compliance-matrix-preview.ts`, and `requirement-trace-preview.ts`'s `.rt-dangling`.
- Rename the coverage-metric RAG middle-band label and threshold/tooltip copy to Warning in `coverage-metric-preview.ts` — colors were already mapped to the warning token, only the copy lagged (per `brand/ui-conventions.md` §3: functional-palette role names, not brand hues, in UI copy).
- Severity-high/low (`#b91c1c`/`#2563eb`) and the `cm-bar-amber`/`cm-rag-amber` internal CSS class names (tied to the shared `RagStatus` type) are left untouched — out of scope per the task's acceptance criteria (purple / `#b45309`-class only).

No new tokens invented; `pending_owner`'s mapping to `info` follows an existing in-repo precedent rather than requiring a strategy proposal.

## Test plan
- [x] `npm run compile:extension` — clean
- [x] `npm run test:core` — same 3 pre-existing failures as on `main` (unrelated `cli-migrate.test.ts` tests that require a methodology repo checkout), no new failures
- [x] Confirmed no remaining `#b45309` / `#f3e8ff` / `#6b21a8` hardcodes in `extension/src`