### PR TITLE
chore(release): bump extension to 3.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+## [3.1.3] — 2026-07-29
+
+### Fixed
+
+- **`@transitrix/cli` on npm shipped a stale diagrams bundle** (#426). Published `@transitrix/cli@2.2.0` still carried the pre-#421 `BL-006` TYPE registry, so `npx @transitrix/cli validate` rejected current TYPE-prefixed block ids (`HAZARD-*`, `RISK_CONTROL-*`, …) that the extension accepted. Root cause: the idempotent npm publish step compared only the CLI's own version — if diagrams bumped without a matching CLI bump, the publish silently no-oped. Fix: bump CLI to `2.3.0`, record the bundled diagrams version in `dist/diagrams-version.json`, expose it via `transitrix --version`, and add a PR-level CI guard (`cli-diagrams-alignment.yml`) that fails a diagrams bump without a matching CLI bump.
+- **Residual Cervin identifiers scrubbed** (#427). Internal class names, localStorage keys, dev-UI plugin names, debug-script fixture paths, test variables, and stale comments still referencing the pre-rename `cervin`/`Cervin*` identifier — replaced with Transitrix equivalents. Removed the unused `@deprecated CompileCervinOptions` type alias. Migration guards and CHANGELOG history are kept per the task's "must keep" list.
+
+### Packages
+
+- **Transitrix Studio extension** 3.1.2 → 3.1.3
+- **`@transitrix/cli`** 2.2.0 → 2.3.0 — rebundled with `@transitrix/diagrams` 1.8.21, `transitrix --version` now reports the bundled diagrams version.
+- **`@transitrix/diagrams`** 1.8.20 → 1.8.21 — Cervin identifier cleanup in compliance HTML renderer.
+
 ## [3.1.2] — 2026-07-29
 
 ### Fixed

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+## 3.1.3 — 2026-07-29
+
+The CLI npm package now ships the same diagrams behavior as the extension (fixes false `BL-006` rejections on current element types), and internal legacy identifiers have been cleaned up.
+
+### Fixed
+
+- **`transitrix validate` on the npm CLI no longer rejects current element types** like `HAZARD`, `RISK_CONTROL`, `REQUIREMENT`, and `VERIFICATION` in blocks diagrams — the published CLI bundle was stale. Bumped to `@transitrix/cli@2.3.0` with current diagrams; `transitrix --version` now reports the bundled diagrams version so mismatches are easy to spot.
+- **Internal Cervin identifiers cleaned up** — no user-visible change, but the last legacy naming remnants in preview classes, dev-UI keys, and debug scripts are now Transitrix-native.
+
 ## 3.1.2 — 2026-07-29
 
 Network/PSND dependency arcs no longer cross the diagram title, and Blocks diagrams accept the current methodology element types (including the hazard → verification chain).

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Diagrams as text. Write goals, processes, capabilities, BPMN, and more as plain YAML — 17 notations, live preview in VS Code. Diffable in git. AI-friendly. Open source.",
   "license": "MIT",
   "icon": "icon.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "transitrix-studio",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "transitrix-studio",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -7771,7 +7771,7 @@
     },
     "packages/cli": {
       "name": "@transitrix/cli",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",
@@ -7789,7 +7789,7 @@
     },
     "packages/diagrams": {
       "name": "@transitrix/diagrams",
-      "version": "1.8.20",
+      "version": "1.8.21",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
﻿## Why

Two PRs merged since v3.1.2: #426 (CLI rebundle with current diagrams + alignment CI guard) and #427 (residual Cervin identifier scrub). The CLI rebundle is the adopter-facing fix — published `@transitrix/cli@2.2.0` rejected current TYPE-prefixed block ids that the extension accepted.

## What this does

- `extension/package.json` + `package.json`: `3.1.2` -> `3.1.3` (via `npm run bump-extension-version -- set 3.1.3`).
- `CHANGELOG.md`: closes `Unreleased` as `## [3.1.3] — 2026-07-29`, opens a fresh empty `Unreleased`.
- `extension/CHANGELOG.md`: adds the adopter-facing `3.1.3` entry.
- `package-lock.json`: version bump only (`npm install --package-lock-only`).

`@transitrix/cli` (`2.3.0`) and `@transitrix/diagrams` (`1.8.21`) are already at their target versions on `main` from #426/#427.

## Test plan

- [x] `npm run compile` (build:diagrams + root tsc --noEmit) — clean

## After merge

Cutting the GitHub Release (tag `v3.1.3`) triggers npm package publish (idempotent; already-published versions skip) plus the VS Code / Open VSX / JetBrains marketplace publishes. Leaving that step to Valerii.
