### PR TITLE
fix: residual identifier scrub (Cervin internals -> Transitrix)

### DIFF
--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -3,7 +3,7 @@ import { pathToFileURL } from 'node:url';
 import * as vscode from 'vscode';
 
 import type { CompileFn } from './preview.js';
-import { CervinPreview } from './preview.js';
+import { BpmnJsPreview } from './preview.js';
 import { ProcessPreview, type ProcessLayoutFn, type BpmnDisplayOpts, SAVE_BPMN_PROCESS_SVG_COMMAND, OPEN_BPMN_SETTINGS_COMMAND } from './process-preview.js';
 import { GoalsPreview } from './goals-preview.js';
 import { DGCAPreview, DGAPreview } from './dgca-preview.js';
@@ -198,7 +198,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     return compilerPromise;
   }
 
-  const preview = new CervinPreview(context.extensionUri, (yaml: string) =>
+  const preview = new BpmnJsPreview(context.extensionUri, (yaml: string) =>
     compiler().then((c) => c(yaml)),
   );
 

--- a/extension/src/preview.ts
+++ b/extension/src/preview.ts
@@ -14,7 +14,7 @@ const DOCS_BASE_URL = 'https://github.com/transitrix/transitrix-studio/blob/main
 const VALIDATION_DOC_PATH = /^docs\/[A-Za-z0-9._/-]+\.md(#[A-Za-z0-9._-]+)?$/;
 
 /** Webview: bpmn-js viewer + compile loop. */
-export class CervinPreview {
+export class BpmnJsPreview {
   readonly panelTitle = 'BPMN Preview';
   private panel: vscode.WebviewPanel | undefined;
   private trackedUri: string | undefined;

--- a/extension/src/process-preview.ts
+++ b/extension/src/process-preview.ts
@@ -3,7 +3,7 @@
  * emitter from @transitrix/diagrams (custom process renderer programme, P1–P3).
  *
  * Active when `transitrix.bpmnRenderer` is set to `"custom"`. The default
- * bpmn.io path (CervinPreview) is unaffected.
+ * bpmn.io path (BpmnJsPreview) is unaffected.
  *
  * P3: migrated to buildDiagramFrame for zoom/pan parity with all other
  * diagram previews.

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.8.20",
+  "version": "1.8.21",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",

--- a/packages/diagrams/src/compliance/html.ts
+++ b/packages/diagrams/src/compliance/html.ts
@@ -230,7 +230,7 @@ export interface ImpactMatrixHtmlOptions {
  * Renders an `ImpactMatrix` (from `buildImpactMatrix`) as a self-contained
  * A4 HTML document suitable for WeasyPrint PDF output.
  *
- * Used by `cervin export-compliance --report <id> --format pdf`.
+ * Used by `transitrix export-compliance --report <id> --format pdf`.
  */
 export function renderImpactMatrixHtml(matrix: ImpactMatrix, options: ImpactMatrixHtmlOptions = {}): string {
   const STATUS_GLYPH: Partial<Record<string, string>> = {

--- a/scripts/debug/analyze-metrics.mjs
+++ b/scripts/debug/analyze-metrics.mjs
@@ -8,7 +8,7 @@ import { computeLayoutMetrics } from '../../dist/metrics.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const projectRoot = path.resolve(__dirname, '../../')
-const inputFile = process.argv[2] || path.join(projectRoot, 'tests/fixtures/notation-corpus/bpmn/feature-release.cervin.yaml')
+const inputFile = process.argv[2] || path.join(projectRoot, 'tests/fixtures/notation-corpus/bpmn/feature-release.bpmn.transitrix.yaml')
 const yaml = await fs.readFile(inputFile, 'utf-8')
 const { ir, layout } = await compileTransitrixYamlWithLayout(yaml)
 const metrics = computeLayoutMetrics(layout)

--- a/scripts/debug/debug-elements.mjs
+++ b/scripts/debug/debug-elements.mjs
@@ -7,7 +7,7 @@ import { compileTransitrixYamlWithLayout } from '../../dist/compiler.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const projectRoot = path.resolve(__dirname, '../../')
-const inputFile = process.argv[2] || path.join(projectRoot, 'tests/fixtures/notation-corpus/bpmn/feature-release.cervin.yaml')
+const inputFile = process.argv[2] || path.join(projectRoot, 'tests/fixtures/notation-corpus/bpmn/feature-release.bpmn.transitrix.yaml')
 const yaml = await fs.readFile(inputFile, 'utf-8')
 const { ir, layout } = await compileTransitrixYamlWithLayout(yaml)
 

--- a/scripts/debug/debug-ports.mjs
+++ b/scripts/debug/debug-ports.mjs
@@ -7,7 +7,7 @@ import { compileTransitrixYamlWithLayout } from '../../dist/compiler.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const projectRoot = path.resolve(__dirname, '../../')
-const inputFile = process.argv[2] || path.join(projectRoot, 'tests/fixtures/notation-corpus/bpmn/feature-release.cervin.yaml')
+const inputFile = process.argv[2] || path.join(projectRoot, 'tests/fixtures/notation-corpus/bpmn/feature-release.bpmn.transitrix.yaml')
 const yaml = await fs.readFile(inputFile, 'utf-8')
 const { layout } = await compileTransitrixYamlWithLayout(yaml, { layout: {} })
 

--- a/scripts/debug/debug-spine.mjs
+++ b/scripts/debug/debug-spine.mjs
@@ -7,7 +7,7 @@ import { compileTransitrixYamlWithLayout } from '../../dist/compiler.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const projectRoot = path.resolve(__dirname, '../../')
-const inputFile = process.argv[2] || path.join(projectRoot, 'tests/fixtures/notation-corpus/bpmn/feature-release.cervin.yaml')
+const inputFile = process.argv[2] || path.join(projectRoot, 'tests/fixtures/notation-corpus/bpmn/feature-release.bpmn.transitrix.yaml')
 const yaml = await fs.readFile(inputFile, 'utf-8')
 const { layout } = await compileTransitrixYamlWithLayout(yaml, { layout: {} })
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -356,7 +356,7 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
 
   // Read first, so we can probe the `notation:` field before the extension gate:
   // diagram-notation files (*.goals.transitrix.yaml, …) don't match the default
-  // BPMN/Cervin extension list, and their notation field — not the filename — is
+  // BPMN/Transitrix extension list, and their notation field — not the filename — is
   // the authoritative signal. TX-R004 — keep the read inside try so a missing
   // file exits 1 cleanly instead of throwing.
   let fileText: string;

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -15,9 +15,6 @@ export interface CompileTransitrixOptions {
   layout?: Partial<LayoutDiagramOptions>
 }
 
-/** @deprecated Use {@link CompileTransitrixOptions}. */
-export type CompileCervinOptions = CompileTransitrixOptions
-
 export interface CompileResult {
   ir: ProcessIr
   layout: LayoutIr

--- a/src/export-compliance.ts
+++ b/src/export-compliance.ts
@@ -1,4 +1,4 @@
-// `transitrix export-compliance` handler (vkgeorgia/strategy#84 Phase 5 + PDF follow-on).
+// `transitrix export-compliance` handler.
 //
 // Lives in its own module — separate from cli.ts — because it imports the
 // compliance library from `@transitrix/diagrams` *source*. The root emit build

--- a/src/export-compliance.ts
+++ b/src/export-compliance.ts
@@ -1,4 +1,4 @@
-// `cervin export-compliance` handler (vkgeorgia/strategy#84 Phase 5 + PDF follow-on).
+// `transitrix export-compliance` handler (vkgeorgia/strategy#84 Phase 5 + PDF follow-on).
 //
 // Lives in its own module — separate from cli.ts — because it imports the
 // compliance library from `@transitrix/diagrams` *source*. The root emit build

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -12,11 +12,11 @@ import { layoutProcess } from '../src/layout.js';
 import { irFromValidatedDsl, parseYamlToIr, type YamlDocumentRoot } from '../src/parser.js';
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
-const sampleCervinPath = join(repoRoot, 'tests', 'fixtures', 'notation-corpus', 'bpmn', 'order-fulfillment.bpmn.transitrix.yaml');
+const sampleTransitrixPath = join(repoRoot, 'tests', 'fixtures', 'notation-corpus', 'bpmn', 'order-fulfillment.bpmn.transitrix.yaml');
 
 describe('parser', () => {
   it('parses sample and collects flows', () => {
-    const yaml = readFileSync(sampleCervinPath, 'utf8');
+    const yaml = readFileSync(sampleTransitrixPath, 'utf8');
     const ir = parseYamlToIr(yaml);
     expect(ir.id).toBe('order-fulfillment');
     expect(ir.flows).toHaveLength(6);
@@ -257,7 +257,7 @@ process:
 
 describe('layout', () => {
   it('assigns geometry to every element via ELK', async () => {
-    const yaml = readFileSync(sampleCervinPath, 'utf8');
+    const yaml = readFileSync(sampleTransitrixPath, 'utf8');
     const ir = parseYamlToIr(yaml);
     const layout = await layoutProcess(ir);
     for (const id of ir.lanes.flatMap((l) => l.elements.map((e) => e.id))) {
@@ -267,7 +267,7 @@ describe('layout', () => {
   });
 
   it('respects layout options (lane vertical gap changes pool height)', async () => {
-    const yaml = readFileSync(sampleCervinPath, 'utf8');
+    const yaml = readFileSync(sampleTransitrixPath, 'utf8');
     const ir = parseYamlToIr(yaml);
     const baseline = await layoutProcess(ir);
     const wideGap = await layoutProcess(ir, { laneVerticalGap: 120 });
@@ -1061,7 +1061,7 @@ describe('layout', () => {
 
 describe('compiler + bpmn-moddle', () => {
   it('emits XML that the BPMN 2.0 parser accepts', async () => {
-    const yaml = readFileSync(sampleCervinPath, 'utf8');
+    const yaml = readFileSync(sampleTransitrixPath, 'utf8');
     const xml = await compileTransitrixYaml(yaml);
     expect(xml).toContain(`exporterVersion="${transitrixPackageVersion()}"`);
     expect(xml).toContain('<definitions');

--- a/ui/index.html
+++ b/ui/index.html
@@ -8,7 +8,7 @@
     <script>
       (function () {
         try {
-          var t = localStorage.getItem('cervin-ui-theme');
+          var t = localStorage.getItem('transitrix-ui-theme');
           var dark = t === 'dark';
           document.documentElement.dataset.theme = dark ? 'dark' : 'light';
           document.documentElement.style.colorScheme = dark ? 'dark' : 'light';

--- a/ui/src/export-diagram.ts
+++ b/ui/src/export-diagram.ts
@@ -24,7 +24,7 @@ export function guessExportBasenameFromYaml(yamlText: string): string {
     .replace(/[^a-zA-Z0-9._-]+/g, '-')
     .replace(/^-+|-+$/g, '')
     .slice(0, 96);
-  return sanitized || 'cervin-diagram';
+  return sanitized || 'transitrix-diagram';
 }
 
 /**

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -5,7 +5,7 @@ import './style.css';
 import NavigatedViewer from 'bpmn-js/lib/NavigatedViewer.js';
 import yaml from 'js-yaml';
 
-import initialYaml from '../../tests/fixtures/notation-corpus/bpmn/order-fulfillment.cervin.yaml?raw';
+import initialYaml from '../../tests/fixtures/notation-corpus/bpmn/order-fulfillment.bpmn.transitrix.yaml?raw';
 import nestedBlocksAscii from '../../tests/fixtures/notation-corpus/nested-blocks/nested.txt?raw';
 import blocksTablesMarkdown from '../../tests/fixtures/notation-corpus/nested-blocks/tables.md?raw';
 import initialGoalsYaml from '../../tests/fixtures/notation-corpus/goals/strategy-2026.goals.transitrix.yaml?raw';
@@ -30,10 +30,10 @@ import {
   rasterSvgStringToPngBlob,
 } from './export-diagram.ts';
 
-const THEME_STORAGE_KEY = 'cervin-ui-theme';
-const LAYOUT_STORAGE_KEY = 'cervin-layout-defaults';
+const THEME_STORAGE_KEY = 'transitrix-ui-theme';
+const LAYOUT_STORAGE_KEY = 'transitrix-layout-defaults';
 /** Stored value must match backends/blocks compile ``mode``. */
-const BLOCKS_MODE_STORAGE_KEY = 'cervin-ui-blocks-mode';
+const BLOCKS_MODE_STORAGE_KEY = 'transitrix-ui-blocks-mode';
 type UiTheme = 'light' | 'dark';
 
 type BlocksCompileUiMode = 'ascii' | 'markdown_table' | 'markdown_tables';
@@ -144,7 +144,7 @@ function renderShell(root: HTMLElement): void {
 <div class="shell-header">
   <h1>Transitrix Studio <span class="sub">text-first BPMN</span></h1>
   <div class="actions">
-    <input id="pick-file" class="a11y-file" type="file" accept=".yaml,.yml,.cervin.yaml,.bpmn.transitrix.yaml,.txt,.md,.markdown,text/yaml,text/x-yaml,text/plain" aria-label="Open source file from disk" />
+    <input id="pick-file" class="a11y-file" type="file" accept=".yaml,.yml,.bpmn.transitrix.yaml,.txt,.md,.markdown,text/yaml,text/x-yaml,text/plain" aria-label="Open source file from disk" />
     <button type="button" id="btn-open">Open…</button>
     <button type="button" id="btn-compile">Rebuild</button>
     <button type="button" id="btn-reset">Sample</button>

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -10,7 +10,7 @@ import { handleBlocksCompile } from '../src/serve-ui.ts';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(__dirname, '..');
 
-function cervinCompileMiddleware() {
+function transitrixCompileMiddleware() {
   return async (req: IncomingMessage, res: {
     statusCode: number;
     setHeader(name: string, value: string): void;
@@ -96,28 +96,28 @@ function cervinCompileMiddleware() {
         res.end(JSON.stringify({ message: (e as PayloadTooLargeError).message, details: [] }));
         return;
       }
-      console.error('cervin dev api: unhandled error', e);
+      console.error('transitrix dev api: unhandled error', e);
       res.statusCode = 500;
       res.end('Internal server error');
     }
   };
 }
 
-function cervinDevApi(): Plugin {
+function transitrixDevApi(): Plugin {
   return {
-    name: 'cervin-dev-compile-api',
+    name: 'transitrix-dev-compile-api',
     configureServer(server) {
-      server.middlewares.use(cervinCompileMiddleware() as Parameters<typeof server.middlewares.use>[0]);
+      server.middlewares.use(transitrixCompileMiddleware() as Parameters<typeof server.middlewares.use>[0]);
     },
     configurePreviewServer(server) {
-      server.middlewares.use(cervinCompileMiddleware() as Parameters<typeof server.middlewares.use>[0]);
+      server.middlewares.use(transitrixCompileMiddleware() as Parameters<typeof server.middlewares.use>[0]);
     },
   };
 }
 
-function cervinBlocksDevApi(): Plugin {
+function transitrixBlocksDevApi(): Plugin {
   return {
-    name: 'cervin-dev-blocks-compile-api',
+    name: 'transitrix-dev-blocks-compile-api',
     configureServer(server) {
       server.middlewares.use(async (req, res, next) => {
         const pathOnly = (req.url ?? '').split('?')[0];
@@ -128,7 +128,7 @@ function cervinBlocksDevApi(): Plugin {
         try {
           await handleBlocksCompile(req as IncomingMessage, res as ServerResponse);
         } catch (e) {
-          console.error('cervin dev nested-blocks api: error', e);
+          console.error('transitrix dev nested-blocks api: error', e);
           if (!(res as ServerResponse & { writableEnded?: boolean }).writableEnded) {
             res.statusCode = 500;
             res.setHeader('Content-Type', 'application/json; charset=utf-8');
@@ -147,7 +147,7 @@ function cervinBlocksDevApi(): Plugin {
         try {
           await handleBlocksCompile(req as IncomingMessage, res as ServerResponse);
         } catch (e) {
-          console.error('cervin preview nested-blocks api: error', e);
+          console.error('transitrix preview nested-blocks api: error', e);
           if (!(res as ServerResponse & { writableEnded?: boolean }).writableEnded) {
             res.statusCode = 500;
             res.setHeader('Content-Type', 'application/json; charset=utf-8');
@@ -176,5 +176,5 @@ export default {
   optimizeDeps: {
     include: ['bpmn-js', 'diagram-js', 'inherits-browser', 'min-dash'],
   },
-  plugins: [cervinDevApi(), cervinBlocksDevApi()],
+  plugins: [transitrixDevApi(), transitrixBlocksDevApi()],
 };


### PR DESCRIPTION
## Summary
- Rename leftover internal `cervin`/`Cervin*` identifiers that don't carry user-facing meaning:
  - `CervinPreview` -> `BpmnJsPreview` (`extension/src/preview.ts`, `extension.ts`, `process-preview.ts` comment)
  - Dev-UI middleware/plugin functions, plugin `name` fields, and log prefixes in `ui/vite.config.ts` (`cervinCompileMiddleware`/`cervinDevApi`/`cervinBlocksDevApi` -> `transitrix*`)
  - localStorage keys `cervin-ui-theme` / `cervin-layout-defaults` / `cervin-ui-blocks-mode` -> `transitrix-ui-*` / `transitrix-layout-defaults` (`ui/src/main.ts`, `ui/index.html`)
  - Export basename fallback `cervin-diagram` -> `transitrix-diagram` (`ui/src/export-diagram.ts`)
  - Test variable `sampleCervinPath` -> `sampleTransitrixPath` (`tests/integration.test.ts`)
  - Stray comments in `src/cli.ts`, `src/export-compliance.ts`, `packages/diagrams/src/compliance/html.ts`
- Removed the unused `@deprecated CompileCervinOptions` alias from `src/compiler.ts` — no callers found in-repo.
- Fixed two stale references to a nonexistent `*.cervin.yaml` fixture that should have pointed at the tracked `*.bpmn.transitrix.yaml` file: `ui/src/main.ts`'s raw import (was a broken import), and the `feature-release.cervin.yaml` default path in all four `scripts/debug/*.mjs` scripts.
- Dropped `.cervin.yaml` from the `ui/index.html` file-picker `accept` list (legacy suffix, not accepted by extension 3.0+).

## Left as-is (per issue's "must keep" list)
- `scripts/check-no-cervin-yaml.mjs` (CI guard) and its `package.json` script name.
- `packages/cli/README.md`'s "legacy `cervin` bin alias" naming note.
- `tests/cli-parse.test.ts` — intentionally asserts `.cervin.yaml` as an accepted legacy input string.
- `tests/transitrixrc.test.ts`'s `describe('loadTransitrixrc (Cervin deprecation P7)')` — historical migration-phase marker, not a live identifier.
- CHANGELOG.md history.

## Verification
- `rg -i cervin extension/src src/ ui packages --glob '!**/CHANGELOG*'` → only hit is the README migration note above (and a gitignored `packages/diagrams/dist/**` build artifact that regenerates from `src/`).
- `npm test` → 476 passing, same pre-existing 3 failures in `tests/cli-migrate.test.ts` reproduce identically on unmodified `main` (unrelated to this change — methodology-repo-dependent migrate recipe tests).
- `npx tsc -p extension/tsconfig.json --noEmit` and root `npm run compile` (includes `packages/diagrams` build + root `tsc --noEmit`) → clean.
- `npm run ui:build` fails, but identically on unmodified `main` — pre-existing, unrelated `ui/vite.config.ts` import of `handleBlocksCompile` which `src/serve-ui.ts` doesn't export. Not touched or introduced by this PR; flagging here rather than silently leaving unmentioned.

## Test plan
- [x] `npm test`
- [x] `npm run compile`
- [x] `npx tsc -p extension/tsconfig.json --noEmit`
- [x] `rg -i cervin` sweep per acceptance criteria