### PR TITLE
fix(hygiene): scan commit messages for work-item references

### DIFF
--- a/scripts/ci-hygiene-check.mjs
+++ b/scripts/ci-hygiene-check.mjs
@@ -8,6 +8,8 @@
 
 import { execSync } from 'node:child_process';
 
+import { parseCommitLog } from './hygiene-patterns.mjs';
+
 const blocklist = process.env.HYGIENE_BLOCKLIST;
 if (!blocklist || blocklist.trim() === '') {
   console.warn('[hygiene] HYGIENE_BLOCKLIST secret is not set — skipping check.');
@@ -115,6 +117,22 @@ for (const line of diff.split('\n')) {
   }
 }
 
+// Commit messages over the PR's commit range — a diff pass sees added file
+// content, never the message that landed the commit.
+let log = '';
+try {
+  log = execSync(`git log --format=%H%x1f%B%x1e ${baseSha}..${headSha}`, {
+    encoding: 'utf8',
+    maxBuffer: 128 * 1024 * 1024,
+  });
+} catch (err) {
+  console.error('[hygiene] failed to read commit messages:', err.message);
+  process.exit(2);
+}
+for (const { sha, body } of parseCommitLog(log)) {
+  if (pattern.test(body)) hits.push({ file: `commit ${sha.slice(0, 12)}`, line: null });
+}
+
 const titleHit = pattern.test(process.env.PR_TITLE || '');
 const bodyHit = pattern.test(process.env.PR_BODY || '');
 
@@ -128,6 +146,6 @@ console.error('[hygiene] (matched terms are intentionally not printed — repeat
 if (titleHit) console.error('  - PR title contains a match');
 if (bodyHit) console.error('  - PR body contains a match');
 for (const h of hits) {
-  console.error(`  - ${h.file}:${h.line}`);
+  console.error(`  - ${h.file}${h.line ? ':' + h.line : ''}`);
 }
 process.exit(1);

--- a/scripts/ci-hygiene-hashrefs.mjs
+++ b/scripts/ci-hygiene-hashrefs.mjs
@@ -34,7 +34,7 @@
 import { execSync } from 'node:child_process';
 import { readFileSync, statSync } from 'node:fs';
 
-import { HASHREF, WORKITEM } from './hygiene-patterns.mjs';
+import { HASHREF, WORKITEM, parseCommitLog } from './hygiene-patterns.mjs';
 
 const SKIP = new Set([
   'scripts/ci-hygiene-check.mjs',
@@ -110,7 +110,26 @@ for (const [label, value] of [
   if (hit) problems.push(`${label} — ${hit.join(', ')}`);
 }
 
-// 3) Full tree — the diff pass cannot see what already landed.
+// 3) Commit messages over the PR's commit range — a diff pass sees added file
+// content, never the message that landed the commit.
+if (baseSha && headSha) {
+  let log = '';
+  try {
+    log = execSync(`git log --format=%H%x1f%B%x1e ${baseSha}..${headSha}`, {
+      encoding: 'utf8',
+      maxBuffer: 128 * 1024 * 1024,
+    });
+  } catch (err) {
+    console.error('[hygiene-hashrefs] failed to read commit messages:', err.message);
+    process.exit(2);
+  }
+  for (const { sha, body } of parseCommitLog(log)) {
+    const hit = tokens(body, WORKITEM);
+    if (hit) problems.push(`commit ${sha.slice(0, 12)} — ${hit.join(', ')}`);
+  }
+}
+
+// 4) Full tree — the diff pass cannot see what already landed.
 let files = [];
 try {
   files = execSync('git ls-files -z', { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 })

--- a/scripts/hygiene-patterns.mjs
+++ b/scripts/hygiene-patterns.mjs
@@ -20,3 +20,18 @@ export const HASHREF = /\b(?:task|epic|hub|issue)s?[\s:]+#\d+|\bhub\s+(?:task|ep
 // HASHREF plus the neutral HUB-<number> form — forbidden in committed content
 // (diff + full tree).
 export const WORKITEM = /\bHUB-\d+|\b(?:task|epic|hub|issue)s?[\s:]+#\d+|\bhub\s+(?:task|epic|issue)s?\s+#?\d+/gi;
+
+// Parses `git log --format=%H%x1f%B%x1e <range>` output into per-commit
+// records. A commit message is text a diff pass never sees — the delimiters
+// (unit/record separators) survive arbitrary commit-message content that a
+// plain newline split would not.
+export function parseCommitLog(raw) {
+  return String(raw ?? '')
+    .split('\x1e')
+    .map((entry) => entry.replace(/^\n/, '').trim())
+    .filter(Boolean)
+    .map((entry) => {
+      const sep = entry.indexOf('\x1f');
+      return { sha: entry.slice(0, sep), body: entry.slice(sep + 1) };
+    });
+}

--- a/tests/ci-hygiene-hashrefs.test.ts
+++ b/tests/ci-hygiene-hashrefs.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { HASHREF, WORKITEM } from '../scripts/hygiene-patterns.mjs';
+import { HASHREF, WORKITEM, parseCommitLog } from '../scripts/hygiene-patterns.mjs';
 
 // Fixed sample strings only — never a real scanned line. This file is in the
 // guard's own SKIP list (scripts/ci-hygiene-hashrefs.mjs), so these fixtures
@@ -29,5 +29,25 @@ describe('hygiene work-item reference patterns', () => {
     expect(matches(HASHREF, 'HUB-905'), 'HUB-905 via HASHREF').toBe(false);
     expect(matches(HASHREF, 'issue #7'), 'issue #7 via HASHREF').toBe(true);
     expect(matches(HASHREF, 'hub task 217'), 'hub task 217 via HASHREF').toBe(true);
+  });
+});
+
+describe('parseCommitLog', () => {
+  it('splits a `git log --format=%H%x1f%B%x1e` stream into per-commit records', () => {
+    const raw = 'aaa111\x1fSubject line\n\nBody text\x1e\nbbb222\x1fAnother subject\x1e';
+    expect(parseCommitLog(raw)).toEqual([
+      { sha: 'aaa111', body: 'Subject line\n\nBody text' },
+      { sha: 'bbb222', body: 'Another subject' },
+    ]);
+  });
+
+  it('returns an empty list for an empty range', () => {
+    expect(parseCommitLog('')).toEqual([]);
+  });
+
+  it('finds a leaked work-item reference inside a multi-line commit body', () => {
+    const raw = 'ccc333\x1fSubject\n\nFirst cut of hub epic #123 (proj:example)\x1e';
+    const [commit] = parseCommitLog(raw);
+    expect(matches(WORKITEM, commit.body)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- The work-item-reference guard (`scripts/ci-hygiene-hashrefs.mjs`) and the secret-backed blocklist guard (`scripts/ci-hygiene-check.mjs`) now also scan commit messages over a PR's commit range, alongside the diff, PR metadata, and full tree they already cover.
- Shared commit-log parsing extracted to `scripts/hygiene-patterns.mjs` (`parseCommitLog`) so both guards use one implementation and it has its own unit coverage.

## Test plan
- [x] `node --check` on all three edited scripts
- [x] `npm run test:core` — no new failures beyond the pre-existing unrelated ones on unmodified `main`
- [x] Verified against real commit ranges: correctly flags a known-bad range, passes clean on an unrelated range