### PR TITLE
docs(acme-corp): worked example references canonical DGCA notation key

### DIFF
--- a/organizations/acme_corp/canon/elements/01_motivation/factors/DRIVER-EU-REG-1.yaml
+++ b/organizations/acme_corp/canon/elements/01_motivation/factors/DRIVER-EU-REG-1.yaml
@@ -1,7 +1,7 @@
 # Worked example — DRIVER element primitive (external driver, PESTLE: legal).
 # Schema: notations/ELEMENT_PRIMITIVES.md §7.1 + envelope §3.
-# Definition home for this driver; referenced inline from the FGCA view
-# (canon/views/fgca/) which is the authoring surface.
+# Definition home for this driver; referenced inline from the DGCA view
+# (canon/views/dgca/) which is the authoring surface.
 #
 # Neutral Driver — the standing external regulatory force, not a finding about
 # its current state. Dated findings about this driver (e.g. a closing window,

--- a/organizations/acme_corp/canon/elements/01_motivation/goals/GOAL-EU-1.yaml
+++ b/organizations/acme_corp/canon/elements/01_motivation/goals/GOAL-EU-1.yaml
@@ -1,6 +1,6 @@
 # Worked example — GOAL element primitive.
 # Schema: notations/ELEMENT_PRIMITIVES.md §7.2 + envelope §3.
-# Shared element: defined here, referenced from the goals-tree and FGCA views.
+# Shared element: defined here, referenced from the goals-tree and DGCA views.
 # The goal's parent (GOAL-REVENUE-1) is a time-aware relation (goal_parent)
 # carried inline by the goals-tree view in v0.x; not stored on this element
 # file. See ELEMENT_PRIMITIVES.md §7.2 + notations/elements/17-relations.md §3.

--- a/organizations/acme_corp/canon/elements/05_implementation/actions/ACTION-CRM-EU-1.yaml
+++ b/organizations/acme_corp/canon/elements/05_implementation/actions/ACTION-CRM-EU-1.yaml
@@ -1,7 +1,7 @@
 # Worked example — ACTION element primitive (Work Package).
 # Schema: notations/ELEMENT_PRIMITIVES.md §7.4 + envelope §3.
 # ArchiMate Implementation & Migration layer (05_implementation).
-# Arranged by the FGCA view (canon/views/fgca/).
+# Arranged by the DGCA view (canon/views/dgca/).
 
 notation: action
 id: ACTION-CRM-EU-1

--- a/organizations/acme_corp/canon/elements/05_implementation/changes/CHANGE-EU-CRM-1.yaml
+++ b/organizations/acme_corp/canon/elements/05_implementation/changes/CHANGE-EU-CRM-1.yaml
@@ -1,7 +1,7 @@
 # Worked example — CHANGE element primitive (BDN Gap).
 # Schema: notations/ELEMENT_PRIMITIVES.md §7.3 + envelope §3.
 # ArchiMate Implementation & Migration layer (05_implementation).
-# Arranged by the FGCA view (canon/views/fgca/).
+# Arranged by the DGCA view (canon/views/dgca/).
 
 notation: change
 id: CHANGE-EU-CRM-1

--- a/organizations/acme_corp/canon/views/action-card/eu-gdpr-remediation.action-card.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/action-card/eu-gdpr-remediation.action-card.transitrix.yaml
@@ -1,7 +1,7 @@
 # Single-project narrative card for the GDPR remediation programme.
 # Notation spec: notations/views/18-action-card.md. Binds to a project Action
 # and adds narrative milestones; the motivation chain and child actions are
-# pulled by reference from the FGCA and Action documents, not duplicated here.
+# pulled by reference from the DGCA and Action documents, not duplicated here.
 
 notation: action-card
 spec_version: "0.1"

--- a/organizations/acme_corp/tools/dsm-demo-seed.sql
+++ b/organizations/acme_corp/tools/dsm-demo-seed.sql
@@ -1,4 +1,4 @@
--- DSM demo seed — acme-corp FGCA example
+-- DSM demo seed — acme-corp DGCA example
 -- Populates a running DSM instance with the acme-corp Factor → Goal → Change → Activity chain.
 --
 -- Usage:


### PR DESCRIPTION
## Summary
- fgca is a retired notation key; the acme-corp worked example (`organizations/acme_corp/`) still referenced it in comments and a doc-directory path.
- Switched every reference (element comments, a view comment, a demo-seed script header) to the canonical `dgca` key and the corresponding `canon/views/dgca/` path — no semantic YAML fields touched, naming only.

## Test plan
- [x] `grep -ri fgca organizations/` returns nothing
- [x] `npx tsx src/cli.ts validate --scope=repo` passes (repo-scope validation green)
- [x] Diff limited to comment/header text — no `notation:`/`id:` field changes