### PR TITLE
fix: blocks grid preview no longer paints solid black over the matrix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7771,7 +7771,7 @@
     },
     "packages/cli": {
       "name": "@transitrix/cli",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",
@@ -7789,7 +7789,7 @@
     },
     "packages/diagrams": {
       "name": "@transitrix/diagrams",
-      "version": "1.8.21",
+      "version": "1.8.22",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/cli",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "type": "module",
   "description": "Transitrix CLI — compile, validate, and report on Transitrix diagrams (BPMN, Goals, DGCA, …) from any shell or CI pipeline.",
   "license": "MIT",

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.8.21",
+  "version": "1.8.22",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",

--- a/packages/diagrams/src/theme/themes.ts
+++ b/packages/diagrams/src/theme/themes.ts
@@ -184,7 +184,8 @@ ${levelRules}
 .tree-maturity-5{fill:var(${cv.treeMaturity5});}
 .tree-collapse-btn{cursor:pointer;fill:white;stroke:var(${cv.nodeStroke});stroke-width:1.5;}
 .tree-collapse-btn:hover{fill:var(${cv.bgElevated});}
-.tree-collapse-lbl{fill:var(${cv.textSecondary});font-family:${t.fontFamily};font-size:12px;font-weight:700;dominant-baseline:central;pointer-events:none;}`;
+.tree-collapse-lbl{fill:var(${cv.textSecondary});font-family:${t.fontFamily};font-size:12px;font-weight:700;dominant-baseline:central;pointer-events:none;}
+.blocks-grid-border{fill:none;stroke:var(${cv.border});}`;
 }
 
 /**

--- a/packages/diagrams/src/webview/__tests__/render-blocks.test.ts
+++ b/packages/diagrams/src/webview/__tests__/render-blocks.test.ts
@@ -9,9 +9,11 @@
 import { describe, expect, it } from 'vitest';
 
 import type { BlocksFile, GridFile } from '../../blocks/types.js';
-import { renderBlocksSvg, renderGridSvg } from '../render-blocks.js';
+import { layoutGrid } from '../../blocks/layout.js';
+import { renderBlocksSvg, renderGridSvg, renderGridLayoutSvg } from '../render-blocks.js';
 import { CHAR_W_PRIMARY as CHAR_W, CHAR_W_ID, TEXT_MARGIN_X } from '../entity-text-layout.js';
 import { ENTITY_NODE_SIZE } from '../../node-size-presets.js';
+import { generateWebviewCss } from '../../theme/index.js';
 
 const LEAF_W = ENTITY_NODE_SIZE.normal.width;
 const LEAF_H = ENTITY_NODE_SIZE.normal.height;
@@ -263,5 +265,50 @@ describe('renderGridSvg — matrix subset', () => {
   it('returns a zero-size svg for an empty grid', () => {
     const svg = renderGridSvg({ notation: 'blocks', grid: { columns: [], rows: [] } });
     expect(svg).toContain('width="0" height="0"');
+  });
+});
+
+// Regression for hub #853: the grid preview rendered as a solid black
+// rectangle in the VS Code webview (CLI validation and `nested_blocks`
+// preview were unaffected). Root cause: the full-bounds border rect —
+// the last, topmost element emitted — carried a CSS class
+// (`.blocks-grid-border`) that was only ever defined in a locally-embedded
+// `<style>` block passed by the CLI/IntelliJ host path. The live VS Code
+// webview builds its SVG body via `renderGridLayoutSvg` *without*
+// `embedCssTheme` (see `extension/src/blocks-preview.ts`'s `gridLayoutToSvg`)
+// and supplies CSS separately via the webview shell — so that class never
+// resolved there, and the rect fell back to SVG's default opaque black fill,
+// painting over every header/cell beneath it.
+describe('renderGridLayoutSvg — webview render pipeline (no embedded CSS)', () => {
+  const layout = layoutGrid(RACI_GRID);
+
+  it('the full-bounds border rect is explicitly fill="none", independent of any CSS class resolving', () => {
+    // This is the path blocks-preview.ts (VS Code) actually takes: no
+    // embedCssTheme, CSS supplied live by the webview shell instead.
+    const svg = renderGridLayoutSvg(layout);
+    const borderRect = svg.match(/<rect class="blocks-grid-border"[^>]*\/>/)?.[0];
+    expect(borderRect).toBeDefined();
+    expect(borderRect).toContain('fill="none"');
+  });
+
+  it('does not paint an opaque rect on top of the header/cell content', () => {
+    const svg = renderGridLayoutSvg(layout);
+    // Any <rect> without an explicit fill="none" and without a
+    // .diagram-node/level-N class relies on the webview to supply the fill —
+    // guard that only the known, level-classed background/header/row rects
+    // do that; every other rect must be self-defensive.
+    const rects = svg.match(/<rect[^>]*\/>/g) ?? [];
+    for (const rect of rects) {
+      const hasLevelClass = /class="diagram-node level-\d"/.test(rect);
+      const hasExplicitFillNone = /fill="none"/.test(rect);
+      expect(hasLevelClass || hasExplicitFillNone).toBe(true);
+    }
+  });
+
+  it('the live webview theme CSS (both themes) defines .blocks-grid-border with fill:none', () => {
+    for (const themeId of ['transitrix', 'transitrix-dark'] as const) {
+      const css = generateWebviewCss(themeId);
+      expect(css).toMatch(/\.blocks-grid-border\{fill:none;stroke:var\(--ts-border\);\}/);
+    }
   });
 });

--- a/packages/diagrams/src/webview/render-blocks.ts
+++ b/packages/diagrams/src/webview/render-blocks.ts
@@ -163,8 +163,6 @@ export function renderBlocksSvg(doc: BlocksFile, options: RenderBlocksOptions = 
  */
 const GRID_CELL_PAD_X = 8;
 const GRID_LINE_HEIGHT = 15;
-const GRID_EMBED_CSS = `
-.blocks-grid-border { fill: none; stroke: var(--ts-border, #cbd5e1); }`;
 
 function centeredGridCellTextSvg(
   lines: string[],
@@ -246,7 +244,13 @@ export function renderGridBody(layout: GridLayout, ox: number, oy: number): stri
     parts.push(`<line class="diagram-edge" x1="${colLineX}" y1="${gridY1}" x2="${colLineX}" y2="${gridY2}"/>`);
   }
 
-  parts.push(`<rect class="blocks-grid-border" x="${ox}" y="${oy}" width="${tw}" height="${th}"/>`);
+  // Explicit fill="none" alongside the class: this rect covers the full grid
+  // bounds and is the last (topmost) element emitted, so if `.blocks-grid-border`
+  // is ever missing from a host's CSS (as it was in the VS Code webview path —
+  // see hub #853), it must not fall back to SVG's default opaque black fill.
+  parts.push(
+    `<rect class="blocks-grid-border" fill="none" x="${ox}" y="${oy}" width="${tw}" height="${th}"/>`,
+  );
 
   return parts.join('\n');
 }
@@ -270,7 +274,7 @@ export function renderGridLayoutSvg(layout: GridLayout, options: RenderGridLayou
   const oy = PAD + topInset;
 
   const body = renderGridBody(layout, ox, oy);
-  const styleLine = embedCssTheme ? `\n<style>${generateSvgEmbedCss(embedCssTheme)}${GRID_EMBED_CSS}</style>` : '';
+  const styleLine = embedCssTheme ? `\n<style>${generateSvgEmbedCss(embedCssTheme)}</style>` : '';
 
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">${styleLine}
 ${title}


### PR DESCRIPTION
## Summary

A valid `blocks` document using the `grid` subset could render in the Studio preview as a solid black rectangle, even though CLI validation passed and the equivalent `nested_blocks` document rendered fine.

**Root cause:** the VS Code webview path (`extension/src/blocks-preview.ts`) builds the grid SVG via `renderGridLayoutSvg` *without* `embedCssTheme`, relying on the live webview CSS for styling. The full-bounds border rect — the last (topmost) SVG element emitted — used a CSS class (`.blocks-grid-border`) that was only ever defined in a locally-embedded `<style>` block, injected exclusively on the CLI/IntelliJ host-neutral path. In the live webview that class never resolved, so the rect fell back to SVG's default opaque black fill, painting over every header and cell beneath it.

## Fix

- Moved `.blocks-grid-border` into the shared theme CSS (`packages/diagrams/src/theme/themes.ts`) so the live webview always defines it, for both light and dark themes.
- Made the border rect explicitly `fill="none"` in the SVG markup itself, so it can't silently default to an opaque fill again if a class is ever missing from any host.
- Removed the now-redundant locally-embedded CSS constant that only covered the CLI/IntelliJ path.

## Test plan

- [x] Added regression tests exercising the exact VS Code webview code path (`renderGridLayoutSvg` with no `embedCssTheme`), confirming the border rect is self-defensive and the shared webview theme CSS defines the class for both themes.
- [x] `nested_blocks` preview path unchanged (no test changes to that suite; existing tests pass).
- [x] Full `packages/diagrams` test suite passes (1476 tests).
- [x] `tsc --noEmit` clean for `packages/diagrams` and `extension`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)