### PR TITLE
fix(hygiene): widen work-item guard to the unpunctuated hub-task form

### DIFF
--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -356,7 +356,7 @@ const TITLE_TOGGLE_CSS = `
 `;
 
 /**
- * CSS-only discrete zoom control (orchestrator decision on issue #30):
+ * CSS-only discrete zoom control (orchestrator decision):
  * 50 / 75 / 100 (default) / 150 / 200 % through hidden radios + labels.
  * Same pattern as TX-R009 title toggle and Network/Gantt switcher — no
  * script enablement, the security backstop on previews stays intact.
@@ -515,7 +515,7 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
   const showTheme = Boolean(themeCommand);
   // Zoom control gates on the same signal as Save .svg — the six vector
   // previews opt in by passing a saveSvgCommand. HTML catalogues are out of
-  // scope per the orchestrator's call on issue #30.
+  // scope per the orchestrator's call.
   const showZoom = Boolean(canvasContent) && Boolean(saveSvgCommand);
   const showLegendToggle = Boolean(legendToggle);
   const legendToggleInput = showLegendToggle

--- a/packages/diagrams/src/theme/__tests__/tokens.test.ts
+++ b/packages/diagrams/src/theme/__tests__/tokens.test.ts
@@ -1,5 +1,5 @@
 /**
- * Brand default-theme regression tests (hub issue #548).
+ * Brand default-theme regression tests.
  *
  * Locks in the three-role brand mapping from `brand/transitrix_brand.md`:
  *   - Petrol = structure (node/edge stroke) and hierarchy depth (fill tint).

--- a/scripts/ci-hygiene-hashrefs.mjs
+++ b/scripts/ci-hygiene-hashrefs.mjs
@@ -34,14 +34,14 @@
 import { execSync } from 'node:child_process';
 import { readFileSync, statSync } from 'node:fs';
 
-// Committed content: either form. PR metadata: the bare form only.
-const HASHREF = /\b(?:task|epic|hub)s?[\s:]+#\d+/gi;
-const WORKITEM = /\bHUB-\d+|\b(?:task|epic|hub)s?[\s:]+#\d+/gi;
+import { HASHREF, WORKITEM } from './hygiene-patterns.mjs';
 
 const SKIP = new Set([
   'scripts/ci-hygiene-check.mjs',
   'scripts/ci-hygiene-tree.mjs',
   'scripts/ci-hygiene-hashrefs.mjs',
+  'scripts/hygiene-patterns.mjs',
+  'tests/ci-hygiene-hashrefs.test.ts',
   '.github/workflows/public-surface-hygiene.yml',
   '.gitignore',
 ]);

--- a/scripts/hygiene-patterns.mjs
+++ b/scripts/hygiene-patterns.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+// Shared regex patterns for the work-item-reference hygiene guard
+// (scripts/ci-hygiene-hashrefs.mjs). Extracted to their own module so the
+// self-test (tests/ci-hygiene-hashrefs.test.ts) exercises the exact patterns
+// the guard runs in CI, not a hand-copied approximation of them.
+//
+// Two forms leak a work-item reference:
+//   - the neutral HUB-<number> form
+//   - a hash-number dressed as task / epic / hub / issue work, punctuated
+//     (a qualifier followed by a hash-number) or, discriminated by the
+//     literal qualifier "hub", unpunctuated (hub + task/epic/issue + number)
+// A bare hash-number alone, and the closes/fixes auto-close keywords, are
+// this repository's own issue/PR references and stay untouched.
+
+// Bare hash-number form (punctuated and unpunctuated) — forbidden on every
+// surface, including PR title/body, where the neutral HUB-<number> form is
+// otherwise allowed.
+export const HASHREF = /\b(?:task|epic|hub|issue)s?[\s:]+#\d+|\bhub\s+(?:task|epic|issue)s?\s+#?\d+/gi;
+
+// HASHREF plus the neutral HUB-<number> form — forbidden in committed content
+// (diff + full tree).
+export const WORKITEM = /\bHUB-\d+|\b(?:task|epic|hub|issue)s?[\s:]+#\d+|\bhub\s+(?:task|epic|issue)s?\s+#?\d+/gi;

--- a/tests/ci-hygiene-hashrefs.test.ts
+++ b/tests/ci-hygiene-hashrefs.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { HASHREF, WORKITEM } from '../scripts/hygiene-patterns.mjs';
+
+// Fixed sample strings only — never a real scanned line. This file is in the
+// guard's own SKIP list (scripts/ci-hygiene-hashrefs.mjs), so these fixtures
+// are exempt from the very scan they exercise.
+const POSITIVE = ['hub task 217', 'hub epic 391', 'HUB-905', 'issue #7'];
+const NEGATIVE = ['task 3 of the pipeline', 'closes #12', 'GitHub 3'];
+
+function matches(pattern: RegExp, text: string): boolean {
+  return new RegExp(pattern.source, pattern.flags).test(text);
+}
+
+describe('hygiene work-item reference patterns', () => {
+  it('flags every leaked work-item reference form', () => {
+    for (const sample of POSITIVE) {
+      expect(matches(WORKITEM, sample), sample).toBe(true);
+    }
+  });
+
+  it('leaves ordinary prose and this-repo references alone', () => {
+    for (const sample of NEGATIVE) {
+      expect(matches(WORKITEM, sample), sample).toBe(false);
+    }
+  });
+
+  it('allows the neutral HUB-<number> form in PR metadata but not the dressed hash form', () => {
+    expect(matches(HASHREF, 'HUB-905'), 'HUB-905 via HASHREF').toBe(false);
+    expect(matches(HASHREF, 'issue #7'), 'issue #7 via HASHREF').toBe(true);
+    expect(matches(HASHREF, 'hub task 217'), 'hub task 217 via HASHREF').toBe(true);
+  });
+});

--- a/tests/snapshot-writer.test.ts
+++ b/tests/snapshot-writer.test.ts
@@ -8,7 +8,7 @@ import {
   parseSnapshotForDisplay,
 } from '../extension/src/snapshot-writer.js';
 
-// Unit coverage for the snapshot-writer utilities (issue #303).
+// Unit coverage for the snapshot-writer utilities.
 // These functions are pure (no vscode, no fs) so they are fully testable here.
 
 describe('snapshotFilename', () => {


### PR DESCRIPTION
## Summary
- The public-surface work-item guard required a literal `#`, so the unpunctuated spelling of a dressed hash reference slipped through the diff scan, the full-tree scan, and the PR-metadata scan.
- Extracted the guard's regex patterns into `scripts/hygiene-patterns.mjs` (shared by `scripts/ci-hygiene-hashrefs.mjs` and a new vitest self-test) and widened them to catch the unpunctuated form, discriminated by the literal qualifier `hub`, plus an `issue` qualifier for the punctuated form.
- Swept the full tree with the widened pattern and fixed the 4 live hits it surfaced (`extension/src/diagram-frame.ts` x2, `packages/diagrams/src/theme/__tests__/tokens.test.ts`, `tests/snapshot-writer.test.ts`) — kept the reason, dropped the number, per the guard's own remediation advice.

## Test plan
- [x] `npx vitest run tests/ci-hygiene-hashrefs.test.ts` — positive/negative self-test passes (3/3)
- [x] `node scripts/ci-hygiene-hashrefs.mjs` — clean run across all 787 tracked files after the fixes
- [x] `npx vitest run` — full suite green (8 files that failed on the first pass were CLI-subprocess timeouts from concurrent load; all pass in isolation)
- [x] `npx tsc --noEmit` — no new errors (pre-existing unrelated errors on `main` confirmed via `git stash`)