### PR TITLE
feat(validators): register RISK/METRIC/NEED/VALIDATION rule codes for the methodology 3.1.0 vocabulary

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -192,6 +192,10 @@ validators the VS Code preview uses:
 | `canon/elements/**/CONSTRAINT-*.yaml` | `CONST-*` shape | `CONST-004`/`005` with scanned `CanonCatalog` |
 | `canon/assertions/ASSERTION-*.yaml` | `ASSERT-*` shape | `ASSERT-002`..`005` + `ASSERT-007`/`008` warnings |
 | `canon/verifications/VERIFICATION-*.yaml` | `VERIF-*` shape | `VERIF-002`/`005` with scanned `CanonCatalog` + `REQ-VERIF-COVERAGE-001`/`002` warnings |
+| `canon/elements/**/RISK-*.yaml` | `RISK-*` shape + `RISK-COVERAGE-001` warning | `RISK-003`/`004` with scanned `CanonCatalog` |
+| `canon/elements/**/METRIC-*.yaml` | `METRIC-*` shape | `METRIC-002`/`004` with scanned `CanonCatalog` |
+| `canon/elements/**/NEED-*.yaml` | `NEED-001` shape | `NEED-002` with scanned `CanonCatalog` + `NEED-COVERAGE-001`/`NEED-VALIDATION-COVERAGE-001`/`002` warnings |
+| `canon/validations/VALIDATION-*.yaml` | `VALID-*` shape | `VALID-002`/`005` with scanned `CanonCatalog` |
 | `codex/**` | `CODEX-*` | folder jurisdiction (`CODEX-005`) |
 | `canon/views/**.compliance-impact.*` | `COMPIMP-001` parse | `COMPIMP-REF`, `COMPIMP-009`..`011`, `buildImpactMatrix` |
 | `canon/views/**.coverage-metric.*` | `COVMET-*` parse | `COVMET-REF`, `buildCoverageMatrix` |
@@ -223,6 +227,44 @@ the **Compliance Gap Dashboard** lists every affected requirement repo-wide.
 Both re-scan on save of any `VERIFICATION-*.yaml` file. The core validator is
 the single source of the verdict — the previews render `buildGapReport`'s
 output, they never compute their own judgement.
+
+**`RISK` / `METRIC` / `NEED` / `VALIDATION` — the methodology 3.1.0 vocabulary
+follow-on** (`ELEMENT_PRIMITIVES.md` §7.26–§7.28, §9; `15-requirement.md`
+§2.5–§2.7; `28-validation.md`). `RISK-001..004`, `METRIC-001..004`, and
+`NEED-001..002` are single-file shape/resolution rules for the three new
+standalone motivation-layer elements, following the same
+`validate<Notation>(input, { catalog })` shape as `validateRequirement` /
+`validateVerification`. `VALID-001..006` is the shape/resolution suite for
+`VALIDATION` — the validation-domain claim type anchored on `NEED`, structured
+the same way as `VERIFICATION` but one layer further upstream (§28
+§1/§4). `REQUIREMENT` grew three matching fields: `level` (`REQ-005`, the
+ISO/IEC/IEEE 29148 StRS/SyRS/SRS tier), `kind` (`REQ-006`, functional vs
+quality), and `serves` (`REQ-SERVES-001`, tracing back to the upstream `NEED`
+it satisfies).
+
+`RISK-COVERAGE-001` (an untreated risk — empty/absent `treated_by`) is a
+single-file check, unlike the other `*-COVERAGE-*` rules: it reads only the
+`RISK` element's own field, no catalogue scan required. `NEED` carries the
+same cross-cutting reverse-trace shape as `REQUIREMENT`/`VERIFICATION`,
+computed the same way as `GAP-REQ-NO-ASSERT` / `REQ-VERIF-COVERAGE-*`:
+
+| ruleId | Fires when |
+|---|---|
+| `NEED-COVERAGE-001` | No admitted `REQUIREMENT` carries `serves: <this NEED id>`. |
+| `NEED-VALIDATION-COVERAGE-001` | No admitted `VALIDATION` carries `validates: <this NEED id>`. |
+| `NEED-VALIDATION-COVERAGE-002` | One or more `VALIDATION`s target the need, but every one is still `not_yet_run`/`inconclusive` — none has reached `pass`/`fail`. Mutually exclusive with `-001` by construction. |
+
+All three are `warning`-severity, same posture as `REQ-VERIF-COVERAGE-*` (a
+newly admitted `NEED` legitimately has no serving requirement or validation
+yet), surfaced in the `compliance` findings bucket. There is no dedicated
+`NEED`/`VALIDATION` IDE preview surface yet (28-validation.md §7), and the
+Compliance Gap Dashboard export/preview (`compliance/html.ts`,
+`compliance/markdown.ts`, `extension/src/gap-dashboard-preview.ts`) render
+`GapReport`'s `requirementsWith*` fields explicitly and were not extended for
+the new `needsWith*` fields in this pass — `buildGapReport` computes them
+(consumed today by `runGapDashboardWarnings` for `--scope=repo`'s
+`compliance` findings), but surfacing them in the dashboard's own sections is
+follow-up work, not yet wired.
 
 File-scope `transitrix validate <requirement.yaml>` runs shape rules only unless
 you pass a catalogue (repo-scope builds one automatically from `canon/**` +

--- a/package-lock.json
+++ b/package-lock.json
@@ -6977,7 +6977,7 @@
     },
     "packages/cli": {
       "name": "@transitrix/cli",
-      "version": "2.4.1",
+      "version": "2.4.2",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6995,7 +6995,7 @@
     },
     "packages/diagrams": {
       "name": "@transitrix/diagrams",
-      "version": "1.9.1",
+      "version": "1.9.2",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/cli",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "type": "module",
   "description": "Transitrix CLI — compile, validate, and report on Transitrix diagrams (BPMN, Goals, DGCA, …) from any shell or CI pipeline.",
   "license": "MIT",

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",

--- a/packages/diagrams/src/compliance/classify.ts
+++ b/packages/diagrams/src/compliance/classify.ts
@@ -5,7 +5,8 @@
 
 import type { AssertionStatus } from '../assertion/types.js';
 import type { VerificationMethod, VerificationOutcome } from '../verification/types.js';
-import type { IndexAssertion, IndexRequirement, IndexVerification } from './types.js';
+import type { ValidationMethod, ValidationOutcome } from '../validation/types.js';
+import type { IndexAssertion, IndexRequirement, IndexVerification, IndexNeed, IndexValidation } from './types.js';
 
 export interface ComplianceProduct {
   id: string;
@@ -32,10 +33,26 @@ export interface ComplianceCanon {
    * `ingestComplianceDoc` for the corresponding notation values.
    */
   subjects: ComplianceProduct[];
+  /** NEED elements (ELEMENT_PRIMITIVES.md §7.28) — upstream of `requirements`.
+   *  Ingested so NEED-COVERAGE-001 / NEED-VALIDATION-COVERAGE-001..002 can
+   *  compute coverage over the full needs catalogue. */
+  needs: IndexNeed[];
+  /** VALIDATION artefacts (28-validation.md) — the validation-domain peer of
+   *  `verifications`, anchored on NEED instead of REQUIREMENT. */
+  validations: IndexValidation[];
 }
 
 export function emptyCanon(): ComplianceCanon {
-  return { products: [], requirements: [], assertions: [], verifications: [], codex: [], subjects: [] };
+  return {
+    products: [],
+    requirements: [],
+    assertions: [],
+    verifications: [],
+    codex: [],
+    subjects: [],
+    needs: [],
+    validations: [],
+  };
 }
 
 const str = (v: unknown): string | undefined => (typeof v === 'string' ? v : undefined);
@@ -82,6 +99,24 @@ export function ingestComplianceDoc(canon: ComplianceCanon, doc: unknown): strin
       element_kind: d.notation,
       description: str(d.description),
       next_review_at: str(d.next_review_at),
+      serves: str(d.serves),
+    });
+    return id;
+  }
+  if (d.notation === 'need') {
+    canon.needs.push({ id, name: str(d.name) ?? id });
+    return id;
+  }
+  if (d.notation === 'validation') {
+    const validates = str(d.validates);
+    const method = str(d.method) as ValidationMethod | undefined;
+    const outcome = str(d.outcome) as ValidationOutcome | undefined;
+    if (!validates || !method || !outcome) return null;
+    canon.validations.push({
+      id, validates, method, outcome,
+      performed_at: str(d.performed_at),
+      evidenceCount: Array.isArray(d.evidence) ? d.evidence.length : 0,
+      admitted_at: str(d.admitted_at),
     });
     return id;
   }

--- a/packages/diagrams/src/compliance/gap-report.ts
+++ b/packages/diagrams/src/compliance/gap-report.ts
@@ -18,9 +18,10 @@
 //      still `not_yet_run` / `inconclusive` — REQ-VERIF-COVERAGE-002. Mutually
 //      exclusive with #5 by construction.
 
-import type { ComplianceIndex, IndexAssertion, IndexRequirement } from './types.js';
+import type { ComplianceIndex, IndexAssertion, IndexRequirement, IndexNeed } from './types.js';
 import { computeDeadlineStatus } from './impact.js';
 import { CLOSED_VERIFICATION_OUTCOMES } from '../verification/types.js';
+import { CLOSED_VALIDATION_OUTCOMES } from '../validation/types.js';
 
 export interface GapReport {
   /** Requirements with no assertion about them, severity-sorted then id. */
@@ -47,6 +48,24 @@ export interface GapReport {
    * `not_yet_run`/`inconclusive`. Severity-sorted then id.
    */
   requirementsWithUnresolvedVerification: IndexRequirement[];
+  /**
+   * NEED-COVERAGE-001: needs with no REQUIREMENT whose `serves` names them —
+   * the NEED-side analogue of `requirementsWithoutAssertions`, id-sorted.
+   */
+  needsWithoutRequirements: IndexNeed[];
+  /**
+   * NEED-VALIDATION-COVERAGE-001: needs with no VALIDATION targeting them,
+   * id-sorted — the validation-side analogue of
+   * `requirementsWithoutVerification`.
+   */
+  needsWithoutValidation: IndexNeed[];
+  /**
+   * NEED-VALIDATION-COVERAGE-002: needs with one or more VALIDATIONs
+   * targeting them, but none closed (`pass`/`fail`) — every one is still
+   * `not_yet_run`/`inconclusive`. Mutually exclusive with
+   * `needsWithoutValidation` by construction. Id-sorted.
+   */
+  needsWithUnresolvedValidation: IndexNeed[];
 }
 
 export interface GapReportOptions {
@@ -133,8 +152,30 @@ export function buildGapReport(index: ComplianceIndex, options: GapReportOptions
       return d !== 0 ? d : a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
     });
 
+  // NEED-COVERAGE-001 — no REQUIREMENT.serves names this need.
+  const needsWithoutRequirements = [...index.needById.values()]
+    .filter(n => (index.requirementsByNeed.get(n.id) ?? []).length === 0)
+    .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+
+  // NEED-VALIDATION-COVERAGE-001 — no VALIDATION targets the need at all.
+  const needsWithoutValidation = [...index.needById.values()]
+    .filter(n => (index.validationsByNeed.get(n.id) ?? []).length === 0)
+    .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+
+  // NEED-VALIDATION-COVERAGE-002 — has validations, but none closed (pass/fail).
+  // Mutually exclusive with -001 by construction (only needs with at least
+  // one validation are considered here).
+  const needsWithUnresolvedValidation = [...index.needById.values()]
+    .filter(n => {
+      const validations = index.validationsByNeed.get(n.id) ?? [];
+      return validations.length > 0
+        && !validations.some(v => (CLOSED_VALIDATION_OUTCOMES as readonly string[]).includes(v.outcome));
+    })
+    .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+
   return {
     requirementsWithoutAssertions, assertionsWithoutEvidence, staleAssertions, pastDeadlineRequirements,
     requirementsWithoutVerification, requirementsWithUnresolvedVerification,
+    needsWithoutRequirements, needsWithoutValidation, needsWithUnresolvedValidation,
   };
 }

--- a/packages/diagrams/src/compliance/index.ts
+++ b/packages/diagrams/src/compliance/index.ts
@@ -6,6 +6,7 @@ export type { GapReport, GapReportOptions } from './gap-report.js';
 export { emptyCanon, ingestComplianceDoc } from './classify.js';
 export type { ComplianceCanon, ComplianceProduct, ComplianceCodexDoc } from './classify.js';
 export { CLOSED_VERIFICATION_OUTCOMES } from '../verification/types.js';
+export { CLOSED_VALIDATION_OUTCOMES } from '../validation/types.js';
 export {
   admitDocumentToCatalog,
   buildComplianceScan,
@@ -60,6 +61,8 @@ export type {
   IndexRequirement,
   IndexAssertion,
   IndexVerification,
+  IndexNeed,
+  IndexValidation,
   LawTree,
   LawTreeRequirement,
   ProductView,

--- a/packages/diagrams/src/compliance/reverse-index.ts
+++ b/packages/diagrams/src/compliance/reverse-index.ts
@@ -1,6 +1,14 @@
 // Reverse-index builder (Phase 3).
 
-import type { ComplianceIndex, ComplianceIndexInput, IndexAssertion, IndexRequirement, IndexVerification } from './types.js';
+import type {
+  ComplianceIndex,
+  ComplianceIndexInput,
+  IndexAssertion,
+  IndexRequirement,
+  IndexVerification,
+  IndexNeed,
+  IndexValidation,
+} from './types.js';
 
 function push<K, V>(map: Map<K, V[]>, key: K, value: V): void {
   const list = map.get(key);
@@ -14,6 +22,10 @@ function push<K, V>(map: Map<K, V[]>, key: K, value: V): void {
  * not appear under any law; assertions are indexed by both their requirement
  * (`about`) and their subject; verifications are indexed by their requirement
  * (`verifies`) — an independent catalogue from assertions (27-verification.md §4).
+ * Needs are indexed by id; requirements are additionally indexed by the NEED
+ * they `serves` (15-requirement.md §2.7), and validations by the NEED they
+ * `validate` (28-validation.md §2) — both feed the NEED-side coverage rules
+ * (ELEMENT_PRIMITIVES.md §9).
  */
 export function buildComplianceIndex(input: ComplianceIndexInput): ComplianceIndex {
   const requirementById = new Map<string, IndexRequirement>();
@@ -22,11 +34,15 @@ export function buildComplianceIndex(input: ComplianceIndexInput): ComplianceInd
   const assertionsBySubject = new Map<string, IndexAssertion[]>();
   const requirementsByParent = new Map<string, IndexRequirement[]>();
   const verificationsByRequirement = new Map<string, IndexVerification[]>();
+  const needById = new Map<string, IndexNeed>();
+  const requirementsByNeed = new Map<string, IndexRequirement[]>();
+  const validationsByNeed = new Map<string, IndexValidation[]>();
 
   for (const r of input.requirements) {
     requirementById.set(r.id, r);
     for (const law of r.derived_from ?? []) push(requirementsByLaw, law, r);
     if (r.parent) push(requirementsByParent, r.parent, r);
+    if (r.serves) push(requirementsByNeed, r.serves, r);
   }
   for (const a of input.assertions) {
     push(assertionsByRequirement, a.about, a);
@@ -35,9 +51,16 @@ export function buildComplianceIndex(input: ComplianceIndexInput): ComplianceInd
   for (const v of input.verifications ?? []) {
     push(verificationsByRequirement, v.verifies, v);
   }
+  for (const n of input.needs ?? []) {
+    needById.set(n.id, n);
+  }
+  for (const v of input.validations ?? []) {
+    push(validationsByNeed, v.validates, v);
+  }
 
   return {
     requirementById, requirementsByLaw, assertionsByRequirement, assertionsBySubject,
     requirementsByParent, verificationsByRequirement,
+    needById, requirementsByNeed, validationsByNeed,
   };
 }

--- a/packages/diagrams/src/compliance/types.ts
+++ b/packages/diagrams/src/compliance/types.ts
@@ -4,6 +4,7 @@
 
 import type { AssertionStatus } from '../assertion/types.js';
 import type { VerificationMethod, VerificationOutcome } from '../verification/types.js';
+import type { ValidationMethod, ValidationOutcome } from '../validation/types.js';
 import type { ComplianceCodexDoc } from './classify.js';
 
 /** Projection of a REQUIREMENT (or CONSTRAINT) the compliance views need. */
@@ -53,6 +54,35 @@ export interface IndexRequirement {
    * Present when the author has scheduled a review; drives `REQ-STALE-001`.
    */
   next_review_at?: string;
+  /**
+   * Typed ID of the upstream `NEED` this requirement traces to
+   * (15-requirement.md §2.7; `REQ-SERVES-001`). Optional, singular. Feeds
+   * `NEED-COVERAGE-001` (ELEMENT_PRIMITIVES.md §9) on the NEED side.
+   */
+  serves?: string;
+}
+
+/** Projection of a `NEED` element (ELEMENT_PRIMITIVES.md §7.28) the compliance
+ *  views need — just enough to list an unaddressed / unvalidated need. */
+export interface IndexNeed {
+  id: string;
+  name: string;
+}
+
+/** Projection of a `VALIDATION` claim (28-validation.md §2) the compliance
+ *  views need — the validation-domain peer of `IndexVerification`, anchored
+ *  on NEED instead of REQUIREMENT. */
+export interface IndexValidation {
+  id: string;
+  /** Typed ID of the NEED this validation targets. */
+  validates: string;
+  method: ValidationMethod;
+  outcome: ValidationOutcome;
+  performed_at?: string;
+  /** Number of evidence entries — feeds the VALID-006 gap. */
+  evidenceCount?: number;
+  /** Admission date (CONTRACT §6) — feeds DQ-1 freshness decay. */
+  admitted_at?: string;
 }
 
 // ── Temporal status (CV-3) ──────────────────────────────────────────────────
@@ -144,6 +174,10 @@ export interface ComplianceIndexInput {
   assertions: IndexAssertion[];
   /** Optional — absent inputs (existing callers) simply index no verifications. */
   verifications?: IndexVerification[];
+  /** Optional — absent inputs (existing callers) simply index no needs. */
+  needs?: IndexNeed[];
+  /** Optional — absent inputs (existing callers) simply index no validations. */
+  validations?: IndexValidation[];
 }
 
 /** The reverse-index — all maps are keyed by canonical id. */
@@ -164,6 +198,14 @@ export interface ComplianceIndex {
    *  (27-verification.md §2). The engineering V&V analogue of
    *  `assertionsByRequirement` — the two catalogues are independent. */
   verificationsByRequirement: Map<string, IndexVerification[]>;
+  /** NEED id → needs, keyed by their own id (single-entry lookup convenience). */
+  needById: Map<string, IndexNeed>;
+  /** NEED id → requirements whose `serves` names it (15-requirement.md §2.7).
+   *  Feeds `NEED-COVERAGE-001`. */
+  requirementsByNeed: Map<string, IndexRequirement[]>;
+  /** NEED id → validations whose `validates` names it (28-validation.md §2).
+   *  Feeds `NEED-VALIDATION-COVERAGE-001..002`. */
+  validationsByNeed: Map<string, IndexValidation[]>;
 }
 
 // ── Single-law tree ─────────────────────────────────────────────────────────

--- a/packages/diagrams/src/metric/__tests__/validate.test.ts
+++ b/packages/diagrams/src/metric/__tests__/validate.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { validateMetric } from '../validate.js';
+import type { CanonCatalog } from '../../typed-id.js';
+
+function valid(): Record<string, unknown> {
+  return {
+    notation: 'metric',
+    id: 'METRIC-CHECKOUT-CONVERSION-1',
+    name: 'Checkout conversion rate',
+    description: 'Share of started checkouts that complete successfully.',
+    measures: ['GOAL-CHECKOUT-SIMPLIFICATION-1'],
+    unit: 'percent',
+    target: 68,
+    direction_of_good: 'higher_is_better',
+    owner_role: 'ROLE-ECOMMERCE-LEAD-1',
+    zone: 'canon',
+    admitted_at: '2026-07-30',
+    admitted_by: 'v.korobeinikov',
+    gate_checks: { uniqueness: 'pass', consistency: 'pass', completeness: 'pass' },
+    valid_from: '2026-07-30',
+    valid_to: null,
+  };
+}
+
+const codes = (input: unknown, opts?: Parameters<typeof validateMetric>[1]): string[] =>
+  validateMetric(input, opts).errors.map(e => e.code);
+
+describe('validateMetric — positive', () => {
+  it('accepts a well-formed metric', () => {
+    const r = validateMetric(valid());
+    expect(r.valid, JSON.stringify(r.errors)).toBe(true);
+    expect(r.errors).toHaveLength(0);
+  });
+});
+
+describe('validateMetric — METRIC-001 (shape / id grammar / required fields)', () => {
+  it('flags id grammar and wrong notation', () => {
+    expect(codes({ ...valid(), id: 'MET-1' })).toContain('METRIC-001');
+    expect(codes({ ...valid(), notation: 'indicator' })).toContain('METRIC-001');
+  });
+
+  it('flags missing admission/lifecycle fields', () => {
+    const noAdmit = valid(); delete noAdmit.admitted_at;
+    expect(codes(noAdmit)).toContain('METRIC-001');
+    const noValidTo = valid(); delete noValidTo.valid_to;
+    expect(codes(noValidTo)).toContain('METRIC-001');
+  });
+
+  it('flags each missing required per-type field', () => {
+    for (const f of ['measures', 'unit', 'target', 'direction_of_good', 'owner_role']) {
+      const r = valid();
+      delete r[f];
+      expect(codes(r), f).toContain('METRIC-001');
+    }
+  });
+
+  it('flags a non-numeric target', () => {
+    expect(codes({ ...valid(), target: '68' })).toContain('METRIC-001');
+  });
+
+  it('flags an empty measures list as METRIC-001', () => {
+    expect(codes({ ...valid(), measures: [] })).toContain('METRIC-001');
+  });
+
+  it('rejects a non-object', () => {
+    expect(codes(null)).toEqual(['METRIC-001']);
+  });
+});
+
+describe('validateMetric — METRIC-002 (measures → GOAL | CAPABILITY | PROCESS)', () => {
+  it('flags a measures entry of the wrong TYPE', () => {
+    expect(codes({ ...valid(), measures: ['PRODUCT-X-1'] })).toContain('METRIC-002');
+  });
+
+  it('accepts GOAL, CAPABILITY, and PROCESS entries', () => {
+    expect(codes({ ...valid(), measures: ['GOAL-X-1'] })).not.toContain('METRIC-002');
+    expect(codes({ ...valid(), measures: ['CAPABILITY-V1'] })).not.toContain('METRIC-002');
+    expect(codes({ ...valid(), measures: ['PROCESS-X-1'] })).not.toContain('METRIC-002');
+  });
+
+  it('with a catalog, flags an unresolved measures entry', () => {
+    const catalog: CanonCatalog = { typeOf: () => undefined };
+    expect(codes({ ...valid() }, { catalog })).toContain('METRIC-002');
+  });
+});
+
+describe('validateMetric — METRIC-003 (direction_of_good enum)', () => {
+  it('flags an out-of-enum value', () => {
+    expect(codes({ ...valid(), direction_of_good: 'bigger_is_better' })).toContain('METRIC-003');
+  });
+
+  it('accepts every direction_of_good value', () => {
+    for (const v of ['higher_is_better', 'lower_is_better', 'on_target']) {
+      expect(codes({ ...valid(), direction_of_good: v })).not.toContain('METRIC-003');
+    }
+  });
+});
+
+describe('validateMetric — METRIC-004 (owner_role → ROLE)', () => {
+  it('flags an owner_role that is not a typed ROLE id', () => {
+    expect(codes({ ...valid(), owner_role: 'ACTOR-X-1' })).toContain('METRIC-004');
+  });
+
+  it('accepts a well-formed ROLE id without a catalog', () => {
+    expect(codes({ ...valid(), owner_role: 'ROLE-X-1' })).not.toContain('METRIC-004');
+  });
+
+  it('with a catalog, flags an unresolved owner_role', () => {
+    const catalog: CanonCatalog = { typeOf: () => undefined };
+    expect(codes({ ...valid() }, { catalog })).toContain('METRIC-004');
+  });
+});

--- a/packages/diagrams/src/metric/index.ts
+++ b/packages/diagrams/src/metric/index.ts
@@ -1,0 +1,4 @@
+export type { Metric, MetricDirectionOfGood } from './types.js';
+export { METRIC_DIRECTIONS_OF_GOOD } from './types.js';
+export { validateMetric } from './validate.js';
+export type { MetricValidateOptions } from './validate.js';

--- a/packages/diagrams/src/metric/types.ts
+++ b/packages/diagrams/src/metric/types.ts
@@ -1,0 +1,38 @@
+// METRIC — motivation-layer managed indicator (no ArchiMate counterpart).
+// Schema: methodology notations/ELEMENT_PRIMITIVES.md §7.27.
+
+import type { GateChecks } from '../requirement/types.js';
+
+/** How to read movement relative to `target` (§7.27). */
+export type MetricDirectionOfGood = 'higher_is_better' | 'lower_is_better' | 'on_target';
+
+export const METRIC_DIRECTIONS_OF_GOOD: readonly MetricDirectionOfGood[] = [
+  'higher_is_better',
+  'lower_is_better',
+  'on_target',
+];
+
+export interface Metric {
+  notation: 'metric';
+  id: string;
+  name: string;
+  /** Typed IDs of what this metric tracks — GOAL, CAPABILITY, or PROCESS. Non-empty. */
+  measures: string[];
+  /** Free-form unit the value and `target` are expressed in (percent, days, …). */
+  unit: string;
+  target: number;
+  direction_of_good: MetricDirectionOfGood;
+  /** ROLE-… accountable for tracking this metric and acting on it. */
+  owner_role: string;
+  description?: string;
+
+  // Admission record (CONTRACT.md §6).
+  zone: 'canon';
+  admitted_at: string;
+  admitted_by: string;
+  gate_checks: GateChecks;
+
+  // Primitive lifecycle (CONTRACT.md §7).
+  valid_from: string;
+  valid_to: string | null;
+}

--- a/packages/diagrams/src/metric/validate.ts
+++ b/packages/diagrams/src/metric/validate.ts
@@ -1,0 +1,102 @@
+// METRIC validator — methodology ELEMENT_PRIMITIVES.md §7.27 / §9.
+//
+// Codes:
+//   METRIC-001 — shape / id grammar / required envelope + per-type fields
+//               (measures, unit, target, direction_of_good, owner_role).
+//   METRIC-002 — measures is empty, or an entry does not resolve to an
+//               admitted GOAL / CAPABILITY / PROCESS in canon.
+//   METRIC-003 — direction_of_good outside {higher_is_better, lower_is_better,
+//               on_target}.
+//   METRIC-004 — owner_role does not resolve to an admitted ROLE in canon.
+//
+// Resolution rules (METRIC-002/004) that need artefact *existence* run only
+// when a `CanonCatalog` is supplied; the TYPE checks are derivable from the
+// id prefix and run either way.
+
+import type { ValidationError, ValidationWarning, ValidationResult } from '../validation-types.js';
+import { typeOfId, isCanonicalIdOfType, type CanonCatalog } from '../typed-id.js';
+import { METRIC_DIRECTIONS_OF_GOOD } from './types.js';
+
+export interface MetricValidateOptions {
+  /** When provided, METRIC-002/004 enforce artefact existence for cross-refs. */
+  catalog?: CanonCatalog;
+}
+
+const MEASURES_TYPES = ['GOAL', 'CAPABILITY', 'PROCESS'] as const;
+
+export function validateMetric(input: unknown, options: MetricValidateOptions = {}): ValidationResult {
+  const errors: ValidationError[] = [];
+  const warnings: ValidationWarning[] = [];
+
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    errors.push({ code: 'METRIC-001', message: 'Metric must be a YAML mapping.' });
+    return { valid: false, errors, warnings };
+  }
+  const m = input as Record<string, unknown>;
+
+  // METRIC-001 — id grammar + notation tag + envelope + plain per-type fields.
+  if (!isCanonicalIdOfType(m.id, 'METRIC')) {
+    errors.push({ code: 'METRIC-001', message: `id "${String(m.id)}" must match METRIC-[<middle>-]<INTEGER>.`, path: 'id' });
+  }
+  if (m.notation !== 'metric') {
+    errors.push({ code: 'METRIC-001', message: 'notation must be the fixed value "metric".', path: 'notation' });
+  }
+  if (m.zone !== 'canon') {
+    errors.push({ code: 'METRIC-001', message: 'zone is required and must be "canon".', path: 'zone' });
+  }
+  for (const f of ['name', 'admitted_at', 'admitted_by', 'valid_from', 'unit', 'owner_role'] as const) {
+    if (typeof m[f] !== 'string' || (m[f] as string).trim() === '') {
+      errors.push({ code: 'METRIC-001', message: `${f} is required.`, path: f });
+    }
+  }
+  if (m.gate_checks === null || typeof m.gate_checks !== 'object') {
+    errors.push({ code: 'METRIC-001', message: 'gate_checks is required and must be a mapping.', path: 'gate_checks' });
+  }
+  if (!('valid_to' in m) || !(typeof m.valid_to === 'string' || m.valid_to === null)) {
+    errors.push({ code: 'METRIC-001', message: 'valid_to is required (an ISO date string or null).', path: 'valid_to' });
+  }
+  if (typeof m.target !== 'number' || Number.isNaN(m.target)) {
+    errors.push({ code: 'METRIC-001', message: 'target is required and must be a number.', path: 'target' });
+  }
+
+  // direction_of_good — required (METRIC-001) + enum (METRIC-003).
+  const dir = m.direction_of_good;
+  if (dir === undefined || dir === null || dir === '') {
+    errors.push({ code: 'METRIC-001', message: 'direction_of_good is required.', path: 'direction_of_good' });
+  } else if (!(METRIC_DIRECTIONS_OF_GOOD as readonly string[]).includes(dir as string)) {
+    errors.push({
+      code: 'METRIC-003',
+      message: `direction_of_good "${String(dir)}" must be one of ${METRIC_DIRECTIONS_OF_GOOD.join(', ')}.`,
+      path: 'direction_of_good',
+    });
+  }
+
+  // measures — required non-empty list (METRIC-001), each resolves to GOAL/CAPABILITY/PROCESS (METRIC-002).
+  const measures = m.measures;
+  if (!Array.isArray(measures) || measures.length === 0) {
+    errors.push({ code: 'METRIC-001', message: 'measures is required and must be a non-empty list of typed IDs.', path: 'measures' });
+  } else {
+    measures.forEach((ref, i) => {
+      const type = typeOfId(ref);
+      if (!type || !(MEASURES_TYPES as readonly string[]).includes(type as typeof MEASURES_TYPES[number])) {
+        errors.push({ code: 'METRIC-002', message: `measures[${i}] "${String(ref)}" must resolve to a GOAL, CAPABILITY, or PROCESS.`, path: `measures[${i}]` });
+        return;
+      }
+      if (options.catalog && options.catalog.typeOf(ref as string) === undefined) {
+        errors.push({ code: 'METRIC-002', message: `measures[${i}] "${String(ref)}" does not resolve to an admitted artefact.`, path: `measures[${i}]` });
+      }
+    });
+  }
+
+  // owner_role — must be a typed ROLE id (METRIC-004), and resolve when a catalog is supplied.
+  const ownerRole = m.owner_role;
+  if (typeof ownerRole === 'string' && ownerRole.trim() !== '') {
+    if (!isCanonicalIdOfType(ownerRole, 'ROLE')) {
+      errors.push({ code: 'METRIC-004', message: `owner_role "${ownerRole}" must be a typed ROLE id.`, path: 'owner_role' });
+    } else if (options.catalog && options.catalog.typeOf(ownerRole) === undefined) {
+      errors.push({ code: 'METRIC-004', message: `owner_role "${ownerRole}" does not resolve to an admitted artefact.`, path: 'owner_role' });
+    }
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}

--- a/packages/diagrams/src/need/__tests__/validate.test.ts
+++ b/packages/diagrams/src/need/__tests__/validate.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { validateNeed } from '../validate.js';
+import type { CanonCatalog } from '../../typed-id.js';
+
+function valid(): Record<string, unknown> {
+  return {
+    notation: 'need',
+    id: 'NEED-TIMELY-OUTAGE-STATUS-1',
+    name: 'Customers need to know service status within minutes of an outage starting',
+    description: 'When the service is degraded or unavailable, affected customers need a reliable, timely signal.',
+    stakeholder: 'STAKEHOLDER-ENTERPRISE-CUSTOMERS-1',
+    zone: 'canon',
+    admitted_at: '2026-07-30',
+    admitted_by: 'v.korobeinikov',
+    gate_checks: { uniqueness: 'pass', consistency: 'pass', completeness: 'pass' },
+    valid_from: '2026-07-30',
+    valid_to: null,
+  };
+}
+
+const codes = (input: unknown, opts?: Parameters<typeof validateNeed>[1]): string[] =>
+  validateNeed(input, opts).errors.map(e => e.code);
+
+describe('validateNeed — positive', () => {
+  it('accepts a well-formed need', () => {
+    const r = validateNeed(valid());
+    expect(r.valid, JSON.stringify(r.errors)).toBe(true);
+    expect(r.errors).toHaveLength(0);
+  });
+});
+
+describe('validateNeed — NEED-001 (shape / id grammar / required fields)', () => {
+  it('flags id grammar and wrong notation', () => {
+    expect(codes({ ...valid(), id: 'NEED_1' })).toContain('NEED-001');
+    expect(codes({ ...valid(), notation: 'stakeholder-need' })).toContain('NEED-001');
+  });
+
+  it('flags missing admission/lifecycle fields', () => {
+    const noAdmit = valid(); delete noAdmit.admitted_at;
+    expect(codes(noAdmit)).toContain('NEED-001');
+    const noValidTo = valid(); delete noValidTo.valid_to;
+    expect(codes(noValidTo)).toContain('NEED-001');
+  });
+
+  it('flags a missing stakeholder as NEED-001', () => {
+    const r = valid(); delete r.stakeholder;
+    expect(codes(r)).toContain('NEED-001');
+  });
+
+  it('rejects a non-object', () => {
+    expect(codes(null)).toEqual(['NEED-001']);
+  });
+});
+
+describe('validateNeed — NEED-002 (stakeholder → STAKEHOLDER)', () => {
+  it('flags a stakeholder that is not a typed STAKEHOLDER id', () => {
+    expect(codes({ ...valid(), stakeholder: 'ACTOR-CUSTOMERS-1' })).toContain('NEED-002');
+  });
+
+  it('accepts a well-formed STAKEHOLDER id without a catalog', () => {
+    expect(codes(valid())).not.toContain('NEED-002');
+  });
+
+  it('with a catalog, flags an unresolved stakeholder and accepts a resolved one', () => {
+    const missing: CanonCatalog = { typeOf: () => undefined };
+    expect(codes(valid(), { catalog: missing })).toContain('NEED-002');
+
+    const present: CanonCatalog = {
+      typeOf: (id) => (id === 'STAKEHOLDER-ENTERPRISE-CUSTOMERS-1' ? 'STAKEHOLDER' : undefined),
+    };
+    expect(codes(valid(), { catalog: present })).not.toContain('NEED-002');
+  });
+});

--- a/packages/diagrams/src/need/index.ts
+++ b/packages/diagrams/src/need/index.ts
@@ -1,0 +1,3 @@
+export type { Need } from './types.js';
+export { validateNeed } from './validate.js';
+export type { NeedValidateOptions } from './validate.js';

--- a/packages/diagrams/src/need/types.ts
+++ b/packages/diagrams/src/need/types.ts
@@ -1,0 +1,23 @@
+// NEED — motivation-layer stakeholder/user need (no ArchiMate counterpart).
+// Upstream of REQUIREMENT — schema: methodology notations/ELEMENT_PRIMITIVES.md §7.28.
+
+import type { GateChecks } from '../requirement/types.js';
+
+export interface Need {
+  notation: 'need';
+  id: string;
+  name: string;
+  /** Typed ID of the STAKEHOLDER whose need this is. */
+  stakeholder: string;
+  description?: string;
+
+  // Admission record (CONTRACT.md §6).
+  zone: 'canon';
+  admitted_at: string;
+  admitted_by: string;
+  gate_checks: GateChecks;
+
+  // Primitive lifecycle (CONTRACT.md §7).
+  valid_from: string;
+  valid_to: string | null;
+}

--- a/packages/diagrams/src/need/validate.ts
+++ b/packages/diagrams/src/need/validate.ts
@@ -1,0 +1,67 @@
+// NEED validator — methodology ELEMENT_PRIMITIVES.md §7.28 / §9.
+//
+// Codes:
+//   NEED-001 — shape / id grammar / required envelope fields, including the
+//              required per-type `stakeholder` field.
+//   NEED-002 — stakeholder does not resolve to an admitted STAKEHOLDER in canon.
+//
+// The cross-cutting NEED-COVERAGE-001 / NEED-VALIDATION-COVERAGE-001..002
+// reverse-trace rules are owned elsewhere (CONTRACT.md §8, the compliance
+// reverse-index) and are out of scope for this single-artefact validator —
+// same posture as `validateRequirement` / `validateVerification`.
+//
+// Resolution (NEED-002 existence) runs only when a `CanonCatalog` is
+// supplied; the TYPE check is derivable from the id prefix and runs either way.
+
+import type { ValidationError, ValidationWarning, ValidationResult } from '../validation-types.js';
+import { isCanonicalIdOfType, type CanonCatalog } from '../typed-id.js';
+
+export interface NeedValidateOptions {
+  /** When provided, NEED-002 enforces artefact existence for `stakeholder`. */
+  catalog?: CanonCatalog;
+}
+
+export function validateNeed(input: unknown, options: NeedValidateOptions = {}): ValidationResult {
+  const errors: ValidationError[] = [];
+  const warnings: ValidationWarning[] = [];
+
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    errors.push({ code: 'NEED-001', message: 'Need must be a YAML mapping.' });
+    return { valid: false, errors, warnings };
+  }
+  const n = input as Record<string, unknown>;
+
+  // NEED-001 — id grammar + notation tag + envelope.
+  if (!isCanonicalIdOfType(n.id, 'NEED')) {
+    errors.push({ code: 'NEED-001', message: `id "${String(n.id)}" must match NEED-[<middle>-]<INTEGER>.`, path: 'id' });
+  }
+  if (n.notation !== 'need') {
+    errors.push({ code: 'NEED-001', message: 'notation must be the fixed value "need".', path: 'notation' });
+  }
+  if (n.zone !== 'canon') {
+    errors.push({ code: 'NEED-001', message: 'zone is required and must be "canon".', path: 'zone' });
+  }
+  for (const f of ['name', 'admitted_at', 'admitted_by', 'valid_from'] as const) {
+    if (typeof n[f] !== 'string' || (n[f] as string).trim() === '') {
+      errors.push({ code: 'NEED-001', message: `${f} is required.`, path: f });
+    }
+  }
+  if (n.gate_checks === null || typeof n.gate_checks !== 'object') {
+    errors.push({ code: 'NEED-001', message: 'gate_checks is required and must be a mapping.', path: 'gate_checks' });
+  }
+  if (!('valid_to' in n) || !(typeof n.valid_to === 'string' || n.valid_to === null)) {
+    errors.push({ code: 'NEED-001', message: 'valid_to is required (an ISO date string or null).', path: 'valid_to' });
+  }
+
+  // stakeholder — required (NEED-001) + resolves to STAKEHOLDER (NEED-002).
+  const stakeholder = n.stakeholder;
+  if (typeof stakeholder !== 'string' || stakeholder.trim() === '') {
+    errors.push({ code: 'NEED-001', message: 'stakeholder is required.', path: 'stakeholder' });
+  } else if (!isCanonicalIdOfType(stakeholder, 'STAKEHOLDER')) {
+    errors.push({ code: 'NEED-002', message: `stakeholder "${stakeholder}" must be a typed STAKEHOLDER id.`, path: 'stakeholder' });
+  } else if (options.catalog && options.catalog.typeOf(stakeholder) === undefined) {
+    errors.push({ code: 'NEED-002', message: `stakeholder "${stakeholder}" does not resolve to an admitted artefact.`, path: 'stakeholder' });
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}

--- a/packages/diagrams/src/requirement/__tests__/validate.test.ts
+++ b/packages/diagrams/src/requirement/__tests__/validate.test.ts
@@ -94,3 +94,57 @@ describe('validateRequirement — REQ-003 (derived_from TYPE)', () => {
     }
   });
 });
+
+describe('validateRequirement — REQ-005 (level closed vocabulary)', () => {
+  it('is not checked when absent', () => {
+    expect(codes(valid())).not.toContain('REQ-005');
+  });
+
+  it('accepts each permitted level value', () => {
+    for (const level of ['stakeholder', 'system', 'software']) {
+      expect(codes({ ...valid(), level })).not.toContain('REQ-005');
+    }
+  });
+
+  it('flags an out-of-enum level', () => {
+    expect(codes({ ...valid(), level: 'business' })).toContain('REQ-005');
+  });
+});
+
+describe('validateRequirement — REQ-006 (kind closed vocabulary)', () => {
+  it('is not checked when absent', () => {
+    expect(codes(valid())).not.toContain('REQ-006');
+  });
+
+  it('accepts each permitted kind value', () => {
+    for (const kind of ['functional', 'quality']) {
+      expect(codes({ ...valid(), kind })).not.toContain('REQ-006');
+    }
+  });
+
+  it('flags an out-of-enum kind', () => {
+    expect(codes({ ...valid(), kind: 'nonfunctional' })).toContain('REQ-006');
+  });
+});
+
+describe('validateRequirement — REQ-SERVES-001 (serves → NEED)', () => {
+  it('is not checked when absent', () => {
+    expect(codes(valid())).not.toContain('REQ-SERVES-001');
+  });
+
+  it('flags a serves that is not a NEED typed id', () => {
+    expect(codes({ ...valid(), serves: 'STAKEHOLDER-CUSTOMERS-1' })).toContain('REQ-SERVES-001');
+  });
+
+  it('accepts a well-formed NEED id without a catalog', () => {
+    expect(codes({ ...valid(), serves: 'NEED-DATA-SUBJECT-CONTROL-1' })).not.toContain('REQ-SERVES-001');
+  });
+
+  it('with a catalog, flags an unresolved serves and accepts a resolved one', () => {
+    const missing: CanonCatalog = { typeOf: () => undefined };
+    expect(codes({ ...valid(), serves: 'NEED-DATA-SUBJECT-CONTROL-1' }, { catalog: missing })).toContain('REQ-SERVES-001');
+
+    const present: CanonCatalog = { typeOf: (id) => (id === 'NEED-DATA-SUBJECT-CONTROL-1' ? 'NEED' : undefined) };
+    expect(codes({ ...valid(), serves: 'NEED-DATA-SUBJECT-CONTROL-1' }, { catalog: present })).not.toContain('REQ-SERVES-001');
+  });
+});

--- a/packages/diagrams/src/requirement/index.ts
+++ b/packages/diagrams/src/requirement/index.ts
@@ -1,4 +1,4 @@
-export type { Requirement, RequirementSeverity, GateChecks } from './types.js';
-export { REQUIREMENT_DERIVED_FROM_TYPES } from './types.js';
+export type { Requirement, RequirementSeverity, RequirementLevel, RequirementKind, GateChecks } from './types.js';
+export { REQUIREMENT_DERIVED_FROM_TYPES, REQUIREMENT_LEVELS, REQUIREMENT_KINDS } from './types.js';
 export { validateRequirement } from './validate.js';
 export type { RequirementValidateOptions } from './validate.js';

--- a/packages/diagrams/src/requirement/types.ts
+++ b/packages/diagrams/src/requirement/types.ts
@@ -13,6 +13,16 @@ export interface GateChecks {
 /** TYPEs a requirement may be derived from (15-requirement.md §2, REQ-003). */
 export const REQUIREMENT_DERIVED_FROM_TYPES = ['LAW', 'REGULATION', 'POLICY', 'INTERNAL_STANDARD'] as const;
 
+/** ISO/IEC/IEEE 29148 specification-tier ladder (15-requirement.md §2.5, REQ-005). */
+export type RequirementLevel = 'stakeholder' | 'system' | 'software';
+
+export const REQUIREMENT_LEVELS: readonly RequirementLevel[] = ['stakeholder', 'system', 'software'];
+
+/** Functional vs quality classification (15-requirement.md §2.6, REQ-006). */
+export type RequirementKind = 'functional' | 'quality';
+
+export const REQUIREMENT_KINDS: readonly RequirementKind[] = ['functional', 'quality'];
+
 export interface Requirement {
   notation: 'requirement';
   id: string;
@@ -20,8 +30,14 @@ export interface Requirement {
   description: string;
   /** Organisation-defined priority. */
   severity?: RequirementSeverity;
+  /** ISO/IEC/IEEE 29148 specification tier (§2.5, REQ-005). */
+  level?: RequirementLevel;
+  /** Functional vs quality classification (§2.6, REQ-006). */
+  kind?: RequirementKind;
   /** Typed IDs of the codex source documents this requirement is drawn from. */
   derived_from?: string[];
+  /** Typed ID of the upstream NEED this requirement traces to (§2.7, REQ-SERVES-001). Optional, singular. */
+  serves?: string;
 
   // Admission record (CONTRACT.md §6).
   zone: 'canon';

--- a/packages/diagrams/src/requirement/validate.ts
+++ b/packages/diagrams/src/requirement/validate.ts
@@ -11,7 +11,7 @@
 
 import type { ValidationError, ValidationWarning, ValidationResult } from '../validation-types.js';
 import { typeOfId, isCanonicalIdOfType, type CanonCatalog } from '../typed-id.js';
-import { REQUIREMENT_DERIVED_FROM_TYPES } from './types.js';
+import { REQUIREMENT_DERIVED_FROM_TYPES, REQUIREMENT_LEVELS, REQUIREMENT_KINDS } from './types.js';
 
 export interface RequirementValidateOptions {
   /** When provided, REQ-002 enforces that each `derived_from` id is admitted. */
@@ -85,6 +85,26 @@ export function validateRequirement(input: unknown, options: RequirementValidate
           errors.push({ code: 'REQ-002', message: `derived_from[${i}] "${String(ref)}" does not resolve to an admitted codex artefact.`, path: `derived_from[${i}]` });
         }
       });
+    }
+  }
+
+  // REQ-005 — level closed vocabulary (optional; only checked when present).
+  if (r.level !== undefined && !(REQUIREMENT_LEVELS as readonly string[]).includes(r.level as string)) {
+    errors.push({ code: 'REQ-005', message: `level "${String(r.level)}" must be one of ${REQUIREMENT_LEVELS.join(', ')}.`, path: 'level' });
+  }
+
+  // REQ-006 — kind closed vocabulary (optional; only checked when present).
+  if (r.kind !== undefined && !(REQUIREMENT_KINDS as readonly string[]).includes(r.kind as string)) {
+    errors.push({ code: 'REQ-006', message: `kind "${String(r.kind)}" must be one of ${REQUIREMENT_KINDS.join(', ')}.`, path: 'kind' });
+  }
+
+  // REQ-SERVES-001 — serves resolves to an admitted NEED (optional, singular).
+  if (r.serves !== undefined) {
+    const serves = r.serves;
+    if (typeof serves !== 'string' || serves.trim() === '' || typeOfId(serves) !== 'NEED') {
+      errors.push({ code: 'REQ-SERVES-001', message: `serves "${String(serves)}" must be a typed NEED id.`, path: 'serves' });
+    } else if (options.catalog && options.catalog.typeOf(serves) === undefined) {
+      errors.push({ code: 'REQ-SERVES-001', message: `serves "${serves}" does not resolve to an admitted NEED.`, path: 'serves' });
     }
   }
 

--- a/packages/diagrams/src/risk/__tests__/validate.test.ts
+++ b/packages/diagrams/src/risk/__tests__/validate.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import { validateRisk } from '../validate.js';
+import type { CanonCatalog } from '../../typed-id.js';
+
+function valid(): Record<string, unknown> {
+  return {
+    notation: 'risk',
+    id: 'RISK-VENDOR-OUTAGE-1',
+    name: 'Primary payment-gateway vendor suffers an extended outage',
+    description: 'The organisation\'s sole payment-gateway integration has no failover provider.',
+    likelihood: 'medium',
+    impact: 'high',
+    residual: 'medium',
+    owner_role: 'ROLE-PAYMENTS-LEAD-1',
+    threatens: ['DRIVER-CHECKOUT-AVAILABILITY-1'],
+    treated_by: ['REQUIREMENT-PAYMENT-FAILOVER-1'],
+    zone: 'canon',
+    admitted_at: '2026-07-30',
+    admitted_by: 'v.korobeinikov',
+    gate_checks: { uniqueness: 'pass', consistency: 'pass', completeness: 'pass' },
+    valid_from: '2026-07-30',
+    valid_to: null,
+  };
+}
+
+const codes = (input: unknown, opts?: Parameters<typeof validateRisk>[1]): string[] =>
+  validateRisk(input, opts).errors.map(e => e.code);
+const warnCodes = (input: unknown, opts?: Parameters<typeof validateRisk>[1]): string[] =>
+  validateRisk(input, opts).warnings.map(w => w.code);
+
+describe('validateRisk — positive', () => {
+  it('accepts a well-formed risk', () => {
+    const r = validateRisk(valid());
+    expect(r.valid, JSON.stringify(r.errors)).toBe(true);
+    expect(r.errors).toHaveLength(0);
+  });
+});
+
+describe('validateRisk — RISK-001 (shape / id grammar / required fields)', () => {
+  it('flags id grammar and wrong notation', () => {
+    expect(codes({ ...valid(), id: 'RSK-1' })).toContain('RISK-001');
+    expect(codes({ ...valid(), notation: 'hazard' })).toContain('RISK-001');
+  });
+
+  it('flags missing admission/lifecycle fields', () => {
+    const noAdmit = valid(); delete noAdmit.admitted_at;
+    expect(codes(noAdmit)).toContain('RISK-001');
+    const noValidTo = valid(); delete noValidTo.valid_to;
+    expect(codes(noValidTo)).toContain('RISK-001');
+  });
+
+  it('flags each missing required per-type field', () => {
+    for (const f of ['likelihood', 'impact', 'residual', 'owner_role', 'threatens']) {
+      const r = valid();
+      delete r[f];
+      expect(codes(r), f).toContain('RISK-001');
+    }
+  });
+
+  it('flags an empty threatens list as RISK-001', () => {
+    expect(codes({ ...valid(), threatens: [] })).toContain('RISK-001');
+  });
+
+  it('rejects a non-object', () => {
+    expect(codes(null)).toEqual(['RISK-001']);
+  });
+});
+
+describe('validateRisk — RISK-002 (likelihood/impact/residual enum)', () => {
+  it('flags an out-of-enum value for each field', () => {
+    expect(codes({ ...valid(), likelihood: 'extreme' })).toContain('RISK-002');
+    expect(codes({ ...valid(), impact: 'extreme' })).toContain('RISK-002');
+    expect(codes({ ...valid(), residual: 'extreme' })).toContain('RISK-002');
+  });
+
+  it('accepts every level value', () => {
+    for (const v of ['low', 'medium', 'high']) {
+      expect(codes({ ...valid(), likelihood: v, impact: v, residual: v })).not.toContain('RISK-002');
+    }
+  });
+});
+
+describe('validateRisk — RISK-003 (threatens resolution)', () => {
+  it('flags a malformed threatens entry', () => {
+    expect(codes({ ...valid(), threatens: ['not an id'] })).toContain('RISK-003');
+  });
+
+  it('accepts any resolvable TYPE without a catalog', () => {
+    expect(codes({ ...valid(), threatens: ['GOAL-CHECKOUT-1'] })).not.toContain('RISK-003');
+  });
+
+  it('with a catalog, flags an unresolved threatens entry', () => {
+    const catalog: CanonCatalog = { typeOf: () => undefined };
+    expect(codes({ ...valid() }, { catalog })).toContain('RISK-003');
+  });
+});
+
+describe('validateRisk — RISK-004 (treated_by → REQUIREMENT | CONSTRAINT)', () => {
+  it('is not checked when treated_by is absent', () => {
+    const r = valid(); delete r.treated_by;
+    expect(codes(r)).not.toContain('RISK-004');
+  });
+
+  it('flags a treated_by entry of the wrong TYPE', () => {
+    expect(codes({ ...valid(), treated_by: ['GOAL-X-1'] })).toContain('RISK-004');
+  });
+
+  it('accepts REQUIREMENT and CONSTRAINT treated_by entries', () => {
+    expect(codes({ ...valid(), treated_by: ['REQUIREMENT-X-1'] })).not.toContain('RISK-004');
+    expect(codes({ ...valid(), treated_by: ['CONSTRAINT-X-1'] })).not.toContain('RISK-004');
+  });
+
+  it('with a catalog, flags an unresolved treated_by entry', () => {
+    const catalog: CanonCatalog = { typeOf: () => undefined };
+    expect(codes({ ...valid() }, { catalog })).toContain('RISK-004');
+  });
+});
+
+describe('validateRisk — RISK-COVERAGE-001 (untreated risk, warning)', () => {
+  it('warns when treated_by is absent', () => {
+    const r = valid(); delete r.treated_by;
+    expect(warnCodes(r)).toContain('RISK-COVERAGE-001');
+  });
+
+  it('warns when treated_by is empty', () => {
+    expect(warnCodes({ ...valid(), treated_by: [] })).toContain('RISK-COVERAGE-001');
+  });
+
+  it('does not warn when treated_by is non-empty', () => {
+    expect(warnCodes(valid())).not.toContain('RISK-COVERAGE-001');
+  });
+});

--- a/packages/diagrams/src/risk/index.ts
+++ b/packages/diagrams/src/risk/index.ts
@@ -1,0 +1,4 @@
+export type { Risk, RiskLevel } from './types.js';
+export { RISK_LEVELS } from './types.js';
+export { validateRisk } from './validate.js';
+export type { RiskValidateOptions } from './validate.js';

--- a/packages/diagrams/src/risk/types.ts
+++ b/packages/diagrams/src/risk/types.ts
@@ -1,0 +1,35 @@
+// RISK — motivation-layer projected event (no ArchiMate counterpart).
+// Schema: methodology notations/ELEMENT_PRIMITIVES.md §7.26.
+
+import type { GateChecks } from '../requirement/types.js';
+
+/** Likelihood / impact / residual severity vocabulary (§7.26). */
+export type RiskLevel = 'low' | 'medium' | 'high';
+
+export const RISK_LEVELS: readonly RiskLevel[] = ['low', 'medium', 'high'];
+
+export interface Risk {
+  notation: 'risk';
+  id: string;
+  name: string;
+  likelihood: RiskLevel;
+  impact: RiskLevel;
+  residual: RiskLevel;
+  /** ROLE-… accountable for tracking and treating this risk. */
+  owner_role: string;
+  /** Typed IDs of the elements this risk threatens. Non-empty; any TYPE. */
+  threatens: string[];
+  /** Typed IDs (REQUIREMENT-… / CONSTRAINT-…) of the treatment obligations. */
+  treated_by?: string[];
+  description?: string;
+
+  // Admission record (CONTRACT.md §6).
+  zone: 'canon';
+  admitted_at: string;
+  admitted_by: string;
+  gate_checks: GateChecks;
+
+  // Primitive lifecycle (CONTRACT.md §7).
+  valid_from: string;
+  valid_to: string | null;
+}

--- a/packages/diagrams/src/risk/validate.ts
+++ b/packages/diagrams/src/risk/validate.ts
@@ -1,0 +1,121 @@
+// RISK validator — methodology ELEMENT_PRIMITIVES.md §7.26 / §9.
+//
+// Codes:
+//   RISK-001 — shape / id grammar / required envelope + per-type fields
+//              (likelihood, impact, residual, owner_role, threatens).
+//   RISK-002 — likelihood / impact / residual outside {low, medium, high}.
+//   RISK-003 — threatens is empty, or an entry does not resolve to an
+//              admitted element in canon (no TYPE restriction — any core
+//              element may be threatened).
+//   RISK-004 — a treated_by entry does not resolve, or resolves to a TYPE
+//              other than REQUIREMENT / CONSTRAINT.
+//   RISK-COVERAGE-001 (warning) — treated_by is empty/absent (an untreated
+//              risk). Unlike the cross-cutting *-COVERAGE-001 rules this
+//              reads only the RISK element's own field — no catalogue scan
+//              required — so it is implemented inline here rather than via
+//              the compliance reverse-index.
+//
+// Resolution rules (RISK-003/004) that need artefact *existence* run only
+// when a `CanonCatalog` is supplied; the TYPE check RISK-004 also carries is
+// derivable from the id prefix and runs either way.
+
+import type { ValidationError, ValidationWarning, ValidationResult } from '../validation-types.js';
+import { typeOfId, isCanonicalIdOfType, type CanonCatalog } from '../typed-id.js';
+import { RISK_LEVELS } from './types.js';
+
+export interface RiskValidateOptions {
+  /** When provided, RISK-003/004 enforce artefact existence for cross-refs. */
+  catalog?: CanonCatalog;
+}
+
+const TREATED_BY_TYPES = ['REQUIREMENT', 'CONSTRAINT'] as const;
+
+export function validateRisk(input: unknown, options: RiskValidateOptions = {}): ValidationResult {
+  const errors: ValidationError[] = [];
+  const warnings: ValidationWarning[] = [];
+
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    errors.push({ code: 'RISK-001', message: 'Risk must be a YAML mapping.' });
+    return { valid: false, errors, warnings };
+  }
+  const r = input as Record<string, unknown>;
+
+  // RISK-001 — id grammar + notation tag + envelope + plain per-type fields.
+  if (!isCanonicalIdOfType(r.id, 'RISK')) {
+    errors.push({ code: 'RISK-001', message: `id "${String(r.id)}" must match RISK-[<middle>-]<INTEGER>.`, path: 'id' });
+  }
+  if (r.notation !== 'risk') {
+    errors.push({ code: 'RISK-001', message: 'notation must be the fixed value "risk".', path: 'notation' });
+  }
+  if (r.zone !== 'canon') {
+    errors.push({ code: 'RISK-001', message: 'zone is required and must be "canon".', path: 'zone' });
+  }
+  for (const f of ['name', 'admitted_at', 'admitted_by', 'valid_from', 'owner_role'] as const) {
+    if (typeof r[f] !== 'string' || (r[f] as string).trim() === '') {
+      errors.push({ code: 'RISK-001', message: `${f} is required.`, path: f });
+    }
+  }
+  if (r.gate_checks === null || typeof r.gate_checks !== 'object') {
+    errors.push({ code: 'RISK-001', message: 'gate_checks is required and must be a mapping.', path: 'gate_checks' });
+  }
+  if (!('valid_to' in r) || !(typeof r.valid_to === 'string' || r.valid_to === null)) {
+    errors.push({ code: 'RISK-001', message: 'valid_to is required (an ISO date string or null).', path: 'valid_to' });
+  }
+
+  // likelihood / impact / residual — required (RISK-001) + enum (RISK-002).
+  for (const f of ['likelihood', 'impact', 'residual'] as const) {
+    const v = r[f];
+    if (v === undefined || v === null || v === '') {
+      errors.push({ code: 'RISK-001', message: `${f} is required.`, path: f });
+    } else if (!(RISK_LEVELS as readonly string[]).includes(v as string)) {
+      errors.push({ code: 'RISK-002', message: `${f} "${String(v)}" must be one of ${RISK_LEVELS.join(', ')}.`, path: f });
+    }
+  }
+
+  // threatens — required non-empty list (RISK-001), each entry resolves (RISK-003).
+  const threatens = r.threatens;
+  if (!Array.isArray(threatens) || threatens.length === 0) {
+    errors.push({ code: 'RISK-001', message: 'threatens is required and must be a non-empty list of typed IDs.', path: 'threatens' });
+  } else {
+    threatens.forEach((ref, i) => {
+      const type = typeOfId(ref);
+      if (!type) {
+        errors.push({ code: 'RISK-003', message: `threatens[${i}] "${String(ref)}" is not a resolvable typed ID.`, path: `threatens[${i}]` });
+        return;
+      }
+      if (options.catalog && options.catalog.typeOf(ref as string) === undefined) {
+        errors.push({ code: 'RISK-003', message: `threatens[${i}] "${String(ref)}" does not resolve to an admitted element.`, path: `threatens[${i}]` });
+      }
+    });
+  }
+
+  // treated_by — optional list; each entry must resolve to REQUIREMENT/CONSTRAINT (RISK-004).
+  const treatedBy = r.treated_by;
+  if (treatedBy !== undefined) {
+    if (!Array.isArray(treatedBy)) {
+      errors.push({ code: 'RISK-001', message: 'treated_by must be a list of typed IDs.', path: 'treated_by' });
+    } else {
+      treatedBy.forEach((ref, i) => {
+        const type = typeOfId(ref);
+        if (!type || !(TREATED_BY_TYPES as readonly string[]).includes(type as typeof TREATED_BY_TYPES[number])) {
+          errors.push({ code: 'RISK-004', message: `treated_by[${i}] "${String(ref)}" must resolve to a REQUIREMENT or CONSTRAINT.`, path: `treated_by[${i}]` });
+          return;
+        }
+        if (options.catalog && options.catalog.typeOf(ref as string) === undefined) {
+          errors.push({ code: 'RISK-004', message: `treated_by[${i}] "${String(ref)}" does not resolve to an admitted artefact.`, path: `treated_by[${i}]` });
+        }
+      });
+    }
+  }
+
+  // RISK-COVERAGE-001 (warning) — untreated risk; single-file check, no catalogue needed.
+  if (!Array.isArray(treatedBy) || treatedBy.length === 0) {
+    warnings.push({
+      code: 'RISK-COVERAGE-001',
+      message: 'treated_by is empty or absent — this risk has no recorded treatment obligation.',
+      path: 'treated_by',
+    });
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}

--- a/packages/diagrams/src/validation/__tests__/validate.test.ts
+++ b/packages/diagrams/src/validation/__tests__/validate.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { validateValidation } from '../validate.js';
+import type { CanonCatalog } from '../../typed-id.js';
+
+function valid(): Record<string, unknown> {
+  return {
+    notation: 'validation',
+    id: 'VALIDATION-OUTAGE-STATUS-UAT-1',
+    validates: 'NEED-TIMELY-OUTAGE-STATUS-1',
+    method: 'user_acceptance',
+    protocol: 'Simulate a service outage in staging; observe whether participants notice the status update within 5 minutes.',
+    result: '9/10 participants noticed the status update within 5 minutes.',
+    outcome: 'pass',
+    evidence: [{ kind: 'note', text: '9/10 within 5 minutes.' }],
+    performed_at: '2026-07-22',
+    performed_by: 'ROLE-UX-RESEARCH-LEAD-1',
+    zone: 'canon',
+    admitted_at: '2026-07-23',
+    admitted_by: 'v.korobeinikov',
+    gate_checks: { uniqueness: 'pass', consistency: 'pass', completeness: 'pass' },
+    valid_from: '2026-07-23',
+    valid_to: null,
+  };
+}
+
+const codes = (input: unknown, opts?: Parameters<typeof validateValidation>[1]): string[] =>
+  validateValidation(input, opts).errors.map(e => e.code);
+const warnCodes = (input: unknown, opts?: Parameters<typeof validateValidation>[1]): string[] =>
+  validateValidation(input, opts).warnings.map(w => w.code);
+
+describe('validateValidation — positive', () => {
+  it('accepts a well-formed validation', () => {
+    const r = validateValidation(valid());
+    expect(r.valid, JSON.stringify(r.errors)).toBe(true);
+    expect(r.errors).toHaveLength(0);
+  });
+});
+
+describe('validateValidation — VALID-001 (shape / id grammar)', () => {
+  it('flags id grammar, wrong notation, missing admission/lifecycle/protocol fields', () => {
+    expect(codes({ ...valid(), id: 'VALID-1' })).toContain('VALID-001');
+    expect(codes({ ...valid(), notation: 'claim' })).toContain('VALID-001');
+    const noAdmit = valid(); delete noAdmit.admitted_at;
+    expect(codes(noAdmit)).toContain('VALID-001');
+    const noValidTo = valid(); delete noValidTo.valid_to;
+    expect(codes(noValidTo)).toContain('VALID-001');
+    const noProtocol = valid(); delete noProtocol.protocol;
+    expect(codes(noProtocol)).toContain('VALID-001');
+  });
+
+  it('flags a missing method or outcome as VALID-001 (required field)', () => {
+    const noMethod = valid(); delete noMethod.method;
+    expect(codes(noMethod)).toContain('VALID-001');
+    const noOutcome = valid(); delete noOutcome.outcome;
+    expect(codes(noOutcome)).toContain('VALID-001');
+  });
+
+  it('rejects a non-object', () => {
+    expect(codes(null)).toEqual(['VALID-001']);
+  });
+});
+
+describe('validateValidation — VALID-002 (validates → NEED)', () => {
+  it('flags a missing validates', () => {
+    const r = valid(); delete r.validates;
+    expect(codes(r)).toContain('VALID-002');
+  });
+  it('flags a validates that is not a NEED typed id', () => {
+    expect(codes({ ...valid(), validates: 'REQUIREMENT-X-1' })).toContain('VALID-002');
+  });
+  it('with a catalog, flags an unresolved validates and a wrong-type validates', () => {
+    expect(codes({ ...valid() }, { catalog: { typeOf: () => undefined } })).toContain('VALID-002');
+    const catalog: CanonCatalog = { typeOf: (id) => (id === 'NEED-TIMELY-OUTAGE-STATUS-1' ? 'GOAL' : 'NEED') };
+    expect(codes(valid(), { catalog })).toContain('VALID-002');
+  });
+});
+
+describe('validateValidation — VALID-003 (method enum)', () => {
+  it('flags an out-of-enum method', () => {
+    expect(codes({ ...valid(), method: 'vibes' })).toContain('VALID-003');
+  });
+  it('accepts every method value', () => {
+    for (const m of ['user_acceptance', 'field_trial', 'stakeholder_review', 'usability_study']) {
+      expect(codes({ ...valid(), method: m })).not.toContain('VALID-003');
+    }
+  });
+});
+
+describe('validateValidation — VALID-004 (outcome enum)', () => {
+  it('flags an out-of-enum outcome', () => {
+    expect(codes({ ...valid(), outcome: 'maybe' })).toContain('VALID-004');
+  });
+  it('accepts every outcome value', () => {
+    for (const o of ['pass', 'fail', 'inconclusive', 'not_yet_run']) {
+      expect(codes({ ...valid(), outcome: o, evidence: [{ kind: 'note', text: 'x' }] })).not.toContain('VALID-004');
+    }
+  });
+});
+
+describe('validateValidation — VALID-005 (canonical_ref evidence resolves)', () => {
+  it('flags a malformed canonical_ref', () => {
+    expect(codes({ ...valid(), evidence: [{ kind: 'canonical_ref', ref: 'nope' }] })).toContain('VALID-005');
+  });
+  it('with a catalog, flags an unresolved canonical_ref', () => {
+    const catalog: CanonCatalog = { typeOf: () => undefined };
+    expect(codes({ ...valid(), evidence: [{ kind: 'canonical_ref', ref: 'PROCESS-X-1' }] }, { catalog })).toContain('VALID-005');
+  });
+  it('ignores external_doc and note evidence kinds for resolution', () => {
+    const ev = [{ kind: 'external_doc', title: 't', url: 'u' }, { kind: 'note', text: 'n' }];
+    expect(codes({ ...valid(), evidence: ev })).not.toContain('VALID-005');
+  });
+});
+
+describe('validateValidation — VALID-006 (pass outcome without evidence)', () => {
+  it('warns when evidence is empty and outcome is pass', () => {
+    expect(warnCodes({ ...valid(), evidence: [], outcome: 'pass' })).toContain('VALID-006');
+  });
+  it('does not warn for fail / inconclusive / not_yet_run with empty evidence', () => {
+    for (const o of ['fail', 'inconclusive', 'not_yet_run']) {
+      expect(warnCodes({ ...valid(), evidence: [], outcome: o })).not.toContain('VALID-006');
+    }
+  });
+});

--- a/packages/diagrams/src/validation/index.ts
+++ b/packages/diagrams/src/validation/index.ts
@@ -1,0 +1,4 @@
+export type { Validation, ValidationMethod, ValidationOutcome } from './types.js';
+export { VALIDATION_METHODS, VALIDATION_OUTCOMES, CLOSED_VALIDATION_OUTCOMES } from './types.js';
+export { validateValidation } from './validate.js';
+export type { ValidationValidateOptions } from './validate.js';

--- a/packages/diagrams/src/validation/types.ts
+++ b/packages/diagrams/src/validation/types.ts
@@ -1,0 +1,57 @@
+// VALIDATION — validation-domain claim against a NEED.
+// Schema: methodology notations/elements/28-validation.md §2.
+//
+// VALIDATION is the validation-domain counterpart to VERIFICATION (same claim
+// shape, anchored one layer further upstream on NEED instead of REQUIREMENT).
+
+import type { GateChecks } from '../requirement/types.js';
+import type { Evidence } from '../assertion/types.js';
+
+/** Validation method vocabulary (28-validation.md §3). */
+export type ValidationMethod = 'user_acceptance' | 'field_trial' | 'stakeholder_review' | 'usability_study';
+
+export const VALIDATION_METHODS: readonly ValidationMethod[] = [
+  'user_acceptance',
+  'field_trial',
+  'stakeholder_review',
+  'usability_study',
+];
+
+/** Pass/fail judgement vocabulary (28-validation.md §3). */
+export type ValidationOutcome = 'pass' | 'fail' | 'inconclusive' | 'not_yet_run';
+
+export const VALIDATION_OUTCOMES: readonly ValidationOutcome[] = [
+  'pass',
+  'fail',
+  'inconclusive',
+  'not_yet_run',
+];
+
+/** Outcomes that count as "closed" — the trace link has resolved one way or
+ *  the other, distinct from still-open (`not_yet_run` / `inconclusive`)
+ *  (28-validation.md §5, NEED-VALIDATION-COVERAGE-002). */
+export const CLOSED_VALIDATION_OUTCOMES: readonly ValidationOutcome[] = ['pass', 'fail'];
+
+export interface Validation {
+  notation: 'validation';
+  id: string;
+  /** Typed ID of the NEED this validation targets. */
+  validates: string;
+  method: ValidationMethod;
+  protocol: string;
+  result?: string;
+  outcome: ValidationOutcome;
+  evidence?: Evidence[];
+  performed_at?: string;
+  performed_by?: string;
+
+  // Admission record (CONTRACT.md §6).
+  zone: 'canon';
+  admitted_at: string;
+  admitted_by: string;
+  gate_checks: GateChecks;
+
+  // Primitive lifecycle (CONTRACT.md §7).
+  valid_from: string;
+  valid_to: string | null;
+}

--- a/packages/diagrams/src/validation/validate.ts
+++ b/packages/diagrams/src/validation/validate.ts
@@ -1,0 +1,113 @@
+// VALIDATION validator — methodology notations/elements/28-validation.md §5.
+//
+// Implements VALID-001..006. The shared HDR-/LIFECYCLE- rules and the
+// cross-cutting NEED-VALIDATION-COVERAGE-001/002 reverse-trace rules are
+// owned elsewhere (CONTRACT.md §8) and are out of scope for this
+// single-artefact validator — same posture as `validateVerification`
+// (../verification/validate.ts), which VALIDATION mirrors one layer upstream
+// (anchored on NEED instead of REQUIREMENT).
+//
+// Resolution rules (VALID-002/005) that need artefact *existence* run only
+// when a `CanonCatalog` is supplied; the TYPE check VALID-002 also carries is
+// derivable from the id prefix and runs either way.
+
+import type { ValidationError, ValidationWarning, ValidationResult } from '../validation-types.js';
+import { typeOfId, isCanonicalIdOfType, type CanonCatalog } from '../typed-id.js';
+import { VALIDATION_METHODS, VALIDATION_OUTCOMES } from './types.js';
+
+export interface ValidationValidateOptions {
+  /** When provided, the resolution rules enforce artefact existence. */
+  catalog?: CanonCatalog;
+}
+
+export function validateValidation(input: unknown, options: ValidationValidateOptions = {}): ValidationResult {
+  const errors: ValidationError[] = [];
+  const warnings: ValidationWarning[] = [];
+  const { catalog } = options;
+
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    errors.push({ code: 'VALID-001', message: 'Validation must be a YAML mapping.' });
+    return { valid: false, errors, warnings };
+  }
+  const v = input as Record<string, unknown>;
+
+  // ── VALID-001 — id grammar + plain required fields ───────────────────────
+  if (!isCanonicalIdOfType(v.id, 'VALIDATION')) {
+    errors.push({ code: 'VALID-001', message: `id "${String(v.id)}" must match VALIDATION-[<middle>-]<INTEGER>.`, path: 'id' });
+  }
+  if (v.notation !== 'validation') {
+    errors.push({ code: 'VALID-001', message: 'notation must be the fixed value "validation".', path: 'notation' });
+  }
+  if (v.zone !== 'canon') {
+    errors.push({ code: 'VALID-001', message: 'zone is required and must be "canon".', path: 'zone' });
+  }
+  for (const f of ['admitted_at', 'admitted_by', 'valid_from', 'protocol'] as const) {
+    if (typeof v[f] !== 'string' || (v[f] as string).trim() === '') {
+      errors.push({ code: 'VALID-001', message: `${f} is required.`, path: f });
+    }
+  }
+  if (v.gate_checks === null || typeof v.gate_checks !== 'object') {
+    errors.push({ code: 'VALID-001', message: 'gate_checks is required and must be a mapping.', path: 'gate_checks' });
+  }
+  if (!('valid_to' in v) || !(typeof v.valid_to === 'string' || v.valid_to === null)) {
+    errors.push({ code: 'VALID-001', message: 'valid_to is required (an ISO date string or null).', path: 'valid_to' });
+  }
+
+  // ── VALID-002 — validates → NEED ─────────────────────────────────────────
+  const validates = v.validates;
+  if (typeof validates !== 'string' || validates.trim() === '') {
+    errors.push({ code: 'VALID-002', message: 'validates is required and must be a typed NEED id.', path: 'validates' });
+  } else if (catalog) {
+    const t = catalog.typeOf(validates);
+    if (t === undefined) {
+      errors.push({ code: 'VALID-002', message: `validates "${validates}" does not resolve to an admitted artefact.`, path: 'validates' });
+    } else if (t !== 'NEED') {
+      errors.push({ code: 'VALID-002', message: `validates "${validates}" resolves to a ${t}, not a NEED.`, path: 'validates' });
+    }
+  } else if (typeOfId(validates) !== 'NEED') {
+    errors.push({ code: 'VALID-002', message: `validates "${validates}" must be a NEED typed id.`, path: 'validates' });
+  }
+
+  // ── VALID-003 — method enum ───────────────────────────────────────────────
+  const method = v.method;
+  if (method === undefined || method === null) {
+    errors.push({ code: 'VALID-001', message: 'method is required.', path: 'method' });
+  } else if (!VALIDATION_METHODS.includes(method as never)) {
+    errors.push({ code: 'VALID-003', message: `method "${String(method)}" must be one of ${VALIDATION_METHODS.join(', ')}.`, path: 'method' });
+  }
+
+  // ── VALID-004 — outcome enum ──────────────────────────────────────────────
+  const outcome = v.outcome;
+  if (outcome === undefined || outcome === null) {
+    errors.push({ code: 'VALID-001', message: 'outcome is required.', path: 'outcome' });
+  } else if (!VALIDATION_OUTCOMES.includes(outcome as never)) {
+    errors.push({ code: 'VALID-004', message: `outcome "${String(outcome)}" must be one of ${VALIDATION_OUTCOMES.join(', ')}.`, path: 'outcome' });
+  }
+
+  // ── VALID-005 — canonical_ref evidence resolves ──────────────────────────
+  if (v.evidence !== undefined) {
+    if (!Array.isArray(v.evidence)) {
+      errors.push({ code: 'VALID-001', message: 'evidence must be a list.', path: 'evidence' });
+    } else {
+      v.evidence.forEach((e, i) => {
+        if (e === null || typeof e !== 'object') return;
+        const entry = e as Record<string, unknown>;
+        if (entry.kind !== 'canonical_ref') return;
+        const ref = entry.ref;
+        if (!typeOfId(ref)) {
+          errors.push({ code: 'VALID-005', message: `evidence[${i}] canonical_ref "${String(ref)}" is not a resolvable typed ID.`, path: `evidence[${i}].ref` });
+        } else if (catalog && catalog.typeOf(ref as string) === undefined) {
+          errors.push({ code: 'VALID-005', message: `evidence[${i}] canonical_ref "${String(ref)}" does not resolve.`, path: `evidence[${i}].ref` });
+        }
+      });
+    }
+  }
+
+  // ── VALID-006 (warning) — pass outcome with no evidence ──────────────────
+  const evidenceEmpty = !Array.isArray(v.evidence) || v.evidence.length === 0;
+  if (evidenceEmpty && outcome === 'pass') {
+    warnings.push({ code: 'VALID-006', message: 'outcome "pass" has no evidence — an undefended positive claim.', path: 'evidence' });
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}

--- a/src/repo-validate.ts
+++ b/src/repo-validate.ts
@@ -490,7 +490,13 @@ export function runComplianceValidate(root: string, ctx: RepoValidateContext): V
       continue;
     }
     const notation = notationOf(data);
-    if (notation !== 'requirement' && notation !== 'constraint') continue;
+    if (
+      notation !== 'requirement' &&
+      notation !== 'constraint' &&
+      notation !== 'risk' &&
+      notation !== 'metric' &&
+      notation !== 'need'
+    ) continue;
     for (const f of validateNotationDoc(notation, data, validateOpts).findings) {
       if (f.severity === 'info') continue;
       findings.push({
@@ -575,6 +581,42 @@ export function runComplianceValidate(root: string, ctx: RepoValidateContext): V
     }
   }
 
+  let validationEntries: string[] = [];
+  try {
+    validationEntries = readdirSync(path.join(root, 'canon', 'validations'), { recursive: true }) as string[];
+  } catch {
+    validationEntries = [];
+  }
+  for (const rel of validationEntries) {
+    if (typeof rel !== 'string' || !isYaml(rel) || shouldSkip(rel)) continue;
+    const fullRel = path.join('canon', 'validations', rel).replace(/\\/g, '/');
+    let data: unknown;
+    try {
+      data = loadNotationYaml(readFileSync(path.join(root, fullRel), 'utf-8'));
+    } catch (e) {
+      findings.push({
+        file: fullRel,
+        notation: '',
+        ruleId: 'YAML',
+        severity: 'error',
+        message: (e as Error).message,
+      });
+      continue;
+    }
+    const notation = notationOf(data);
+    if (notation !== 'validation') continue;
+    for (const f of validateNotationDoc('validation', data, validateOpts).findings) {
+      if (f.severity === 'info') continue;
+      findings.push({
+        file: fullRel,
+        notation: 'validation',
+        ruleId: f.ruleId,
+        severity: f.severity,
+        message: f.message,
+      });
+    }
+  }
+
   return findings;
 }
 
@@ -585,6 +627,8 @@ export function runGapDashboardWarnings(ctx: RepoValidateContext): ViewFinding[]
     requirements: ctx.complianceCanon.requirements,
     assertions: ctx.complianceCanon.assertions,
     verifications: ctx.complianceCanon.verifications,
+    needs: ctx.complianceCanon.needs,
+    validations: ctx.complianceCanon.validations,
   });
   const report = buildGapReport(index, { today: new Date().toISOString().slice(0, 10) });
 
@@ -631,6 +675,33 @@ export function runGapDashboardWarnings(ctx: RepoValidateContext): ViewFinding[]
       ruleId: 'REQ-VERIF-COVERAGE-002',
       severity: 'warning',
       message: `${req.element_kind === 'constraint' ? 'Constraint' : 'Requirement'} "${req.id}" has verification(s), but none has reached outcome pass or fail.`,
+    });
+  }
+  for (const need of report.needsWithoutRequirements) {
+    findings.push({
+      file: ctx.pathById.get(need.id) ?? need.id,
+      notation: 'need',
+      ruleId: 'NEED-COVERAGE-001',
+      severity: 'warning',
+      message: `Need "${need.id}" has no requirement serving it.`,
+    });
+  }
+  for (const need of report.needsWithoutValidation) {
+    findings.push({
+      file: ctx.pathById.get(need.id) ?? need.id,
+      notation: 'need',
+      ruleId: 'NEED-VALIDATION-COVERAGE-001',
+      severity: 'warning',
+      message: `Need "${need.id}" has no validation targeting it.`,
+    });
+  }
+  for (const need of report.needsWithUnresolvedValidation) {
+    findings.push({
+      file: ctx.pathById.get(need.id) ?? need.id,
+      notation: 'need',
+      ruleId: 'NEED-VALIDATION-COVERAGE-002',
+      severity: 'warning',
+      message: `Need "${need.id}" has validation(s), but none has reached outcome pass or fail.`,
     });
   }
 

--- a/src/validate-notation.ts
+++ b/src/validate-notation.ts
@@ -44,6 +44,10 @@ import { validateRequirement } from '@transitrix/diagrams/requirement/validate.j
 import { validateConstraint } from '@transitrix/diagrams/constraint/validate.js';
 import { validateAssertion } from '@transitrix/diagrams/assertion/validate.js';
 import { validateVerification } from '@transitrix/diagrams/verification/validate.js';
+import { validateRisk } from '@transitrix/diagrams/risk/validate.js';
+import { validateMetric } from '@transitrix/diagrams/metric/validate.js';
+import { validateNeed } from '@transitrix/diagrams/need/validate.js';
+import { validateValidation } from '@transitrix/diagrams/validation/validate.js';
 import { parseImpactViewConfig } from '@transitrix/diagrams/compliance/impact.js';
 import { parseCoverageMetricConfig } from '@transitrix/diagrams/compliance/coverage-metric.js';
 import {
@@ -96,6 +100,22 @@ function validateVerificationDoc(input: unknown, options: ValidateNotationOption
 
 function validateConstraintDoc(input: unknown, options: ValidateNotationOptions = {}): NotationValidationResult {
   return mapPackageResult(validateConstraint(input, { catalog: options.catalog }));
+}
+
+function validateRiskDoc(input: unknown, options: ValidateNotationOptions = {}): NotationValidationResult {
+  return mapPackageResult(validateRisk(input, { catalog: options.catalog }));
+}
+
+function validateMetricDoc(input: unknown, options: ValidateNotationOptions = {}): NotationValidationResult {
+  return mapPackageResult(validateMetric(input, { catalog: options.catalog }));
+}
+
+function validateNeedDoc(input: unknown, options: ValidateNotationOptions = {}): NotationValidationResult {
+  return mapPackageResult(validateNeed(input, { catalog: options.catalog }));
+}
+
+function validateValidationDoc(input: unknown, options: ValidateNotationOptions = {}): NotationValidationResult {
+  return mapPackageResult(validateValidation(input, { catalog: options.catalog }));
 }
 
 function validateBlocksDoc(input: unknown, options: ValidateNotationOptions = {}): NotationValidationResult {
@@ -183,6 +203,10 @@ const VALIDATORS: Record<string, NotationValidator> = {
   constraint: validateConstraintDoc,
   assertion: validateAssertionDoc,
   verification: validateVerificationDoc,
+  risk: validateRiskDoc,
+  metric: validateMetricDoc,
+  need: validateNeedDoc,
+  validation: validateValidationDoc,
   'compliance-impact': wrapValidator(validateComplianceImpactDoc),
   'coverage-metric': wrapValidator(validateCoverageMetricDoc),
   // Group C — codex zone (#518 Phase C2); `zone: codex`, not a notation: tag.
@@ -229,6 +253,10 @@ export function inferNotationFromFilename(filePath: string): string | undefined 
   if (base.startsWith('constraint-') && base.endsWith('.yaml')) return 'constraint';
   if (base.startsWith('assertion-') && base.endsWith('.yaml')) return 'assertion';
   if (base.startsWith('verification-') && base.endsWith('.yaml')) return 'verification';
+  if (base.startsWith('risk-') && base.endsWith('.yaml')) return 'risk';
+  if (base.startsWith('metric-') && base.endsWith('.yaml')) return 'metric';
+  if (base.startsWith('need-') && base.endsWith('.yaml')) return 'need';
+  if (base.startsWith('validation-') && base.endsWith('.yaml')) return 'validation';
   const rawBase = (filePath.replace(/\\/g, '/').split('/').pop() ?? '').replace(/\.ya?ml$/i, '');
   const idType = typeOfId(rawBase);
   if (idType && (CODEX_ARTEFACT_TYPES as readonly string[]).includes(idType)) return 'codex';

--- a/tests/fixtures/notation-corpus/metric/METRIC-CHECKOUT-CONVERSION-1.yaml
+++ b/tests/fixtures/notation-corpus/metric/METRIC-CHECKOUT-CONVERSION-1.yaml
@@ -1,0 +1,31 @@
+# Worked example — managed indicator tracking a GOAL.
+# Schema: notations/ELEMENT_PRIMITIVES.md §7.27.
+
+notation: metric
+id: METRIC-CHECKOUT-CONVERSION-1
+name: "Checkout conversion rate"
+description: >
+  Share of started checkouts that complete successfully. Tracks whether
+  the checkout-simplification goal is moving the organisation's core
+  revenue lever in the intended direction.
+
+measures:
+  - GOAL-CHECKOUT-SIMPLIFICATION-1
+
+unit: percent
+target: 68
+direction_of_good: higher_is_better
+owner_role: ROLE-ECOMMERCE-LEAD-1
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-07-30"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-07-30"
+valid_to: null

--- a/tests/fixtures/notation-corpus/need/NEED-TIMELY-OUTAGE-STATUS-1.yaml
+++ b/tests/fixtures/notation-corpus/need/NEED-TIMELY-OUTAGE-STATUS-1.yaml
@@ -1,0 +1,28 @@
+# Worked example — stakeholder/user need, upstream of REQUIREMENT.
+# Schema: notations/ELEMENT_PRIMITIVES.md §7.28.
+# A REQUIREMENT.serves and a VALIDATION.validates may both point here — see
+# tests/fixtures/notation-corpus/validation/VALIDATION-OUTAGE-STATUS-UAT-1.yaml.
+
+notation: need
+id: NEED-TIMELY-OUTAGE-STATUS-1
+name: "Customers need to know service status within minutes of an outage starting"
+description: >
+  When the service is degraded or unavailable, affected customers need a
+  reliable, timely signal that something is wrong and that it is being
+  worked on — independent of whatever mechanism (status page, email,
+  in-app banner) ends up delivering that signal.
+
+stakeholder: STAKEHOLDER-ENTERPRISE-CUSTOMERS-1
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-07-30"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-07-30"
+valid_to: null

--- a/tests/fixtures/notation-corpus/risk/RISK-VENDOR-OUTAGE-1.yaml
+++ b/tests/fixtures/notation-corpus/risk/RISK-VENDOR-OUTAGE-1.yaml
@@ -1,0 +1,34 @@
+# Worked example — a projected event threatening a DRIVER, treated by a REQUIREMENT.
+# Schema: notations/ELEMENT_PRIMITIVES.md §7.26.
+
+notation: risk
+id: RISK-VENDOR-OUTAGE-1
+name: "Primary payment-gateway vendor suffers an extended outage"
+description: >
+  The organisation's sole payment-gateway integration has no failover
+  provider; an extended vendor-side outage would stop order checkout
+  entirely for the duration of the incident.
+
+likelihood: medium
+impact: high
+residual: medium
+owner_role: ROLE-PAYMENTS-LEAD-1
+
+threatens:
+  - DRIVER-CHECKOUT-AVAILABILITY-1
+
+treated_by:
+  - REQUIREMENT-PAYMENT-FAILOVER-1
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-07-30"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-07-30"
+valid_to: null

--- a/tests/fixtures/notation-corpus/validation/VALIDATION-OUTAGE-STATUS-UAT-1.yaml
+++ b/tests/fixtures/notation-corpus/validation/VALIDATION-OUTAGE-STATUS-UAT-1.yaml
@@ -1,0 +1,36 @@
+# Worked example — closed (pass) user-acceptance claim against a NEED.
+# Schema: notations/elements/28-validation.md §2.
+# Demonstrates: method = user_acceptance, outcome = pass, external_doc evidence.
+
+notation: validation
+id: VALIDATION-OUTAGE-STATUS-UAT-1
+validates: NEED-TIMELY-OUTAGE-STATUS-1                # → canon/elements/01_motivation/needs/
+
+method: user_acceptance
+protocol: >
+  Simulate a service outage in the staging environment; observe whether ten
+  enterprise-customer participants notice the status-page update within 5
+  minutes without being prompted.
+result: "9/10 participants noticed the status update within 5 minutes; the tenth noticed at 6 minutes 40 seconds."
+outcome: pass
+
+evidence:
+  - kind: external_doc
+    title: "Outage-status usability study, session recordings and notes"
+    url: "https://internal.example/reports/outage-status-uat-1.pdf"
+
+performed_at: "2026-07-22"
+performed_by: ROLE-UX-RESEARCH-LEAD-1
+
+# Admission record (CONTRACT.md §6)
+zone: canon
+admitted_at: "2026-07-23"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+# Primitive lifecycle (CONTRACT.md §7)
+valid_from: "2026-07-23"
+valid_to: null

--- a/tests/validate-notation.test.ts
+++ b/tests/validate-notation.test.ts
@@ -51,8 +51,13 @@ const GROUP_B = [
   'process-map',
 ];
 
-// Group C — compliance suite wired in #518 Phase C1–C4.
-const GROUP_C = ['requirement', 'constraint', 'assertion', 'verification', 'compliance-impact', 'coverage-metric', 'codex'];
+// Group C — compliance suite wired in #518 Phase C1–C4, plus the
+// methodology-3.1.0 vocabulary follow-on (RISK / METRIC / NEED / VALIDATION).
+const GROUP_C = [
+  'requirement', 'constraint', 'assertion', 'verification',
+  'risk', 'metric', 'need', 'validation',
+  'compliance-impact', 'coverage-metric', 'codex',
+];
 
 const ALL_NOTATIONS = [...GROUP_A, ...GROUP_B, ...GROUP_C];
 
@@ -163,7 +168,7 @@ describe('validate-notation — the view notation corpus validates clean (#258)'
 });
 
 describe('validate-notation — element notation corpus validates clean (#518 C1)', () => {
-  for (const notation of ['requirement', 'assertion', 'verification'] as const) {
+  for (const notation of ['requirement', 'assertion', 'verification', 'risk', 'metric', 'need', 'validation'] as const) {
     for (const file of elementFixtures(notation)) {
       const name = file.slice(corpusRoot.length + 1).replace(/\\/g, '/');
       it(`${name} → valid`, () => {


### PR DESCRIPTION
## Summary

Implements the Studio-side validator registry for methodology 3.1.0's new
motivation-layer vocabulary — `RISK`, `METRIC`, `NEED` (`ELEMENT_PRIMITIVES.md`
§7.26–§7.28), and the `VALIDATION` claim type anchored on `NEED`
(`28-validation.md`) — plus three new `REQUIREMENT` fields tracing the
requirement/need relationship (`level`, `kind`, `serves`; `15-requirement.md`
§2.5–§2.7).

- New single-artefact validators: `packages/diagrams/src/{risk,metric,need,validation}`,
  following the existing `validate<Notation>(input, { catalog })` shape used by
  `requirement`/`assertion`/`verification`.
- `REQUIREMENT` grows `level` (`REQ-005`), `kind` (`REQ-006`), and `serves`
  (`REQ-SERVES-001`, tracing to the upstream `NEED`).
- CLI (`src/validate-notation.ts`) and repo-scope (`src/repo-validate.ts`)
  wiring, matching the parity convention every other compliance notation
  follows.
- Cross-cutting reverse-trace coverage — `NEED-COVERAGE-001` and
  `NEED-VALIDATION-COVERAGE-001`/`002` — added to the compliance reverse-index
  (`packages/diagrams/src/compliance/*`) alongside the existing
  `REQ-VERIF-COVERAGE-*` rules. `RISK-COVERAGE-001` is a single-file check
  (no catalogue scan needed), implemented inline in the risk validator.
- `docs/validation.md` updated with the new rule-coverage table rows and a
  prose section, including an explicit note that the Compliance Gap
  Dashboard export/preview was *not* extended to render the new
  `needsWith*` fields in this pass (follow-up, not silently dropped).
- `packages/diagrams` bumped 1.9.1 → 1.9.2 (patch) for the
  diagrams-version-bump CI guard.

Verified zero new findings running `transitrix validate --scope=repo`
against a scratch copy of methodology's own worked example
(`notations/examples/validation/`) — only the expected
`GAP-REQ-NO-ASSERT`/`REQ-VERIF-COVERAGE-001` warnings on the example's
`REQUIREMENT`, nothing on the `NEED`/`VALIDATION` elements.

## Test plan

- [x] `npm --workspace packages/diagrams test` — 1566 tests pass
- [x] `npm test` (root) — 469 pass, 21 skipped; the sole failure
      (`bpmn-dsl.schema.json is identical in root and extension directories`)
      is a pre-existing generated-file gap unrelated to this change (the
      extension bundle sync step wasn't run in this checkout)
- [x] `npm run build` (root `tsc -p tsconfig.build.json` + diagrams build) —
      clean
- [x] Manually ran `transitrix validate --scope=repo` against a scratch copy
      of methodology's `notations/examples/validation/` fixture — validates
      clean