### PR TITLE
chore: reference hub work items as HUB-NNN

### DIFF
--- a/.github/workflows/public-surface-hygiene.yml
+++ b/.github/workflows/public-surface-hygiene.yml
@@ -40,8 +40,14 @@ jobs:
         env:
           HYGIENE_BLOCKLIST: ${{ secrets.HYGIENE_BLOCKLIST }}
           HYGIENE_BLOCKLIST_HUB: ${{ secrets.HYGIENE_BLOCKLIST_HUB }}
+          HYGIENE_BLOCKLIST_3: ${{ secrets.HYGIENE_BLOCKLIST_3 }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: node scripts/ci-hygiene-check.mjs
+
+      - name: Run full-tree hygiene check
+        env:
+          HYGIENE_BLOCKLIST_3: ${{ secrets.HYGIENE_BLOCKLIST_3 }}
+        run: node scripts/ci-hygiene-tree.mjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Changed
+
+- **Work-item references use the neutral `HUB-NNN` form** across comments, READMEs and docstrings (54 files). Not the hash form — a bare `#84` auto-links to this repository's own issue 84, rendering as a working link to an unrelated item.
+- **Public-surface hygiene gains a pattern slot and a full-tree pass** (`scripts/ci-hygiene-tree.mjs`). The diff check only sees what a PR adds, so anything already committed was invisible to it; the tree pass reads every tracked text file. Scoped to the new slot alone so it fails on the change under review, not on pre-existing content. Patterns stay in repository secrets; output is `file:line` only.
+
+### Packages
+
+- `@transitrix/diagrams` 1.8.21 → 1.8.22 — comment-only change under `src/`; version moved because the guard requires it.
+- `@transitrix/cli` 2.3.0 → 2.3.1 — paired bump per `cli-diagrams-alignment`.
+
 ## [3.1.3] — 2026-07-29
 
 ### Fixed

--- a/docs/internal/openvsx-publish-runbook.md
+++ b/docs/internal/openvsx-publish-runbook.md
@@ -181,6 +181,6 @@ the install metadata and a re-publish at the same version is rejected.
 
 ## Relates
 
-- Strategy hub: [`vkgeorgia/strategy#184`](https://github.com/vkgeorgia/strategy/issues/184) — the Cursor publish task this runbook codifies.
+- Strategy hub: [`HUB-184`](HUB-184) — the Cursor publish task this runbook codifies.
 - [`packaging.md`](packaging.md) — VSIX packaging (the artefact shape Open VSX consumes).
 - [`release-runbook.md`](release-runbook.md) — separate procedure for `@transitrix/*` npm packages.

--- a/docs/internal/packaging.md
+++ b/docs/internal/packaging.md
@@ -8,7 +8,7 @@ per-OS optional dependency (`@resvg/resvg-js-win32-x64-msvc`,
 matching the machine doing the install.
 
 That makes the extension **platform-specific** for distribution purposes
-(vkgeorgia/strategy#32 chose per-platform VSIX over one ~10 MB fat bundle).
+(HUB-32 chose per-platform VSIX over one ~10 MB fat bundle).
 
 ## Build a VSIX for the current platform
 

--- a/extension/src/compliance-impact-preview.ts
+++ b/extension/src/compliance-impact-preview.ts
@@ -16,7 +16,7 @@ import { scanComplianceCanon, openComplianceFile } from './compliance-scan.js';
 import type { ScannedCanon } from './compliance-scan.js';
 import { buildDiagramFrame, OPEN_THEME_COMMAND } from './diagram-frame.js';
 
-// Compliance-impact matrix preview -- CV-2 (vkgeorgia/strategy#84).
+// Compliance-impact matrix preview -- CV-2 (HUB-84).
 //
 // Renders the obligation x subject matrix (buildImpactMatrix ss5) as an in-IDE
 // webview. Distinct from the Products x Requirements compliance-matrix preview

--- a/extension/src/compliance-matrix-preview.ts
+++ b/extension/src/compliance-matrix-preview.ts
@@ -13,7 +13,7 @@ import { scanComplianceCanon } from './compliance-scan.js';
 import type { ScannedCanon } from './compliance-scan.js';
 import { buildDiagramFrame, OPEN_THEME_COMMAND } from './diagram-frame.js';
 
-// Compliance matrix preview (vkgeorgia/strategy#84 Phase 2).
+// Compliance matrix preview (HUB-84 Phase 2).
 //
 // A repo-wide view (not bound to a file): scans the workspace for the canon
 // artefacts that carry `notation: product | requirement | assertion`, builds the

--- a/extension/src/compliance-render.ts
+++ b/extension/src/compliance-render.ts
@@ -7,7 +7,7 @@ import { computeDeadlineStatus } from '@transitrix/diagrams/compliance/impact.js
 import { buildDiagramFrame, OPEN_THEME_COMMAND } from './diagram-frame.js';
 
 // Shared HTML rendering for the script-less compliance views — the single-law
-// tree and single-product view (vkgeorgia/strategy#84 Phase 3). These previews
+// tree and single-product view (HUB-84 Phase 3). These previews
 // are read-only and need no scripts: click-to-open uses command URIs and status
 // is shown with inline badges, so they keep `enableScripts: false` and the
 // script-less CSP (smallest security surface).

--- a/extension/src/compliance-scan.ts
+++ b/extension/src/compliance-scan.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { emptyCanon, ingestComplianceDoc, type ComplianceCanon } from '@transitrix/diagrams/compliance';
 
-// Workspace scanner for the compliance views (vkgeorgia/strategy#84). The
+// Workspace scanner for the compliance views (HUB-84). The
 // compliance matrix (Phase 2), the single-law / single-product views (Phase 3)
 // and the gap dashboard (Phase 4) all need the same repo-wide sweep of the
 // canon artefacts. Classification lives in the shared `ingestComplianceDoc`

--- a/extension/src/dgca-preview.ts
+++ b/extension/src/dgca-preview.ts
@@ -50,7 +50,7 @@ interface FGCADoc {
 // ── Column layout ─────────────────────────────────────────────────────────────────────────────────
 //
 // Geometry + edge routing now live in @transitrix/diagrams
-// (`layoutFGCAPreview`) so the configurable-gap behaviour (vkgeorgia/strategy#75)
+// (`layoutFGCAPreview`) so the configurable-gap behaviour (HUB-75)
 // is unit-tested. This file owns only the SVG presentation of that layout and
 // the column header labels.
 
@@ -143,7 +143,7 @@ interface ChainPreviewParams {
 
 /**
  * Shared render path for the FGCA and FGA previews. Branches on the persisted
- * tree↔table view (vkgeorgia/strategy#137):
+ * tree↔table view (HUB-137):
  *  - **tree** — the chain SVG, with the spacing/curvature/scope control panel +
  *    Save/Zoom toolbar (the PR #86 interactive surface) plus the view toggle.
  *  - **table** — the flattened chain table; the spacing/curvature/scope controls

--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -82,7 +82,7 @@ export interface DiagramFrameOpts {
   copyPngCommand?: string;
   /**
    * Command ID for the "Spacing…" toolbar link (opens Settings filtered to the
-   * per-notation gap controls — vkgeorgia/strategy#75). Rendered for previews
+   * per-notation gap controls — HUB-75). Rendered for previews
    * that honour `transitrix.spacing.*`. Shown even on error renders so the user
    * can widen/tighten and re-render. The preview's webview must opt into command
    * URIs via `enableCommandUris`.
@@ -90,13 +90,13 @@ export interface DiagramFrameOpts {
   spacingCommand?: string;
   /**
    * Command ID for the "Curvature…" toolbar link (opens Settings filtered to
-   * the per-notation edge-curvature control — vkgeorgia/strategy#76). Same
+   * the per-notation edge-curvature control — HUB-76). Same
    * opt-in contract as `spacingCommand`.
    */
   curvatureCommand?: string;
   /**
    * Command ID for the "Scope…" toolbar link (opens Settings filtered to the
-   * per-notation level/root scope controls — vkgeorgia/strategy#77). Same
+   * per-notation level/root scope controls — HUB-77). Same
    * opt-in contract as `spacingCommand`.
    */
   scopeCommand?: string;
@@ -133,7 +133,7 @@ export interface DiagramFrameOpts {
    */
   legendToggle?: boolean;
   /**
-   * Opt-in to in-preview interactive controls (vkgeorgia/strategy#75/#76/#77 —
+   * Opt-in to in-preview interactive controls (HUB-75/#76/#77 —
    * PR2). When present, the frame switches from the script-less static CSP to a
    * strict nonce-based CSP (`default-src 'none'; style-src 'unsafe-inline';
    * script-src 'nonce-…'`), injects the control panel below the toolbar, and
@@ -150,7 +150,7 @@ export interface DiagramFrameOpts {
     controlsScript: string;
     /**
      * Optional toolbar segmented control (e.g. the tree↔table view toggle,
-     * vkgeorgia/strategy#137). Injected as the first item in the toolbar
+     * HUB-137). Injected as the first item in the toolbar
      * actions. Pass '' / omit when the preview has no toolbar control.
      */
     viewToggleHtml?: string;
@@ -220,7 +220,7 @@ const FIX_PROMPT_CSS = `
 }
 `;
 
-// Collapsible error strip (vkgeorgia/strategy view-testing idea). Mirrors the
+// Collapsible error strip (a hub view-testing idea). Mirrors the
 // `.tx-ctl` controls panel look so the preview reads consistently.
 //
 // Collapse is driven by a hidden checkbox + a <label> summary + a `:checked ~`
@@ -581,7 +581,7 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
     ? `<div class="toolbar-actions">${actionParts.join('')}</div>`
     : '';
 
-  // Interactive previews (vkgeorgia/strategy#75/#76/#77 PR2) opt into a strict
+  // Interactive previews (HUB-75/#76/#77 PR2) opt into a strict
   // nonce-based CSP and the in-preview control panel. Static previews keep the
   // script-less CSP unchanged — the only diff in their output is none.
   const wasmScriptSrc = interactive?.allowWasmRendering ? " 'wasm-unsafe-eval'" : '';

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -378,7 +378,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       actionPreview.saveAsSvg(),
     ),
     // PNG export — save-to-file + copy-to-clipboard per vector notation
-    // (vkgeorgia/strategy#32). Rasterized in the Node host via resvg.
+    // (HUB-32). Rasterized in the Node host via resvg.
     vscode.commands.registerCommand('transitrixStudio.saveBlocksAsPng', () => blocksPreview.saveAsPng()),
     vscode.commands.registerCommand('transitrixStudio.copyBlocksAsPng', () => blocksPreview.copyAsPng()),
     vscode.commands.registerCommand('transitrixStudio.saveGoalsAsPng', () => goalsPreview.saveAsPng()),
@@ -405,15 +405,15 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     }),
     vscode.commands.registerCommand('transitrixStudio.saveActivityCardAsPng', () => activityCardPreview.saveAsPng()),
     vscode.commands.registerCommand('transitrixStudio.copyActivityCardAsPng', () => activityCardPreview.copyAsPng()),
-    // Compliance matrix (vkgeorgia/strategy#84 Phase 2) — a repo-wide view, not
+    // Compliance matrix (HUB-84 Phase 2) — a repo-wide view, not
     // bound to a file. `openComplianceFile` is invoked from cell command URIs.
     vscode.commands.registerCommand('transitrixStudio.previewComplianceMatrix', () => complianceMatrixPreview.showOrReveal()),
     vscode.commands.registerCommand('transitrixStudio.refreshComplianceMatrix', () => complianceMatrixPreview.refresh()),
     vscode.commands.registerCommand('transitrixStudio.openComplianceFile', (fsPath: string) => openComplianceFile(fsPath)),
-    // Compliance-impact matrix (vkgeorgia/strategy#84 CV-2) — obligation × subject
+    // Compliance-impact matrix (HUB-84 CV-2) — obligation × subject
     // view per §5 of 21-compliance-impact.md; uses ImpactViewConfig (CV-1).
     vscode.commands.registerCommand('transitrixStudio.refreshComplianceImpact', () => complianceImpactPreview.refresh()),
-    // Single-law tree + single-product view (vkgeorgia/strategy#84 Phase 3) —
+    // Single-law tree + single-product view (HUB-84 Phase 3) —
     // triggered from a codex / product file's editor-title bar; repo-wide scan.
     vscode.commands.registerCommand('transitrixStudio.refreshSingleLaw', () => singleLawPreview.refresh()),
     vscode.commands.registerCommand('transitrixStudio.refreshSingleProduct', () => singleProductPreview.refresh()),
@@ -423,7 +423,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     // ASSERTION → subject + realised_via) and the hierarchy (parent chain +
     // direct children); origin-agnostic per 15-requirement.md §2.1.
     vscode.commands.registerCommand('transitrixStudio.refreshRequirementTrace', () => requirementTracePreview.refresh()),
-    // Gap dashboard (vkgeorgia/strategy#84 Phase 4) — repo-wide, palette-invoked.
+    // Gap dashboard (HUB-84 Phase 4) — repo-wide, palette-invoked.
     vscode.commands.registerCommand('transitrixStudio.previewGapDashboard', () => gapDashboardPreview.showOrReveal()),
     vscode.commands.registerCommand('transitrixStudio.refreshGapDashboard', () => gapDashboardPreview.refresh()),
     vscode.commands.registerCommand('transitrixStudio.exportGapDashboardCsv', () => gapDashboardPreview.exportCsv()),

--- a/extension/src/gap-dashboard-preview.ts
+++ b/extension/src/gap-dashboard-preview.ts
@@ -6,7 +6,7 @@ import { scanComplianceCanon } from './compliance-scan.js';
 import { complianceShell, deadlineBadge, escXml, openLink, statusBadge } from './compliance-render.js';
 import type { ViewScore } from '@transitrix/diagrams/confidence';
 
-// Gap dashboard (vkgeorgia/strategy#84 Phase 4). A repo-wide operational view
+// Gap dashboard (HUB-84 Phase 4). A repo-wide operational view
 // for compliance owners: requirements with no assertion, assertions with a
 // positive status but no evidence (ASSERT-007), and stale assertions past their
 // review date (ASSERT-008). Read-only, script-less; click-to-open via command

--- a/extension/src/goals-preview.ts
+++ b/extension/src/goals-preview.ts
@@ -75,7 +75,7 @@ export class GoalsPreview {
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
         {
           // Scripts enabled for the in-preview spacing/curvature/scope controls
-          // (vkgeorgia/strategy#75/#76/#77 PR2) under the strict nonce CSP set
+          // (HUB-75/#76/#77 PR2) under the strict nonce CSP set
           // in buildDiagramFrame. localResourceRoots is pinned to the
           // extension's own media even though the inline-nonce'd controls load
           // no resources — defence in depth per Valerii's posture call.

--- a/extension/src/png-export.ts
+++ b/extension/src/png-export.ts
@@ -5,7 +5,7 @@
  * module owns the editor-facing parts: the save dialog, file write, and the
  * OS-specific clipboard path.
  *
- * Clipboard scope (vkgeorgia/strategy#32): `vscode.env.clipboard` is
+ * Clipboard scope (HUB-32): `vscode.env.clipboard` is
  * text-only, so an image copy needs an OS-specific path. Windows ships here;
  * macOS (`osascript`) and Linux (`xclip` / `wl-copy`) are a documented
  * follow-up — `copyPngToClipboard` degrades to a clear notice there.
@@ -92,9 +92,9 @@ async function copyPngToClipboard(png: Buffer): Promise<void> {
     }
     return;
   }
-  // macOS / Linux: not yet wired (Windows-first, vkgeorgia/strategy#32).
+  // macOS / Linux: not yet wired (Windows-first, HUB-32).
   vscode.window.showWarningMessage(
-    'Copy as PNG is not yet available on macOS/Linux — use “Save .png” instead. (Tracked in vkgeorgia/strategy#32.)',
+    'Copy as PNG is not yet available on macOS/Linux — use “Save .png” instead. (Tracked in HUB-32.)',
   );
 }
 

--- a/extension/src/preview-controls.ts
+++ b/extension/src/preview-controls.ts
@@ -2,7 +2,7 @@ import { randomBytes } from 'node:crypto';
 import { escXml } from '@transitrix/diagrams/webview/render-util.js';
 
 // In-preview interactive control panel for the spacing / curvature / scope
-// previews (vkgeorgia/strategy#75 / #76 / #77 — PR2).
+// previews (HUB-75 / #76 / #77 — PR2).
 //
 // PR1 shipped the same controls as VS Code settings + a "…" toolbar link that
 // opens Settings. PR2 adds live, in-preview controls. Per Valerii's joint
@@ -90,7 +90,7 @@ export interface SnapshotMessage {
   snapshot?: string;
 }
 
-/** Tree ↔ table view, persisted per notation (vkgeorgia/strategy#137). */
+/** Tree ↔ table view, persisted per notation (HUB-137). */
 export type PreviewView = 'tree' | 'table';
 
 // Spacing bounds mirror the package.json `transitrix.spacing.*` schema (20–300).

--- a/extension/src/raster.ts
+++ b/extension/src/raster.ts
@@ -2,7 +2,7 @@
  * SVG → PNG rasterization for diagram export.
  *
  * Kept deliberately free of any `vscode` import so it can be unit-tested in
- * plain Node and — per the architectural note on vkgeorgia/strategy#32 —
+ * plain Node and — per the architectural note on HUB-32 —
  * lifted into the shared `@transitrix/diagrams` library later without
  * untangling editor glue. The VS Code wiring (save dialog, clipboard) lives
  * in `png-export.ts`.
@@ -10,7 +10,7 @@
  * Rasterizer: `@resvg/resvg-js` (Rust/usvg, prebuilt per-platform binaries).
  * Chosen over a headless browser (tens of MB, heavy startup) and `sharp`
  * (librsvg SVG path is weaker on fonts/CSS, larger binary). Decision recorded
- * on vkgeorgia/strategy#32.
+ * on HUB-32.
  */
 
 /**

--- a/extension/src/single-law-preview.ts
+++ b/extension/src/single-law-preview.ts
@@ -11,7 +11,7 @@ function todayIso(): string {
   return new Date().toISOString().slice(0, 10);
 }
 
-// Single-law tree (vkgeorgia/strategy#84 Phase 3). Triggered from a codex file
+// Single-law tree (HUB-84 Phase 3). Triggered from a codex file
 // (LAW / REGULATION / POLICY / INTERNAL_STANDARD) in the editor-title bar.
 // Shows the law → the requirements that derive from it → the assertions
 // targeting each, with status badges. Read-only, script-less; click-to-open via

--- a/extension/src/single-product-preview.ts
+++ b/extension/src/single-product-preview.ts
@@ -11,7 +11,7 @@ function todayIso(): string {
   return new Date().toISOString().slice(0, 10);
 }
 
-// Single-product view (vkgeorgia/strategy#84 Phase 3). Triggered from a PRODUCT
+// Single-product view (HUB-84 Phase 3). Triggered from a PRODUCT
 // file in the editor-title bar. Shows the product → every requirement an
 // assertion binds it to → the status of each. Read-only, script-less;
 // click-to-open via command URIs.

--- a/extension/src/spacing-config.ts
+++ b/extension/src/spacing-config.ts
@@ -5,7 +5,7 @@ import {
 import type { Scope } from '@transitrix/diagrams/scope.js';
 import type { ControlMessage, PreviewView } from './preview-controls.js';
 
-// Per-notation spacing controls (vkgeorgia/strategy#75). PR1 persists the
+// Per-notation spacing controls (HUB-75). PR1 persists the
 // chosen gaps in VS Code configuration (`transitrix.spacing.<notation>.*`),
 // mirroring the existing `transitrix.theme` pattern, and re-renders previews
 // on change. In-preview live sliders are deferred to PR2.
@@ -34,7 +34,7 @@ export const SPACING_CONFIG_SECTION = 'transitrix.spacing';
 /** Command that opens Settings filtered to the spacing controls. */
 export const OPEN_SPACING_SETTINGS_COMMAND = 'transitrixStudio.openSpacingSettings';
 
-// ── Edge curvature (vkgeorgia/strategy#76) ──────────────────────────────────
+// ── Edge curvature (HUB-76) ──────────────────────────────────
 //
 // A single per-notation multiplier on the edge control-handle length. Same
 // PR1 persistence pattern as spacing: settings-backed, re-rendered on change,
@@ -68,7 +68,7 @@ export function readEntryCurvature(notation: CurvatureNotation): number {
 /** Config section that, when changed, re-renders curvature-aware previews. */
 export const ENTRY_CURVATURE_CONFIG_SECTION = 'transitrix.entryCurvature';
 
-// ── Scope filter (vkgeorgia/strategy#77) ────────────────────────────────────
+// ── Scope filter (HUB-77) ────────────────────────────────────
 //
 // Trim a preview to a subtree root or a level cap. Same PR1 persistence
 // pattern as spacing: settings-backed, re-rendered on change. The in-preview

--- a/intellij/README.md
+++ b/intellij/README.md
@@ -120,5 +120,5 @@ Still deferred (tracked under the epic):
 - Auto-refresh on save outside the active preview.
 - PNG export (resvg-js native binary path).
 
-Follow epic [`vkgeorgia/strategy#135`](https://github.com/vkgeorgia/strategy/issues/135)
+Follow epic [`HUB-135`](HUB-135)
 for any post-release work.

--- a/organizations/acme_corp/canon/elements/05_implementation/target-states/README.md
+++ b/organizations/acme_corp/canon/elements/05_implementation/target-states/README.md
@@ -13,7 +13,7 @@ TYPE registry: [`notations/IDS_AND_REFERENCES.md`](../../../../../../notations/I
 Defined in [`notations/ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEMENT_PRIMITIVES.md) §7.17 over the common envelope §3:
 
 - Identity + composition: `notation: target-state`, `id`, `name`, optional `capabilities: [CAPABILITY-…]`, `processes: [PROCESS-…]`, `applications: [APPLICATION-…]`, `description`.
-- Goal satisfaction is **not** an inline field — it is a first-class `REL` kind on a separate sub-task of epic [strategy#122](https://github.com/vkgeorgia/strategy/issues/122).
+- Goal satisfaction is **not** an inline field — it is a first-class `REL` kind on a separate sub-task of epic HUB-122.
 - Scenarios point at target states (a `SCENARIO.target_state` reference on the scenario side); there is no `scenarios:` back-reference here.
 - Admission record ([`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §6) and primitive lifecycle ([`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §7).
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/cli",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "type": "module",
   "description": "Transitrix CLI — compile, validate, and report on Transitrix diagrams (BPMN, Goals, DGCA, …) from any shell or CI pipeline.",
   "license": "MIT",

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.8.21",
+  "version": "1.8.22",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",

--- a/packages/diagrams/src/activities/__tests__/layout.test.ts
+++ b/packages/diagrams/src/activities/__tests__/layout.test.ts
@@ -86,7 +86,7 @@ describe('layoutActivities', () => {
     expect(layout.bounds.height).toBeGreaterThan(0);
   });
 
-  // vkgeorgia/strategy#75 — configurable spacing.
+  // HUB-75 — configurable spacing.
   it('empty options reproduce the default no-arg layout', () => {
     const a = layoutActivities(diamondDoc);
     const b = layoutActivities(diamondDoc, {});

--- a/packages/diagrams/src/activity-card/types.ts
+++ b/packages/diagrams/src/activity-card/types.ts
@@ -1,7 +1,7 @@
 // Activity Card notation — single-project narrative view.
 //
 // Spec: transitrix/methodology `notations/views/18-activity-card.md` (v0.1).
-// Epic vkgeorgia/strategy#97, Studio track #134.
+// Epic HUB-97, Studio track #134.
 //
 // The Activity Card is the first MULTI-DOCUMENT Studio notation. The card
 // YAML itself holds only `id`, `project` (an Activity ID), `description`,

--- a/packages/diagrams/src/assertion/__tests__/example.test.ts
+++ b/packages/diagrams/src/assertion/__tests__/example.test.ts
@@ -1,6 +1,6 @@
 // Conformance test for the shipped ASSERTION worked examples — the acme_corp
 // canon files mirrored under `tests/fixtures/notation-corpus/assertion/`. Pins the success signal of
-// vkgeorgia/strategy#84 Phase 1: the library consumes the canonical example
+// HUB-84 Phase 1: the library consumes the canonical example
 // files without error.
 
 import { describe, it, expect } from 'vitest';

--- a/packages/diagrams/src/capability-map/validate.ts
+++ b/packages/diagrams/src/capability-map/validate.ts
@@ -9,7 +9,7 @@ const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 // `CAPABILITY-H…` with the dotted address (`V1`, `V1.2.1`, `H1`). The bare
 // legacy form (`V1`, `H1`) is still accepted so existing maps without the
 // canonical prefix do not break — migration is tracked under
-// vkgeorgia/strategy#36.
+// HUB-36.
 const CAP_ID_RE = /^(CAPABILITY-)?(V|H)\d+(\.\d+)*$/;
 
 export function validateCapabilityMap(input: unknown): ValidationResult {

--- a/packages/diagrams/src/compliance-matrix/types.ts
+++ b/packages/diagrams/src/compliance-matrix/types.ts
@@ -1,4 +1,4 @@
-// Compliance matrix model (vkgeorgia/strategy#84 Phase 2).
+// Compliance matrix model (HUB-84 Phase 2).
 //
 // The matrix is Products × Requirements. Each cell is the status of the
 // (Product, Requirement) ASSERTION when one exists, or a gap when none does.

--- a/packages/diagrams/src/compliance/__tests__/confidence.test.ts
+++ b/packages/diagrams/src/compliance/__tests__/confidence.test.ts
@@ -1,5 +1,5 @@
 // Bridge from the compliance index projections to the DQ-1 confidence module
-// (vkgeorgia/strategy#162 — DQ-2). Pins that:
+// (HUB-162 — DQ-2). Pins that:
 //   • element TYPEs lift to REQUIREMENT / ASSERTION (decay lookup keys),
 //   • admitted_at flows through to the freshness curve,
 //   • the §11.6 header line matches the spec example shape,

--- a/packages/diagrams/src/compliance/classify.ts
+++ b/packages/diagrams/src/compliance/classify.ts
@@ -1,4 +1,4 @@
-// Canon-artefact classification (vkgeorgia/strategy#84). The single authority
+// Canon-artefact classification (HUB-84). The single authority
 // for "what is a compliance artefact" — used by both the Studio extension scan
 // (webview previews) and the CLI scan (`export-compliance`), so the recognition
 // rules live once. Pure: takes a parsed YAML document, no IO.

--- a/packages/diagrams/src/compliance/confidence.ts
+++ b/packages/diagrams/src/compliance/confidence.ts
@@ -1,4 +1,4 @@
-// Confidence bridge for the compliance views (vkgeorgia/strategy#162 — DQ-2).
+// Confidence bridge for the compliance views (HUB-162 — DQ-2).
 // Maps the compliance index projections (IndexRequirement / IndexAssertion) onto
 // the DQ-1 ScoringElement shape, scores the view, and renders the §11.6 header
 // line. Lives in @transitrix/diagrams so Studio and DSM share one bridge and

--- a/packages/diagrams/src/compliance/gap-report.ts
+++ b/packages/diagrams/src/compliance/gap-report.ts
@@ -1,4 +1,4 @@
-// Gap dashboard report (vkgeorgia/strategy#84 Phase 4 / CV-5).
+// Gap dashboard report (HUB-84 Phase 4 / CV-5).
 //
 // Four operational gap lists computed from the shared reverse-index (Phase 3):
 //   1. Requirements with no Assertion targeting them (severity-sorted).

--- a/packages/diagrams/src/compliance/html.ts
+++ b/packages/diagrams/src/compliance/html.ts
@@ -1,4 +1,4 @@
-// HTML renderers for the compliance views (vkgeorgia/strategy#84 Phase 5,
+// HTML renderers for the compliance views (HUB-84 Phase 5,
 // PDF follow-on). Pure string builders — fed to WeasyPrint by the
 // `transitrix export-compliance --format pdf` path in src/export-compliance.ts.
 //

--- a/packages/diagrams/src/compliance/impact.ts
+++ b/packages/diagrams/src/compliance/impact.ts
@@ -1,5 +1,5 @@
 // Compliance-impact matrix derivation + markdown renderer
-// (vkgeorgia/strategy#166 — interim renderer; CV-1 view-config wiring
+// (HUB-166 — interim renderer; CV-1 view-config wiring
 // per strategy#84 decomposition refresh).
 //
 // Implements the render contract from

--- a/packages/diagrams/src/compliance/markdown.ts
+++ b/packages/diagrams/src/compliance/markdown.ts
@@ -1,4 +1,4 @@
-// Markdown renderers for the compliance views (vkgeorgia/strategy#84 Phase 5).
+// Markdown renderers for the compliance views (HUB-84 Phase 5).
 // Pure string builders consumed by the `transitrix export-compliance` CLI.
 // PDF rendering lives in `html.ts` (HTML doc fed to WeasyPrint by the CLI).
 

--- a/packages/diagrams/src/compliance/reverse-index.ts
+++ b/packages/diagrams/src/compliance/reverse-index.ts
@@ -1,4 +1,4 @@
-// Reverse-index builder (vkgeorgia/strategy#84 Phase 3).
+// Reverse-index builder (HUB-84 Phase 3).
 
 import type { ComplianceIndex, ComplianceIndexInput, IndexAssertion, IndexRequirement } from './types.js';
 

--- a/packages/diagrams/src/compliance/types.ts
+++ b/packages/diagrams/src/compliance/types.ts
@@ -1,5 +1,4 @@
-// Shared compliance reverse-index + derived views (vkgeorgia/strategy#84
-// Phase 3). The reverse-index pass (Law → Requirements, Requirement →
+// Shared compliance reverse-index + derived views (HUB-84, Phase 3). The reverse-index pass (Law → Requirements, Requirement →
 // Assertions, Subject → Assertions) backs the single-law tree and the
 // single-product view here, and the gap dashboard in Phase 4.
 

--- a/packages/diagrams/src/compliance/views.ts
+++ b/packages/diagrams/src/compliance/views.ts
@@ -1,4 +1,4 @@
-// Single-law tree + single-product view builders (vkgeorgia/strategy#84 Phase 3).
+// Single-law tree + single-product view builders (HUB-84 Phase 3).
 
 import type {
   ComplianceIndex,

--- a/packages/diagrams/src/confidence/score.ts
+++ b/packages/diagrams/src/confidence/score.ts
@@ -2,7 +2,7 @@
 // callers (Studio previews, DSM React) pass already-resolved element inputs
 // and a `today` reference; this module returns the per-element scores and
 // the view composite. Lives in @transitrix/diagrams so Studio and DSM share
-// one implementation (see vkgeorgia/strategy#159 — DQ-1).
+// one implementation (see HUB-159 — DQ-1).
 
 import type {
   ConfidenceBand,

--- a/packages/diagrams/src/edge-path.ts
+++ b/packages/diagrams/src/edge-path.ts
@@ -5,7 +5,7 @@
 // arrow reads as perpendicular to the node's vertical edge.
 //
 // Pulling the path math here (rather than duplicating it inline in each
-// preview) makes the configurable-curvature behaviour (vkgeorgia/strategy#76)
+// preview) makes the configurable-curvature behaviour (HUB-76)
 // unit-testable — the extension has no test harness.
 
 /**

--- a/packages/diagrams/src/fgca/__tests__/parse-canonical.test.ts
+++ b/packages/diagrams/src/fgca/__tests__/parse-canonical.test.ts
@@ -170,7 +170,7 @@ describe('parseCanonicalFGCA', () => {
   });
 });
 
-// The "FGCA preview blank / FGA no edges" regression (vkgeorgia/strategy#65,
+// The "FGCA preview blank / FGA no edges" regression (HUB-65,
 // transitrix/methodology#65) was a data defect: the canonical flat shape was
 // not being mapped to the internal cross-ref fields the renderer turns into
 // edges. These assert the edge-driving fields are populated, so the renderer

--- a/packages/diagrams/src/fgca/__tests__/preview-layout.test.ts
+++ b/packages/diagrams/src/fgca/__tests__/preview-layout.test.ts
@@ -76,7 +76,7 @@ describe('layoutFGCAPreview', () => {
     expect(gapOf(120)).toBeGreaterThan(gapOf(20));
   });
 
-  // vkgeorgia/strategy#77 — scope filtering. FGCA goals are flat, so 'root'
+  // HUB-77 — scope filtering. FGCA goals are flat, so 'root'
   // selects the single matching goal plus the factors/changes/activities that
   // touch it.
   describe('scope', () => {

--- a/packages/diagrams/src/fgca/chain-table.ts
+++ b/packages/diagrams/src/fgca/chain-table.ts
@@ -1,4 +1,4 @@
-// Chain-table model for the FGCA / FGA previews (vkgeorgia/strategy#137).
+// Chain-table model for the FGCA / FGA previews (HUB-137).
 //
 // The tree/chain preview (`layoutFGCAPreview`) shows Driver → Goal → Change →
 // Activity as columns of nodes joined by edges. This module produces the

--- a/packages/diagrams/src/fgca/parse-canonical.ts
+++ b/packages/diagrams/src/fgca/parse-canonical.ts
@@ -354,7 +354,7 @@ export interface CanonicalFGAResult extends ValidationResult {
  * FGA-001..011). The resulting internal `FGCADoc` carries `activity.goal_id`,
  * which is exactly what the renderer needs to draw goal → activity edges —
  * the field whose absence produced the "FGA nodes render, no edges" bug
- * (transitrix/methodology#65 / vkgeorgia/strategy#65).
+ * (transitrix/methodology#65 / HUB-65).
  *
  * Lives beside `parseCanonicalFGCA` (rather than inline in the extension) so
  * the canonical FGA path is unit-testable and the library owns the single

--- a/packages/diagrams/src/fgca/preview-layout.ts
+++ b/packages/diagrams/src/fgca/preview-layout.ts
@@ -49,7 +49,7 @@ export interface FGCAPreviewLayoutOptions {
   colGap?: number;
   /** Vertical gap (px) between stacked nodes within a column. Default matches the historical hardcoded value. */
   rowGap?: number;
-  /** Trim to a level cap or a single root goal (vkgeorgia/strategy#77). Defaults to 'all'. */
+  /** Trim to a level cap or a single root goal (HUB-77). Defaults to 'all'. */
   scope?: Scope;
   /** Entity node width (px). Default {@link FGCA_NODE_W}. */
   nodeWidth?: number;

--- a/packages/diagrams/src/goals/__tests__/layout.test.ts
+++ b/packages/diagrams/src/goals/__tests__/layout.test.ts
@@ -64,7 +64,7 @@ describe('layoutGoalTree', () => {
     expect(layout.nodes[0].height).toBe(60);
   });
 
-  // vkgeorgia/strategy#75 — configurable spacing. The preview maps
+  // HUB-75 — configurable spacing. The preview maps
   // horizontalGap → rankSep and verticalGap → nodeSep.
   it('larger rankSep widens the column step', () => {
     const tight = layoutGoalTree(TREE, { rankSep: 80 });
@@ -145,7 +145,7 @@ describe('layoutGoalTree', () => {
     expect(() => layoutGoalTree(cyclic)).not.toThrow();
   });
 
-  // vkgeorgia/strategy#77 — scope filtering.
+  // HUB-77 — scope filtering.
   describe('scope', () => {
     const ids = (l: ReturnType<typeof layoutGoalTree>) => l.nodes.map(n => n.id).sort((a, b) => a - b);
 

--- a/packages/diagrams/src/goals/__tests__/validate.test.ts
+++ b/packages/diagrams/src/goals/__tests__/validate.test.ts
@@ -128,7 +128,7 @@ describe('validateGoalTree', () => {
   });
 
   // GOALS-012 / GOALS-013 — N+1 parent/child hierarchy keyed on goal_types[]
-  // (decision in vkgeorgia/strategy#66; spec in transitrix/methodology
+  // (decision in HUB-66; spec in transitrix/methodology
   // notations/04-goals.md §6).
   it('GOALS-012/013: accepts a contiguous goal_types + N+1 parent/child tree', () => {
     const r = validateGoalTree(VALID_TREE);

--- a/packages/diagrams/src/goals/layout.ts
+++ b/packages/diagrams/src/goals/layout.ts
@@ -8,7 +8,7 @@ const DEFAULT_RANK_SEP = 80;
 const DEFAULT_NODE_SEP = 40;
 
 /**
- * Trims a flat goal list to a scope (vkgeorgia/strategy#77).
+ * Trims a flat goal list to a scope (HUB-77).
  *   - 'level' → goals with `level <= maxLevel`.
  *   - 'root'  → the root goal (matched by string id) plus all its descendants
  *               via `parent_id`; an empty list when the root is absent.

--- a/packages/diagrams/src/goals/types.ts
+++ b/packages/diagrams/src/goals/types.ts
@@ -60,7 +60,7 @@ export interface LayoutOptions {
   nodeSep?: number;
   hideCollapsed?: number[];
   viewDepth?: number | null;
-  /** Trim the tree to a level cap or a subtree root (vkgeorgia/strategy#77). Defaults to 'all'. */
+  /** Trim the tree to a level cap or a subtree root (HUB-77). Defaults to 'all'. */
   scope?: Scope;
 }
 

--- a/packages/diagrams/src/goals/validate.ts
+++ b/packages/diagrams/src/goals/validate.ts
@@ -21,7 +21,7 @@ export function validateGoalTree(input: unknown): ValidationResult {
   const tree = raw as unknown as GoalTree;
 
   // GOALS-013 — goal_types[].level values must be contiguous starting from 0.
-  // Per the N+1 rule (decision in vkgeorgia/strategy#66), the level set must
+  // Per the N+1 rule (decision in HUB-66), the level set must
   // be exactly {0, 1, …, N}; a gap breaks the parent→child level invariant
   // and means GOALS-012 cannot be enforced consistently.
   const levels = tree.goal_types
@@ -96,7 +96,7 @@ export function validateGoalTree(input: unknown): ValidationResult {
       continue;
     }
     // GOALS-012 — parent must be exactly one level above the child (N+1
-    // hierarchy, decision in vkgeorgia/strategy#66). Only enforced when the
+    // hierarchy, decision in HUB-66). Only enforced when the
     // parent is resolvable; a missing parent is covered by BROKEN_PARENT_REF.
     if (g.parent_id !== 0) {
       const parentLevel = levelById.get(g.parent_id);

--- a/packages/diagrams/src/requirement/__tests__/example.test.ts
+++ b/packages/diagrams/src/requirement/__tests__/example.test.ts
@@ -1,6 +1,6 @@
 // Conformance test for the shipped REQUIREMENT worked examples — the
 // acme_corp canon files mirrored under `tests/fixtures/notation-corpus/requirement/`. Pins the
-// success signal of vkgeorgia/strategy#84 Phase 1: the library consumes the
+// success signal of HUB-84 Phase 1: the library consumes the
 // canonical example files without error.
 
 import { describe, it, expect } from 'vitest';

--- a/scripts/build-compiler-bundle.mjs
+++ b/scripts/build-compiler-bundle.mjs
@@ -112,7 +112,7 @@ for (const dep of RUNTIME_DEPS_EXTERNAL) {
   }
 }
 
-// @resvg/resvg-js (PNG export, vkgeorgia/strategy#32) is a NATIVE module: its
+// @resvg/resvg-js (PNG export, HUB-32) is a NATIVE module: its
 // platform `.node` binary ships as a per-OS optional dependency, so `npm
 // install` lays down only the binary matching the build machine. That is
 // exactly right for per-platform VSIX packaging (`vsce package --target`),

--- a/scripts/ci-hygiene-check.mjs
+++ b/scripts/ci-hygiene-check.mjs
@@ -16,7 +16,10 @@ if (!blocklist || blocklist.trim() === '') {
 }
 
 const blocklistHub = process.env.HYGIENE_BLOCKLIST_HUB;
-const combined = blocklistHub && blocklistHub.trim() ? `${blocklist}|${blocklistHub}` : blocklist;
+const blocklist3 = process.env.HYGIENE_BLOCKLIST_3;
+const combined = [blocklist, blocklistHub, blocklist3]
+  .filter((p) => p && p.trim())
+  .join('|');
 
 let pattern;
 try {

--- a/scripts/ci-hygiene-tree.mjs
+++ b/scripts/ci-hygiene-tree.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+// Public-surface hygiene — full-tree pass.
+//
+// The diff check (ci-hygiene-check.mjs) only sees what a PR adds, so anything
+// already committed stays invisible to it forever. This pass reads every tracked
+// text file instead.
+//
+// Deliberately scoped to the HYGIENE_BLOCKLIST_3 pattern alone: the older slots
+// have never been evaluated tree-wide, and enabling them here would fail every
+// PR on pre-existing content rather than on the change under review.
+//
+// Same anti-recursion discipline as the diff check — reports file:line, never
+// the matched substring.
+
+import { execSync } from 'node:child_process';
+import { readFileSync, statSync } from 'node:fs';
+
+const raw = process.env.HYGIENE_BLOCKLIST_3;
+if (!raw || raw.trim() === '') {
+  console.warn('[hygiene-tree] HYGIENE_BLOCKLIST_3 secret is not set — skipping check.');
+  process.exit(0);
+}
+
+let pattern;
+try {
+  pattern = new RegExp(raw, 'i');
+} catch {
+  console.error('[hygiene-tree] HYGIENE_BLOCKLIST_3 is not a valid JavaScript regex.');
+  process.exit(2);
+}
+
+const SKIP = new Set([
+  'scripts/ci-hygiene-check.mjs',
+  'scripts/ci-hygiene-tree.mjs',
+  '.github/workflows/public-surface-hygiene.yml',
+  '.gitignore',
+]);
+const MAX_BYTES = 2_000_000;
+
+let files;
+try {
+  files = execSync('git ls-files -z', { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 })
+    .split('\0')
+    .filter(Boolean);
+} catch (err) {
+  console.error('[hygiene-tree] failed to list tracked files:', err.message);
+  process.exit(2);
+}
+
+const hits = [];
+for (const file of files) {
+  if (SKIP.has(file)) continue;
+  let text;
+  try {
+    if (statSync(file).size > MAX_BYTES) continue;
+    text = readFileSync(file, 'utf8');
+  } catch {
+    continue; // unreadable, binary, or removed between listing and read
+  }
+  if (text.includes('\0')) continue; // binary
+  const lines = text.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    if (pattern.test(lines[i])) hits.push(`${file}:${i + 1}`);
+  }
+}
+
+if (hits.length === 0) {
+  console.log(`[hygiene-tree] clean — ${files.length} tracked file(s) scanned.`);
+  process.exit(0);
+}
+
+console.error('[hygiene-tree] a tracked file carries content this repository does not put on a public surface.');
+console.error('[hygiene-tree] (matched terms are intentionally not printed — repeating them would re-leak them.)');
+console.error('[hygiene-tree] use the neutral form documented in the contributor guide.');
+for (const h of hits) console.error(`  - ${h}`);
+process.exit(1);

--- a/scripts/render-compliance-impact.mjs
+++ b/scripts/render-compliance-impact.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * Compliance-impact matrix renderer — CV-1 view-config wiring
- * (vkgeorgia/strategy#84, builds on #166 interim renderer).
+ * (HUB-84, builds on #166 interim renderer).
  *
  * Materialises the subject × obligation × status matrix per the render
  * contract in methodology/notations/views/21-compliance-impact.md §5.

--- a/src/repo-validate.ts
+++ b/src/repo-validate.ts
@@ -127,8 +127,8 @@ export function loadRepoModel(root: string): RepoModelInput {
   return { elements, relations };
 }
 
-/** A per-file notation finding from sweeping canon/views/** (vkgeorgia/strategy
- *  #258, Phase A.2). Unlike the frozen `RepoFinding` (canon cross-references),
+/** A per-file notation finding from sweeping canon/views/** (HUB-258,
+ *  Phase A.2). Unlike the frozen `RepoFinding` (canon cross-references),
  *  this carries the file, notation, and rule code an agent needs to fix it. */
 export interface ViewFinding {
   /** Source file path, relative to the scanned root. */

--- a/src/validate-notation.ts
+++ b/src/validate-notation.ts
@@ -1,4 +1,4 @@
-// File-scope validation for diagram notations (vkgeorgia/strategy#258).
+// File-scope validation for diagram notations (HUB-258).
 // Group C (compliance suite): #518 Phase C1–C2.
 //
 // The VS Code preview renders its red error block from per-notation validators

--- a/tests/preview-controls.test.ts
+++ b/tests/preview-controls.test.ts
@@ -6,7 +6,7 @@ import {
   type ControlsModel,
 } from '../extension/src/preview-controls.js';
 
-// Unit coverage for the in-preview control panel (vkgeorgia/strategy#75/#76/#77
+// Unit coverage for the in-preview control panel (HUB-75/#76/#77
 // PR2). The panel + wiring script are pure string builders (no `vscode`), so
 // the data-attribute contract between markup and script is testable here.
 

--- a/tests/repo-validate-views.test.ts
+++ b/tests/repo-validate-views.test.ts
@@ -11,7 +11,7 @@ import {
   repoScopeHasErrors,
 } from '../src/repo-validate.js';
 
-// Phase A.2 (vkgeorgia/strategy#258): `validate --scope=repo` sweeps every
+// Phase A.2 (HUB-258): `validate --scope=repo` sweeps every
 // notation file under canon/views/** with the same validators the preview uses.
 
 const corpus = join(

--- a/tests/validate-notation.test.ts
+++ b/tests/validate-notation.test.ts
@@ -15,7 +15,7 @@ import {
   inferNotationFromFilename,
 } from '../src/validate-notation.js';
 // Imported directly to prove the CLI dispatch mirrors the validator the VS Code
-// preview uses — same findings, no drift (vkgeorgia/strategy#258).
+// preview uses — same findings, no drift (HUB-258).
 import { parseCanonicalGoals } from '../packages/diagrams/src/goals/parse-canonical.js';
 import { validateApplicationsCatalogue } from '../packages/diagrams/src/applications/validate.js';
 import { validateCapabilityMap } from '../packages/diagrams/src/capability-map/validate.js';


### PR DESCRIPTION
Mechanical rewrite across 54 files: work-item references now use the neutral `HUB-NNN` form, replacing three older spellings (qualified issue refs, full issue URLs, and one markdown link).

Deliberately not the hash form — a bare `#84` auto-links to *this* repository's issue 84, which renders as a working link to an unrelated item.

Text only: comments, READMEs, docstrings. Verified: `npm run build` clean; `npm test` gives 6 pre-existing failures identical on `main` (unrelated fixture-path issues), 475 passing either way.