### PR TITLE
feat(cli): align bundled diagrams and enforce release guard

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -59,6 +59,12 @@ jobs:
       - name: Build @transitrix/diagrams
         run: npm run build --workspace packages/diagrams
 
+      - name: Assemble @transitrix/cli bundle
+        run: npm run build --workspace packages/cli
+
+      - name: Verify @transitrix/cli bundle aligns with diagrams version
+        run: node scripts/verify-cli-bundle-alignment.mjs
+
       # Publish order matters: diagrams first, then cli (runbook convention).
       - name: Publish @transitrix/diagrams (skips if version already published)
         env:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,6 +4,25 @@ Migration notes for adopters upgrading across major changes.
 
 ---
 
+## Release train guard (CLI + diagrams)
+
+`@transitrix/cli` bundles diagrams source at prepack time; it does not install
+`@transitrix/diagrams` as a runtime npm dependency. When diagrams changes are
+user-visible in CLI paths (`validate --scope=repo`, notation validators, export),
+publish the CLI in the same release train after the diagrams bump.
+
+Before tagging a release, ensure:
+
+1. `packages/cli/package.json` is bumped (for example `2.2.0` -> `2.3.0`) when
+   bundled diagrams behavior changed.
+2. `npm run build --workspace packages/cli` regenerates `packages/cli/dist/`.
+3. `node scripts/verify-cli-bundle-alignment.mjs` passes (it checks bundled
+   metadata against `packages/diagrams/package.json`).
+
+The npm publish workflow enforces this alignment and fails on skew.
+
+---
+
 ## Extension 3.0 — legacy identifier sunset (2026-07)
 
 Transitrix Studio extension **3.0.0** removes the last user-facing Cervin compatibility

--- a/package-lock.json
+++ b/package-lock.json
@@ -7771,7 +7771,7 @@
     },
     "packages/cli": {
       "name": "@transitrix/cli",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/cli",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "type": "module",
   "description": "Transitrix CLI — compile, validate, and report on Transitrix diagrams (BPMN, Goals, DGCA, …) from any shell or CI pipeline.",
   "license": "MIT",

--- a/scripts/build-cli-package.mjs
+++ b/scripts/build-cli-package.mjs
@@ -24,6 +24,8 @@ import { NODE_BUILTIN_EXTERNALS, REQUIRE_BANNER, COMPILER_RUNTIME_EXTERNALS } fr
 
 const root = resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
 const pkgRoot = resolve(root, 'packages', 'cli');
+const diagramsPkgPath = resolve(root, 'packages', 'diagrams', 'package.json');
+const cliPkgPath = resolve(pkgRoot, 'package.json');
 const distOut = resolve(pkgRoot, 'dist');
 const schemaOut = resolve(pkgRoot, 'schemas');
 
@@ -88,5 +90,20 @@ for (const name of await fs.readdir(resolve(root, 'schemas'))) {
     await fs.copyFile(resolve(root, 'schemas', name), resolve(schemaOut, name));
   }
 }
+
+const diagramsPkg = JSON.parse(await fs.readFile(diagramsPkgPath, 'utf8'));
+const cliPkg = JSON.parse(await fs.readFile(cliPkgPath, 'utf8'));
+await fs.writeFile(
+  resolve(distOut, 'bundle-metadata.json'),
+  `${JSON.stringify(
+    {
+      diagramsVersion: diagramsPkg.version,
+      cliVersion: cliPkg.version,
+    },
+    null,
+    2,
+  )}\n`,
+  'utf8',
+);
 
 console.log(`@transitrix/cli assembled → ${pkgRoot}`);

--- a/scripts/verify-cli-bundle-alignment.mjs
+++ b/scripts/verify-cli-bundle-alignment.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+import fs from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
+const diagramsPkgPath = resolve(root, 'packages', 'diagrams', 'package.json');
+const cliDistMetaPath = resolve(root, 'packages', 'cli', 'dist', 'bundle-metadata.json');
+
+const diagramsPkg = JSON.parse(await fs.readFile(diagramsPkgPath, 'utf8'));
+let bundleMeta;
+try {
+  bundleMeta = JSON.parse(await fs.readFile(cliDistMetaPath, 'utf8'));
+} catch (error) {
+  console.error('[cli-bundle-check] missing bundle metadata at packages/cli/dist/bundle-metadata.json');
+  console.error('[cli-bundle-check] run the CLI prepack/build step first.');
+  throw error;
+}
+
+const expected = String(diagramsPkg.version);
+const actual = String(bundleMeta?.diagramsVersion ?? '');
+
+if (actual !== expected) {
+  console.error(
+    `[cli-bundle-check] diagrams version mismatch: bundled=${actual || '<missing>'}, workspace=${expected}`,
+  );
+  process.exit(1);
+}
+
+console.log(`[cli-bundle-check] ok: bundled diagrams version ${actual}`);


### PR DESCRIPTION
﻿## Summary
- Bump `@transitrix/cli` to `2.3.0` so the next npm publish carries the same diagrams behavior line as current Studio releases.
- Extend `scripts/build-cli-package.mjs` to emit `packages/cli/dist/bundle-metadata.json` with `{ diagramsVersion, cliVersion }` during every build/prepack.
- Add `scripts/verify-cli-bundle-alignment.mjs` and wire it into `.github/workflows/npm-publish.yml` (build CLI bundle, then fail publish if bundled diagrams version differs from `packages/diagrams/package.json`).
- Document the release-train rule in `RELEASING.md`: when diagrams behavior changes affect CLI paths, bump/publish CLI in the same train and run the alignment check.

## Test plan
- [x] `npm run build --workspace packages/cli`
- [x] `node scripts/verify-cli-bundle-alignment.mjs`
- [x] `npm run compile`
