### PR TITLE
feat: surface REQUIREMENT -> VERIFICATION coverage as an obligation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- **`REQUIREMENT` → `VERIFICATION` coverage surfaced as an obligation.** New `VERIFICATION` element (`canon/verifications/`, `VERIF-001..006`) — the engineering V&V analogue of `ASSERTION`. The reverse-trace completeness rules `REQ-VERIF-COVERAGE-001` (no verification targets a requirement) and `-002` (every verification against it is still unresolved) are computed cross-cuttingly and surfaced in `validate --scope=repo`'s `compliance` findings. The Requirement Trace preview renders a "Verification" section labelled "Not verified" / "Unresolved" for a gap rather than a blank section; the Compliance Gap Dashboard lists every affected requirement repo-wide (both re-scan on save of any `VERIFICATION-*.yaml` file).
+
 ## [3.1.3] — 2026-07-29
 
 ### Fixed

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -191,6 +191,7 @@ validators the VS Code preview uses:
 | `canon/elements/**/REQUIREMENT-*.yaml` | `REQ-*` shape | `REQ-002`/`003` with scanned `CanonCatalog` |
 | `canon/elements/**/CONSTRAINT-*.yaml` | `CONST-*` shape | `CONST-004`/`005` with scanned `CanonCatalog` |
 | `canon/assertions/ASSERTION-*.yaml` | `ASSERT-*` shape | `ASSERT-002`..`005` + `ASSERT-007`/`008` warnings |
+| `canon/verifications/VERIFICATION-*.yaml` | `VERIF-*` shape | `VERIF-002`/`005` with scanned `CanonCatalog` + `REQ-VERIF-COVERAGE-001`/`002` warnings |
 | `codex/**` | `CODEX-*` | folder jurisdiction (`CODEX-005`) |
 | `canon/views/**.compliance-impact.*` | `COMPIMP-001` parse | `COMPIMP-REF`, `COMPIMP-009`..`011`, `buildImpactMatrix` |
 | `canon/views/**.coverage-metric.*` | `COVMET-*` parse | `COVMET-REF`, `buildCoverageMatrix` |
@@ -198,6 +199,30 @@ validators the VS Code preview uses:
 **Derived views** (no YAML config file) — `compliance-matrix`, `gap-dashboard`,
 `single-law`, `single-product`, `requirement-trace` — are built interactively in
 the preview / `export-compliance`; they are not separate file validators.
+
+**`VERIFICATION` (27-verification.md) — the engineering V&V analogue of
+`ASSERTION`.** `VERIF-001..006` are the single-file
+shape rules (mirrors `ASSERT-001..008` — no staleness rule, since a
+verification has no `next_review_at`). The reverse-trace completeness check —
+"does every `REQUIREMENT` have a verification, and has it closed?" — is
+cross-cutting, computed the same way as `GAP-REQ-NO-ASSERT`:
+
+| ruleId | Fires when |
+|---|---|
+| `REQ-VERIF-COVERAGE-001` | No admitted `VERIFICATION` carries `verifies: <this REQUIREMENT id>`. |
+| `REQ-VERIF-COVERAGE-002` | One or more `VERIFICATION`s target the requirement, but every one is still `not_yet_run`/`inconclusive` — none has reached `pass`/`fail`. Mutually exclusive with `-001` by construction. |
+
+Both are `warning`-severity (a newly admitted REQUIREMENT legitimately has no
+verification yet), surfaced in the `compliance` findings bucket alongside
+`GAP-REQ-NO-ASSERT`. The Studio extension surfaces the same verdict where the
+author is working, not only in a report: the **Requirement Trace** preview
+(opened from a `REQUIREMENT-*.yaml`/`CONSTRAINT-*.yaml` file) renders a
+"Verification" section that reads as an open obligation — labelled "Not
+verified" or "Unresolved" — rather than a blank section when the gap exists;
+the **Compliance Gap Dashboard** lists every affected requirement repo-wide.
+Both re-scan on save of any `VERIFICATION-*.yaml` file. The core validator is
+the single source of the verdict — the previews render `buildGapReport`'s
+output, they never compute their own judgement.
 
 File-scope `transitrix validate <requirement.yaml>` runs shape rules only unless
 you pass a catalogue (repo-scope builds one automatically from `canon/**` +

--- a/extension/src/compliance-render.ts
+++ b/extension/src/compliance-render.ts
@@ -2,6 +2,7 @@ import { type ThemeId } from '@transitrix/diagrams/theme';
 import { escXml } from '@transitrix/diagrams/webview/render-util.js';
 export { escXml };
 import type { AssertionStatus } from '@transitrix/diagrams/assertion/types.js';
+import type { VerificationOutcome } from '@transitrix/diagrams/verification/types.js';
 import type { ViewScore } from '@transitrix/diagrams/confidence';
 import { computeDeadlineStatus } from '@transitrix/diagrams/compliance/impact.js';
 import { buildDiagramFrame, OPEN_THEME_COMMAND } from './diagram-frame.js';
@@ -23,6 +24,17 @@ export const STATUS_LABELS: Record<AssertionStatus, string> = {
 /** A coloured status pill. */
 export function statusBadge(status: AssertionStatus): string {
   return `<span class="cmp-badge cmp-${status}">${escXml(STATUS_LABELS[status])}</span>`;
+}
+
+export const OUTCOME_LABELS: Record<VerificationOutcome, string> = {
+  pass: 'Pass',
+  fail: 'Fail',
+  inconclusive: 'Inconclusive',
+  not_yet_run: 'Not yet run',
+};
+/** A coloured verification-outcome pill (27-verification.md §3). */
+export function outcomeBadge(outcome: VerificationOutcome): string {
+  return `<span class="cmp-badge cmp-outcome-${outcome}">${escXml(OUTCOME_LABELS[outcome])}</span>`;
 }
 
 /**
@@ -64,6 +76,11 @@ const COMPLIANCE_CSS = `
 .cmp-under_review { background: var(--ts-status-info-bg, #e0f2fe); color: var(--ts-status-info-fg, #0c4a6e); }
 .cmp-n_a { background: var(--ts-bg-subtle, #f1f5f9); color: var(--ts-text-muted, #64748b); }
 .cmp-pending_owner { background: var(--ts-status-info-bg, #e0f2fe); color: var(--ts-status-info-fg, #0c4a6e); }
+.cmp-outcome-pass { background: var(--ts-status-success-bg, #d1fae5); color: var(--ts-status-success-fg, #065f46); }
+.cmp-outcome-fail { background: var(--ts-status-error-bg, #fee2e2); color: var(--ts-status-error-fg, #991b1b); }
+.cmp-outcome-inconclusive { background: var(--ts-status-warning-bg, #fef9c3); color: var(--ts-status-warning-fg, #854d0e); }
+.cmp-outcome-not_yet_run { background: var(--ts-bg-subtle, #f1f5f9); color: var(--ts-text-muted, #64748b); }
+.cmp-gap { color: var(--ts-status-warning-fg, #854d0e); font-weight: 600; }
 
 /* Tree (single-law) */
 .cmp-req { margin: 0 0 14px; border: 1px solid var(--ts-border, #cbd5e1); border-radius: 6px; overflow: hidden; }

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -518,7 +518,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       void goalsPreview.refreshIfSiblingSaved(doc);
       // Compliance views are repo-wide: re-scan the open ones whenever a canon
       // artefact (by filename convention) is saved. No-op when no panel is open.
-      if (/^(PRODUCT|REQUIREMENT|CONSTRAINT|ASSERTION|LAW|REGULATION|POLICY|INTERNAL_STANDARD)-.*\.ya?ml$/.test(path.basename(doc.fileName))) {
+      if (/^(PRODUCT|REQUIREMENT|CONSTRAINT|ASSERTION|VERIFICATION|LAW|REGULATION|POLICY|INTERNAL_STANDARD)-.*\.ya?ml$/.test(path.basename(doc.fileName))) {
         void complianceMatrixPreview.refresh();
         void complianceImpactPreview.refresh();
         void singleLawPreview.refresh();

--- a/extension/src/gap-dashboard-preview.ts
+++ b/extension/src/gap-dashboard-preview.ts
@@ -49,7 +49,11 @@ export class GapDashboardPreview {
     if (!this.panel) return;
     const scan = await scanComplianceCanon();
     this.pathById = scan.pathById;
-    const index = buildComplianceIndex({ requirements: scan.requirements, assertions: scan.assertions });
+    const index = buildComplianceIndex({
+      requirements: scan.requirements,
+      assertions: scan.assertions,
+      verifications: scan.verifications,
+    });
     const today = todayIso();
     this.lastReport = buildGapReport(index, { today });
     // Confidence across the full scanned canon — the dashboard's "view" is
@@ -89,11 +93,19 @@ export class GapDashboardPreview {
     for (const r of report.pastDeadlineRequirements) {
       rows.push(['past_deadline_requirement', r.id, r.name, r.severity ?? '', r.deadline ?? '']);
     }
+    for (const r of report.requirementsWithoutVerification) {
+      rows.push(['requirement_without_verification', r.id, r.name, r.severity ?? '', '']);
+    }
+    for (const r of report.requirementsWithUnresolvedVerification) {
+      rows.push(['requirement_unresolved_verification', r.id, r.name, r.severity ?? '', '']);
+    }
     return rows.map(cols => cols.map(esc).join(',')).join('\r\n') + '\r\n';
   }
 
   private buildHtml(report: GapReport, themeId: ThemeId): string {
-    const total = report.requirementsWithoutAssertions.length + report.assertionsWithoutEvidence.length + report.staleAssertions.length + report.pastDeadlineRequirements.length;
+    const total = report.requirementsWithoutAssertions.length + report.assertionsWithoutEvidence.length
+      + report.staleAssertions.length + report.pastDeadlineRequirements.length
+      + report.requirementsWithoutVerification.length + report.requirementsWithUnresolvedVerification.length;
 
     const today = todayIso();
     const reqRows = report.requirementsWithoutAssertions.map(r => {
@@ -116,6 +128,16 @@ export class GapDashboardPreview {
       return `<li>${sev}${openLink(OPEN_FILE_COMMAND, this.pathById.get(r.id), escXml(r.name), `Open ${r.id}`)}<span class="cmp-meta">${escXml(r.id)}</span> ${dl}</li>`;
     }).join('');
 
+    const noVerifRows = report.requirementsWithoutVerification.map(r => {
+      const sev = r.severity ? `<span class="cmp-sev cmp-sev-${escXml(r.severity)}">${escXml(r.severity)}</span>` : '';
+      return `<li>${sev}${openLink(OPEN_FILE_COMMAND, this.pathById.get(r.id), escXml(r.name), `Open ${r.id}`)}<span class="cmp-meta">${escXml(r.id)}</span></li>`;
+    }).join('');
+
+    const unresolvedVerifRows = report.requirementsWithUnresolvedVerification.map(r => {
+      const sev = r.severity ? `<span class="cmp-sev cmp-sev-${escXml(r.severity)}">${escXml(r.severity)}</span>` : '';
+      return `<li>${sev}${openLink(OPEN_FILE_COMMAND, this.pathById.get(r.id), escXml(r.name), `Open ${r.id}`)}<span class="cmp-meta">${escXml(r.id)}</span></li>`;
+    }).join('');
+
     const section = (title: string, count: number, rowsHtml: string, okMessage: string): string =>
       `<div class="cmp-section">
         <h2>${escXml(title)} <span class="cmp-count">(${count})</span></h2>
@@ -126,12 +148,14 @@ export class GapDashboardPreview {
       ${section('Requirements without assertions', report.requirementsWithoutAssertions.length, reqRows, 'Every requirement has at least one assertion.')}
       ${section('Assertions without evidence (ASSERT-007)', report.assertionsWithoutEvidence.length, noEvRows, 'No compliant/partial assertion is missing evidence.')}
       ${section('Stale assertions — review overdue (ASSERT-008)', report.staleAssertions.length, staleRows, 'No assertion is past its review date.')}
-      ${section('Past-deadline requirements (CV-5)', report.pastDeadlineRequirements.length, pastDlRows, 'No requirement has a past deadline without full compliance.')}`;
+      ${section('Past-deadline requirements (CV-5)', report.pastDeadlineRequirements.length, pastDlRows, 'No requirement has a past deadline without full compliance.')}
+      ${section('Requirements without verification (REQ-VERIF-COVERAGE-001)', report.requirementsWithoutVerification.length, noVerifRows, 'Every requirement has at least one verification.')}
+      ${section('Requirements with unresolved verification (REQ-VERIF-COVERAGE-002)', report.requirementsWithUnresolvedVerification.length, unresolvedVerifRows, 'No requirement is stuck with only not-yet-run/inconclusive verifications.')}`;
 
     return complianceShell({
       notation: 'Gap dashboard',
       title: 'Compliance Gap Dashboard',
-      subtitle: total === 0 ? 'No gaps found' : `${total} gap(s) across 4 checks`,
+      subtitle: total === 0 ? 'No gaps found' : `${total} gap(s) across 6 checks`,
       date: todayIso(),
       themeId,
       refreshCommand: REFRESH_COMMAND,

--- a/extension/src/requirement-trace-preview.ts
+++ b/extension/src/requirement-trace-preview.ts
@@ -7,19 +7,23 @@ import {
   buildRequirementTrace,
   buildTraceElementCatalog,
   scoreComplianceView,
+  CLOSED_VERIFICATION_OUTCOMES,
   type RequirementTrace,
 } from '@transitrix/diagrams/compliance';
 import { scanComplianceCanon } from './compliance-scan.js';
-import { complianceShell, escXml, openLink, statusBadge } from './compliance-render.js';
+import { complianceShell, escXml, openLink, statusBadge, outcomeBadge } from './compliance-render.js';
 
 // Requirement traceability + hierarchy view. Triggered
 // from a REQUIREMENT-*.yaml or CONSTRAINT-*.yaml file in the editor-title bar.
 // Shows the trace chain (derived_from → element → ASSERTION → subject +
-// realised_via) and the hierarchy (parent chain + direct children). Read-only,
-// script-less; click-to-open via command URIs.
+// realised_via), the V&V trace via VERIFICATION, and the hierarchy (parent
+// chain + direct children). Read-only, script-less; click-to-open via command
+// URIs.
 //
 // Assertion coverage applies to REQUIREMENT only (16-assertion.md §1) — a
 // CONSTRAINT-side trace shows sources + hierarchy but no assertion block.
+// Same posture for VERIFICATION (27-verification.md §4): the engineering V&V
+// leg applies to REQUIREMENT only.
 
 const OPEN_FILE_COMMAND = 'transitrixStudio.openComplianceFile';
 const REFRESH_COMMAND = 'transitrixStudio.refreshRequirementTrace';
@@ -96,7 +100,11 @@ export class RequirementTracePreview {
     }
 
     const scan = await scanComplianceCanon();
-    const index = buildComplianceIndex({ requirements: scan.requirements, assertions: scan.assertions });
+    const index = buildComplianceIndex({
+      requirements: scan.requirements,
+      assertions: scan.assertions,
+      verifications: scan.verifications,
+    });
     const catalog = buildTraceElementCatalog(scan.products, scan.subjects);
     const trace = buildRequirementTrace(elementId, index, catalog, scan.codex);
 
@@ -134,7 +142,7 @@ export class RequirementTracePreview {
     kind: 'requirement' | 'constraint',
     pathById: Map<string, string>,
   ): string {
-    const { requirement, sources, assertions, ancestors, children } = trace;
+    const { requirement, sources, assertions, verifications, ancestors, children } = trace;
 
     const description = requirement.description
       ? `<p class="rt-desc">${escXml(requirement.description)}</p>`
@@ -237,7 +245,53 @@ export class RequirementTracePreview {
       </section>`;
     }
 
-    return `<style>${RT_CSS}</style>${description}${hierarchyHtml}${sourcesHtml}${assertionsHtml}${childrenHtml}`;
+    // Forward trace via VERIFICATION — REQUIREMENT only (27-verification.md §4),
+    // same posture as ASSERTION. A gap is rendered as a defect, not a blank
+    // section — never silently omitted.
+    let verificationsHtml = '';
+    if (kind === 'constraint') {
+      verificationsHtml = `<section class="rt-section">
+        <h2>Verification</h2>
+        <p class="rt-note">CONSTRAINT-side VERIFICATION mechanism is out of scope for v1 (27-verification.md §4).
+          Engineering V&amp;V for this element is tracked via its <code>status</code> or downstream tooling.</p>
+      </section>`;
+    } else if (verifications.length === 0) {
+      verificationsHtml = `<section class="rt-section">
+        <h2>Verification</h2>
+        <p class="rt-note rt-gap">No VERIFICATION targets this requirement — V&amp;V gap
+          (<code>REQ-VERIF-COVERAGE-001</code>). Not verified.</p>
+      </section>`;
+    } else {
+      const hasClosedVerification = verifications.some(row =>
+        (CLOSED_VERIFICATION_OUTCOMES as readonly string[]).includes(row.verification.outcome),
+      );
+      const gapNote = hasClosedVerification
+        ? ''
+        : `<p class="rt-note rt-gap">Every verification against this requirement is still open
+            (<code>REQ-VERIF-COVERAGE-002</code>). Unresolved — the trace link exists but has not closed.</p>`;
+      const rows = verifications.map(row => {
+        const v = row.verification;
+        const vLink = openLink(OPEN_FILE_COMMAND, pathById.get(v.id), escXml(v.id), `Open ${v.id}`);
+        const meta = [
+          `method: ${v.method}`,
+          v.performed_at ? `performed ${v.performed_at}` : null,
+        ].filter(Boolean).join(' · ');
+        return `<li class="rt-assertion">
+          <div class="rt-assertion-head">
+            ${outcomeBadge(v.outcome)}
+            <span class="rt-assertion-id">${vLink}</span>
+          </div>
+          ${meta ? `<div class="cmp-meta">${escXml(meta)}</div>` : ''}
+        </li>`;
+      }).join('');
+      verificationsHtml = `<section class="rt-section">
+        <h2>Verification <span class="cmp-count">(${verifications.length} verification${verifications.length === 1 ? '' : 's'})</span></h2>
+        ${gapNote}
+        <ul class="rt-assertions">${rows}</ul>
+      </section>`;
+    }
+
+    return `<style>${RT_CSS}</style>${description}${hierarchyHtml}${sourcesHtml}${assertionsHtml}${verificationsHtml}${childrenHtml}`;
   }
 }
 
@@ -256,6 +310,7 @@ const RT_CSS = `
 .rt-parent-chain li.rt-self { font-weight: 600; color: var(--ts-text, #0f172a); }
 .rt-note { color: var(--ts-text-muted, #64748b); font-size: 12px; margin: 0; }
 .rt-note code { font-family: var(--vscode-editor-font-family, monospace); }
+.rt-note.rt-gap { color: var(--ts-status-warning-fg, #854d0e); font-weight: 600; margin: 0 0 8px; }
 .rt-jur { display: inline-block; padding: 0 6px; margin-left: 4px; border-radius: 3px; font-size: 10px; background: var(--ts-bg-subtle, #f1f5f9); color: var(--ts-text-muted, #64748b); text-transform: uppercase; letter-spacing: 0.04em; }
 .rt-dangling { color: var(--ts-status-warning-fg, #854d0e); font-size: 11px; font-style: normal; }
 .rt-origin { display: inline-block; padding: 0 6px; margin-left: 6px; border-radius: 3px; font-size: 10px; background: var(--ts-bg-subtle, #f1f5f9); color: var(--ts-text-muted, #64748b); text-transform: uppercase; letter-spacing: 0.04em; }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/cli",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "type": "module",
   "description": "Transitrix CLI — compile, validate, and report on Transitrix diagrams (BPMN, Goals, DGCA, …) from any shell or CI pipeline.",
   "license": "MIT",

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.8.21",
+  "version": "1.9.0",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",

--- a/packages/diagrams/src/compliance/__tests__/gap-report.test.ts
+++ b/packages/diagrams/src/compliance/__tests__/gap-report.test.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import yaml from 'js-yaml';
 import { buildComplianceIndex } from '../reverse-index.js';
 import { buildGapReport } from '../gap-report.js';
-import type { ComplianceIndexInput, IndexAssertion, IndexRequirement } from '../types.js';
+import type { ComplianceIndexInput, IndexAssertion, IndexRequirement, IndexVerification } from '../types.js';
 
 const input: ComplianceIndexInput = {
   requirements: [
@@ -45,6 +45,56 @@ describe('buildGapReport', () => {
 
   it('produces no stale list when today is not supplied (clock-free)', () => {
     expect(buildGapReport(index, {}).staleAssertions).toEqual([]);
+  });
+});
+
+describe('buildGapReport — REQ-VERIF-COVERAGE-001/002', () => {
+  const verifInput: ComplianceIndexInput = {
+    requirements: [
+      { id: 'REQUIREMENT-A-1', name: 'A', severity: 'high' },   // closed verification -> covered
+      { id: 'REQUIREMENT-B-1', name: 'B', severity: 'low' },    // no verification at all -> -001
+      { id: 'REQUIREMENT-C-1', name: 'C', severity: 'medium' }, // only unresolved verifications -> -002
+      { id: 'REQUIREMENT-D-1', name: 'D' },                     // no verification, no severity
+    ],
+    assertions: [],
+    verifications: [
+      { id: 'VERIFICATION-1', verifies: 'REQUIREMENT-A-1', method: 'test', outcome: 'pass' },
+      { id: 'VERIFICATION-2', verifies: 'REQUIREMENT-C-1', method: 'test', outcome: 'not_yet_run' },
+      { id: 'VERIFICATION-3', verifies: 'REQUIREMENT-C-1', method: 'analysis', outcome: 'inconclusive' },
+    ],
+  };
+  const verifIndex = buildComplianceIndex(verifInput);
+  const verifReport = buildGapReport(verifIndex);
+
+  it('lists requirements with no verification at all, severity-sorted (REQ-VERIF-COVERAGE-001)', () => {
+    expect(verifReport.requirementsWithoutVerification.map(r => r.id)).toEqual(['REQUIREMENT-B-1', 'REQUIREMENT-D-1']);
+  });
+
+  it('excludes requirements whose verifications are merely unresolved from -001', () => {
+    expect(verifReport.requirementsWithoutVerification.map(r => r.id)).not.toContain('REQUIREMENT-C-1');
+  });
+
+  it('lists requirements whose verifications never closed (REQ-VERIF-COVERAGE-002)', () => {
+    expect(verifReport.requirementsWithUnresolvedVerification.map(r => r.id)).toEqual(['REQUIREMENT-C-1']);
+  });
+
+  it('-001 and -002 are mutually exclusive by construction', () => {
+    const inBoth = verifReport.requirementsWithoutVerification
+      .filter(r => verifReport.requirementsWithUnresolvedVerification.some(u => u.id === r.id));
+    expect(inBoth).toEqual([]);
+  });
+
+  it('a requirement with a closed (pass/fail) verification is in neither list', () => {
+    expect(verifReport.requirementsWithoutVerification.map(r => r.id)).not.toContain('REQUIREMENT-A-1');
+    expect(verifReport.requirementsWithUnresolvedVerification.map(r => r.id)).not.toContain('REQUIREMENT-A-1');
+  });
+
+  it('with no verifications supplied at all, every requirement is a -001 gap (backward compatible)', () => {
+    const noVerif = buildGapReport(buildComplianceIndex({ requirements: verifInput.requirements, assertions: [] }));
+    expect(noVerif.requirementsWithoutVerification.map(r => r.id).sort()).toEqual(
+      verifInput.requirements.map(r => r.id).sort(),
+    );
+    expect(noVerif.requirementsWithUnresolvedVerification).toEqual([]);
   });
 });
 

--- a/packages/diagrams/src/compliance/__tests__/html.test.ts
+++ b/packages/diagrams/src/compliance/__tests__/html.test.ts
@@ -100,9 +100,17 @@ describe('renderComplianceHtml — gap', () => {
     expect(html).toContain('class="cmp-ok">✓ none');
   });
 
-  it('counts gaps in the summary line', () => {
+  it('lists both requirements as gaps under REQ-VERIF-COVERAGE-001 — no VERIFICATION artefacts scanned', () => {
+    const html = renderComplianceHtml(synthetic(), { mode: 'gap' }, { today: '2026-06-02' });
+    expect(html).toContain('Requirements without verification — REQ-VERIF-COVERAGE-001');
+    expect(html).toContain('REQUIREMENT-ERASURE-1');
+    expect(html).toContain('Requirements with unresolved verification — REQ-VERIF-COVERAGE-002');
+  });
+
+  it('counts gaps in the summary line, including the REQ-VERIF-COVERAGE-001 gaps', () => {
     const html = renderComplianceHtml(synthetic(), { mode: 'gap' });
-    expect(html).toMatch(/1 gap\(s\)/);
+    // 1 requirement without an assertion + 2 requirements without any verification (neither in `synthetic()` has one).
+    expect(html).toMatch(/3 gap\(s\)/);
   });
 });
 

--- a/packages/diagrams/src/compliance/__tests__/markdown.test.ts
+++ b/packages/diagrams/src/compliance/__tests__/markdown.test.ts
@@ -90,6 +90,6 @@ describe('gapMarkdown CV-5 pastDeadlineRequirements section', () => {
     expect(md).toContain('Past-deadline requirements');
     expect(md).toContain('REQ-PD-1');
     expect(md).toContain('2020-01-01');
-    expect(md).toContain('4 checks');
+    expect(md).toContain('6 checks');
   });
 });

--- a/packages/diagrams/src/compliance/classify.ts
+++ b/packages/diagrams/src/compliance/classify.ts
@@ -4,7 +4,8 @@
 // rules live once. Pure: takes a parsed YAML document, no IO.
 
 import type { AssertionStatus } from '../assertion/types.js';
-import type { IndexAssertion, IndexRequirement } from './types.js';
+import type { VerificationMethod, VerificationOutcome } from '../verification/types.js';
+import type { IndexAssertion, IndexRequirement, IndexVerification } from './types.js';
 
 export interface ComplianceProduct {
   id: string;
@@ -22,6 +23,8 @@ export interface ComplianceCanon {
   products: ComplianceProduct[];
   requirements: IndexRequirement[];
   assertions: IndexAssertion[];
+  /** VERIFICATION artefacts (27-verification.md) — the engineering V&V peer of `assertions`. */
+  verifications: IndexVerification[];
   codex: ComplianceCodexDoc[];
   /**
    * Named elements that can serve as assertion subjects beyond `products`:
@@ -32,7 +35,7 @@ export interface ComplianceCanon {
 }
 
 export function emptyCanon(): ComplianceCanon {
-  return { products: [], requirements: [], assertions: [], codex: [], subjects: [] };
+  return { products: [], requirements: [], assertions: [], verifications: [], codex: [], subjects: [] };
 }
 
 const str = (v: unknown): string | undefined => (typeof v === 'string' ? v : undefined);
@@ -95,6 +98,19 @@ export function ingestComplianceDoc(canon: ComplianceCanon, doc: unknown): strin
       admitted_at: str(d.admitted_at),
       realised_via: strArray(d.realised_via),
       owner_to_confirm: str(d.owner_to_confirm),
+    });
+    return id;
+  }
+  if (d.notation === 'verification') {
+    const verifies = str(d.verifies);
+    const method = str(d.method) as VerificationMethod | undefined;
+    const outcome = str(d.outcome) as VerificationOutcome | undefined;
+    if (!verifies || !method || !outcome) return null;
+    canon.verifications.push({
+      id, verifies, method, outcome,
+      performed_at: str(d.performed_at),
+      evidenceCount: Array.isArray(d.evidence) ? d.evidence.length : 0,
+      admitted_at: str(d.admitted_at),
     });
     return id;
   }

--- a/packages/diagrams/src/compliance/gap-report.ts
+++ b/packages/diagrams/src/compliance/gap-report.ts
@@ -1,6 +1,7 @@
-// Gap dashboard report (vkgeorgia/strategy#84 Phase 4 / CV-5).
+// Gap dashboard report (Phase 4 / CV-5; REQ-VERIF-COVERAGE-001/002 per
+// 15-requirement.md §4).
 //
-// Four operational gap lists computed from the shared reverse-index (Phase 3):
+// Operational gap lists computed from the shared reverse-index (Phase 3):
 //   1. Requirements with no Assertion targeting them (severity-sorted).
 //   2. Assertions without evidence — the ASSERT-007 case: status ∈
 //      {compliant, partial} AND no evidence. `under_review` / `non_compliant` /
@@ -9,9 +10,17 @@
 //   3. Stale Assertions — the ASSERT-008 case: `next_review_at` is in the past.
 //   4. Past-deadline requirements (CV-5) — REQUIREMENT.deadline < today AND
 //      the requirement has no fully-compliant assertion. Deadline-missed gaps.
+//   5. Requirements with no Verification targeting them — REQ-VERIF-COVERAGE-001
+//      (27-verification.md §5 / 15-requirement.md §4). Independent of #1 — the
+//      ASSERTION and VERIFICATION catalogues never disagree with each other by
+//      construction; a requirement may have one, both, or neither.
+//   6. Requirements whose verifications exist but never closed — every one is
+//      still `not_yet_run` / `inconclusive` — REQ-VERIF-COVERAGE-002. Mutually
+//      exclusive with #5 by construction.
 
 import type { ComplianceIndex, IndexAssertion, IndexRequirement } from './types.js';
 import { computeDeadlineStatus } from './impact.js';
+import { CLOSED_VERIFICATION_OUTCOMES } from '../verification/types.js';
 
 export interface GapReport {
   /** Requirements with no assertion about them, severity-sorted then id. */
@@ -26,6 +35,18 @@ export interface GapReport {
    * (oldest first). Empty when `today` is not supplied.
    */
   pastDeadlineRequirements: IndexRequirement[];
+  /**
+   * REQ-VERIF-COVERAGE-001: requirements with no VERIFICATION targeting them,
+   * severity-sorted then id — the engineering V&V analogue of
+   * `requirementsWithoutAssertions`.
+   */
+  requirementsWithoutVerification: IndexRequirement[];
+  /**
+   * REQ-VERIF-COVERAGE-002: requirements with one or more VERIFICATIONs
+   * targeting them, but none closed (`pass`/`fail`) — every one is still
+   * `not_yet_run`/`inconclusive`. Severity-sorted then id.
+   */
+  requirementsWithUnresolvedVerification: IndexRequirement[];
 }
 
 export interface GapReportOptions {
@@ -90,5 +111,30 @@ export function buildGapReport(index: ComplianceIndex, options: GapReportOptions
         })
     : [];
 
-  return { requirementsWithoutAssertions, assertionsWithoutEvidence, staleAssertions, pastDeadlineRequirements };
+  // REQ-VERIF-COVERAGE-001 — no VERIFICATION targets the requirement at all.
+  const requirementsWithoutVerification = [...index.requirementById.values()]
+    .filter(r => (index.verificationsByRequirement.get(r.id) ?? []).length === 0)
+    .sort((a, b) => {
+      const d = severityRank(a.severity) - severityRank(b.severity);
+      return d !== 0 ? d : a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+    });
+
+  // REQ-VERIF-COVERAGE-002 — has verifications, but none closed (pass/fail).
+  // Mutually exclusive with -001 by construction (only requirements with at
+  // least one verification are considered here).
+  const requirementsWithUnresolvedVerification = [...index.requirementById.values()]
+    .filter(r => {
+      const verifications = index.verificationsByRequirement.get(r.id) ?? [];
+      return verifications.length > 0
+        && !verifications.some(v => (CLOSED_VERIFICATION_OUTCOMES as readonly string[]).includes(v.outcome));
+    })
+    .sort((a, b) => {
+      const d = severityRank(a.severity) - severityRank(b.severity);
+      return d !== 0 ? d : a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+    });
+
+  return {
+    requirementsWithoutAssertions, assertionsWithoutEvidence, staleAssertions, pastDeadlineRequirements,
+    requirementsWithoutVerification, requirementsWithUnresolvedVerification,
+  };
 }

--- a/packages/diagrams/src/compliance/html.ts
+++ b/packages/diagrams/src/compliance/html.ts
@@ -183,11 +183,13 @@ export function renderComplianceHtml(canon: ComplianceCanon, scope: ReportScope,
     }
 
     case 'gap': {
-      const index = buildComplianceIndex({ requirements: canon.requirements, assertions: canon.assertions });
+      const index = buildComplianceIndex({
+        requirements: canon.requirements,
+        assertions: canon.assertions,
+        verifications: canon.verifications,
+      });
       const report = buildGapReport(index, { today: options.today });
       const title = options.title ?? 'Compliance Gap Dashboard';
-      const total = report.requirementsWithoutAssertions.length + report.assertionsWithoutEvidence.length + report.staleAssertions.length;
-      const summary = `<p class="cmp-summary">${total} gap(s)</p>`;
       const section = (heading: string, count: number, items: string[]): string => {
         const body = items.length === 0
           ? '<p class="cmp-ok">✓ none</p>'
@@ -206,13 +208,23 @@ export function renderComplianceHtml(canon: ComplianceCanon, scope: ReportScope,
       const pastDl = report.pastDeadlineRequirements.map(r => (
         `<li><code>${escHtml(r.id)}</code> ${escHtml(r.name)} <span class="cmp-meta">deadline ${r.deadline ? escHtml(r.deadline) : '—'}${r.severity ? `, severity ${escHtml(r.severity)}` : ''}</span></li>`
       ));
-      const total4 = report.requirementsWithoutAssertions.length + report.assertionsWithoutEvidence.length + report.staleAssertions.length + report.pastDeadlineRequirements.length;
+      const noVerif = report.requirementsWithoutVerification.map(r => (
+        `<li><code>${escHtml(r.id)}</code> ${escHtml(r.name)}${r.severity ? ` <span class="cmp-meta">severity ${escHtml(r.severity)}</span>` : ''}</li>`
+      ));
+      const unresolvedVerif = report.requirementsWithUnresolvedVerification.map(r => (
+        `<li><code>${escHtml(r.id)}</code> ${escHtml(r.name)}${r.severity ? ` <span class="cmp-meta">severity ${escHtml(r.severity)}</span>` : ''}</li>`
+      ));
+      const total6 = report.requirementsWithoutAssertions.length + report.assertionsWithoutEvidence.length
+        + report.staleAssertions.length + report.pastDeadlineRequirements.length
+        + report.requirementsWithoutVerification.length + report.requirementsWithUnresolvedVerification.length;
       const body = [
-        `<p class="cmp-summary">${total4} gap(s) across 4 checks</p>`,
+        `<p class="cmp-summary">${total6} gap(s) across 6 checks</p>`,
         section('Requirements without assertions', report.requirementsWithoutAssertions.length, reqs),
         section('Assertions without evidence — ASSERT-007', report.assertionsWithoutEvidence.length, noEvidence),
         section('Stale assertions — ASSERT-008', report.staleAssertions.length, stale),
         section('Past-deadline requirements (CV-5)', report.pastDeadlineRequirements.length, pastDl),
+        section('Requirements without verification — REQ-VERIF-COVERAGE-001', report.requirementsWithoutVerification.length, noVerif),
+        section('Requirements with unresolved verification — REQ-VERIF-COVERAGE-002', report.requirementsWithUnresolvedVerification.length, unresolvedVerif),
       ].join('');
       return htmlDoc(title, options.today, body);
     }

--- a/packages/diagrams/src/compliance/index.ts
+++ b/packages/diagrams/src/compliance/index.ts
@@ -5,6 +5,7 @@ export { buildGapReport } from './gap-report.js';
 export type { GapReport, GapReportOptions } from './gap-report.js';
 export { emptyCanon, ingestComplianceDoc } from './classify.js';
 export type { ComplianceCanon, ComplianceProduct, ComplianceCodexDoc } from './classify.js';
+export { CLOSED_VERIFICATION_OUTCOMES } from '../verification/types.js';
 export {
   admitDocumentToCatalog,
   buildComplianceScan,
@@ -58,6 +59,7 @@ export type {
   DeadlineStatus,
   IndexRequirement,
   IndexAssertion,
+  IndexVerification,
   LawTree,
   LawTreeRequirement,
   ProductView,
@@ -66,6 +68,7 @@ export type {
   ObjectDetailInput,
   RequirementTrace,
   TraceAssertionRow,
+  TraceVerificationRow,
   TraceElementCatalog,
   TraceElementRef,
   TraceSourceRef,

--- a/packages/diagrams/src/compliance/markdown.ts
+++ b/packages/diagrams/src/compliance/markdown.ts
@@ -111,10 +111,16 @@ function productMarkdown(canon: ComplianceCanon, productId: string): string {
 }
 
 function gapMarkdown(canon: ComplianceCanon, today?: string): string {
-  const index = buildComplianceIndex({ requirements: canon.requirements, assertions: canon.assertions });
+  const index = buildComplianceIndex({
+    requirements: canon.requirements,
+    assertions: canon.assertions,
+    verifications: canon.verifications,
+  });
   const report = buildGapReport(index, { today });
-  const total = report.requirementsWithoutAssertions.length + report.assertionsWithoutEvidence.length + report.staleAssertions.length + report.pastDeadlineRequirements.length;
-  const out: string[] = ['# Compliance Gap Dashboard', '', `_${total} gap(s) across 4 checks_`, ''];
+  const total = report.requirementsWithoutAssertions.length + report.assertionsWithoutEvidence.length
+    + report.staleAssertions.length + report.pastDeadlineRequirements.length
+    + report.requirementsWithoutVerification.length + report.requirementsWithUnresolvedVerification.length;
+  const out: string[] = ['# Compliance Gap Dashboard', '', `_${total} gap(s) across 6 checks_`, ''];
 
   out.push(`## Requirements without assertions (${report.requirementsWithoutAssertions.length})`, '');
   if (report.requirementsWithoutAssertions.length === 0) out.push('_✓ none_', '');
@@ -131,6 +137,14 @@ function gapMarkdown(canon: ComplianceCanon, today?: string): string {
   out.push(`## Past-deadline requirements — CV-5 (${report.pastDeadlineRequirements.length})`, '');
   if (report.pastDeadlineRequirements.length === 0) out.push('_✓ none_', '');
   else { for (const r of report.pastDeadlineRequirements) out.push(`- [ ] \`${r.id}\` ${r.name} — deadline: ${r.deadline ?? '—'}${r.severity ? `, severity: ${r.severity}` : ''}`); out.push(''); }
+
+  out.push(`## Requirements without verification — REQ-VERIF-COVERAGE-001 (${report.requirementsWithoutVerification.length})`, '');
+  if (report.requirementsWithoutVerification.length === 0) out.push('_✓ none_', '');
+  else { for (const r of report.requirementsWithoutVerification) out.push(`- [ ] \`${r.id}\` ${r.name}${r.severity ? ` — severity: ${r.severity}` : ''}`); out.push(''); }
+
+  out.push(`## Requirements with unresolved verification — REQ-VERIF-COVERAGE-002 (${report.requirementsWithUnresolvedVerification.length})`, '');
+  if (report.requirementsWithUnresolvedVerification.length === 0) out.push('_✓ none_', '');
+  else { for (const r of report.requirementsWithUnresolvedVerification) out.push(`- [ ] \`${r.id}\` ${r.name}${r.severity ? ` — severity: ${r.severity}` : ''}`); out.push(''); }
 
   return out.join('\n');
 }

--- a/packages/diagrams/src/compliance/reverse-index.ts
+++ b/packages/diagrams/src/compliance/reverse-index.ts
@@ -1,6 +1,6 @@
 // Reverse-index builder (vkgeorgia/strategy#84 Phase 3).
 
-import type { ComplianceIndex, ComplianceIndexInput, IndexAssertion, IndexRequirement } from './types.js';
+import type { ComplianceIndex, ComplianceIndexInput, IndexAssertion, IndexRequirement, IndexVerification } from './types.js';
 
 function push<K, V>(map: Map<K, V[]>, key: K, value: V): void {
   const list = map.get(key);
@@ -12,7 +12,8 @@ function push<K, V>(map: Map<K, V[]>, key: K, value: V): void {
  * Builds the reverse indexes used by every compliance view. Pure; the input
  * arrays are read, not mutated. Requirements with no `derived_from` simply do
  * not appear under any law; assertions are indexed by both their requirement
- * (`about`) and their subject.
+ * (`about`) and their subject; verifications are indexed by their requirement
+ * (`verifies`) — an independent catalogue from assertions (27-verification.md §4).
  */
 export function buildComplianceIndex(input: ComplianceIndexInput): ComplianceIndex {
   const requirementById = new Map<string, IndexRequirement>();
@@ -20,6 +21,7 @@ export function buildComplianceIndex(input: ComplianceIndexInput): ComplianceInd
   const assertionsByRequirement = new Map<string, IndexAssertion[]>();
   const assertionsBySubject = new Map<string, IndexAssertion[]>();
   const requirementsByParent = new Map<string, IndexRequirement[]>();
+  const verificationsByRequirement = new Map<string, IndexVerification[]>();
 
   for (const r of input.requirements) {
     requirementById.set(r.id, r);
@@ -30,6 +32,12 @@ export function buildComplianceIndex(input: ComplianceIndexInput): ComplianceInd
     push(assertionsByRequirement, a.about, a);
     push(assertionsBySubject, a.subject, a);
   }
+  for (const v of input.verifications ?? []) {
+    push(verificationsByRequirement, v.verifies, v);
+  }
 
-  return { requirementById, requirementsByLaw, assertionsByRequirement, assertionsBySubject, requirementsByParent };
+  return {
+    requirementById, requirementsByLaw, assertionsByRequirement, assertionsBySubject,
+    requirementsByParent, verificationsByRequirement,
+  };
 }

--- a/packages/diagrams/src/compliance/trace.ts
+++ b/packages/diagrams/src/compliance/trace.ts
@@ -22,6 +22,7 @@ import type {
   IndexRequirement,
   RequirementTrace,
   TraceAssertionRow,
+  TraceVerificationRow,
   TraceElementCatalog,
   TraceElementRef,
   TraceSourceRef,
@@ -95,10 +96,15 @@ export function buildRequirementTrace(
       realisedVia: (assertion.realised_via ?? []).map(rid => resolveElement(rid, catalog)),
     }));
 
+  const rawVerifications = index.verificationsByRequirement.get(requirementId) ?? [];
+  const verifications: TraceVerificationRow[] = [...rawVerifications]
+    .sort(byId)
+    .map(verification => ({ verification }));
+
   const ancestors = collectAncestors(requirement, index);
   const children = [...(index.requirementsByParent.get(requirementId) ?? [])].sort(byId);
 
-  return { requirement, sources, assertions, ancestors, children };
+  return { requirement, sources, assertions, verifications, ancestors, children };
 }
 
 /**

--- a/packages/diagrams/src/compliance/types.ts
+++ b/packages/diagrams/src/compliance/types.ts
@@ -4,6 +4,7 @@
 // single-product view here, and the gap dashboard in Phase 4.
 
 import type { AssertionStatus } from '../assertion/types.js';
+import type { VerificationMethod, VerificationOutcome } from '../verification/types.js';
 import type { ComplianceCodexDoc } from './classify.js';
 
 /** Projection of a REQUIREMENT (or CONSTRAINT) the compliance views need. */
@@ -91,6 +92,20 @@ export interface IndexAssertion {
   owner_to_confirm?: string;
 }
 
+/** Projection of a VERIFICATION the compliance views need (27-verification.md §2). */
+export interface IndexVerification {
+  id: string;
+  /** Typed ID of the REQUIREMENT this verification targets. */
+  verifies: string;
+  method: VerificationMethod;
+  outcome: VerificationOutcome;
+  performed_at?: string;
+  /** Number of evidence entries — feeds the VERIF-006 gap. */
+  evidenceCount?: number;
+  /** Admission date (CONTRACT §6) — feeds DQ-1 freshness decay. */
+  admitted_at?: string;
+}
+
 // ── Stage grouping (CV-3a) ──────────────────────────────────────────────────
 
 /** One stage (or task) element of a business object, used as a matrix sub-column. */
@@ -128,6 +143,8 @@ export interface ObjectDetailInput {
 export interface ComplianceIndexInput {
   requirements: IndexRequirement[];
   assertions: IndexAssertion[];
+  /** Optional — absent inputs (existing callers) simply index no verifications. */
+  verifications?: IndexVerification[];
 }
 
 /** The reverse-index — all maps are keyed by canonical id. */
@@ -144,6 +161,10 @@ export interface ComplianceIndex {
    * (15-requirement.md §2.4). Enables the requirement-hierarchy view.
    */
   requirementsByParent: Map<string, IndexRequirement[]>;
+  /** Requirement id → verifications whose `verifies` names it
+   *  (27-verification.md §2). The engineering V&V analogue of
+   *  `assertionsByRequirement` — the two catalogues are independent. */
+  verificationsByRequirement: Map<string, IndexVerification[]>;
 }
 
 // ── Single-law tree ─────────────────────────────────────────────────────────
@@ -198,6 +219,13 @@ export interface TraceAssertionRow {
   realisedVia: TraceElementRef[];
 }
 
+/** One VERIFICATION targeting the traced requirement (27-verification.md §2).
+ *  No subject/realised_via — a verification claims a protocol was run against
+ *  the requirement's acceptance criteria directly (16-assertion.md §4). */
+export interface TraceVerificationRow {
+  verification: IndexVerification;
+}
+
 /**
  * Requirement traceability + hierarchy view.
  *
@@ -219,6 +247,10 @@ export interface RequirementTrace {
   sources: TraceSourceRef[];
   /** Forward-trace via ASSERTION. Empty for CONSTRAINT elements (16-assertion.md §1) or for a REQUIREMENT with no filed assertion. */
   assertions: TraceAssertionRow[];
+  /** Forward-trace via VERIFICATION (27-verification.md §2). Empty for CONSTRAINT
+   *  elements (the engineering V&V leg applies to REQUIREMENT only, same posture
+   *  as ASSERTION) or for a REQUIREMENT with no filed verification. */
+  verifications: TraceVerificationRow[];
   /** Parent chain: immediate parent first, root last. Empty when the element has no `parent`. */
   ancestors: IndexRequirement[];
   /** Direct children: elements naming this one as their `parent`, id-sorted. */

--- a/packages/diagrams/src/verification/__tests__/validate.test.ts
+++ b/packages/diagrams/src/verification/__tests__/validate.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { validateVerification } from '../validate.js';
+import type { CanonCatalog } from '../../typed-id.js';
+
+function valid(): Record<string, unknown> {
+  return {
+    notation: 'verification',
+    id: 'VERIFICATION-DEVICE-ALARM-TEST-1',
+    verifies: 'REQUIREMENT-DEVICE-ALARM-1',
+    method: 'test',
+    protocol: 'Discharge battery under controlled load to 10% state of charge; confirm the alert triggers within 2 seconds.',
+    result: 'Alert triggered at 9.7% state of charge, 1.4 seconds after threshold crossing.',
+    outcome: 'pass',
+    evidence: [{ kind: 'note', text: '10/10 runs passed.' }],
+    performed_at: '2026-07-20',
+    performed_by: 'ROLE-VERIFICATION-ENG-1',
+    zone: 'canon',
+    admitted_at: '2026-07-21',
+    admitted_by: 'v.korobeinikov',
+    gate_checks: { uniqueness: 'pass' },
+    valid_from: '2026-07-21',
+    valid_to: null,
+  };
+}
+
+const codes = (input: unknown, opts?: Parameters<typeof validateVerification>[1]): string[] =>
+  validateVerification(input, opts).errors.map(e => e.code);
+const warnCodes = (input: unknown, opts?: Parameters<typeof validateVerification>[1]): string[] =>
+  validateVerification(input, opts).warnings.map(w => w.code);
+
+describe('validateVerification — positive', () => {
+  it('accepts a well-formed verification', () => {
+    const r = validateVerification(valid());
+    expect(r.valid, JSON.stringify(r.errors)).toBe(true);
+    expect(r.errors).toHaveLength(0);
+  });
+});
+
+describe('validateVerification — VERIF-001 (shape / id grammar)', () => {
+  it('flags id grammar, wrong notation, missing admission/lifecycle/protocol fields', () => {
+    expect(codes({ ...valid(), id: 'VERIF-1' })).toContain('VERIF-001');
+    expect(codes({ ...valid(), notation: 'claim' })).toContain('VERIF-001');
+    const noAdmit = valid(); delete noAdmit.admitted_at;
+    expect(codes(noAdmit)).toContain('VERIF-001');
+    const noValidTo = valid(); delete noValidTo.valid_to;
+    expect(codes(noValidTo)).toContain('VERIF-001');
+    const noProtocol = valid(); delete noProtocol.protocol;
+    expect(codes(noProtocol)).toContain('VERIF-001');
+  });
+
+  it('flags a missing method or outcome as VERIF-001 (required field)', () => {
+    const noMethod = valid(); delete noMethod.method;
+    expect(codes(noMethod)).toContain('VERIF-001');
+    const noOutcome = valid(); delete noOutcome.outcome;
+    expect(codes(noOutcome)).toContain('VERIF-001');
+  });
+
+  it('rejects a non-object', () => {
+    expect(codes(null)).toEqual(['VERIF-001']);
+  });
+});
+
+describe('validateVerification — VERIF-002 (verifies → REQUIREMENT)', () => {
+  it('flags a missing verifies', () => {
+    const r = valid(); delete r.verifies;
+    expect(codes(r)).toContain('VERIF-002');
+  });
+  it('flags a verifies that is not a REQUIREMENT typed id', () => {
+    expect(codes({ ...valid(), verifies: 'PRODUCT-MOBILE-1' })).toContain('VERIF-002');
+  });
+  it('with a catalog, flags an unresolved verifies and a wrong-type verifies', () => {
+    expect(codes({ ...valid() }, { catalog: { typeOf: () => undefined } })).toContain('VERIF-002');
+    const catalog: CanonCatalog = { typeOf: (id) => (id === 'REQUIREMENT-DEVICE-ALARM-1' ? 'GOAL' : 'PRODUCT') };
+    expect(codes(valid(), { catalog })).toContain('VERIF-002');
+  });
+});
+
+describe('validateVerification — VERIF-003 (method enum)', () => {
+  it('flags an out-of-enum method', () => {
+    expect(codes({ ...valid(), method: 'vibes' })).toContain('VERIF-003');
+  });
+  it('accepts every method value', () => {
+    for (const m of ['test', 'analysis', 'inspection', 'demonstration']) {
+      expect(codes({ ...valid(), method: m })).not.toContain('VERIF-003');
+    }
+  });
+});
+
+describe('validateVerification — VERIF-004 (outcome enum)', () => {
+  it('flags an out-of-enum outcome', () => {
+    expect(codes({ ...valid(), outcome: 'maybe' })).toContain('VERIF-004');
+  });
+  it('accepts every outcome value', () => {
+    for (const o of ['pass', 'fail', 'inconclusive', 'not_yet_run']) {
+      expect(codes({ ...valid(), outcome: o, evidence: [{ kind: 'note', text: 'x' }] })).not.toContain('VERIF-004');
+    }
+  });
+});
+
+describe('validateVerification — VERIF-005 (canonical_ref evidence resolves)', () => {
+  it('flags a malformed canonical_ref', () => {
+    expect(codes({ ...valid(), evidence: [{ kind: 'canonical_ref', ref: 'nope' }] })).toContain('VERIF-005');
+  });
+  it('with a catalog, flags an unresolved canonical_ref', () => {
+    const catalog: CanonCatalog = { typeOf: () => undefined };
+    expect(codes({ ...valid(), evidence: [{ kind: 'canonical_ref', ref: 'PROCESS-X-1' }] }, { catalog })).toContain('VERIF-005');
+  });
+  it('ignores external_doc and note evidence kinds for resolution', () => {
+    const ev = [{ kind: 'external_doc', title: 't', url: 'u' }, { kind: 'note', text: 'n' }];
+    expect(codes({ ...valid(), evidence: ev })).not.toContain('VERIF-005');
+  });
+});
+
+describe('validateVerification — VERIF-006 (pass outcome without evidence)', () => {
+  it('warns when evidence is empty and outcome is pass', () => {
+    expect(warnCodes({ ...valid(), evidence: [], outcome: 'pass' })).toContain('VERIF-006');
+  });
+  it('does not warn for fail / inconclusive / not_yet_run with empty evidence', () => {
+    for (const o of ['fail', 'inconclusive', 'not_yet_run']) {
+      expect(warnCodes({ ...valid(), evidence: [], outcome: o })).not.toContain('VERIF-006');
+    }
+  });
+});

--- a/packages/diagrams/src/verification/index.ts
+++ b/packages/diagrams/src/verification/index.ts
@@ -1,0 +1,4 @@
+export type { Verification, VerificationMethod, VerificationOutcome } from './types.js';
+export { VERIFICATION_METHODS, VERIFICATION_OUTCOMES, CLOSED_VERIFICATION_OUTCOMES } from './types.js';
+export { validateVerification } from './validate.js';
+export type { VerificationValidateOptions } from './validate.js';

--- a/packages/diagrams/src/verification/types.ts
+++ b/packages/diagrams/src/verification/types.ts
@@ -1,0 +1,48 @@
+// VERIFICATION — engineering V&V claim against a REQUIREMENT.
+// Schema: methodology notations/elements/27-verification.md §2.
+
+import type { GateChecks } from '../requirement/types.js';
+import type { Evidence } from '../assertion/types.js';
+
+/** V&V method vocabulary (27-verification.md §3). */
+export type VerificationMethod = 'test' | 'analysis' | 'inspection' | 'demonstration';
+
+export const VERIFICATION_METHODS: readonly VerificationMethod[] = [
+  'test', 'analysis', 'inspection', 'demonstration',
+];
+
+/** Pass/fail judgement vocabulary (27-verification.md §3). */
+export type VerificationOutcome = 'pass' | 'fail' | 'inconclusive' | 'not_yet_run';
+
+export const VERIFICATION_OUTCOMES: readonly VerificationOutcome[] = [
+  'pass', 'fail', 'inconclusive', 'not_yet_run',
+];
+
+/** Outcomes that count as "closed" — the trace link has resolved one way or
+ *  the other, distinct from still-open (`not_yet_run` / `inconclusive`)
+ *  (27-verification.md §5, REQ-VERIF-COVERAGE-002). */
+export const CLOSED_VERIFICATION_OUTCOMES: readonly VerificationOutcome[] = ['pass', 'fail'];
+
+export interface Verification {
+  notation: 'verification';
+  id: string;
+  /** Typed ID of the REQUIREMENT this verification targets. */
+  verifies: string;
+  method: VerificationMethod;
+  protocol: string;
+  result?: string;
+  outcome: VerificationOutcome;
+  evidence?: Evidence[];
+  performed_at?: string;
+  performed_by?: string;
+
+  // Admission record (CONTRACT.md §6).
+  zone: 'canon';
+  admitted_at: string;
+  admitted_by: string;
+  gate_checks: GateChecks;
+
+  // Primitive lifecycle (CONTRACT.md §7).
+  valid_from: string;
+  valid_to: string | null;
+}

--- a/packages/diagrams/src/verification/validate.ts
+++ b/packages/diagrams/src/verification/validate.ts
@@ -1,0 +1,111 @@
+// VERIFICATION validator — methodology notations/elements/27-verification.md §5.
+//
+// Implements VERIF-001..006. The shared HDR-/LIFECYCLE- rules and the
+// cross-cutting REQ-VERIF-COVERAGE-001/002 reverse-trace rules are owned
+// elsewhere (CONTRACT.md §8) and are out of scope for this single-artefact
+// validator — same posture as `validateAssertion` (../assertion/validate.ts).
+//
+// Resolution rules (VERIF-002/005) that need artefact *existence* run only
+// when a `CanonCatalog` is supplied; the TYPE check VERIF-002 also carries is
+// derivable from the id prefix and runs either way.
+
+import type { ValidationError, ValidationWarning, ValidationResult } from '../validation-types.js';
+import { typeOfId, isCanonicalIdOfType, type CanonCatalog } from '../typed-id.js';
+import { VERIFICATION_METHODS, VERIFICATION_OUTCOMES } from './types.js';
+
+export interface VerificationValidateOptions {
+  /** When provided, the resolution rules enforce artefact existence. */
+  catalog?: CanonCatalog;
+}
+
+export function validateVerification(input: unknown, options: VerificationValidateOptions = {}): ValidationResult {
+  const errors: ValidationError[] = [];
+  const warnings: ValidationWarning[] = [];
+  const { catalog } = options;
+
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    errors.push({ code: 'VERIF-001', message: 'Verification must be a YAML mapping.' });
+    return { valid: false, errors, warnings };
+  }
+  const v = input as Record<string, unknown>;
+
+  // ── VERIF-001 — id grammar + plain required fields ───────────────────────
+  if (!isCanonicalIdOfType(v.id, 'VERIFICATION')) {
+    errors.push({ code: 'VERIF-001', message: `id "${String(v.id)}" must match VERIFICATION-[<middle>-]<INTEGER>.`, path: 'id' });
+  }
+  if (v.notation !== 'verification') {
+    errors.push({ code: 'VERIF-001', message: 'notation must be the fixed value "verification".', path: 'notation' });
+  }
+  if (v.zone !== 'canon') {
+    errors.push({ code: 'VERIF-001', message: 'zone is required and must be "canon".', path: 'zone' });
+  }
+  for (const f of ['admitted_at', 'admitted_by', 'valid_from', 'protocol'] as const) {
+    if (typeof v[f] !== 'string' || (v[f] as string).trim() === '') {
+      errors.push({ code: 'VERIF-001', message: `${f} is required.`, path: f });
+    }
+  }
+  if (v.gate_checks === null || typeof v.gate_checks !== 'object') {
+    errors.push({ code: 'VERIF-001', message: 'gate_checks is required and must be a mapping.', path: 'gate_checks' });
+  }
+  if (!('valid_to' in v) || !(typeof v.valid_to === 'string' || v.valid_to === null)) {
+    errors.push({ code: 'VERIF-001', message: 'valid_to is required (an ISO date string or null).', path: 'valid_to' });
+  }
+
+  // ── VERIF-002 — verifies → REQUIREMENT ───────────────────────────────────
+  const verifies = v.verifies;
+  if (typeof verifies !== 'string' || verifies.trim() === '') {
+    errors.push({ code: 'VERIF-002', message: 'verifies is required and must be a typed REQUIREMENT id.', path: 'verifies' });
+  } else if (catalog) {
+    const t = catalog.typeOf(verifies);
+    if (t === undefined) {
+      errors.push({ code: 'VERIF-002', message: `verifies "${verifies}" does not resolve to an admitted artefact.`, path: 'verifies' });
+    } else if (t !== 'REQUIREMENT') {
+      errors.push({ code: 'VERIF-002', message: `verifies "${verifies}" resolves to a ${t}, not a REQUIREMENT.`, path: 'verifies' });
+    }
+  } else if (typeOfId(verifies) !== 'REQUIREMENT') {
+    errors.push({ code: 'VERIF-002', message: `verifies "${verifies}" must be a REQUIREMENT typed id.`, path: 'verifies' });
+  }
+
+  // ── VERIF-003 — method enum ───────────────────────────────────────────────
+  const method = v.method;
+  if (method === undefined || method === null) {
+    errors.push({ code: 'VERIF-001', message: 'method is required.', path: 'method' });
+  } else if (!VERIFICATION_METHODS.includes(method as never)) {
+    errors.push({ code: 'VERIF-003', message: `method "${String(method)}" must be one of ${VERIFICATION_METHODS.join(', ')}.`, path: 'method' });
+  }
+
+  // ── VERIF-004 — outcome enum ──────────────────────────────────────────────
+  const outcome = v.outcome;
+  if (outcome === undefined || outcome === null) {
+    errors.push({ code: 'VERIF-001', message: 'outcome is required.', path: 'outcome' });
+  } else if (!VERIFICATION_OUTCOMES.includes(outcome as never)) {
+    errors.push({ code: 'VERIF-004', message: `outcome "${String(outcome)}" must be one of ${VERIFICATION_OUTCOMES.join(', ')}.`, path: 'outcome' });
+  }
+
+  // ── VERIF-005 — canonical_ref evidence resolves ──────────────────────────
+  if (v.evidence !== undefined) {
+    if (!Array.isArray(v.evidence)) {
+      errors.push({ code: 'VERIF-001', message: 'evidence must be a list.', path: 'evidence' });
+    } else {
+      v.evidence.forEach((e, i) => {
+        if (e === null || typeof e !== 'object') return;
+        const entry = e as Record<string, unknown>;
+        if (entry.kind !== 'canonical_ref') return;
+        const ref = entry.ref;
+        if (!typeOfId(ref)) {
+          errors.push({ code: 'VERIF-005', message: `evidence[${i}] canonical_ref "${String(ref)}" is not a resolvable typed ID.`, path: `evidence[${i}].ref` });
+        } else if (catalog && catalog.typeOf(ref as string) === undefined) {
+          errors.push({ code: 'VERIF-005', message: `evidence[${i}] canonical_ref "${String(ref)}" does not resolve.`, path: `evidence[${i}].ref` });
+        }
+      });
+    }
+  }
+
+  // ── VERIF-006 (warning) — pass outcome with no evidence ──────────────────
+  const evidenceEmpty = !Array.isArray(v.evidence) || v.evidence.length === 0;
+  if (evidenceEmpty && outcome === 'pass') {
+    warnings.push({ code: 'VERIF-006', message: 'outcome "pass" has no evidence — an undefended positive claim.', path: 'evidence' });
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}

--- a/src/repo-validate.ts
+++ b/src/repo-validate.ts
@@ -539,6 +539,42 @@ export function runComplianceValidate(root: string, ctx: RepoValidateContext): V
     }
   }
 
+  let verificationEntries: string[] = [];
+  try {
+    verificationEntries = readdirSync(path.join(root, 'canon', 'verifications'), { recursive: true }) as string[];
+  } catch {
+    verificationEntries = [];
+  }
+  for (const rel of verificationEntries) {
+    if (typeof rel !== 'string' || !isYaml(rel) || shouldSkip(rel)) continue;
+    const fullRel = path.join('canon', 'verifications', rel).replace(/\\/g, '/');
+    let data: unknown;
+    try {
+      data = loadNotationYaml(readFileSync(path.join(root, fullRel), 'utf-8'));
+    } catch (e) {
+      findings.push({
+        file: fullRel,
+        notation: '',
+        ruleId: 'YAML',
+        severity: 'error',
+        message: (e as Error).message,
+      });
+      continue;
+    }
+    const notation = notationOf(data);
+    if (notation !== 'verification') continue;
+    for (const f of validateNotationDoc('verification', data, validateOpts).findings) {
+      if (f.severity === 'info') continue;
+      findings.push({
+        file: fullRel,
+        notation: 'verification',
+        ruleId: f.ruleId,
+        severity: f.severity,
+        message: f.message,
+      });
+    }
+  }
+
   return findings;
 }
 
@@ -548,6 +584,7 @@ export function runGapDashboardWarnings(ctx: RepoValidateContext): ViewFinding[]
   const index = buildComplianceIndex({
     requirements: ctx.complianceCanon.requirements,
     assertions: ctx.complianceCanon.assertions,
+    verifications: ctx.complianceCanon.verifications,
   });
   const report = buildGapReport(index, { today: new Date().toISOString().slice(0, 10) });
 
@@ -576,6 +613,24 @@ export function runGapDashboardWarnings(ctx: RepoValidateContext): ViewFinding[]
       ruleId: 'ASSERT-008',
       severity: 'warning',
       message: `Assertion "${a.id}" next_review_at (${a.next_review_at}) is in the past.`,
+    });
+  }
+  for (const req of report.requirementsWithoutVerification) {
+    findings.push({
+      file: ctx.pathById.get(req.id) ?? req.id,
+      notation: req.element_kind ?? 'requirement',
+      ruleId: 'REQ-VERIF-COVERAGE-001',
+      severity: 'warning',
+      message: `${req.element_kind === 'constraint' ? 'Constraint' : 'Requirement'} "${req.id}" has no verification targeting it.`,
+    });
+  }
+  for (const req of report.requirementsWithUnresolvedVerification) {
+    findings.push({
+      file: ctx.pathById.get(req.id) ?? req.id,
+      notation: req.element_kind ?? 'requirement',
+      ruleId: 'REQ-VERIF-COVERAGE-002',
+      severity: 'warning',
+      message: `${req.element_kind === 'constraint' ? 'Constraint' : 'Requirement'} "${req.id}" has verification(s), but none has reached outcome pass or fail.`,
     });
   }
 

--- a/src/validate-notation.ts
+++ b/src/validate-notation.ts
@@ -43,6 +43,7 @@ import { validateProcessMap } from '@transitrix/diagrams/process-map/validate.js
 import { validateRequirement } from '@transitrix/diagrams/requirement/validate.js';
 import { validateConstraint } from '@transitrix/diagrams/constraint/validate.js';
 import { validateAssertion } from '@transitrix/diagrams/assertion/validate.js';
+import { validateVerification } from '@transitrix/diagrams/verification/validate.js';
 import { parseImpactViewConfig } from '@transitrix/diagrams/compliance/impact.js';
 import { parseCoverageMetricConfig } from '@transitrix/diagrams/compliance/coverage-metric.js';
 import {
@@ -87,6 +88,10 @@ function validateRequirementDoc(input: unknown, options: ValidateNotationOptions
 function validateAssertionDoc(input: unknown, options: ValidateNotationOptions = {}): NotationValidationResult {
   const today = new Date().toISOString().slice(0, 10);
   return mapPackageResult(validateAssertion(input, { catalog: options.catalog, today }));
+}
+
+function validateVerificationDoc(input: unknown, options: ValidateNotationOptions = {}): NotationValidationResult {
+  return mapPackageResult(validateVerification(input, { catalog: options.catalog }));
 }
 
 function validateConstraintDoc(input: unknown, options: ValidateNotationOptions = {}): NotationValidationResult {
@@ -177,6 +182,7 @@ const VALIDATORS: Record<string, NotationValidator> = {
   requirement: validateRequirementDoc,
   constraint: validateConstraintDoc,
   assertion: validateAssertionDoc,
+  verification: validateVerificationDoc,
   'compliance-impact': wrapValidator(validateComplianceImpactDoc),
   'coverage-metric': wrapValidator(validateCoverageMetricDoc),
   // Group C — codex zone (#518 Phase C2); `zone: codex`, not a notation: tag.
@@ -222,6 +228,7 @@ export function inferNotationFromFilename(filePath: string): string | undefined 
   if (base.startsWith('requirement-') && base.endsWith('.yaml')) return 'requirement';
   if (base.startsWith('constraint-') && base.endsWith('.yaml')) return 'constraint';
   if (base.startsWith('assertion-') && base.endsWith('.yaml')) return 'assertion';
+  if (base.startsWith('verification-') && base.endsWith('.yaml')) return 'verification';
   const rawBase = (filePath.replace(/\\/g, '/').split('/').pop() ?? '').replace(/\.ya?ml$/i, '');
   const idType = typeOfId(rawBase);
   if (idType && (CODEX_ARTEFACT_TYPES as readonly string[]).includes(idType)) return 'codex';

--- a/tests/fixtures/notation-corpus/verification/VERIFICATION-DATA-ERASURE-TEST-1.yaml
+++ b/tests/fixtures/notation-corpus/verification/VERIFICATION-DATA-ERASURE-TEST-1.yaml
@@ -1,0 +1,35 @@
+# Worked example — closed (pass) V&V claim against a REQUIREMENT.
+# Schema: notations/elements/27-verification.md §2.
+# Demonstrates: method = test, outcome = pass, note evidence.
+
+notation: verification
+id: VERIFICATION-DATA-ERASURE-TEST-1
+verifies: REQUIREMENT-DATA-ERASURE-1                  # → canon/elements/01_motivation/requirements/
+
+method: test
+protocol: >
+  Submit a data-subject erasure request against a seeded test account; poll
+  the erasure job queue until completion; confirm no personal-data record for
+  the account remains in any downstream store after 30 days.
+result: "Erasure completed and confirmed across all downstream stores at day 4."
+outcome: pass
+
+evidence:
+  - kind: note
+    text: "Automated erasure-verification suite run 2026-07-20, 10/10 accounts cleared within window."
+
+performed_at: "2026-07-20"
+performed_by: ROLE-VERIFICATION-ENG-1
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-07-21"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-07-21"
+valid_to: null

--- a/tests/repo-validate-compliance.test.ts
+++ b/tests/repo-validate-compliance.test.ts
@@ -7,6 +7,7 @@ import { afterAll, beforeAll, describe, it, expect } from 'vitest';
 
 import {
   runComplianceValidate,
+  runGapDashboardWarnings,
   runRepoValidate,
   repoScopeHasErrors,
   buildRepoValidateContext,
@@ -63,6 +64,11 @@ describe('repo-scope compliance catalogue (#518 C3)', () => {
       root,
       'canon/assertions/ASSERTION-MOBILE-DATA-ERASURE-1.yaml',
       'assertion/ASSERTION-MOBILE-DATA-ERASURE-1.yaml',
+    );
+    copyCorpus(
+      root,
+      'canon/verifications/VERIFICATION-DATA-ERASURE-TEST-1.yaml',
+      'verification/VERIFICATION-DATA-ERASURE-TEST-1.yaml',
     );
     copyCorpus(
       root,
@@ -135,6 +141,35 @@ describe('repo-scope compliance catalogue (#518 C3)', () => {
           || f.file.endsWith('ASSERTION-MOBILE-DATA-ERASURE-1.yaml')),
     );
     expect(clean).toEqual([]);
+  });
+
+  it('runComplianceValidate passes the clean verification file with full catalogue', () => {
+    const ctx = buildRepoValidateContext(root);
+    const findings = runComplianceValidate(root, ctx);
+    const clean = findings.filter(
+      (f) => f.severity === 'error' && f.file.endsWith('VERIFICATION-DATA-ERASURE-TEST-1.yaml'),
+    );
+    expect(clean).toEqual([]);
+  });
+
+  it('runGapDashboardWarnings does not flag REQ-VERIF-COVERAGE-001 for a requirement with a verification', () => {
+    const ctx = buildRepoValidateContext(root);
+    const findings = runGapDashboardWarnings(ctx);
+    expect(
+      findings.some(
+        (f) => f.ruleId === 'REQ-VERIF-COVERAGE-001' && f.file.endsWith('REQUIREMENT-DATA-ERASURE-1.yaml'),
+      ),
+    ).toBe(false);
+  });
+
+  it('runGapDashboardWarnings flags REQ-VERIF-COVERAGE-001 for a requirement with no verification', () => {
+    const ctx = buildRepoValidateContext(root);
+    const findings = runGapDashboardWarnings(ctx);
+    expect(
+      findings.some(
+        (f) => f.ruleId === 'REQ-VERIF-COVERAGE-001' && f.file.endsWith('REQUIREMENT-BAD-REF-1.yaml'),
+      ),
+    ).toBe(true);
   });
 
   it('runComplianceValidate validates constraint elements with catalogue', () => {

--- a/tests/validate-notation.test.ts
+++ b/tests/validate-notation.test.ts
@@ -24,6 +24,7 @@ import { validateScenario } from '../packages/diagrams/src/scenarios/validate.js
 import { validateProcessMap } from '../packages/diagrams/src/process-map/validate.js';
 import { validateRequirement } from '../packages/diagrams/src/requirement/validate.js';
 import { validateAssertion } from '../packages/diagrams/src/assertion/validate.js';
+import { validateVerification } from '../packages/diagrams/src/verification/validate.js';
 import { parseImpactViewConfig } from '../packages/diagrams/src/compliance/impact.js';
 import { parseCoverageMetricConfig } from '../packages/diagrams/src/compliance/coverage-metric.js';
 import { validateCodex } from '../packages/diagrams/src/codex/validate.js';
@@ -51,7 +52,7 @@ const GROUP_B = [
 ];
 
 // Group C — compliance suite wired in #518 Phase C1–C4.
-const GROUP_C = ['requirement', 'constraint', 'assertion', 'compliance-impact', 'coverage-metric', 'codex'];
+const GROUP_C = ['requirement', 'constraint', 'assertion', 'verification', 'compliance-impact', 'coverage-metric', 'codex'];
 
 const ALL_NOTATIONS = [...GROUP_A, ...GROUP_B, ...GROUP_C];
 
@@ -100,6 +101,10 @@ describe('validate-notation — canonical extension helpers (#343)', () => {
 
   it('inferNotationFromFilename recognises constraint typed-id filenames', () => {
     expect(inferNotationFromFilename('canon/elements/constraints/CONSTRAINT-GDPR-1.yaml')).toBe('constraint');
+  });
+
+  it('inferNotationFromFilename recognises verification typed-id filenames', () => {
+    expect(inferNotationFromFilename('canon/verifications/VERIFICATION-DEVICE-ALARM-TEST-1.yaml')).toBe('verification');
   });
 
   it('inferNotationFromFilename returns undefined for non-canonical names', () => {
@@ -158,7 +163,7 @@ describe('validate-notation — the view notation corpus validates clean (#258)'
 });
 
 describe('validate-notation — element notation corpus validates clean (#518 C1)', () => {
-  for (const notation of ['requirement', 'assertion'] as const) {
+  for (const notation of ['requirement', 'assertion', 'verification'] as const) {
     for (const file of elementFixtures(notation)) {
       const name = file.slice(corpusRoot.length + 1).replace(/\\/g, '/');
       it(`${name} → valid`, () => {
@@ -294,6 +299,15 @@ describe('validate-notation — parity with the preview validator (#258, #518 C1
     const today = new Date().toISOString().slice(0, 10);
     const raw = validateAssertion(broken, { today });
     const report = validateNotationDoc('assertion', broken);
+    expect(report.isValid).toBe(raw.valid);
+    expect(report.findings.filter((f) => f.severity === 'error').map((f) => f.ruleId))
+      .toEqual(raw.errors.map((e) => e.code));
+  });
+
+  it('verification: CLI findings mirror validateVerification exactly', () => {
+    const broken = { notation: 'verification' };
+    const raw = validateVerification(broken);
+    const report = validateNotationDoc('verification', broken);
     expect(report.isValid).toBe(raw.valid);
     expect(report.findings.filter((f) => f.severity === 'error').map((f) => f.ruleId))
       .toEqual(raw.errors.map((e) => e.code));


### PR DESCRIPTION
## Summary

- Adds the core `VERIFICATION` element (`canon/verifications/`, `VERIF-001..006`) — the engineering V&V analogue of `ASSERTION` — per methodology `27-verification.md`.
- Adds the cross-cutting reverse-trace completeness rules `REQ-VERIF-COVERAGE-001` (no verification targets a requirement) and `REQ-VERIF-COVERAGE-002` (every verification against it is still unresolved), per `15-requirement.md` §4.
- Surfaces both in `validate --scope=repo`'s `compliance` findings bucket, and in the `export-compliance` HTML/Markdown gap-dashboard report.
- Extends the **Requirement Trace** preview: a `REQUIREMENT`'s Verification section reads as an open obligation ("Not verified" / "Unresolved") rather than a blank section when the gap exists — never a silent pass by omission. `CONSTRAINT` gets an explicit out-of-scope note (V&V applies to `REQUIREMENT` only, same posture as `ASSERTION`).
- Extends the **Compliance Gap Dashboard** (editor preview and `export-compliance` HTML/Markdown reports) to list every affected requirement repo-wide, for both rules — a repo with zero `VERIFICATION` coverage can no longer render as a clean report by omission.
- Both preview views re-scan on save of any `VERIFICATION-*.yaml` file.
- `@transitrix/diagrams` bumped `1.8.21` → `1.9.0`; `@transitrix/cli` bumped `2.3.0` → `2.4.0` to satisfy the CLI/diagrams alignment guard.

Scope note: the design-controls trace matrix and the ISO 14971 risk chain (`HAZARD` → `RISK_CONTROL`) are explicitly out of scope for this schema/PR — not built here.

## Test plan

- [x] `npm run compile` / `npm run compile:extension` — clean
- [x] `npm test` (root) — 484 passed; the only 3 failures (`tests/cli-migrate.test.ts`, 0.5→0.6 migration fixtures) are pre-existing on `main` (confirmed by running the same file against `main`), unrelated to this change — external `methodology` repo recipe drift.
- [x] `npm --workspace packages/diagrams test` — 1496 passed.
- [x] New unit coverage: `VERIF-001..006` validator (`packages/diagrams/src/verification/__tests__/validate.test.ts`), `REQ-VERIF-COVERAGE-001/-002` gap-report logic, notation-corpus conformance fixture, repo-scope compliance/gap-dashboard integration tests, `export-compliance` HTML/Markdown gap-section coverage.
