### PR TITLE
fix(bpmn): align preview toolbar with shared frame vocabulary

### DIFF
--- a/extension/src/preview.ts
+++ b/extension/src/preview.ts
@@ -189,12 +189,22 @@ export class CervinPreview {
     html,body{width:100%;height:100%;overflow:hidden;}
     /* flex chain so layout height reaches #canvas — otherwise diagram-js measures ~0px */
     body{display:flex;flex-direction:column;min-height:0;}
-    #toolbar{flex-shrink:0;border-bottom:1px solid var(--vscode-panel-border);padding:6px 8px;font-family:var(--vscode-font-family);font-size:12px;display:flex;flex-direction:column;gap:6px;}
-    .toolbar-btn{cursor:pointer;user-select:none;font-size:11px;padding:1px 8px;border-radius:4px;color:var(--ts-text-muted,#64748b);background:transparent;border:none;white-space:nowrap;align-self:flex-end;text-decoration:none;}
+    /* Toolbar layout mirrors the shared diagram-frame vocabulary (toolbar-label
+       left / toolbar-actions right — see buildDiagramFrame in diagram-frame.ts)
+       so this preview reads consistently with the rest of the product, even
+       though bpmn-js's live canvas + postMessage export flow keeps it on its
+       own hand-rolled HTML rather than buildDiagramFrame itself. */
+    #toolbar{flex-shrink:0;border-bottom:1px solid var(--vscode-panel-border);padding:6px 8px;font-family:var(--vscode-font-family);font-size:12px;display:flex;align-items:center;justify-content:space-between;gap:8px;flex-wrap:wrap;}
+    .toolbar-label{flex:1 1 auto;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+    .toolbar-actions{display:flex;gap:4px;align-items:center;flex-wrap:wrap;justify-content:flex-end;}
+    .toolbar-btn{cursor:pointer;user-select:none;font-size:11px;padding:1px 8px;border-radius:4px;color:var(--ts-text-muted,#64748b);background:transparent;border:none;white-space:nowrap;text-decoration:none;}
     .toolbar-btn:hover:not(:disabled){color:var(--ts-text,#0f172a);background:var(--ts-bg-elevated,#f1f5f9);}
     .toolbar-btn:disabled{opacity:0.4;cursor:default;}
-    #toolbar-message{flex-shrink:0;}
     #metrics-display{display:flex;gap:16px;flex-wrap:wrap;align-items:center;font-size:11px;color:var(--vscode-descriptionForeground);}
+    /* :not([hidden]) so the padding/border only render once JS populates and
+       reveals this row — an empty-but-displayed flex box (id selector beats
+       the UA [hidden] rule) would otherwise show as an empty bordered bar. */
+    #metrics-display:not([hidden]){flex-shrink:0;padding:4px 8px 6px;border-bottom:1px solid var(--vscode-panel-border);}
     .metric{display:flex;align-items:center;gap:4px;}
     .metric-label{font-weight:600;opacity:0.85;}
     .metric-value{font-family:monospace;}
@@ -230,10 +240,12 @@ export class CervinPreview {
 <body>
   <div class="layout">
     <div id="toolbar">
-      <span id="toolbar-message" class="muted">Save YAML to refresh the preview.</span>
-      <div id="metrics-display" hidden></div>
-      <button id="save-png-btn" class="toolbar-btn" title="Save the current diagram as a .png file" disabled>Save .png</button>
+      <span id="toolbar-message" class="toolbar-label muted">Save YAML to refresh the preview.</span>
+      <div class="toolbar-actions">
+        <button id="save-png-btn" class="toolbar-btn" title="Save the current diagram as a .png file" disabled>Save .png</button>
+      </div>
     </div>
+    <div id="metrics-display" hidden></div>
     <pre id="err" hidden></pre>
     <div id="findings">
       <div class="findings-header">


### PR DESCRIPTION
## Summary
- The BPMN (bpmn-js) preview's toolbar (`extension/src/preview.ts`) built its own vertical-column layout (status message, metrics row, a single self-aligned button) instead of the label-left/actions-right row every `buildDiagramFrame`-based preview uses (`.toolbar-label` / `.toolbar-actions`, `extension/src/diagram-frame.ts`).
- Restructures the toolbar to the same grouping and class vocabulary — status text in `.toolbar-label`, `Save .png` in `.toolbar-actions` — so it reads consistently with the rest of the product's diagram previews.
- Does **not** force a full migration onto `buildDiagramFrame`: bpmn-js's live canvas + `postMessage` SVG-export flow is a fundamentally different rendering model (dynamic webview-side render vs. server-pre-rendered static SVG), so a thin, hand-rolled adapter stays the right shape here rather than a big-bang rewrite of the bpmn-js integration.
- Moves `#metrics-display` out of `#toolbar` into its own row so the toolbar itself stays a single line like the shared frame's; guards its padding/border behind `:not([hidden])` so the (previously already technically-displayed, since the `#metrics-display{display:flex}` id selector already overrode the UA `[hidden]` rule) empty container doesn't show as a bare bordered bar before a compile populates it.
- No "Theme…" button added: bpmn-js renders through its own vendored `diagram-js.css`/`bpmn-js.css`, independent of the `@transitrix/diagrams` theme tokens (`--ts-*` node/edge palette) that `transitrix.theme` actually controls — the preview isn't even wired into the `onDidChangeConfiguration` theme-refresh list today. Offering a control with no visible effect on this canvas would be misleading, so its absence is intentional per this task's acceptance criteria.
- `CervinPreview` class rename is intentionally left out of this PR — a sibling task owns the broader residual-identifier scrub so this one can stay chrome-only.

## Test plan
- [x] `npm run compile:extension` — clean
- [x] `npm run build` — clean (full tsc build incl. `packages/diagrams`)
- [x] `npm run test:core` — same 3 pre-existing failures as on `main` (`cli-migrate.test.ts`, needs a methodology repo checkout), no new failures
- [ ] Manual VS Code webview smoke test — not run; this session has no Electron/VS Code harness available. The change is CSS/HTML structure only (no script/message-contract changes, verified against `extension/media/viewer.js`'s `getElementById` lookups which are unaffected by the DOM regrouping), so the risk surface is narrow. Flagging for a manual look before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
