### PR TITLE
chore(release): bump extension to 3.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+## [3.1.2] — 2026-07-29
+
+### Fixed
+
+- **Network/PSND skip-edge bows could climb into the title block** (#420). Follow-up to #418: the top-pad floor used the canvas edge (`y=0`), so the arc could still rise through the "Network view — …" heading. `computeNetworkTopPad` now floors against the diagram's own node bounds, so bows stay in the diagram area and leave the title zone alone.
+- **Blocks `BL-006` TYPE allowlist was stale vs the methodology registry** (#421). `REGISTERED_ELEMENT_TYPES` still accepted retired TYPEs (`UNIT`/`EMPLOYEE`/`ISSUE`, plus never-canonical `STAGE`) and rejected current ones adopters need (`HAZARD`, `RISK_CONTROL`, `REQUIREMENT`, `VERIFICATION`, …). Now matches `IDS_AND_REFERENCES.md` §3.1 exactly (plus `VERIFICATION` from §3.7), with a CI-pinned expected-set test so the next drift fails loudly.
+
+### Changed
+
+- **Compliance status colours use functional `--ts-status-*` tokens** (#422) instead of hardcoded purple / `#b45309`-class hexes for `pending_owner`, severity-medium, pending, dangling, and unresolved. Coverage-metric RAG middle-band copy renamed to "Warning".
+- **Compliance Impact preview adopts the shared `buildDiagramFrame` chrome** (#423), including a framed loading state (Theme…/Refresh present) instead of a bare body.
+- **BPMN preview toolbar vocabulary aligned** with the shared frame (#424).
+
+### Packages
+
+- **Transitrix Studio extension** 3.1.1 → 3.1.2
+- **`@transitrix/diagrams`** 1.8.19 → 1.8.20 — skip-edge title-zone floor (#420) and BL-006 TYPE registry sync (#421).
+
 ## [3.1.1] — 2026-07-27
 
 ### Fixed

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+## 3.1.2 — 2026-07-29
+
+Network/PSND dependency arcs no longer cross the diagram title, and Blocks diagrams accept the current methodology element types (including the hazard → verification chain).
+
+### Fixed
+
+- **Network/PSND dependency arcs no longer draw through the diagram title.** A previous fix routed long dependency lines above intermediate nodes; those arcs could still climb into the heading. They now stay below the title.
+- **Blocks diagrams accept the current methodology element types.** Types such as Hazard, Risk Control, Requirement, and Verification were incorrectly rejected; a few retired types that are no longer in the methodology were still accepted. The allowlist now matches the methodology registry.
+
+### Changed
+
+- **Compliance views use the shared status colour roles** (info / warning) instead of one-off hard-coded colours, and the Compliance Impact preview shares the same toolbar chrome as the other diagram previews.
+
 ## 3.1.1 — 2026-07-27
 
 A Network/PSND view rendering fix: an activity dependency line could be drawn straight through an unrelated node instead of around it.

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Diagrams as text. Write goals, processes, capabilities, BPMN, and more as plain YAML — 17 notations, live preview in VS Code. Diffable in git. AI-friendly. Open source.",
   "license": "MIT",
   "icon": "icon.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "transitrix-studio",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "transitrix-studio",
-      "version": "3.1.1",
+      "version": "3.1.2",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
﻿## Why

`CHANGELOG.md`'s `Unreleased` content covers #420-#424 (Network/PSND title-zone skip-edge floor, Blocks BL-006 TYPE registry sync, compliance status tokens + Impact shared-frame chrome, BPMN toolbar vocabulary) with no version behind it yet. The BL-006 allowlist fix in particular unblocks adopter work that was stuck on rejected current TYPEs (`HAZARD`, `RISK_CONTROL`, `REQUIREMENT`, `VERIFICATION`, ...).

## What this does

- `extension/package.json` + `package.json`: `3.1.1` → `3.1.2` (via `npm run bump-extension-version -- set 3.1.2`).
- `CHANGELOG.md`: closes `Unreleased` as `## [3.1.2] — 2026-07-29`, opens a fresh empty `Unreleased`.
- `extension/CHANGELOG.md`: adds the adopter-facing `3.1.2` entry.
- `package-lock.json`: version bump only (`npm install --package-lock-only`).

`@transitrix/diagrams` is already at `1.8.20` on `main` from #420/#421 (lockfile already points at it). `@transitrix/cli` is not bumped — already at its released npm version (`2.2.0`).

## Test plan

- [x] `npm run compile` (build:diagrams + root tsc --noEmit) — clean

## After merge

Cutting the GitHub Release (tag `v3.1.2`) triggers npm package publish (idempotent; already-published versions skip) plus the VS Code / Open VSX / JetBrains marketplace publishes. Leaving that step to Valerii.
