### PR TITLE
chore: add dependabot config for continuous dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+updates:
+  # npm workspace root — "workspaces": ["packages/*"] in the root package.json means
+  # Dependabot's native workspace detection also covers packages/cli and
+  # packages/diagrams from this one entry; listing them separately risks duplicate
+  # or conflicting PRs against the same lockfile.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # extension/ is not under packages/*, so it is not a workspace member — its own manifest.
+  - package-ecosystem: "npm"
+    directory: "/extension"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # JetBrains plugin (Gradle/Kotlin).
+  - package-ecosystem: "gradle"
+    directory: "/intellij"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # GitHub Actions workflow files — 9 in this repo, otherwise nobody reviews them.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,40 @@
+name: Dependabot auto-merge
+
+# Weekly Dependabot updates auto-merge on green, gated by this repository's own
+# CI — including Public-surface hygiene and the PR-description policy, since
+# this repo is public. `dependabot.yml` already excludes major-version bumps;
+# the metadata check below is a second, independent gate on the same property.
+#
+# This repo has no branch-protection rule, so GitHub's native `gh pr merge
+# --auto` would have nothing to wait on and would merge immediately. Waiting
+# on `gh pr checks --watch --fail-fast` explicitly instead keeps the gate
+# self-contained without touching repo-wide branch-protection settings.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Wait for checks, then merge on green
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          set -euo pipefail
+          gh pr checks "$PR_URL" --watch --fail-fast
+          gh pr merge --squash --delete-branch "$PR_URL"


### PR DESCRIPTION
## Summary
- Layer 1 of the cross-project dependency-maintenance decision (strategy hub `architecture/cross-project/2026-07-31-dependency-maintenance-three-layers.md`): a weekly Dependabot bot for security advisories and patch/minor bumps, so a known vulnerability no longer waits for the twice-yearly wave.
- `.github/dependabot.yml` covers every manifest in this repo: the npm workspace root (`/`, which also covers `packages/cli` and `packages/diagrams` via Dependabot's native workspace detection — `extension/` is not part of the `packages/*` workspace glob, so it gets its own entry), Gradle for `intellij/`, and `github-actions` for the 9 workflow files. No Docker manifests exist in this repo.
- `.github/workflows/dependabot-auto-merge.yml` auto-merges Dependabot PRs on green, gated by this public repo's own CI (public-surface hygiene, PR-description policy) via `gh pr checks --watch --fail-fast` before merging — this repo has no branch-protection rule, so GitHub's native `--auto` merge would have nothing to wait on and would merge immediately.
- Major-version bumps are excluded in both `dependabot.yml`'s `ignore` rules and the auto-merge workflow's own independent check on Dependabot's `update-type` metadata — those stay the wave's, per the decision.

Dependabot alerts were already enabled repo-wide as of 2026-07-31 (verified via `GET /repos/transitrix/transitrix-studio/vulnerability-alerts` → 204); no action needed there.

Sibling repos landed the equivalent change already: `transitrix/methodology#420` (same public-gated auto-merge pattern), `transitrix/transitrix-dsm#166` (private-repo native auto-merge). This is transitrix-studio's slice of the same epic (`proj:transitrix-studio`, HUB-877).

## Test plan
- [x] Validated both YAML files parse (`js-yaml` via node)
- [x] Confirmed no branch-protection rule on `main` (`GET /repos/.../branches/main/protection` → 404), matching methodology's rationale for the checks-watch gate over native auto-merge
- [x] Confirmed `allow_auto_merge` is enabled on the repo
- [ ] First Dependabot PR merges cleanly on green (observable only after this lands and the bot runs)
