### PR TITLE
feat(validators): versioned-attribute sidecar (VERSIONED-001..005)

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -181,6 +181,56 @@ per CONTRACT.md §7) are net new — this notation's own schema
 author `valid_from`/`valid_to` inline per §7 regardless, so the checks read
 them directly off the raw untyped node.
 
+### Versioned-attribute sidecar rules (`VERSIONED-00x`)
+
+CONTRACT.md §9's versioned-attribute sidecar (`<primitive_id>.history.yaml`,
+co-located under `canon/elements/**`) — `packages/diagrams/src/
+versioned-attribute/` (the parse/resolve/validate substrate, notation-agnostic)
+plus `packages/diagrams/src/repo-validate/check-versioned-attributes.ts` (the
+repo-scope wiring).
+
+| Rule | Severity | Checks |
+|---|---|---|
+| `VERSIONED-001` | error | A sidecar's `target` does not resolve to an admitted primitive in this model. |
+| `VERSIONED-002` | error | Two or more entries within one attribute's array carry the same `valid_from`. |
+| `VERSIONED-003` | warning | An attribute's array is not sorted by `valid_from` ascending. |
+| `VERSIONED-004` | error | A field declared `time_varying` is present inline on its primitive instead of only in the sidecar. |
+| `VERSIONED-005` | error | A version entry's `valid_from` falls outside `[target.valid_from, target.valid_to]`. |
+
+**`VERSIONED-004`'s field list is deliberately narrower than CONTRACT.md
+§9.4's full candidate table.** It enforces only the fields already
+`time_varying` on methodology's *currently-merged*
+`notations/views/05-capability-map.md`: capability `current_maturity`,
+`owner_role`, `target_date`. `target_maturity` (capability) and `maturity`
+(application) become `time_varying` only once methodology PR #425 (the
+2026-08-02 maturity ADR's remaining half) merges — enforcing them today would
+fail `organizations/acme_corp`'s `CAPABILITY-V1.yaml`, which correctly still
+carries `target_maturity` inline under the spec merged today. Extend
+`TIME_VARYING_FIELDS` in `check-versioned-attributes.ts` once #425 lands, and
+add the applications-catalogue field list at the same time (out of scope
+here — its `maturity` field isn't declared `time_varying` at the CONTRACT.md
+level until that PR merges).
+
+**Not covered here: the native `capability-map` notation's own single-file
+view-document form** (`packages/diagrams/src/capability-map/{types,
+validate}.ts`, the `--scope=file`/VS Code "cards"/"tree" preview). Its worked
+examples (`organizations/acme_corp/canon/views/capabilities/
+compliance-domain.capability-map.transitrix.yaml`, `.templates/
+capability-map_template.yaml`) and its `CMAP-003/005` validator all still
+require `current_maturity` inline on the view document's own capability
+nodes — which is itself inconsistent with CONTRACT.md §9's "not inline on the
+capability-map view **or** on the element file" wording, predating this
+epic. Unlike the DSM-migration `CAPABILITY-V1.yaml` + `.history.yaml` pairing
+above, this notation's inline tree carries no separate element file to hold
+a co-located sidecar, and its renderer (`render-capability-tree.ts`) reads
+`current_maturity` directly off each node for the maturity badge with no
+sidecar-resolution step. Reconciling it needs a design decision — does this
+self-contained preview format grow sidecar resolution (requiring the VS Code
+host to read `<id>.history.yaml` from elsewhere in the workspace), or does it
+stay exempt from §9 as a rendering convenience distinct from "the primitive"
+— not guessed at here. Flagged rather than silently left broken or silently
+changed.
+
 ### Compliance suite (`--scope=repo`, #518)
 
 Repo-scope validation also sweeps the compliance notation surface with the same

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/cli",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "type": "module",
   "description": "Transitrix CLI — compile, validate, and report on Transitrix diagrams (BPMN, Goals, DGCA, …) from any shell or CI pipeline.",
   "license": "MIT",

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",

--- a/packages/diagrams/src/repo-validate/__tests__/check-versioned-attributes.test.ts
+++ b/packages/diagrams/src/repo-validate/__tests__/check-versioned-attributes.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest';
+import { validateRepoModel } from '../validate-repo.js';
+import type { RepoDoc, RepoModelInput } from '../types.js';
+
+function el(path: string, data: Record<string, unknown> | null): RepoDoc {
+  return { path, data };
+}
+
+const CAPABILITY_PATH = 'canon/elements/02_business/capabilities/CAPABILITY-V1.yaml';
+const SIDECAR_PATH = 'canon/elements/02_business/capabilities/CAPABILITY-V1.history.yaml';
+
+function capability(overrides: Record<string, unknown> = {}): RepoDoc {
+  return el(CAPABILITY_PATH, {
+    notation: 'capability',
+    id: 'CAPABILITY-V1',
+    name: 'Order Management',
+    valid_from: '2024-01-01',
+    valid_to: null,
+    ...overrides,
+  });
+}
+
+function sidecar(attributeVersions: Record<string, unknown>): RepoDoc {
+  return el(SIDECAR_PATH, { target: 'CAPABILITY-V1', attribute_versions: attributeVersions });
+}
+
+function model(elements: RepoDoc[]): RepoModelInput {
+  return { elements, relations: [] };
+}
+
+describe('checkVersionedAttributes — VERSIONED-004 (inline time_varying field)', () => {
+  it('flags current_maturity present inline on a capability element', () => {
+    const findings = validateRepoModel(model([capability({ current_maturity: 3 })]));
+    expect(findings.map((f) => f.ruleId)).toContain('VERSIONED-004');
+    expect(findings[0].message).toContain('current_maturity');
+  });
+
+  it('flags owner_role and target_date inline the same way', () => {
+    const findings = validateRepoModel(model([capability({ owner_role: 'ROLE-OPS-1', target_date: '2027-01-01' })]));
+    const flagged = findings.filter((f) => f.ruleId === 'VERSIONED-004').map((f) => f.message);
+    expect(flagged.some((m) => m.includes('owner_role'))).toBe(true);
+    expect(flagged.some((m) => m.includes('target_date'))).toBe(true);
+  });
+
+  it('does not flag target_maturity — not yet time_varying on the merged spec', () => {
+    const findings = validateRepoModel(model([capability({ target_maturity: 3 })]));
+    expect(findings.filter((f) => f.ruleId === 'VERSIONED-004')).toEqual([]);
+  });
+
+  it('produces no findings for a capability with no inline time_varying fields', () => {
+    expect(validateRepoModel(model([capability()]))).toEqual([]);
+  });
+
+  it('only applies the capability field list to capability-notation elements', () => {
+    const findings = validateRepoModel(
+      model([el('canon/elements/03_application/applications/APPLICATION-OMS-1.yaml', {
+        notation: 'application',
+        id: 'APPLICATION-OMS-1',
+        name: 'OMS',
+        current_maturity: 3,
+      })]),
+    );
+    expect(findings.filter((f) => f.ruleId === 'VERSIONED-004')).toEqual([]);
+  });
+});
+
+describe('checkVersionedAttributes — VERSIONED-001 (sidecar target resolution)', () => {
+  it('flags a sidecar whose target does not resolve to an admitted primitive', () => {
+    const findings = validateRepoModel(model([sidecar({ current_maturity: [{ valid_from: '2024-01-01', value: 1 }] })]));
+    expect(findings.map((f) => f.ruleId)).toContain('VERSIONED-001');
+  });
+
+  it('does not flag a sidecar whose target resolves', () => {
+    const findings = validateRepoModel(
+      model([capability(), sidecar({ current_maturity: [{ valid_from: '2024-01-01', value: 1 }] })]),
+    );
+    expect(findings).toEqual([]);
+  });
+});
+
+describe('checkVersionedAttributes — VERSIONED-002/003/005 (sidecar array shape)', () => {
+  it('flags a duplicate valid_from within one attribute', () => {
+    const findings = validateRepoModel(
+      model([
+        capability(),
+        sidecar({
+          current_maturity: [
+            { valid_from: '2024-01-01', value: 1 },
+            { valid_from: '2024-01-01', value: 2 },
+          ],
+        }),
+      ]),
+    );
+    expect(findings.map((f) => f.ruleId)).toContain('VERSIONED-002');
+  });
+
+  it('warns (not errors) on an unsorted attribute array', () => {
+    const findings = validateRepoModel(
+      model([
+        capability(),
+        sidecar({
+          current_maturity: [
+            { valid_from: '2025-01-01', value: 2 },
+            { valid_from: '2024-01-01', value: 1 },
+          ],
+        }),
+      ]),
+    );
+    const f = findings.find((x) => x.ruleId === 'VERSIONED-003');
+    expect(f?.severity).toBe('warning');
+  });
+
+  it('flags an entry dated before the target primitive existed', () => {
+    const findings = validateRepoModel(
+      model([
+        capability({ valid_from: '2024-01-01' }),
+        sidecar({ current_maturity: [{ valid_from: '2020-01-01', value: 1 }] }),
+      ]),
+    );
+    expect(findings.map((f) => f.ruleId)).toContain('VERSIONED-005');
+  });
+
+  it('a still-open primitive (valid_to: null) never bounds the upper end', () => {
+    const findings = validateRepoModel(
+      model([
+        capability({ valid_from: '2024-01-01', valid_to: null }),
+        sidecar({ current_maturity: [{ valid_from: '2099-01-01', value: 1 }] }),
+      ]),
+    );
+    expect(findings.filter((f) => f.ruleId === 'VERSIONED-005')).toEqual([]);
+  });
+});
+
+describe('checkVersionedAttributes — acme_corp-shaped worked example stays clean', () => {
+  it('the CAPABILITY-V1 + sidecar pairing from organizations/acme_corp produces zero findings', () => {
+    const findings = validateRepoModel(
+      model([
+        capability({ target_maturity: 3, valid_from: '2024-01-01', valid_to: null }),
+        sidecar({
+          current_maturity: [
+            { valid_from: '2024-01-01', value: 1 },
+            { valid_from: '2025-06-01', value: 2 },
+            { valid_from: '2026-09-15', value: 3 },
+          ],
+          owner_role: [
+            { valid_from: '2024-01-01', value: 'ROLE-OPS-1' },
+            { valid_from: '2026-07-01', value: 'ROLE-OPS-2' },
+          ],
+          target_date: [
+            { valid_from: '2024-01-01', value: '2027-06-30' },
+            { valid_from: '2026-04-01', value: '2026-12-31' },
+          ],
+        }),
+      ]),
+    );
+    expect(findings).toEqual([]);
+  });
+});

--- a/packages/diagrams/src/repo-validate/check-versioned-attributes.ts
+++ b/packages/diagrams/src/repo-validate/check-versioned-attributes.ts
@@ -1,0 +1,113 @@
+// Versioned-attribute sidecar checks (CONTRACT.md §9) — `VERSIONED-001..005`.
+//
+// A sidecar is any doc under `canon/elements/**` shaped like one (`target` +
+// `attribute_versions`, no `id` — same "no id -> not an element" convention
+// `docId` already uses to skip these docs everywhere else in this file's
+// sibling checks). Both halves of §9.3 live here:
+//   - VERSIONED-001 — a sidecar's `target` must resolve to an admitted
+//     primitive in this same model.
+//   - VERSIONED-002/003/005 — the sidecar's own array shape, delegated to
+//     the shared `../versioned-attribute` module (needs VERSIONED-005's
+//     bound: the target's own `valid_from`/`valid_to`, read from the
+//     resolved target doc).
+//   - VERSIONED-004 — a field declared `time_varying` present inline on its
+//     primitive, instead of only in the sidecar.
+//
+// `TIME_VARYING_FIELDS` is deliberately narrower than the full candidate
+// list in CONTRACT.md §9.4: it only enforces fields already `time_varying`
+// on methodology's *currently-merged* `notations/views/05-capability-map.md`
+// (`current_maturity`, `owner_role`, `target_date`). `target_maturity`
+// (capability) and `maturity` (application) become time_varying only once
+// methodology PR #425 (the other half of the 2026-08-02 maturity ADR)
+// merges — enforcing VERSIONED-004 on those now would fail the acme_corp
+// worked example (`CAPABILITY-V1.yaml` still carries `target_maturity`
+// inline, correctly, under the spec merged today) against a spec that isn't
+// canon yet. Extend this table once #425 lands.
+
+import { parseSidecar, validateSidecar } from '../versioned-attribute/index.js';
+import { docId } from './validate-repo.js';
+import type { RepoDoc, RepoFinding, RepoModelInput } from './types.js';
+
+const PScope: RepoFinding['scope'] = 'repo';
+
+const TIME_VARYING_FIELDS: Record<string, string[]> = {
+  capability: ['current_maturity', 'owner_role', 'target_date'],
+};
+
+function readString(data: Record<string, unknown>, key: string): string | undefined {
+  const v = data[key];
+  return typeof v === 'string' && v.length > 0 ? v : undefined;
+}
+
+/** VERSIONED-004 — a time_varying field present inline on its primitive. */
+function checkInlineTimeVarying(elements: RepoDoc[], findings: RepoFinding[]): void {
+  for (const doc of elements) {
+    if (!doc.data) continue;
+    const id = docId(doc);
+    if (!id) continue; // sidecars carry no id — not a primitive
+    const notation = doc.data['notation'];
+    if (typeof notation !== 'string') continue;
+    const fields = TIME_VARYING_FIELDS[notation];
+    if (!fields) continue;
+
+    for (const field of fields) {
+      if (doc.data[field] !== undefined) {
+        findings.push({
+          scope: PScope,
+          id,
+          ruleId: 'VERSIONED-004',
+          message:
+            `VERSIONED-004: '${id}' declares '${field}' inline; it is time_varying and belongs in ` +
+            `the sidecar '${id}.history.yaml' (CONTRACT.md §9), not on the primitive.`,
+        });
+      }
+    }
+  }
+}
+
+/** VERSIONED-001/002/003/005 — every sidecar doc found under `canon/elements/**`. */
+function checkSidecars(elements: RepoDoc[], findings: RepoFinding[]): void {
+  const elementById = new Map<string, RepoDoc>();
+  for (const doc of elements) {
+    const id = docId(doc);
+    if (id) elementById.set(id, doc);
+  }
+
+  for (const doc of elements) {
+    if (!doc.data || docId(doc)) continue; // sidecars have no id
+    const sidecar = parseSidecar(doc.data);
+    if (!sidecar) continue; // not shaped like a sidecar — ignore, same as docId's element/non-element split
+
+    const targetDoc = elementById.get(sidecar.target);
+    if (!targetDoc) {
+      findings.push({
+        scope: PScope,
+        id: sidecar.target,
+        ruleId: 'VERSIONED-001',
+        message: `VERSIONED-001: sidecar '${doc.path}' target '${sidecar.target}' does not resolve to an admitted primitive.`,
+      });
+      continue;
+    }
+
+    const targetValidFrom = targetDoc.data ? readString(targetDoc.data, 'valid_from') : undefined;
+    const validToRaw = targetDoc.data?.['valid_to'];
+    const targetValidTo = validToRaw === null ? null : typeof validToRaw === 'string' ? validToRaw : undefined;
+
+    for (const f of validateSidecar(sidecar, targetValidFrom, targetValidTo)) {
+      findings.push({
+        scope: PScope,
+        id: sidecar.target,
+        ruleId: f.code,
+        severity: f.severity,
+        message: `${f.code}: sidecar '${doc.path}' ${f.message}`,
+      });
+    }
+  }
+}
+
+/** Run the versioned-attribute sidecar checks (VERSIONED-001..005) over the
+ *  loaded element set and append findings. Pure, deterministic order. */
+export function checkVersionedAttributes(input: RepoModelInput, findings: RepoFinding[]): void {
+  checkInlineTimeVarying(input.elements, findings);
+  checkSidecars(input.elements, findings);
+}

--- a/packages/diagrams/src/repo-validate/validate-repo.ts
+++ b/packages/diagrams/src/repo-validate/validate-repo.ts
@@ -29,6 +29,7 @@
 
 import { checkStrategyChainSemantics } from './check-strategy-chain.js';
 import { checkElementHygiene } from './check-element-hygiene.js';
+import { checkVersionedAttributes } from './check-versioned-attributes.js';
 import type { RepoDoc, RepoFinding, RepoModelInput } from './types.js';
 
 const PScope: RepoFinding['scope'] = 'repo';
@@ -428,5 +429,7 @@ export function validateRepoModel(input: RepoModelInput): RepoFinding[] {
   // Phase 8 — standalone-element envelope rules ported from DSM's Go
   // Validate*Element functions (GOAL-ELEM-001..003, ACTION-001/002/005).
   checkElementHygiene(input, findings);
+  // Phase 9 — versioned-attribute sidecar rules (CONTRACT.md §9, VERSIONED-001..005).
+  checkVersionedAttributes(input, findings);
   return findings;
 }

--- a/packages/diagrams/src/versioned-attribute/__tests__/resolve.test.ts
+++ b/packages/diagrams/src/versioned-attribute/__tests__/resolve.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { resolveAttributeValue, resolveAttributes } from '../resolve.js';
+import type { VersionedAttributeSidecar } from '../types.js';
+
+describe('resolveAttributeValue — CONTRACT.md §9.2', () => {
+  const entries = [
+    { valid_from: '2024-01-01', value: 1 },
+    { valid_from: '2025-06-01', value: 2 },
+    { valid_from: '2026-09-15', value: 3 },
+  ];
+
+  it('picks the entry with the largest valid_from <= atDate', () => {
+    expect(resolveAttributeValue(entries, '2024-06-01')).toBe(1);
+    expect(resolveAttributeValue(entries, '2025-06-01')).toBe(2);
+    expect(resolveAttributeValue(entries, '2026-12-31')).toBe(3);
+  });
+
+  it('returns undefined before the first entry takes effect', () => {
+    expect(resolveAttributeValue(entries, '2023-01-01')).toBeUndefined();
+  });
+
+  it('returns undefined for an empty or missing array', () => {
+    expect(resolveAttributeValue([], '2026-01-01')).toBeUndefined();
+    expect(resolveAttributeValue(undefined, '2026-01-01')).toBeUndefined();
+  });
+
+  it('resolves a gap marker (value: null) as currently unset', () => {
+    const withGap = [
+      { valid_from: '2024-01-01', value: 'ROLE-OPS-1' },
+      { valid_from: '2026-04-01', value: null },
+      { valid_from: '2026-07-01', value: 'ROLE-OPS-2' },
+    ];
+    expect(resolveAttributeValue(withGap, '2026-05-01')).toBeNull();
+    expect(resolveAttributeValue(withGap, '2026-08-01')).toBe('ROLE-OPS-2');
+  });
+
+  it('is insensitive to input array order', () => {
+    const shuffled = [...entries].reverse();
+    expect(resolveAttributeValue(shuffled, '2025-06-01')).toBe(2);
+  });
+});
+
+describe('resolveAttributes', () => {
+  const sidecar: VersionedAttributeSidecar = {
+    target: 'CAPABILITY-V1',
+    attribute_versions: {
+      current_maturity: [
+        { valid_from: '2024-01-01', value: 1 },
+        { valid_from: '2025-06-01', value: 2 },
+      ],
+      owner_role: [{ valid_from: '2024-01-01', value: 'ROLE-OPS-1' }],
+    },
+  };
+
+  it('resolves every attribute at the given date', () => {
+    expect(resolveAttributes(sidecar, '2025-12-01')).toEqual({
+      current_maturity: 2,
+      owner_role: 'ROLE-OPS-1',
+    });
+  });
+
+  it('omits an attribute that has not yet taken effect', () => {
+    expect(resolveAttributes(sidecar, '2023-01-01')).toEqual({});
+  });
+
+  it('returns an empty object for a missing sidecar', () => {
+    expect(resolveAttributes(null, '2026-01-01')).toEqual({});
+    expect(resolveAttributes(undefined, '2026-01-01')).toEqual({});
+  });
+});

--- a/packages/diagrams/src/versioned-attribute/__tests__/validate.test.ts
+++ b/packages/diagrams/src/versioned-attribute/__tests__/validate.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import { parseSidecar, validateAttributeArray, validateSidecar } from '../validate.js';
+
+describe('parseSidecar', () => {
+  it('parses a well-formed sidecar', () => {
+    const parsed = parseSidecar({
+      target: 'CAPABILITY-V1',
+      attribute_versions: {
+        current_maturity: [{ valid_from: '2024-01-01', value: 1 }],
+      },
+    });
+    expect(parsed).toEqual({
+      target: 'CAPABILITY-V1',
+      attribute_versions: {
+        current_maturity: [{ valid_from: '2024-01-01', value: 1 }],
+      },
+    });
+  });
+
+  it('returns null when target is missing or not a string', () => {
+    expect(parseSidecar({ attribute_versions: {} })).toBeNull();
+    expect(parseSidecar({ target: 42, attribute_versions: {} })).toBeNull();
+    expect(parseSidecar({ target: '', attribute_versions: {} })).toBeNull();
+  });
+
+  it('returns null when attribute_versions is missing or the wrong shape', () => {
+    expect(parseSidecar({ target: 'CAPABILITY-V1' })).toBeNull();
+    expect(parseSidecar({ target: 'CAPABILITY-V1', attribute_versions: [] })).toBeNull();
+    expect(parseSidecar({ target: 'CAPABILITY-V1', attribute_versions: 'x' })).toBeNull();
+  });
+
+  it('returns null for a non-object / null doc', () => {
+    expect(parseSidecar(null)).toBeNull();
+    expect(parseSidecar(undefined)).toBeNull();
+  });
+
+  it('drops malformed entries within an attribute array rather than failing the whole sidecar', () => {
+    const parsed = parseSidecar({
+      target: 'CAPABILITY-V1',
+      attribute_versions: {
+        current_maturity: [{ valid_from: '2024-01-01', value: 1 }, { value: 2 }, 'not-an-entry'],
+      },
+    });
+    expect(parsed?.attribute_versions.current_maturity).toEqual([{ valid_from: '2024-01-01', value: 1 }]);
+  });
+});
+
+describe('validateAttributeArray — VERSIONED-002 (duplicate valid_from)', () => {
+  it('flags two entries sharing the same valid_from', () => {
+    const findings = validateAttributeArray('current_maturity', [
+      { valid_from: '2024-01-01', value: 1 },
+      { valid_from: '2024-01-01', value: 2 },
+    ]);
+    expect(findings.map((f) => f.code)).toContain('VERSIONED-002');
+  });
+});
+
+describe('validateAttributeArray — VERSIONED-003 (sort order, warning)', () => {
+  it('flags an unsorted array as a warning', () => {
+    const findings = validateAttributeArray('current_maturity', [
+      { valid_from: '2025-06-01', value: 2 },
+      { valid_from: '2024-01-01', value: 1 },
+    ]);
+    const f = findings.find((x) => x.code === 'VERSIONED-003');
+    expect(f?.severity).toBe('warning');
+  });
+
+  it('does not flag an already-sorted array', () => {
+    const findings = validateAttributeArray('current_maturity', [
+      { valid_from: '2024-01-01', value: 1 },
+      { valid_from: '2025-06-01', value: 2 },
+    ]);
+    expect(findings.map((f) => f.code)).not.toContain('VERSIONED-003');
+  });
+});
+
+describe('validateAttributeArray — VERSIONED-005 (outside target lifecycle)', () => {
+  it('flags an entry before the target valid_from', () => {
+    const findings = validateAttributeArray(
+      'current_maturity',
+      [{ valid_from: '2020-01-01', value: 1 }],
+      '2024-01-01',
+      null,
+    );
+    expect(findings.map((f) => f.code)).toContain('VERSIONED-005');
+  });
+
+  it('flags an entry after the target valid_to', () => {
+    const findings = validateAttributeArray(
+      'current_maturity',
+      [{ valid_from: '2027-01-01', value: 1 }],
+      '2024-01-01',
+      '2026-01-01',
+    );
+    expect(findings.map((f) => f.code)).toContain('VERSIONED-005');
+  });
+
+  it('does not flag entries within the window, and skips the check when bounds are unknown', () => {
+    const withinWindow = validateAttributeArray(
+      'current_maturity',
+      [{ valid_from: '2025-01-01', value: 1 }],
+      '2024-01-01',
+      '2026-01-01',
+    );
+    expect(withinWindow).toHaveLength(0);
+
+    const noBounds = validateAttributeArray('current_maturity', [{ valid_from: '2099-01-01', value: 1 }]);
+    expect(noBounds.map((f) => f.code)).not.toContain('VERSIONED-005');
+  });
+
+  it('a null valid_to (still-open primitive) never bounds the upper end', () => {
+    const findings = validateAttributeArray(
+      'current_maturity',
+      [{ valid_from: '2099-01-01', value: 1 }],
+      '2024-01-01',
+      null,
+    );
+    expect(findings.map((f) => f.code)).not.toContain('VERSIONED-005');
+  });
+});
+
+describe('validateSidecar', () => {
+  it('runs the array checks over every attribute in the sidecar', () => {
+    const findings = validateSidecar(
+      {
+        target: 'CAPABILITY-V1',
+        attribute_versions: {
+          current_maturity: [
+            { valid_from: '2024-01-01', value: 1 },
+            { valid_from: '2024-01-01', value: 2 },
+          ],
+          owner_role: [{ valid_from: '2020-01-01', value: 'ROLE-OPS-1' }],
+        },
+      },
+      '2024-01-01',
+      null,
+    );
+    expect(findings.map((f) => f.code)).toEqual(
+      expect.arrayContaining(['VERSIONED-002', 'VERSIONED-005']),
+    );
+  });
+
+  it('produces no findings for a clean sidecar', () => {
+    const findings = validateSidecar(
+      {
+        target: 'CAPABILITY-V1',
+        attribute_versions: {
+          current_maturity: [
+            { valid_from: '2024-01-01', value: 1 },
+            { valid_from: '2025-06-01', value: 2 },
+          ],
+        },
+      },
+      '2024-01-01',
+      null,
+    );
+    expect(findings).toHaveLength(0);
+  });
+});

--- a/packages/diagrams/src/versioned-attribute/index.ts
+++ b/packages/diagrams/src/versioned-attribute/index.ts
@@ -1,0 +1,4 @@
+export type { AttributeVersionEntry, VersionedAttributeSidecar } from './types.js';
+export { resolveAttributeValue, resolveAttributes, todayIso } from './resolve.js';
+export type { AttributeArrayFinding } from './validate.js';
+export { parseSidecar, validateAttributeArray, validateSidecar } from './validate.js';

--- a/packages/diagrams/src/versioned-attribute/resolve.ts
+++ b/packages/diagrams/src/versioned-attribute/resolve.ts
@@ -1,0 +1,45 @@
+// Current-value resolution for a versioned attribute — CONTRACT.md §9.2.
+
+import type { AttributeVersionEntry, VersionedAttributeSidecar } from './types.js';
+
+/** Pick the entry with the largest `valid_from <= atDate`.
+ *  Returns `undefined` when no entry has taken effect yet as of `atDate`
+ *  (the attribute has not yet taken its first value — CONTRACT.md §9.2 rule
+ *  4). Returns `null` when the resolved entry is itself a gap marker
+ *  (`value: null` — attribute currently unset). */
+export function resolveAttributeValue(
+  entries: AttributeVersionEntry[] | undefined,
+  atDate: string,
+): unknown {
+  if (!entries || entries.length === 0) return undefined;
+  let best: AttributeVersionEntry | undefined;
+  for (const entry of entries) {
+    if (entry.valid_from <= atDate && (!best || entry.valid_from > best.valid_from)) {
+      best = entry;
+    }
+  }
+  return best ? best.value : undefined;
+}
+
+/** Resolve every attribute in a sidecar at `atDate`. An attribute with no
+ *  entry yet in effect is omitted from the result (equivalent to
+ *  `resolveAttributeValue` returning `undefined`) rather than reported as
+ *  `null`, which is reserved for an explicit gap marker. */
+export function resolveAttributes(
+  sidecar: VersionedAttributeSidecar | null | undefined,
+  atDate: string,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  if (!sidecar) return out;
+  for (const name of Object.keys(sidecar.attribute_versions)) {
+    const value = resolveAttributeValue(sidecar.attribute_versions[name], atDate);
+    if (value !== undefined) out[name] = value;
+  }
+  return out;
+}
+
+/** Today, as a quoted-ISO-8601 date string — the default projection date
+ *  every resolver/renderer falls back to when the caller supplies none. */
+export function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}

--- a/packages/diagrams/src/versioned-attribute/types.ts
+++ b/packages/diagrams/src/versioned-attribute/types.ts
@@ -1,0 +1,19 @@
+// Versioned-attribute sidecar (CONTRACT.md §9) — shared shape across every
+// notation that declares a `time_varying` field. A sidecar is a co-located
+// `<primitive_id>.history.yaml` document: no `id`, no admission record, no
+// lifecycle of its own — its temporal window is governed by the target
+// primitive's own `valid_from`/`valid_to` (CONTRACT.md §9.1).
+
+/** One version entry in an attribute's history. `value: null` is a gap
+ *  marker — the attribute is unset from `valid_from` until the next entry. */
+export interface AttributeVersionEntry {
+  valid_from: string;
+  value: unknown;
+}
+
+/** A parsed sidecar document, keyed by attribute name. */
+export interface VersionedAttributeSidecar {
+  /** Canonical id of the primitive this sidecar versions. */
+  target: string;
+  attribute_versions: Record<string, AttributeVersionEntry[]>;
+}

--- a/packages/diagrams/src/versioned-attribute/validate.ts
+++ b/packages/diagrams/src/versioned-attribute/validate.ts
@@ -1,0 +1,109 @@
+// Versioned-attribute sidecar validation — CONTRACT.md §9.3, `VERSIONED-00x`.
+//
+// Split by what each check needs to know:
+//   - `parseSidecar` + `validateAttributeArray` here cover VERSIONED-002/003/005,
+//     which only need the sidecar document itself (plus, for 005, the target
+//     primitive's own lifecycle window).
+//   - `VERSIONED-001` (target resolves to an admitted primitive) and
+//     `VERSIONED-004` (a time_varying field present inline on the primitive)
+//     both need cross-document knowledge — which ids exist, which notation a
+//     primitive is — that a single sidecar document doesn't carry. Those are
+//     repo-scope concerns; see `repo-validate/check-versioned-attributes.ts`.
+
+import type { AttributeVersionEntry, VersionedAttributeSidecar } from './types.js';
+
+export interface AttributeArrayFinding {
+  code: 'VERSIONED-002' | 'VERSIONED-003' | 'VERSIONED-005';
+  severity: 'error' | 'warning';
+  message: string;
+}
+
+function isAttributeVersionEntry(v: unknown): v is AttributeVersionEntry {
+  return typeof v === 'object' && v !== null && !Array.isArray(v) && typeof (v as Record<string, unknown>)['valid_from'] === 'string';
+}
+
+/** Parse a raw parsed-YAML mapping into a typed sidecar, or `null` if it
+ *  isn't shaped like one (missing `target` string or `attribute_versions`
+ *  map) — not every doc under `canon/elements/**` is a sidecar. */
+export function parseSidecar(data: Record<string, unknown> | null | undefined): VersionedAttributeSidecar | null {
+  if (!data) return null;
+  const target = data['target'];
+  const attributeVersions = data['attribute_versions'];
+  if (typeof target !== 'string' || target.trim() === '') return null;
+  if (typeof attributeVersions !== 'object' || attributeVersions === null || Array.isArray(attributeVersions)) return null;
+
+  const out: Record<string, AttributeVersionEntry[]> = {};
+  for (const [name, value] of Object.entries(attributeVersions as Record<string, unknown>)) {
+    if (!Array.isArray(value)) continue;
+    out[name] = value.filter(isAttributeVersionEntry);
+  }
+  return { target, attribute_versions: out };
+}
+
+/** VERSIONED-002/003/005 for one attribute's version array.
+ *  `targetValidFrom`/`targetValidTo` bound VERSIONED-005 — pass `undefined`
+ *  for either to skip that half of the check (e.g. the target element could
+ *  not be found, which is already reported separately as VERSIONED-001). */
+export function validateAttributeArray(
+  attributeName: string,
+  entries: AttributeVersionEntry[],
+  targetValidFrom?: string,
+  targetValidTo?: string | null,
+): AttributeArrayFinding[] {
+  const findings: AttributeArrayFinding[] = [];
+  const seen = new Set<string>();
+  let sorted = true;
+  let prev: string | undefined;
+
+  for (const entry of entries) {
+    if (seen.has(entry.valid_from)) {
+      findings.push({
+        code: 'VERSIONED-002',
+        severity: 'error',
+        message: `attribute '${attributeName}': duplicate valid_from '${entry.valid_from}'.`,
+      });
+    }
+    seen.add(entry.valid_from);
+
+    if (prev !== undefined && entry.valid_from < prev) sorted = false;
+    prev = entry.valid_from;
+
+    if (targetValidFrom !== undefined && entry.valid_from < targetValidFrom) {
+      findings.push({
+        code: 'VERSIONED-005',
+        severity: 'error',
+        message: `attribute '${attributeName}': entry valid_from '${entry.valid_from}' is before the target's valid_from '${targetValidFrom}'.`,
+      });
+    }
+    if (targetValidTo !== undefined && targetValidTo !== null && entry.valid_from > targetValidTo) {
+      findings.push({
+        code: 'VERSIONED-005',
+        severity: 'error',
+        message: `attribute '${attributeName}': entry valid_from '${entry.valid_from}' is after the target's valid_to '${targetValidTo}'.`,
+      });
+    }
+  }
+
+  if (!sorted) {
+    findings.push({
+      code: 'VERSIONED-003',
+      severity: 'warning',
+      message: `attribute '${attributeName}': entries are not sorted by valid_from ascending.`,
+    });
+  }
+
+  return findings;
+}
+
+/** Run VERSIONED-002/003/005 over every attribute in a parsed sidecar. */
+export function validateSidecar(
+  sidecar: VersionedAttributeSidecar,
+  targetValidFrom?: string,
+  targetValidTo?: string | null,
+): AttributeArrayFinding[] {
+  const findings: AttributeArrayFinding[] = [];
+  for (const [name, entries] of Object.entries(sidecar.attribute_versions)) {
+    findings.push(...validateAttributeArray(name, entries, targetValidFrom, targetValidTo));
+  }
+  return findings;
+}


### PR DESCRIPTION
## Summary

Implements CONTRACT.md §9's versioned-attribute sidecar for the CLI's repo-scope validator:

- New notation-agnostic module `packages/diagrams/src/versioned-attribute/` — parses a `<primitive_id>.history.yaml` sidecar, resolves an attribute's current value at a given date (§9.2's "largest `valid_from <= date`" rule), and validates the sidecar's own array shape.
- New `packages/diagrams/src/repo-validate/check-versioned-attributes.ts`, wired into `validateRepoModel` as a new phase: `VERSIONED-001` (sidecar target resolves), `VERSIONED-002`/`003`/`005` (array shape), `VERSIONED-004` (a `time_varying` field present inline on its primitive instead of the sidecar).

**Scope note — `VERSIONED-004`'s field list is deliberately narrow.** It only enforces capability `current_maturity`/`owner_role`/`target_date`, which are already `time_varying` on methodology's *currently-merged* `05-capability-map.md`. `target_maturity` (capability) and `maturity` (applications) only become `time_varying` once methodology PR #425 merges — enforcing them now would fail `organizations/acme_corp`'s own `CAPABILITY-V1.yaml`, which still correctly carries `target_maturity` inline under the spec merged today.

**Not touched — the native `capability-map` notation's own single-file view-document form** (`capability-map/{types,validate}.ts`, the VS Code "cards"/"tree" preview). Its worked examples and its own validator still require `current_maturity` inline on the view document, which is itself inconsistent with the merged CONTRACT.md §9 text — but that notation has no separate element file to hold a co-located sidecar, and its renderer has no sidecar-resolution step to plug into. Reconciling it is a design decision (grow sidecar resolution into the preview host, or treat it as exempt from §9 as a self-contained rendering convenience), not guessed at here. Full detail in `docs/validation.md`.

## Test plan
- [x] `npm test` — 507 passing, same 4 pre-existing unrelated failures reproduce on unmodified `main` (`cli-migrate.test.ts` needs a methodology repo checkout; `ci-hygiene-hashrefs.test.ts` has a pre-existing syntax error) — confirmed via `git stash` before/after
- [x] 22 new unit tests for the `versioned-attribute` module + 12 new tests for `check-versioned-attributes`, all passing
- [x] `npm run compile` clean
- [x] `packages/diagrams` (1.9.2→1.9.3) and `packages/cli` (2.4.2→2.4.3) version bumps for the CI alignment guards