### PR TITLE
fix(compliance): migrate Impact preview onto the shared diagram-frame chrome

### DIFF
--- a/extension/src/compliance-impact-preview.ts
+++ b/extension/src/compliance-impact-preview.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { escXml } from '@transitrix/diagrams/webview/render-util.js';
 import yaml from 'js-yaml';
-import { generateWebviewCss, type ThemeId } from '@transitrix/diagrams/theme';
+import { type ThemeId } from '@transitrix/diagrams/theme';
 import {
   buildImpactMatrix,
   type ImpactColumn,
@@ -14,7 +14,7 @@ import type { IndexRequirement, DeadlineStatus } from '@transitrix/diagrams/comp
 import { genNonce, colWidthPxFromSetting, colWidthRootCss } from './preview-controls.js';
 import { scanComplianceCanon, openComplianceFile } from './compliance-scan.js';
 import type { ScannedCanon } from './compliance-scan.js';
-import { WARN_BLOCK_CSS, buildWarnHtml, ERROR_BLOCK_CSS, buildErrorHtml } from './diagram-frame.js';
+import { buildDiagramFrame, OPEN_THEME_COMMAND } from './diagram-frame.js';
 
 // Compliance-impact matrix preview -- CV-2 (vkgeorgia/strategy#84).
 //
@@ -310,7 +310,8 @@ export class ComplianceImpactPreview {
 
   async refresh(): Promise<void> {
     if (!this.panel) return;
-    this.panel.webview.html = this.buildLoadingHtml();
+    const loadingThemeId = vscode.workspace.getConfiguration('transitrix').get<ThemeId>('theme', 'transitrix');
+    this.panel.webview.html = this.buildLoadingHtml(loadingThemeId);
 
     try {
       const canon = await scanComplianceCanon();
@@ -377,49 +378,48 @@ export class ComplianceImpactPreview {
     this.panel.webview.html = this.buildHtml(themeId);
   }
 
-  private buildLoadingHtml(): string {
-    return `<!DOCTYPE html><html lang="en"><body style="padding:24px;font-family:sans-serif;color:#64748b">Scanning canon&#8230;</body></html>`;
+  private buildLoadingHtml(themeId: ThemeId): string {
+    return buildDiagramFrame({
+      notation: 'Compliance Impact',
+      filename: '',
+      themeId,
+      bodyContent: '<div class="ci-empty"><p>Scanning canon&#8230;</p></div>',
+      themeCommand: OPEN_THEME_COMMAND,
+      refreshCommand: REFRESH_COMMAND,
+      extraStyles: IMPACT_CSS,
+    });
   }
 
   private buildHtml(themeId: ThemeId): string {
     const nonce = genNonce();
-    const { input: errInput, block: errBlock } = buildErrorHtml(this.errorMsg);
-
-    if (!this.matrix || !this.config) {
-      return (
-        '<!DOCTYPE html>\n<html lang="en">\n<head>\n' +
-        '<meta charset="UTF-8"/>\n' +
-        '<meta http-equiv="Content-Security-Policy" content="default-src \'none\'; style-src \'unsafe-inline\';">\n' +
-        '<style>\n' + generateWebviewCss(themeId) + '\n' + IMPACT_CSS + '\n' + ERROR_BLOCK_CSS + '\n</style>\n' +
-        '</head>\n<body data-theme="' + escXml(themeId) + '">\n' +
-        errInput + '\n' +
-        '<div id="toolbar">' +
-        '<span class="toolbar-label">' + escXml(this.config?.name ?? 'Compliance Impact Matrix') + '</span>' +
-        '<div class="toolbar-actions">' +
-        '<a href="command:transitrixStudio.changeTheme" class="toolbar-btn" title="Change the color scheme for all diagram previews">Theme…</a>' +
-        '<a href="command:' + REFRESH_COMMAND + '" class="toolbar-btn" title="Re-scan the workspace and reload view config">Refresh</a>' +
-        '</div>' +
-        '</div>\n' +
-        errBlock + '\n' +
-        '</body>\n</html>'
-      );
-    }
-
     const matrix = this.matrix;
     const config = this.config;
 
-    const { rows, columns, cells } = applyFilter(matrix, this.filter, this.jIndex);
-    const allJurisdictions = collectAllJurisdictions(matrix.rows, this.jIndex);
-
-    const totalGaps = matrix.cells.flat().filter(c => c.kind === 'gap').length;
-    const totalPending = [...this.pendingIndex.values()].reduce((a, b) => a + b, 0);
-    const pendingSummary = totalPending > 0 ? ' &middot; <strong>' + totalPending + '</strong> pending (admission)' : '';
     const skippedList = this.canon?.skippedNotations ?? [];
     const skippedWarnings = skippedList.map(s => 'Skipped — unrecognized notation "' + s.notation + '": ' + s.shortPath);
-    const { input: warnInput, block: warnBlock } = buildWarnHtml(skippedWarnings);
 
-    const empty = rows.length === 0 || columns.length === 0;
-    const bodyHtml = empty ? this.emptyHtml(matrix) : this.gridHtml(rows, columns, cells, matrix.emptyLabels, matrix.obligationsLane, this.filter.showObligationsLane);
+    const allJurisdictions = matrix ? collectAllJurisdictions(matrix.rows, this.jIndex) : [];
+
+    let bodyHtml: string;
+    let summaryTitle: string | undefined;
+    let configLine: string | undefined;
+
+    if (!matrix || !config) {
+      bodyHtml = '<div class="ci-empty"><p>Scan failed — see error above.</p></div>';
+    } else {
+      const { rows, columns, cells } = applyFilter(matrix, this.filter, this.jIndex);
+      const totalGaps = matrix.cells.flat().filter(c => c.kind === 'gap').length;
+      const totalPending = [...this.pendingIndex.values()].reduce((a, b) => a + b, 0);
+      const pendingSummary = totalPending > 0 ? ` · ${totalPending} pending (admission)` : '';
+      const empty = rows.length === 0 || columns.length === 0;
+      bodyHtml = empty
+        ? this.emptyHtml(matrix)
+        : this.gridHtml(rows, columns, cells, matrix.emptyLabels, matrix.obligationsLane, this.filter.showObligationsLane);
+      summaryTitle = `${rows.length} obligations × ${columns.length} subjects · ${totalGaps} gaps${pendingSummary}`;
+      configLine = config.id === 'auto'
+        ? 'Auto-config (add *.compliance-impact.{view,transitrix}.yaml to pin)'
+        : `View: ${config.id}`;
+    }
 
     const statusBoxes = ALL_STATUSES.map(
       s =>
@@ -470,115 +470,64 @@ export class ComplianceImpactPreview {
         .join('') +
       '</select>';
 
-    const configLine =
-      config.id === 'auto'
-        ? 'Auto-config (add *.compliance-impact.{view,transitrix}.yaml to pin)'
-        : 'View: <code>' + escXml(config.id) + '</code>';
+    const filtersPanel = `<div id="ci-filters">
+    <span class="ci-filter-label">Status</span>${statusBoxes}
+    <span class="ci-filter-label">Severity</span>${severityBoxes}
+    ${jurisdictionRow}
+    <span class="ci-filter-label">Lanes</span>${laneToggle}
+    ${colWidthSelect}
+  </div>`;
+
+    const filterScript = `<script nonce="${nonce}">
+(function () {
+  var vscode = acquireVsCodeApi();
+  function collect(attr) {
+    var out = [];
+    document.querySelectorAll('[data-ci-' + attr + ']').forEach(function (el) {
+      if (el.checked) out.push(el.getAttribute('data-ci-' + attr));
+    });
+    return out;
+  }
+  document.querySelectorAll('[data-ci-status],[data-ci-severity],[data-ci-jurisdiction]').forEach(function (el) {
+    el.addEventListener('change', function () {
+      vscode.postMessage({
+        type: 'transitrix:impact-filter',
+        statuses: collect('status'),
+        severities: collect('severity'),
+        jurisdictions: collect('jurisdiction'),
+        showObligationsLane: !!(document.querySelector('[data-ci-lane-obligations]') || {}).checked,
+      });
+    });
+  });
+  var colWidthSel = document.querySelector('[data-ci-col-width]');
+  if (colWidthSel) {
+    colWidthSel.addEventListener('change', function () {
+      vscode.postMessage({ type: 'transitrix:col-width', columnWidth: colWidthSel.value });
+    });
+  }
+}());
+</script>`;
 
     const colWCss = colWidthRootCss(colWidthPxFromSetting(this.colWidth));
 
-    return (
-      '<!DOCTYPE html>\n' +
-      '<html lang="en">\n' +
-      '<head>\n' +
-      '  <meta charset="UTF-8"/>\n' +
-      '  <meta http-equiv="Content-Security-Policy" content="default-src \'none\'; style-src \'unsafe-inline\'; script-src \'nonce-' +
-      nonce +
-      '\';">\n' +
-      '  <style>\n' +
-      colWCss +
-      '\n' +
-      generateWebviewCss(themeId) +
-      '\n' +
-      IMPACT_CSS +
-      '\n' +
-      ERROR_BLOCK_CSS +
-      '\n' +
-      WARN_BLOCK_CSS +
-      '\n' +
-      '  </style>\n' +
-      '</head>\n' +
-      '<body data-theme="' +
-      escXml(themeId) +
-      '">\n' +
-      errInput +
-      warnInput +
-      '  <div id="toolbar">\n' +
-      '    <span class="toolbar-label">' + escXml(config.name) + '</span>\n' +
-      '    <div class="toolbar-actions">\n' +
-      '      <a href="command:transitrixStudio.changeTheme" class="toolbar-btn" title="Change the color scheme for all diagram previews">Theme…</a>\n' +
-      '      <a href="command:' +
-      REFRESH_COMMAND +
-      '" class="toolbar-btn" title="Re-scan the workspace and reload view config">Refresh</a>\n' +
-      '    </div>\n' +
-      '  </div>\n' +
-      errBlock +
-      warnBlock +
-      '  <div id="ci-filters">\n' +
-      '    <span class="ci-summary">' +
-      rows.length +
-      ' obligations &times; ' +
-      columns.length +
-      ' subjects &middot; <strong>' +
-      totalGaps +
-      '</strong> gaps' +
-      pendingSummary +
-      '</span>' +
-      '    <span class="ci-config">' +
-      configLine +
-      '</span>' +
-      '    <span class="ci-filter-sep"></span>' +
-      '    <span class="ci-filter-label">Status</span>' +
-      statusBoxes +
-      '\n' +
-      '    <span class="ci-filter-label">Severity</span>' +
-      severityBoxes +
-      '\n' +
-      '    ' +
-      jurisdictionRow +
-      '\n    <span class="ci-filter-label">Lanes</span>' +
-      laneToggle +
-      '\n    ' +
-      colWidthSelect +
-      '\n' +
-      '  </div>\n' +
-      '\n' +
-      bodyHtml +
-      '\n' +
-      '  <script nonce="' +
-      nonce +
-      '">\n' +
-      '(function () {\n' +
-      "  var vscode = acquireVsCodeApi();\n" +
-      "  function collect(attr) {\n" +
-      "    var out = [];\n" +
-      "    document.querySelectorAll('[data-ci-' + attr + ']').forEach(function (el) {\n" +
-      "      if (el.checked) out.push(el.getAttribute('data-ci-' + attr));\n" +
-      "    });\n" +
-      "    return out;\n" +
-      "  }\n" +
-      "  document.querySelectorAll('[data-ci-status],[data-ci-severity],[data-ci-jurisdiction]').forEach(function (el) {\n" +
-      "    el.addEventListener('change', function () {\n" +
-      "      vscode.postMessage({\n" +
-      "        type: 'transitrix:impact-filter',\n" +
-      "        statuses: collect('status'),\n" +
-      "        severities: collect('severity'),\n" +
-      "        jurisdictions: collect('jurisdiction'),\n" +
-      "        showObligationsLane: !!(document.querySelector('[data-ci-lane-obligations]') || {}).checked,\n" +
-      "      });\n" +
-      "    });\n" +
-      "  });\n" +
-      "  var colWidthSel = document.querySelector('[data-ci-col-width]');\n" +
-      "  if (colWidthSel) {\n" +
-      "    colWidthSel.addEventListener('change', function () {\n" +
-      "      vscode.postMessage({ type: 'transitrix:col-width', columnWidth: colWidthSel.value });\n" +
-      "    });\n" +
-      "  }\n" +
-      '}());\n' +
-      '  </script>\n' +
-      '</body>\n' +
-      '</html>'
-    );
+    return buildDiagramFrame({
+      notation: config?.name ?? 'Compliance Impact',
+      filename: '',
+      title: summaryTitle,
+      subtitle: configLine,
+      themeId,
+      errorMsg: this.errorMsg,
+      warnings: skippedWarnings,
+      bodyContent: bodyHtml,
+      themeCommand: OPEN_THEME_COMMAND,
+      refreshCommand: REFRESH_COMMAND,
+      extraStyles: `${colWCss}\n${IMPACT_CSS}`,
+      interactive: {
+        nonce,
+        controlsPanel: filtersPanel,
+        controlsScript: filterScript,
+      },
+    });
   }
 
   private emptyHtml(matrix: ImpactMatrix): string {
@@ -758,23 +707,13 @@ export class ComplianceImpactPreview {
 }
 
 const IMPACT_CSS = `
-body { padding: 0; display: flex; flex-direction: column; height: 100vh; overflow: hidden; }
-#toolbar { flex-shrink: 0; display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 8px 16px; border-bottom: 1px solid var(--ts-border, #cbd5e1); flex-wrap: wrap; }
-.toolbar-label { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 13px; font-weight: 700; color: var(--ts-header-text, #0f172a); }
-.toolbar-actions { display: flex; gap: 4px; align-items: center; flex-wrap: wrap; justify-content: flex-end; }
-.toolbar-btn { cursor: pointer; user-select: none; font-size: 11px; padding: 1px 8px; border-radius: 4px; color: var(--ts-text-muted, #64748b); white-space: nowrap; text-decoration: none; }
-.toolbar-btn:hover { color: var(--ts-text, #0f172a); background: var(--ts-bg-elevated, #f1f5f9); }
-.ci-summary { font-size: 11px; color: var(--ts-text-muted, #64748b); }
-.ci-summary strong { color: var(--ts-text, #0f172a); }
-.ci-config { font-size: 11px; color: var(--ts-text-muted, #64748b); padding-left: 4px; border-left: 1px solid var(--ts-border, #cbd5e1); margin-left: 4px; }
-.ci-config code { background: var(--ts-bg-subtle, #f1f5f9); padding: 1px 4px; border-radius: 3px; }
-.ci-filter-sep { flex-basis: 100%; height: 0; }
-#ci-filters { flex-shrink: 0; display: flex; align-items: center; gap: 8px; flex-wrap: wrap; padding: 8px 16px; border-bottom: 1px solid var(--ts-border, #cbd5e1); font-size: 11px; }
+#canvas { padding: 0; }
+#ci-filters { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; padding: 8px 16px; border-bottom: 1px solid var(--ts-border, #cbd5e1); font-size: 11px; }
 .ci-filter-label { font-weight: 600; color: var(--ts-text, #0f172a); margin-left: 8px; }
 .ci-filter-label:first-child { margin-left: 0; }
 .ci-chip { display: inline-flex; align-items: center; gap: 4px; color: var(--ts-text-muted, #64748b); cursor: pointer; }
 .ci-col-width-select { font-size: 11px; font-family: var(--vscode-font-family, sans-serif); color: var(--vscode-input-foreground, #333); background: var(--vscode-input-background, #fff); border: 1px solid var(--vscode-input-border, var(--ts-border, #cbd5e1)); border-radius: 3px; padding: 1px 4px; }
-#ci-grid-wrap { flex: 1 1 0; overflow: auto; padding: 12px 16px 24px; min-height: 0; }
+#ci-grid-wrap { overflow: auto; padding: 12px 16px 24px; }
 .ci-type-chip { display: inline-block; padding: 1px 5px; border-radius: 3px; font-size: 9px; font-weight: 700; letter-spacing: 0.05em; text-transform: uppercase; margin-bottom: 3px; }
 .ci-type-product { color: #1e40af; background: #dbeafe; }
 .ci-type-process { color: #065f46; background: #d1fae5; }

--- a/extension/src/compliance-impact-preview.ts
+++ b/extension/src/compliance-impact-preview.ts
@@ -788,14 +788,14 @@ body { padding: 0; display: flex; flex-direction: column; height: 100vh; overflo
 .ci-row-id { font-size: 11px; font-family: var(--vscode-editor-font-family, monospace); color: var(--ts-text-muted, #64748b); }
 .ci-row-name { font-weight: 600; color: var(--ts-text, #0f172a); font-size: 12px; white-space: normal; }
 .ci-sev { font-size: 10px; text-transform: uppercase; letter-spacing: 0.04em; margin-top: 2px; }
-.ci-sev-high { color: #b91c1c; } .ci-sev-medium { color: #b45309; } .ci-sev-low { color: #2563eb; }
+.ci-sev-high { color: #b91c1c; } .ci-sev-medium { color: var(--ts-status-warning-fg, #854d0e); } .ci-sev-low { color: #2563eb; }
 .ci-jur { display: inline-block; padding: 1px 5px; border-radius: 3px; font-size: 10px; color: var(--ts-text-muted, #64748b); background: var(--ts-bg-elevated, #e2e8f0); text-transform: uppercase; letter-spacing: 0.04em; margin-top: 2px; margin-right: 2px; }
 .ci-cell { width: var(--ts-col-w, 120px); height: 40px; text-align: center; vertical-align: middle; }
 .ci-badge { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 11px; font-weight: 600; }
 .ci-link { text-decoration: none; }
 .ci-gap { background: repeating-linear-gradient(-45deg, transparent, transparent 5px, var(--ts-bg-subtle, #f1f5f9) 5px, var(--ts-bg-subtle, #f1f5f9) 10px); }
-.ci-pending { background: #fef9c3; border: 1px dashed #b45309 !important; }
-.ci-badge-pending { display: inline-block; padding: 2px 6px; border-radius: 8px; font-size: 10px; font-weight: 600; color: #b45309; background: #fef9c3; }
+.ci-pending { background: var(--ts-status-warning-bg, #fef9c3); border: 1px dashed var(--ts-status-warning-fg, #854d0e) !important; }
+.ci-badge-pending { display: inline-block; padding: 2px 6px; border-radius: 8px; font-size: 10px; font-weight: 600; color: var(--ts-status-warning-fg, #854d0e); background: var(--ts-status-warning-bg, #fef9c3); }
 .ci-filtered { background: var(--ts-bg-subtle, #f8fafc); opacity: 0.35; }
 .ci-na { background: var(--ts-bg-subtle, #f1f5f9); }
 .ci-badge-na { color: var(--ts-text-muted, #64748b); background: var(--ts-bg-subtle, #f1f5f9); }
@@ -807,8 +807,8 @@ body { padding: 0; display: flex; flex-direction: column; height: 100vh; overflo
 .ci-badge-non_compliant { color: var(--ts-status-error-fg, #991b1b); background: var(--ts-status-error-bg, #fee2e2); }
 .ci-under_review { background: var(--ts-status-info-bg, #e0f2fe); }
 .ci-badge-under_review { color: var(--ts-status-info-fg, #0c4a6e); background: var(--ts-status-info-bg, #e0f2fe); }
-.ci-pending_owner { background: #f3e8ff; }
-.ci-badge-pending_owner { color: #6b21a8; background: #f3e8ff; }
+.ci-pending_owner { background: var(--ts-status-info-bg, #e0f2fe); }
+.ci-badge-pending_owner { color: var(--ts-status-info-fg, #0c4a6e); background: var(--ts-status-info-bg, #e0f2fe); }
 .ci-empty { padding: 40px 24px; color: var(--ts-text-muted, #64748b); max-width: 640px; }
 .ci-empty code { background: var(--ts-bg-subtle, #f1f5f9); padding: 1px 4px; border-radius: 3px; }
 .ci-new { box-shadow: inset 0 0 0 2px #6366f1; }

--- a/extension/src/compliance-matrix-preview.ts
+++ b/extension/src/compliance-matrix-preview.ts
@@ -323,16 +323,16 @@ const MATRIX_CSS = `
 .cm-col-jur { margin-top: 4px; display: flex; flex-wrap: wrap; gap: 3px; }
 .cm-jur-chip { display: inline-block; padding: 1px 5px; border-radius: 3px; font-size: 10px; color: var(--ts-text-muted, #64748b); background: var(--ts-bg-elevated, #e2e8f0); text-transform: uppercase; letter-spacing: 0.04em; }
 .cm-sev-high { color: #b91c1c; }
-.cm-sev-medium { color: #b45309; }
+.cm-sev-medium { color: var(--ts-status-warning-fg, #854d0e); }
 .cm-sev-low { color: #2563eb; }
 .cm-row { padding: 6px 12px; text-align: left; font-weight: 600; color: var(--ts-text, #0f172a); background: var(--ts-bg-subtle, #f1f5f9); white-space: nowrap; position: sticky; left: 0; }
-.cm-unresolved { color: #b45309; }
+.cm-unresolved { color: var(--ts-status-warning-fg, #854d0e); }
 .cm-cell { width: var(--ts-col-w, 120px); height: 38px; text-align: center; vertical-align: middle; }
 .cm-badge { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 11px; font-weight: 600; }
 .cm-cell-link { text-decoration: none; }
 .cm-gap { background-color: var(--ts-bg, #fff); background-image: repeating-linear-gradient(135deg, rgba(100,116,139,0.18) 0, rgba(100,116,139,0.18) 2px, transparent 0, transparent 50%); background-size: 8px 8px; }
-.cm-pending { background: #fef9c3; border: 1px dashed #b45309 !important; }
-.cm-badge-pending { display: inline-block; padding: 2px 6px; border-radius: 8px; font-size: 10px; font-weight: 600; color: #b45309; background: #fef9c3; }
+.cm-pending { background: var(--ts-status-warning-bg, #fef9c3); border: 1px dashed var(--ts-status-warning-fg, #854d0e) !important; }
+.cm-badge-pending { display: inline-block; padding: 2px 6px; border-radius: 8px; font-size: 10px; font-weight: 600; color: var(--ts-status-warning-fg, #854d0e); background: var(--ts-status-warning-bg, #fef9c3); }
 .cm-compliant { background: var(--ts-status-success-bg, #d1fae5); }
 .cm-compliant .cm-badge { color: var(--ts-status-success-fg, #065f46); }
 .cm-partial { background: var(--ts-status-warning-bg, #fef9c3); }
@@ -343,8 +343,8 @@ const MATRIX_CSS = `
 .cm-under_review .cm-badge { color: var(--ts-status-info-fg, #0c4a6e); }
 .cm-n_a { background-color: var(--ts-bg, #fff); background-image: repeating-linear-gradient(135deg, var(--ts-border, #cbd5e1) 0, var(--ts-border, #cbd5e1) 1.5px, transparent 0, transparent 50%); background-size: 8px 8px; }
 .cm-n_a .cm-badge { color: var(--ts-text-muted, #64748b); }
-.cm-pending_owner { background: #f3e8ff; }
-.cm-pending_owner .cm-badge { color: #6b21a8; }
+.cm-pending_owner { background: var(--ts-status-info-bg, #e0f2fe); }
+.cm-pending_owner .cm-badge { color: var(--ts-status-info-fg, #0c4a6e); }
 .cm-empty { padding: 40px 24px; color: var(--ts-text-muted, #64748b); max-width: 640px; }
 .cm-empty code { background: var(--ts-bg-subtle, #f1f5f9); padding: 1px 4px; border-radius: 3px; }
 `;

--- a/extension/src/compliance-render.ts
+++ b/extension/src/compliance-render.ts
@@ -63,7 +63,7 @@ const COMPLIANCE_CSS = `
 .cmp-non_compliant { background: var(--ts-status-error-bg, #fee2e2); color: var(--ts-status-error-fg, #991b1b); }
 .cmp-under_review { background: var(--ts-status-info-bg, #e0f2fe); color: var(--ts-status-info-fg, #0c4a6e); }
 .cmp-n_a { background: var(--ts-bg-subtle, #f1f5f9); color: var(--ts-text-muted, #64748b); }
-.cmp-pending_owner { background: #f3e8ff; color: #6b21a8; }
+.cmp-pending_owner { background: var(--ts-status-info-bg, #e0f2fe); color: var(--ts-status-info-fg, #0c4a6e); }
 
 /* Tree (single-law) */
 .cmp-req { margin: 0 0 14px; border: 1px solid var(--ts-border, #cbd5e1); border-radius: 6px; overflow: hidden; }
@@ -71,7 +71,7 @@ const COMPLIANCE_CSS = `
 .cmp-req-name { font-weight: 600; color: var(--ts-text, #0f172a); }
 .cmp-req-id { font-size: 11px; color: var(--ts-text-muted, #64748b); font-family: var(--vscode-editor-font-family, monospace); }
 .cmp-sev { font-size: 10px; text-transform: uppercase; letter-spacing: 0.04em; }
-.cmp-sev-high { color: #b91c1c; } .cmp-sev-medium { color: #b45309; } .cmp-sev-low { color: #2563eb; }
+.cmp-sev-high { color: #b91c1c; } .cmp-sev-medium { color: var(--ts-status-warning-fg, #854d0e); } .cmp-sev-low { color: #2563eb; }
 .cmp-assertions { list-style: none; margin: 0; padding: 0; }
 .cmp-assertions li { display: flex; align-items: center; gap: 8px; padding: 6px 12px 6px 24px; border-top: 1px solid var(--ts-border, #e2e8f0); font-size: 12px; }
 .cmp-assertions li .cmp-meta { color: var(--ts-text-muted, #64748b); font-size: 11px; }

--- a/extension/src/coverage-metric-preview.ts
+++ b/extension/src/coverage-metric-preview.ts
@@ -29,7 +29,7 @@ function pct(n: number): string {
 
 const RAG_LABELS: Record<RagStatus, string> = {
   green: 'Green',
-  amber: 'Amber',
+  amber: 'Warning',
   red: 'Red',
   no_data: 'No data',
 };
@@ -67,7 +67,7 @@ function buildTableHtml(matrix: CoverageMatrix): string {
   }
 
   const rows = matrix.rows.map(buildRowHtml).join('');
-  const threshLine = `Green ≥ ${pct(matrix.thresholds.green)} · Amber ≥ ${pct(matrix.thresholds.amber)}`;
+  const threshLine = `Green ≥ ${pct(matrix.thresholds.green)} · Warning ≥ ${pct(matrix.thresholds.amber)}`;
 
   return (
     '<div class="cm-wrap">' +
@@ -82,7 +82,7 @@ function buildTableHtml(matrix: CoverageMatrix): string {
     '<th class="cm-under_review" title="Requirements under review">Under review</th>' +
     '<th class="cm-gap" title="Requirements with no assertion for scoped products">Gap</th>' +
     '<th>Coverage</th>' +
-    '<th title="Coverage status against configured thresholds (green / amber / red)">Coverage Status</th>' +
+    '<th title="Coverage status against configured thresholds (green / warning / red)">Coverage Status</th>' +
     '</tr></thead>' +
     '<tbody>' +
     rows +

--- a/extension/src/requirement-trace-preview.ts
+++ b/extension/src/requirement-trace-preview.ts
@@ -257,7 +257,7 @@ const RT_CSS = `
 .rt-note { color: var(--ts-text-muted, #64748b); font-size: 12px; margin: 0; }
 .rt-note code { font-family: var(--vscode-editor-font-family, monospace); }
 .rt-jur { display: inline-block; padding: 0 6px; margin-left: 4px; border-radius: 3px; font-size: 10px; background: var(--ts-bg-subtle, #f1f5f9); color: var(--ts-text-muted, #64748b); text-transform: uppercase; letter-spacing: 0.04em; }
-.rt-dangling { color: #b45309; font-size: 11px; font-style: normal; }
+.rt-dangling { color: var(--ts-status-warning-fg, #854d0e); font-size: 11px; font-style: normal; }
 .rt-origin { display: inline-block; padding: 0 6px; margin-left: 6px; border-radius: 3px; font-size: 10px; background: var(--ts-bg-subtle, #f1f5f9); color: var(--ts-text-muted, #64748b); text-transform: uppercase; letter-spacing: 0.04em; }
 .rt-assertions { list-style: none; margin: 0; padding: 0; }
 .rt-assertion { border: 1px solid var(--ts-border, #cbd5e1); border-radius: 6px; padding: 8px 12px; margin: 0 0 8px; }


### PR DESCRIPTION
﻿## Summary
- Migrates `compliance-impact-preview.ts`'s success/error/empty/loading renders onto `buildDiagramFrame` (`extension/src/diagram-frame.ts`), following the exact pattern already shipped for its closest sibling, `compliance-matrix-preview.ts` — same `interactive: { nonce, controlsPanel, controlsScript }` slot mechanism to host the existing status/severity/jurisdiction/lane filter chips and column-width select as the frame's controls panel.
- Loading state ("Scanning canon…") now renders through the shared frame shell (Theme…/Refresh present) instead of a bare unstyled `<body>`.
- Drops the duplicated `#toolbar`/`.toolbar-label`/`.toolbar-actions`/`.toolbar-btn`/body-flex CSS now covered by the shared theme + `TITLE_TOGGLE_CSS`. The `#ci-summary`/`#ci-config` info moves into the frame's `title`/`subtitle` header slots (mirrors `compliance-matrix-preview.ts`'s `summaryTitle` pattern); the config name (e.g. "Compliance Impact (auto)") now shows in the toolbar label slot.
- No domain-logic change: same `transitrix:impact-filter` / `transitrix:col-width` postMessage contract, same filter state, same matrix-building/grid-rendering code — only the surrounding document chrome changed.

## Test plan
- [x] `npm run compile:extension` — clean
- [x] `npm run build` — clean (full tsc build incl. `packages/diagrams`)
- [x] `npm run test:core` — same 3 pre-existing failures as on `main` (`cli-migrate.test.ts`, needs a methodology repo checkout), no new failures
- [ ] Manual VS Code webview smoke test — not run; this session has no Electron/VS Code harness available. The refactor closely mirrors `compliance-matrix-preview.ts`'s already-shipped, production-tested `buildDiagramFrame` + `interactive` usage, so the risk surface is the same shape as a change already in `main`. Flagging for a manual look before merge given the size of this diff.
