### PR TITLE
fix(cli): republish @transitrix/cli with current diagrams bundle, guard future drift

### DIFF
--- a/.github/workflows/cli-diagrams-alignment.yml
+++ b/.github/workflows/cli-diagrams-alignment.yml
@@ -1,0 +1,42 @@
+name: CLI/diagrams alignment guard
+
+# @transitrix/cli bundles the @transitrix/diagrams *source* into its
+# published dist/ at prepack (scripts/build-cli-package.mjs). If diagrams
+# bumps its version and cli's own version doesn't move too, the idempotent
+# publish step in npm-publish.yml (release trigger) skips republishing cli —
+# its version is already on the registry — and the diagrams change never
+# reaches the published @transitrix/cli, even though the extension and
+# @transitrix/diagrams itself shipped it.
+#
+# This runs pre-release, on every PR, so the gap is caught before merge
+# rather than discovered later as a stale npm package.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  check-cli-diagrams-alignment:
+    runs-on: ubuntu-latest
+    name: diagrams version bump requires a cli version bump
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Check cli/diagrams version alignment
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: node scripts/check-cli-diagrams-alignment.mjs

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -24,6 +24,7 @@ npx @transitrix/cli --help
 ## Quick reference
 
 ```bash
+transitrix --version                            # cli + bundled diagrams version
 transitrix compile <input>.yaml <output>.bpmn   # YAML → BPMN 2.0 XML
 transitrix validate <input>.yaml                # per-file validation
 transitrix validate --scope=repo                # whole-repo canon checks
@@ -53,6 +54,14 @@ PDF compliance export requires WeasyPrint on `PATH`
 `@transitrix/cli` ships on its own version line, independent of the
 Transitrix Studio extension and `@transitrix/diagrams`. The first published
 release is `1.0.0`.
+
+`@transitrix/diagrams` source (not a runtime dependency — see "What's
+included" above) is bundled in at prepack, so a diagrams fix only reaches
+adopters once `@transitrix/cli` itself is republished. A CI guard
+(`scripts/check-cli-diagrams-alignment.mjs`) fails a PR that bumps
+`packages/diagrams/package.json` without also bumping `packages/cli/package.json`,
+so the two never drift apart. Run `transitrix --version` to see exactly which
+`@transitrix/diagrams` version is bundled into an installed CLI.
 
 ## Naming
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/cli",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "type": "module",
   "description": "Transitrix CLI — compile, validate, and report on Transitrix diagrams (BPMN, Goals, DGCA, …) from any shell or CI pipeline.",
   "license": "MIT",

--- a/scripts/build-cli-package.mjs
+++ b/scripts/build-cli-package.mjs
@@ -24,8 +24,23 @@ import { NODE_BUILTIN_EXTERNALS, REQUIRE_BANNER, COMPILER_RUNTIME_EXTERNALS } fr
 
 const root = resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
 const pkgRoot = resolve(root, 'packages', 'cli');
+const diagramsRoot = resolve(root, 'packages', 'diagrams');
 const distOut = resolve(pkgRoot, 'dist');
 const schemaOut = resolve(pkgRoot, 'schemas');
+
+// The bundled @transitrix/diagrams *source* has no package.json of its own
+// once esbuild inlines it — record which workspace version was bundled so
+// `transitrix --version` can report it at runtime (see src/diagrams-version.ts)
+// and so a stale-bundle regression (diagrams bumped, cli republish skipped
+// because npm-publish.yml compares cli's own version) is easy to spot from
+// an installed package.
+const diagramsPkg = JSON.parse(
+  await fs.readFile(resolve(diagramsRoot, 'package.json'), 'utf8'),
+);
+const diagramsVersion = diagramsPkg.version;
+if (typeof diagramsVersion !== 'string' || diagramsVersion.length === 0) {
+  throw new Error(`Could not read a version from ${resolve(diagramsRoot, 'package.json')}`);
+}
 
 await fs.rm(distOut, { recursive: true, force: true });
 await fs.mkdir(distOut, { recursive: true });
@@ -89,4 +104,11 @@ for (const name of await fs.readdir(resolve(root, 'schemas'))) {
   }
 }
 
-console.log(`@transitrix/cli assembled → ${pkgRoot}`);
+// Record the bundled @transitrix/diagrams version next to dist/ — read by
+// src/diagrams-version.ts for `transitrix --version`.
+await fs.writeFile(
+  resolve(distOut, 'diagrams-version.json'),
+  JSON.stringify({ version: diagramsVersion }, null, 2) + '\n',
+);
+
+console.log(`@transitrix/cli assembled → ${pkgRoot} (bundles @transitrix/diagrams ${diagramsVersion})`);

--- a/scripts/check-cli-diagrams-alignment.mjs
+++ b/scripts/check-cli-diagrams-alignment.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+// CI guard: fail if packages/diagrams/package.json bumps its version without
+// packages/cli/package.json also bumping in the same PR.
+//
+// Why: scripts/build-cli-package.mjs bundles the @transitrix/diagrams
+// *source* into @transitrix/cli's published dist/ at prepack — the slim npm
+// package never lists @transitrix/diagrams as a runtime dependency. But
+// .github/workflows/npm-publish.yml only republishes @transitrix/cli when
+// its own package.json version isn't already on the registry. If diagrams
+// changes (fixing a validator bug, say) and cli's version field doesn't move,
+// the publish step silently no-ops and the fix never reaches npm — exactly
+// what happened to the BL-006 TYPE-registry fix (diagrams 1.8.20) while
+// @transitrix/cli stayed on 2.2.0.
+//
+// This mirrors check-diagrams-version-bump.mjs's shape/diffing approach.
+
+import { execSync } from 'node:child_process';
+
+const baseSha = process.env.BASE_SHA;
+const headSha = process.env.HEAD_SHA;
+
+if (!baseSha || !headSha) {
+  console.error('[cli-diagrams-alignment] missing BASE_SHA / HEAD_SHA env vars (must be invoked from a pull_request workflow).');
+  process.exit(2);
+}
+
+try {
+  execSync(`git fetch --no-tags --depth=1 origin ${baseSha}`, { stdio: 'pipe' });
+} catch {
+  // Fallback: rely on existing fetch depth from the checkout step.
+}
+
+function readJsonAt(sha, path) {
+  return JSON.parse(execSync(`git show ${sha}:${path}`, { encoding: 'utf8' }));
+}
+
+let baseDiagramsVersion, headDiagramsVersion;
+try {
+  baseDiagramsVersion = readJsonAt(baseSha, 'packages/diagrams/package.json').version;
+  headDiagramsVersion = readJsonAt(headSha, 'packages/diagrams/package.json').version;
+} catch (err) {
+  console.error('[cli-diagrams-alignment] failed to read packages/diagrams/package.json:', err.message);
+  process.exit(2);
+}
+
+if (baseDiagramsVersion === headDiagramsVersion) {
+  console.log('[cli-diagrams-alignment] packages/diagrams version unchanged — check skipped.');
+  process.exit(0);
+}
+
+console.log(`[cli-diagrams-alignment] packages/diagrams version bumped ${baseDiagramsVersion} → ${headDiagramsVersion}.`);
+
+let baseCliVersion, headCliVersion;
+try {
+  baseCliVersion = readJsonAt(baseSha, 'packages/cli/package.json').version;
+  headCliVersion = readJsonAt(headSha, 'packages/cli/package.json').version;
+} catch (err) {
+  console.error('[cli-diagrams-alignment] failed to read packages/cli/package.json:', err.message);
+  process.exit(2);
+}
+
+if (baseCliVersion === headCliVersion) {
+  console.error(
+    `[cli-diagrams-alignment] FAIL: packages/diagrams bumped to ${headDiagramsVersion} but packages/cli is still ${headCliVersion}.`,
+  );
+  console.error('[cli-diagrams-alignment] @transitrix/cli bundles the @transitrix/diagrams source at prepack — bump');
+  console.error('[cli-diagrams-alignment] packages/cli/package.json too, or npm-publish.yml will skip republishing');
+  console.error('[cli-diagrams-alignment] it (its version is already on the registry) and the diagrams change never');
+  console.error('[cli-diagrams-alignment] reaches npm.');
+  process.exit(1);
+}
+
+console.log(`[cli-diagrams-alignment] OK: packages/cli version bumped ${baseCliVersion} → ${headCliVersion}.`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,6 +27,8 @@ import {
   resolveValidatorKey,
 } from './validate-notation.js';
 import { handleExportComplianceCommand } from './export-compliance.js';
+import { transitrixPackageVersion } from './package-version.js';
+import { bundledDiagramsVersion } from './diagrams-version.js';
 import { isActionViewDoc } from '@transitrix/diagrams/activities';
 import { isFGCAViewDoc } from '@transitrix/diagrams/fgca';
 // Deep import, not the `@transitrix/diagrams/goals` barrel like the two
@@ -47,8 +49,19 @@ const PROJECTION_ONLY_NOTATIONS: Record<string, { check: (d: unknown) => boolean
   goals: { check: isGoalsViewDoc, label: 'Goals Tree', inlineField: 'goals[]' },
 };
 
+function printVersion(): void {
+  const cliVersion = transitrixPackageVersion();
+  const diagramsVersion = bundledDiagramsVersion();
+  console.log(
+    diagramsVersion
+      ? `transitrix ${cliVersion} (bundles @transitrix/diagrams ${diagramsVersion})`
+      : `transitrix ${cliVersion}`,
+  );
+}
+
 function printUsage(): void {
   console.error(`Transitrix Studio CLI — usage:
+       transitrix --version | -v
        transitrix serve [--port 8765] [--host 127.0.0.1]
        transitrix <input.yaml> <output.bpmn> [--no-metrics] [--no-validate]
        transitrix [--ext=.bpmn.transitrix.yaml] <input.yaml> <output.bpmn> [--no-metrics] [--no-validate]
@@ -562,6 +575,15 @@ const subcommand = process.argv[2];
 // rather than falling through to the "unknown command" branch.
 if (subcommand === '--help' || subcommand === '-h' || subcommand === 'help') {
   printUsage();
+  process.exit(0);
+}
+
+// Top-level version: reports both the CLI's own version and the
+// @transitrix/diagrams version bundled into it (BL-006 TYPE-registry drift
+// between the two is exactly what let a stale npm publish go unnoticed —
+// see scripts/check-cli-diagrams-alignment.mjs).
+if (subcommand === '--version' || subcommand === '-v') {
+  printVersion();
   process.exit(0);
 }
 

--- a/src/diagrams-version.ts
+++ b/src/diagrams-version.ts
@@ -1,0 +1,55 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Version of `@transitrix/diagrams` bundled into this CLI build — used by
+ * `transitrix --version`.
+ *
+ * The published `@transitrix/cli` package bundles the `@transitrix/diagrams`
+ * *source* at prepack (`scripts/build-cli-package.mjs`) rather than
+ * depending on it at runtime, so it is not in `node_modules` for a plain
+ * `npm i @transitrix/cli` install (and its ESM-only `exports` map has no
+ * `require` condition, so `createRequire(...).resolve` can't find it either
+ * way). That build script writes a small `diagrams-version.json` manifest
+ * next to `dist/cli.js` recording which workspace version was bundled; this
+ * reads it back.
+ *
+ * When running from the monorepo instead (`npm run transitrix` via `tsx`, or
+ * the `tsc`-built root `dist/` used by tests) that manifest doesn't exist, so
+ * fall back to walking up from this file to the repo root and reading
+ * `packages/diagrams/package.json` directly.
+ */
+export function bundledDiagramsVersion(): string | undefined {
+  const here = dirname(fileURLToPath(import.meta.url));
+
+  const manifestPath = join(here, 'diagrams-version.json');
+  try {
+    if (existsSync(manifestPath)) {
+      const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as { version?: unknown };
+      if (typeof manifest.version === 'string') return manifest.version;
+    }
+  } catch {
+    /* fall through to workspace resolution below */
+  }
+
+  try {
+    let dir = here;
+    for (let i = 0; i < 6; i++) {
+      const candidate = join(dir, 'packages', 'diagrams', 'package.json');
+      if (existsSync(candidate)) {
+        const pkg = JSON.parse(readFileSync(candidate, 'utf8')) as { name?: unknown; version?: unknown };
+        if (pkg.name === '@transitrix/diagrams' && typeof pkg.version === 'string') {
+          return pkg.version;
+        }
+      }
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  } catch {
+    /* unresolvable — report no diagrams version rather than throwing */
+  }
+
+  return undefined;
+}

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -29,3 +29,17 @@ describe('CLI top-level help (#187)', () => {
     expect(runCli(['definitely-not-a-command']).status).not.toBe(0)
   })
 })
+
+describe('CLI --version', () => {
+  it('exits 0 and reports both the cli and bundled @transitrix/diagrams version', () => {
+    const { status, stdout } = runCli(['--version'])
+    expect(status).toBe(0)
+    expect(stdout).toMatch(/^transitrix \d+\.\d+\.\d+ \(bundles @transitrix\/diagrams \d+\.\d+\.\d+\)/)
+  })
+
+  it('-v is an alias for --version', () => {
+    const { status, stdout } = runCli(['-v'])
+    expect(status).toBe(0)
+    expect(stdout).toMatch(/^transitrix \d+\.\d+\.\d+/)
+  })
+})


### PR DESCRIPTION
## Summary

`@transitrix/cli` bundles the `@transitrix/diagrams` *source* into its published `dist/` at prepack (`scripts/build-cli-package.mjs`) — the slim npm package never lists `@transitrix/diagrams` as a runtime dependency. But `npm-publish.yml`'s publish step is idempotent by comparing `packages/cli/package.json`'s version against the registry, so whenever `@transitrix/diagrams` bumped without a matching `@transitrix/cli` bump, the publish step silently skipped republishing — the bundled diagrams code went stale on npm even though `@transitrix/diagrams` itself kept shipping fixes.

Confirmed: `npx @transitrix/cli@2.2.0 validate` on a minimal `blocks` fixture rejects a `HAZARD-BATTERY-1` block id with `BL-006` (TYPE not registered), while a locally-built CLI from current source accepts it — the published bundle still carries a `REGISTERED_ELEMENT_TYPES` set from several diagrams releases ago.

- Bump `@transitrix/cli` to `2.3.0` so the next release republishes it with the current bundle.
- Add `scripts/check-cli-diagrams-alignment.mjs` + a new PR workflow (`cli-diagrams-alignment.yml`) that fails a PR bumping `packages/diagrams/package.json` without also bumping `packages/cli/package.json`, mirroring the existing `diagrams-version-bump` guard shape.
- Record the bundled `@transitrix/diagrams` version at prepack (`packages/cli/dist/diagrams-version.json`) and expose it via a new `transitrix --version` / `-v` command, so an installed CLI's actual bundled version can be checked directly instead of inferred.

## Test plan

- [x] `npm run compile` (typecheck, incl. `packages/diagrams` build)
- [x] `npm run test:core` — 478/481 passing; the 3 failures are pre-existing `tests/cli-migrate.test.ts` 0.5→0.6 recipe failures unrelated to this change (reproduced identically on `main` before this branch)
- [x] `npm run test:diagrams` — 1473/1473 passing
- [x] Manual repro: built `packages/cli` locally, confirmed `transitrix --version` reports the bundled diagrams version and `validate` now accepts the previously-rejected `HAZARD-*` id
- [x] New tests added for `transitrix --version` / `-v` in `tests/cli.test.ts`
