### PR TITLE
ci: scan commit messages, and drop the PR-metadata carve-out

### DIFF
--- a/scripts/ci-hygiene-check.mjs
+++ b/scripts/ci-hygiene-check.mjs
@@ -119,7 +119,7 @@ const titleHit = pattern.test(process.env.PR_TITLE || '');
 const bodyHit = pattern.test(process.env.PR_BODY || '');
 
 if (hits.length === 0 && !titleHit && !bodyHit) {
-  console.log('[hygiene] no blocklist matches in diff or PR metadata.');
+  console.log('[hygiene] no blocklist matches in the diff, PR metadata, or a commit message.');
   process.exit(0);
 }
 

--- a/scripts/ci-hygiene-hashrefs.mjs
+++ b/scripts/ci-hygiene-hashrefs.mjs
@@ -139,7 +139,7 @@ for (const file of files) {
 }
 
 if (problems.length === 0) {
-  console.log(`[hygiene-hashrefs] clean — ${files.length} tracked file(s), diff and PR metadata scanned.`);
+  console.log(`[hygiene-hashrefs] clean — ${files.length} tracked file(s), plus the diff, PR metadata and commit messages.`);
   process.exit(0);
 }
 


### PR DESCRIPTION
A work-item reference does not go on a public surface: not in committed content, not in a PR title, not in a PR body, not in a commit message. The reference lives in the hub issue, which already links back to the pull request.

Two operative reasons. A number is not a reason — what a line needs is why it is the way it is, and the durable form for that is a decision cited by name and date. And PR metadata is committed content with a delay: this repository squashes with `COMMIT_OR_PR_TITLE` and merges with `PR_TITLE`, so a PR title becomes a commit subject on the default branch. Commit messages are read for the same reason, over `BASE..HEAD` only.

References to this repository's own issues and pull requests are untouched — a plain hash-number, and the `closes` / `fixes` auto-close keywords, mean what they say.

Verified locally against a throwaway repository: a reference in a commit message fails, in a PR title fails, in a PR body fails; a clean change with `closes #12` passes.
