### PR TITLE
feat(cli): transitrix new goal — computed envelope, not hand-typed

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,7 @@ import {
 } from './cli-parse.js';
 import { compileTransitrixYamlWithLayout } from './compiler.js';
 import { handleMigrateCommand } from './migrate.js';
+import { handleNewCommand } from './scaffold.js';
 import { computeLayoutMetrics } from './metrics.js';
 import type { ValidationReport, ValidationFinding } from './validator-types.js';
 import { parseYamlToIr } from './parser.js';
@@ -72,6 +73,7 @@ function printUsage(): void {
        transitrix validate --scope=repo [--root <dir>] [--json] [--include-model]
        transitrix export-compliance [--format md|pdf] [--scope law:<ID>|product:<ID>|gap] [--output <path>] [--root <dir>]
        transitrix migrate [--from X.Y] [--to X.Y] [--dry-run] [--recipes <dir>] [target-dir]
+       transitrix new goal --id <GOAL-…> --name "<label>" [--author <name>] [--root <dir>] [--dry-run]
 
 
   serve     — local web UI (run npm run ui:build once beforehand).
@@ -92,6 +94,10 @@ function printUsage(): void {
               the ordered recipes from the methodology repo. Reads the current
               version from transitrix.yaml (or --from X.Y); --dry-run previews
               without writing; --recipes <dir> overrides the recipe source.
+  new goal  — scaffold a standalone GOAL element with the admission record and
+              lifecycle envelope computed (zone/admitted_at/admitted_by/
+              gate_checks/valid_from/valid_to) rather than hand-typed.
+              --author sets admitted_by (default: git config user.name).
 
   --no-metrics  suppress quality metrics report on compile.
   --no-validate suppress validation warnings (errors always run).
@@ -610,6 +616,8 @@ try {
     await handleExportComplianceCommand(process.argv.slice(3));
   } else if (subcommand === 'migrate') {
     await handleMigrateCommand(process.argv.slice(3));
+  } else if (subcommand === 'new') {
+    await handleNewCommand(process.argv.slice(3));
   } else if (!subcommand || subcommand === 'compile') {
     // Default: compile
     const compileArgv = subcommand === 'compile'

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -1,0 +1,349 @@
+// `transitrix new goal` — hub epic #919 ("Authoring a first element requires
+// only its own content — the envelope is supplied"), first cut. Scaffolds a
+// standalone GOAL element file (ELEMENT_PRIMITIVES.md §7.2) with the
+// admission record (CONTRACT.md §6) and primitive lifecycle (CONTRACT.md §7)
+// computed by the tool, not hand-typed by the author.
+//
+// Scope of this first cut: GOAL only, and only the *creation* path (a brand
+// new file, hand-formatted so header comments match the existing
+// `.templates/elements/*_template.yaml` convention). Completing envelope
+// fields on an already-hand-authored file (`validate --fix`) is a distinct,
+// harder problem — this repo has no comment-preserving YAML writer, so a
+// naive parse-mutate-dump round-trip would silently strip every comment in
+// the file — and is left for a follow-up.
+//
+// `admitted_by` identifies the human running this command (CONTRACT.md §6.2:
+// a tool self-identifying would make this an `ai_reviewed` record, not what
+// a human authoring their own canon wants) — resolved from `--author` or
+// `git config user.name`, never invented. `gate_checks` records checks this
+// command actually ran, not a constant `pass` (per the epic's own
+// constraint): `uniqueness` is a real scan of `canon/elements/**` and
+// `canon/relations/**` for an id collision; `consistency` verifies every
+// `factors:` reference resolves to an existing canon id; `completeness` is
+// true by construction (id/name are required CLI args). Any failed check
+// aborts before writing — this command never writes a `gate_checks` entry
+// that says `pass` when the thing it describes didn't happen.
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import * as path from 'node:path';
+import yaml from 'js-yaml';
+
+const SKIP_SEGMENTS = new Set(['node_modules', '.templates', '.validators']);
+const GOAL_ELEM_ID_RE = /^GOAL-([A-Z0-9]+-)*[0-9]+$/;
+
+function segments(rel: string): string[] {
+  return rel.split(/[\\/]/);
+}
+
+function isYaml(rel: string): boolean {
+  return /\.ya?ml$/i.test(rel);
+}
+
+function shouldSkip(rel: string): boolean {
+  return segments(rel).some((s) => SKIP_SEGMENTS.has(s));
+}
+
+/** Every `id:` found under `canon/elements/**` and `canon/relations/**` —
+ *  used for the uniqueness gate check and for resolving `factors:`
+ *  references. Deliberately minimal (id only, no full RepoDoc/RepoFinding
+ *  machinery): this is a pre-write existence check, not a validation pass,
+ *  and an unreadable file is skipped rather than surfaced — a broken
+ *  neighbour file must not block scaffolding a new one. */
+export function collectExistingCanonIds(root: string): Set<string> {
+  const ids = new Set<string>();
+  for (const zone of ['elements', 'relations']) {
+    let entries: string[] = [];
+    try {
+      entries = readdirSync(path.join(root, 'canon', zone), { recursive: true }) as string[];
+    } catch {
+      continue;
+    }
+    for (const rel of entries) {
+      if (typeof rel !== 'string' || !isYaml(rel) || shouldSkip(rel)) continue;
+      try {
+        const data = yaml.load(readFileSync(path.join(root, 'canon', zone, rel), 'utf-8'));
+        if (data && typeof data === 'object' && !Array.isArray(data)) {
+          const id = (data as Record<string, unknown>).id;
+          if (typeof id === 'string' && id) ids.add(id);
+        }
+      } catch {
+        // Unreadable/unparseable neighbour — not this command's concern.
+      }
+    }
+  }
+  return ids;
+}
+
+/** `git config user.name` in `root`, or undefined if git is unavailable /
+ *  unconfigured. Never a fallback guess — an absent identity is surfaced to
+ *  the caller as a missing `--author`, not silently invented. */
+export function gitUserName(root: string): string | undefined {
+  try {
+    const out = execFileSync('git', ['config', 'user.name'], { cwd: root, encoding: 'utf-8' }).trim();
+    return out || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export interface NewGoalOptions {
+  /** Adopter repo root containing `canon/`. */
+  root: string;
+  id: string;
+  name: string;
+  /** Person handle recorded as `admitted_by` (CONTRACT.md §6.2 — a human
+   *  handle here, never a tool id, keeps `admission_state`/`reviewer_authority`
+   *  at their human-authored defaults: absent ⇒ active ⇒ expert_confirmed). */
+  admittedBy: string;
+  /** ISO 8601 date (CONTRACT.md §4) used for `admitted_at` and `valid_from`.
+   *  Caller-supplied rather than computed here so the function stays pure
+   *  and testable without mocking the clock. */
+  today: string;
+  type?: string;
+  level?: number;
+  parent?: string;
+  factors?: string[];
+  description?: string;
+  link?: string;
+}
+
+export type ScaffoldOutcome =
+  | { ok: true; relPath: string; content: string; filled: string[] }
+  | { ok: false; errors: string[] };
+
+/** Renders the GOAL element YAML by hand (not `js-yaml.dump`) so the output
+ *  keeps the same header-comment convention as
+ *  `.templates/elements/01_motivation_template.yaml` and every worked
+ *  example under `organizations/acme_corp/canon/elements/`. */
+function renderGoalYaml(opts: NewGoalOptions): string {
+  const lines: string[] = [];
+  lines.push('notation: goal');
+  lines.push(`id: ${opts.id}`);
+  lines.push(`name: "${opts.name.replace(/"/g, '\\"')}"`);
+  if (opts.type) lines.push(`type: "${opts.type.replace(/"/g, '\\"')}"`);
+  if (opts.level !== undefined) lines.push(`level: ${opts.level}`);
+  if (opts.parent) lines.push(`parent: ${opts.parent}`);
+  if (opts.factors && opts.factors.length > 0) {
+    lines.push(`factors: [${opts.factors.join(', ')}]`);
+  }
+  if (opts.description) lines.push(`description: "${opts.description.replace(/"/g, '\\"')}"`);
+  if (opts.link) lines.push(`link: "${opts.link.replace(/"/g, '\\"')}"`);
+  lines.push('');
+  lines.push('# Admission record (CONTRACT.md §6) — filled by `transitrix new goal`');
+  lines.push('zone: canon');
+  lines.push(`admitted_at: "${opts.today}"`);
+  lines.push(`admitted_by: "${opts.admittedBy.replace(/"/g, '\\"')}"`);
+  lines.push('gate_checks:');
+  lines.push('  uniqueness: pass   # id not already present under canon/elements or canon/relations');
+  lines.push('  consistency: pass  # every factors: reference resolves to an existing canon id');
+  lines.push('  completeness: pass # required fields present');
+  lines.push('');
+  lines.push('# Primitive lifecycle (CONTRACT.md §7)');
+  lines.push(`valid_from: "${opts.today}"`);
+  lines.push('valid_to: null');
+  lines.push('');
+  return lines.join('\n');
+}
+
+/**
+ * Computes the envelope for a new GOAL element and renders its YAML, or
+ * returns the list of gate-check failures without writing anything.
+ * `consistency` and `uniqueness` are real checks against `opts.root`'s
+ * current canon — a failure here means the check that would have produced
+ * that `gate_checks` entry did not pass, so the file is not written rather
+ * than written with a false `pass`.
+ */
+export function scaffoldGoalElement(opts: NewGoalOptions): ScaffoldOutcome {
+  const errors: string[] = [];
+
+  if (!GOAL_ELEM_ID_RE.test(opts.id)) {
+    errors.push(`id '${opts.id}' does not match the canonical GOAL-[<middle>-]<INTEGER> grammar`);
+  }
+  if (!opts.name.trim()) {
+    errors.push('name is required');
+  }
+  if (!opts.admittedBy.trim()) {
+    errors.push(
+      'no admitted_by identity available — pass --author "<name>" or set `git config user.name`',
+    );
+  }
+
+  const existingIds = collectExistingCanonIds(opts.root);
+
+  if (errors.length === 0 && existingIds.has(opts.id)) {
+    errors.push(`gate_checks.uniqueness: id '${opts.id}' already exists in canon`);
+  }
+
+  const missingFactors = (opts.factors ?? []).filter((f) => !existingIds.has(f));
+  if (errors.length === 0 && missingFactors.length > 0) {
+    errors.push(`gate_checks.consistency: factor(s) not found in canon: ${missingFactors.join(', ')}`);
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  const relPath = ['canon', 'elements', '01_motivation', 'goals', `${opts.id}.yaml`].join('/');
+  return {
+    ok: true,
+    relPath,
+    content: renderGoalYaml(opts),
+    filled: ['zone', 'admitted_at', 'admitted_by', 'gate_checks', 'valid_from', 'valid_to'],
+  };
+}
+
+/** Writes a successful {@link scaffoldGoalElement} outcome to disk, creating
+ *  parent directories as needed. Refuses to overwrite an existing file —
+ *  the uniqueness gate check already means this should not happen for a
+ *  well-formed id, but a stray non-canon file at the same path (e.g. a
+ *  `.gitkeep`) must not be clobbered silently. */
+export function writeScaffoldedElement(root: string, outcome: Extract<ScaffoldOutcome, { ok: true }>): string {
+  const absPath = path.join(root, ...outcome.relPath.split('/'));
+  if (existsSync(absPath)) {
+    throw new Error(`refusing to overwrite existing file: ${outcome.relPath}`);
+  }
+  mkdirSync(path.dirname(absPath), { recursive: true });
+  writeFileSync(absPath, outcome.content, 'utf-8');
+  return absPath;
+}
+
+// ── CLI wiring: `transitrix new goal` ───────────────────────────────────────
+
+export interface NewGoalArgs {
+  type: 'goal' | undefined;
+  id: string | undefined;
+  name: string | undefined;
+  author: string | undefined;
+  root: string;
+  goalType: string | undefined;
+  level: number | undefined;
+  parent: string | undefined;
+  factors: string[] | undefined;
+  description: string | undefined;
+  link: string | undefined;
+  dryRun: boolean;
+  wantsHelp: boolean;
+}
+
+export function parseNewArgv(argv: string[]): NewGoalArgs {
+  const type = argv[0] === 'goal' ? 'goal' : undefined;
+  const rest = type ? argv.slice(1) : argv;
+
+  const args: NewGoalArgs = {
+    type,
+    id: undefined,
+    name: undefined,
+    author: undefined,
+    root: process.cwd(),
+    goalType: undefined,
+    level: undefined,
+    parent: undefined,
+    factors: undefined,
+    description: undefined,
+    link: undefined,
+    dryRun: false,
+    wantsHelp: false,
+  };
+
+  for (let i = 0; i < rest.length; i++) {
+    const a = rest[i];
+    if (a === '--help' || a === '-h') { args.wantsHelp = true; continue; }
+    if (a === '--dry-run') { args.dryRun = true; continue; }
+    if (a === '--id') { args.id = rest[++i]; continue; }
+    if (a.startsWith('--id=')) { args.id = a.slice('--id='.length); continue; }
+    if (a === '--name') { args.name = rest[++i]; continue; }
+    if (a.startsWith('--name=')) { args.name = a.slice('--name='.length); continue; }
+    if (a === '--author') { args.author = rest[++i]; continue; }
+    if (a.startsWith('--author=')) { args.author = a.slice('--author='.length); continue; }
+    if (a === '--root') { args.root = rest[++i]; continue; }
+    if (a.startsWith('--root=')) { args.root = a.slice('--root='.length); continue; }
+    if (a === '--type') { args.goalType = rest[++i]; continue; }
+    if (a.startsWith('--type=')) { args.goalType = a.slice('--type='.length); continue; }
+    if (a === '--level') { args.level = Number(rest[++i]); continue; }
+    if (a.startsWith('--level=')) { args.level = Number(a.slice('--level='.length)); continue; }
+    if (a === '--parent') { args.parent = rest[++i]; continue; }
+    if (a.startsWith('--parent=')) { args.parent = a.slice('--parent='.length); continue; }
+    if (a === '--factors') { args.factors = rest[++i]?.split(',').map((s) => s.trim()).filter(Boolean); continue; }
+    if (a.startsWith('--factors=')) { args.factors = a.slice('--factors='.length).split(',').map((s) => s.trim()).filter(Boolean); continue; }
+    if (a === '--description') { args.description = rest[++i]; continue; }
+    if (a.startsWith('--description=')) { args.description = a.slice('--description='.length); continue; }
+    if (a === '--link') { args.link = rest[++i]; continue; }
+    if (a.startsWith('--link=')) { args.link = a.slice('--link='.length); continue; }
+  }
+
+  return args;
+}
+
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export async function handleNewCommand(argv: string[]): Promise<void> {
+  const args = parseNewArgv(argv);
+
+  if (args.wantsHelp || !args.type) {
+    console.error('usage: transitrix new goal --id <GOAL-…> --name "<label>" [options]');
+    console.error('');
+    console.error('  Scaffolds a standalone GOAL element (canon/elements/01_motivation/goals/)');
+    console.error('  with the admission record and lifecycle envelope computed, not hand-typed');
+    console.error('  (hub epic #919).');
+    console.error('');
+    console.error('  --id <GOAL-…>        Required — canonical id (GOAL-[<middle>-]<INTEGER>).');
+    console.error('  --name "<label>"     Required — human-readable name.');
+    console.error('  --author "<name>"    Recorded as admitted_by. Default: `git config user.name`.');
+    console.error('  --root <dir>         Adopter repo root containing canon/ (default: cwd).');
+    console.error('  --type "<label>"     Goal-type label (e.g. "Strategic Goal").');
+    console.error('  --level <n>          Hierarchical level.');
+    console.error('  --parent <GOAL-…>    Parent goal id.');
+    console.error('  --factors <a,b>      Comma-separated DRIVER-… ids; each must already exist in canon.');
+    console.error('  --description "…"    One-paragraph elaboration.');
+    console.error('  --link <url>         Supplementary documentation URL.');
+    console.error('  --dry-run            Print what would be written; do not write the file.');
+    process.exit(args.wantsHelp ? 0 : 1);
+  }
+
+  if (!args.id || !args.name) {
+    console.error('transitrix new goal: --id and --name are required.');
+    process.exit(1);
+  }
+
+  const root = path.resolve(args.root);
+  const admittedBy = args.author ?? gitUserName(root);
+  if (!admittedBy) {
+    console.error('transitrix new goal: no admitted_by identity available.');
+    console.error('  Pass --author "<name>" or set `git config user.name`.');
+    process.exit(1);
+  }
+
+  const outcome = scaffoldGoalElement({
+    root,
+    id: args.id,
+    name: args.name,
+    admittedBy,
+    today: todayIso(),
+    type: args.goalType,
+    level: args.level,
+    parent: args.parent,
+    factors: args.factors,
+    description: args.description,
+    link: args.link,
+  });
+
+  if (!outcome.ok) {
+    console.error('transitrix new goal: cannot scaffold this element:');
+    outcome.errors.forEach((e) => console.error(`  • ${e}`));
+    process.exit(1);
+  }
+
+  if (args.dryRun) {
+    console.log(`Would write ${outcome.relPath}:`);
+    console.log('');
+    console.log(outcome.content);
+    return;
+  }
+
+  const absPath = writeScaffoldedElement(root, outcome);
+  console.log(`✓ wrote ${path.relative(root, absPath).replace(/\\/g, '/')}`);
+  console.log(`  filled envelope fields: ${outcome.filled.join(', ')}`);
+}

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -1,5 +1,5 @@
-// `transitrix new goal` — hub epic #919 ("Authoring a first element requires
-// only its own content — the envelope is supplied"), first cut. Scaffolds a
+// `transitrix new goal` — "authoring a first element requires only its own
+// content, the envelope is supplied" — first cut. Scaffolds a
 // standalone GOAL element file (ELEMENT_PRIMITIVES.md §7.2) with the
 // admission record (CONTRACT.md §6) and primitive lifecycle (CONTRACT.md §7)
 // computed by the tool, not hand-typed by the author.
@@ -286,8 +286,7 @@ export async function handleNewCommand(argv: string[]): Promise<void> {
     console.error('usage: transitrix new goal --id <GOAL-…> --name "<label>" [options]');
     console.error('');
     console.error('  Scaffolds a standalone GOAL element (canon/elements/01_motivation/goals/)');
-    console.error('  with the admission record and lifecycle envelope computed, not hand-typed');
-    console.error('  (hub epic #919).');
+    console.error('  with the admission record and lifecycle envelope computed, not hand-typed.');
     console.error('');
     console.error('  --id <GOAL-…>        Required — canonical id (GOAL-[<middle>-]<INTEGER>).');
     console.error('  --name "<label>"     Required — human-readable name.');

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -1,0 +1,235 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { collectExistingCanonIds, parseNewArgv, scaffoldGoalElement } from '../src/scaffold.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliPath = join(__dirname, '..', 'dist', 'cli.js');
+
+function runCli(args: string[]): { status: number; stdout: string; stderr: string } {
+  const r = spawnSync(process.execPath, [cliPath, ...args], { encoding: 'utf8' });
+  return { status: r.status ?? 1, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+
+function makeRepo(): string {
+  return mkdtempSync(join(tmpdir(), 'tx-scaffold-'));
+}
+
+function writeCanonElement(root: string, relPath: string, id: string): void {
+  const abs = join(root, 'canon', 'elements', relPath);
+  mkdirSync(dirname(abs), { recursive: true });
+  writeFileSync(abs, `notation: driver\nid: ${id}\nname: "Existing"\n`, 'utf-8');
+}
+
+// ── parseNewArgv ─────────────────────────────────────────────────────────
+
+describe('parseNewArgv', () => {
+  it('recognises the goal subtype', () => {
+    expect(parseNewArgv(['goal']).type).toBe('goal');
+    expect(parseNewArgv(['nonsense']).type).toBeUndefined();
+  });
+
+  it('parses --id/--name/--author both as separate and = forms', () => {
+    const r = parseNewArgv(['goal', '--id', 'GOAL-X-1', '--name=Grow revenue', '--author', 'a.b']);
+    expect(r.id).toBe('GOAL-X-1');
+    expect(r.name).toBe('Grow revenue');
+    expect(r.author).toBe('a.b');
+  });
+
+  it('parses --factors as a comma-split list', () => {
+    const r = parseNewArgv(['goal', '--factors', 'DRIVER-A-1, DRIVER-B-2']);
+    expect(r.factors).toEqual(['DRIVER-A-1', 'DRIVER-B-2']);
+  });
+
+  it('parses --level as a number', () => {
+    expect(parseNewArgv(['goal', '--level', '2']).level).toBe(2);
+  });
+
+  it('parses --dry-run and --help', () => {
+    expect(parseNewArgv(['goal', '--dry-run']).dryRun).toBe(true);
+    expect(parseNewArgv(['goal', '--help']).wantsHelp).toBe(true);
+  });
+});
+
+// ── scaffoldGoalElement ──────────────────────────────────────────────────
+
+describe('scaffoldGoalElement', () => {
+  it('computes the full envelope for a minimal valid goal', () => {
+    const root = makeRepo();
+    const outcome = scaffoldGoalElement({
+      root,
+      id: 'GOAL-REVENUE-1',
+      name: 'Grow revenue',
+      admittedBy: 'v.korobeinikov',
+      today: '2026-08-02',
+    });
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+    expect(outcome.relPath).toBe('canon/elements/01_motivation/goals/GOAL-REVENUE-1.yaml');
+    expect(outcome.content).toContain('zone: canon');
+    expect(outcome.content).toContain('admitted_at: "2026-08-02"');
+    expect(outcome.content).toContain('admitted_by: "v.korobeinikov"');
+    expect(outcome.content).toContain('valid_from: "2026-08-02"');
+    expect(outcome.content).toContain('valid_to: null');
+    expect(outcome.content).toContain('uniqueness: pass');
+    expect(outcome.filled).toEqual(
+      expect.arrayContaining(['zone', 'admitted_at', 'admitted_by', 'gate_checks', 'valid_from', 'valid_to']),
+    );
+  });
+
+  it('rejects an id that does not match the GOAL grammar', () => {
+    const root = makeRepo();
+    const outcome = scaffoldGoalElement({
+      root,
+      id: 'NOTAGOAL-1',
+      name: 'x',
+      admittedBy: 'a.b',
+      today: '2026-08-02',
+    });
+    expect(outcome.ok).toBe(false);
+    if (outcome.ok) return;
+    expect(outcome.errors.join(' ')).toMatch(/GOAL-\[<middle>-]<INTEGER>/);
+  });
+
+  it('rejects a missing name', () => {
+    const root = makeRepo();
+    const outcome = scaffoldGoalElement({ root, id: 'GOAL-X-1', name: '  ', admittedBy: 'a.b', today: '2026-08-02' });
+    expect(outcome.ok).toBe(false);
+    if (outcome.ok) return;
+    expect(outcome.errors.join(' ')).toMatch(/name is required/);
+  });
+
+  it('rejects a missing admittedBy identity', () => {
+    const root = makeRepo();
+    const outcome = scaffoldGoalElement({ root, id: 'GOAL-X-1', name: 'x', admittedBy: '', today: '2026-08-02' });
+    expect(outcome.ok).toBe(false);
+    if (outcome.ok) return;
+    expect(outcome.errors.join(' ')).toMatch(/admitted_by identity/);
+  });
+
+  it('gate_checks.uniqueness fails when the id already exists in canon', () => {
+    const root = makeRepo();
+    writeCanonElement(root, '01_motivation/goals/GOAL-DUP-1.yaml', 'GOAL-DUP-1');
+    const outcome = scaffoldGoalElement({ root, id: 'GOAL-DUP-1', name: 'x', admittedBy: 'a.b', today: '2026-08-02' });
+    expect(outcome.ok).toBe(false);
+    if (outcome.ok) return;
+    expect(outcome.errors.join(' ')).toMatch(/uniqueness/);
+  });
+
+  it('gate_checks.consistency fails when a referenced factor does not exist in canon', () => {
+    const root = makeRepo();
+    const outcome = scaffoldGoalElement({
+      root,
+      id: 'GOAL-X-1',
+      name: 'x',
+      admittedBy: 'a.b',
+      today: '2026-08-02',
+      factors: ['DRIVER-MISSING-1'],
+    });
+    expect(outcome.ok).toBe(false);
+    if (outcome.ok) return;
+    expect(outcome.errors.join(' ')).toMatch(/consistency.*DRIVER-MISSING-1/);
+  });
+
+  it('gate_checks.consistency passes when every referenced factor exists in canon', () => {
+    const root = makeRepo();
+    writeCanonElement(root, '01_motivation/factors/DRIVER-A-1.yaml', 'DRIVER-A-1');
+    const outcome = scaffoldGoalElement({
+      root,
+      id: 'GOAL-X-1',
+      name: 'x',
+      admittedBy: 'a.b',
+      today: '2026-08-02',
+      factors: ['DRIVER-A-1'],
+    });
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+    expect(outcome.content).toContain('factors: [DRIVER-A-1]');
+  });
+});
+
+describe('collectExistingCanonIds', () => {
+  it('returns an empty set when canon/ does not exist', () => {
+    const root = makeRepo();
+    expect(collectExistingCanonIds(root).size).toBe(0);
+  });
+
+  it('collects ids from both elements/ and relations/', () => {
+    const root = makeRepo();
+    writeCanonElement(root, '01_motivation/goals/GOAL-A-1.yaml', 'GOAL-A-1');
+    const relAbs = join(root, 'canon', 'relations', 'REL-A-1.yaml');
+    mkdirSync(dirname(relAbs), { recursive: true });
+    writeFileSync(relAbs, 'notation: relation\nid: REL-A-1\ntype: goal_parent\n', 'utf-8');
+    const ids = collectExistingCanonIds(root);
+    expect(ids.has('GOAL-A-1')).toBe(true);
+    expect(ids.has('REL-A-1')).toBe(true);
+  });
+});
+
+// ── CLI integration ──────────────────────────────────────────────────────
+
+describe('transitrix new goal (CLI)', () => {
+  it('writes a complete element file and reports the filled fields', () => {
+    const root = makeRepo();
+    const { status, stdout } = runCli([
+      'new', 'goal',
+      '--id', 'GOAL-REVENUE-1',
+      '--name', 'Grow revenue',
+      '--author', 'a.b',
+      '--root', root,
+    ]);
+    expect(status).toBe(0);
+    expect(stdout).toMatch(/wrote canon\/elements\/01_motivation\/goals\/GOAL-REVENUE-1\.yaml/);
+    const written = readFileSync(
+      join(root, 'canon', 'elements', '01_motivation', 'goals', 'GOAL-REVENUE-1.yaml'),
+      'utf-8',
+    );
+    expect(written).toContain('admitted_by: "a.b"');
+  });
+
+  it('--dry-run prints the content without writing', () => {
+    const root = makeRepo();
+    const { status, stdout } = runCli([
+      'new', 'goal',
+      '--id', 'GOAL-PREVIEW-1',
+      '--name', 'Preview only',
+      '--author', 'a.b',
+      '--root', root,
+      '--dry-run',
+    ]);
+    expect(status).toBe(0);
+    expect(stdout).toMatch(/Would write/);
+    expect(existsSync(join(root, 'canon', 'elements', '01_motivation', 'goals', 'GOAL-PREVIEW-1.yaml'))).toBe(false);
+  });
+
+  it('exits 1 and reports gate-check failures without writing', () => {
+    const root = makeRepo();
+    writeCanonElement(root, '01_motivation/goals/GOAL-DUP-1.yaml', 'GOAL-DUP-1');
+    const { status, stderr } = runCli([
+      'new', 'goal',
+      '--id', 'GOAL-DUP-1',
+      '--name', 'Duplicate',
+      '--author', 'a.b',
+      '--root', root,
+    ]);
+    expect(status).toBe(1);
+    expect(stderr).toMatch(/uniqueness/);
+  });
+
+  it('exits 1 when --id/--name are missing', () => {
+    const root = makeRepo();
+    const { status, stderr } = runCli(['new', 'goal', '--root', root]);
+    expect(status).toBe(1);
+    expect(stderr).toMatch(/--id and --name are required/);
+  });
+
+  it('--help exits 0', () => {
+    const { status, stderr } = runCli(['new', '--help']);
+    expect(status).toBe(0);
+    expect(stderr).toMatch(/transitrix new goal/);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `transitrix new goal --id <GOAL-…> --name "<label>"` — scaffolds a standalone GOAL element (`canon/elements/01_motivation/goals/`) with the admission record (CONTRACT.md §6) and primitive lifecycle (CONTRACT.md §7) **computed by the tool**, not hand-typed: `zone`, `admitted_at`, `admitted_by`, `gate_checks`, `valid_from`, `valid_to`. The author supplies only the element's own content — `id`, `name`, and optional per-TYPE fields (`type`, `level`, `parent`, `factors`, `description`, `link`).
- `gate_checks` reflects checks that actually ran, not a constant `pass`: `uniqueness` scans `canon/elements/**` + `canon/relations/**` for an id collision; `consistency` verifies every `factors:` reference resolves to an existing canon id. Either failing aborts before writing — never a false `pass`.
- `admitted_by` is a **person handle** (`--author`, else `git config user.name`), never a tool id — this keeps `admission_state` / `reviewer_authority` at their human-authored defaults (absent ⇒ `active` ⇒ `expert_confirmed`) per CONTRACT.md §6.2, since this command is run by a human authoring their own canon, not an automated harvest.
- `--dry-run` previews the file content without writing (same UX shape as `migrate --dry-run`).

## Scope — first cut

This is a first cut of a broader "authoring a first element requires only its own content" capability. This PR covers **the CLI creation path, GOAL type only**.

Explicitly deferred, not silently dropped:
1. **Other standalone TYPEs** (`DRIVER`, `CONSTRAINT`, `REQUIREMENT`, …) — same mechanism, not yet wired for each. GOAL was chosen first because it's the most worked-example-rich TYPE with no required per-TYPE fields, keeping the first cut bounded.
2. **The VS Code extension "new element" path** — no creation command of any kind exists in the extension today (confirmed by search); this PR only adds the CLI path.
3. **`validate --fix` for an already-hand-authored file missing envelope fields** — this repo has no comment-preserving YAML writer (only `js-yaml` load/dump everywhere), so a naive parse-mutate-dump round-trip on an *existing* file would silently strip every header comment real canon files carry (see `organizations/acme_corp/canon/elements/**`). This PR sidesteps the problem by only ever generating a **brand-new** file (hand-rendered text, not a round-trip), which has no comments to lose. Repairing an existing file needs its own design decision (targeted text insertion vs. a new comment-preserving YAML dependency) — flagged separately rather than guessed at here.
4. **Onboarding-skill / first-session-guide docs** — the CLI's own `--help` text is the only documentation surface touched in this PR.

## Test plan
- [x] `npx vitest run tests/scaffold.test.ts` — 19/19 passing (unit tests for `scaffoldGoalElement`/`parseNewArgv`/`collectExistingCanonIds`, CLI integration tests via `dist/cli.js`)
- [x] `npx vitest run` — full suite green except 3 pre-existing failures in `cli-migrate.test.ts` (0.5→0.6 recipe fixtures, environment-dependent on the sibling methodology repo's recipe state) — confirmed identical failures on `main` via `git stash`, unrelated to this change
- [x] `npm run compile` (`tsc --noEmit` after building `packages/diagrams`) — clean
- [x] `node scripts/ci-hygiene-hashrefs.mjs` — clean across all tracked files