### PR TITLE
feat(extension): New Goal Element command

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -562,6 +562,11 @@
         }
       },
       {
+        "command": "transitrixStudio.newGoalElement",
+        "title": "Transitrix: New Goal Element",
+        "category": "Transitrix"
+      },
+      {
         "command": "transitrix.exportSvg",
         "title": "Transitrix: Export as SVG",
         "category": "Transitrix",

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -40,6 +40,7 @@ import {
   VIEW_CONFIG_SECTION,
 } from './spacing-config.js';
 import { OPEN_THEME_COMMAND } from './diagram-frame.js';
+import { NEW_GOAL_ELEMENT_COMMAND, newGoalElementCommand } from './new-element-command.js';
 
 function isGoalsFile(doc: vscode.TextDocument): boolean {
   return doc.fileName.endsWith('.goals.transitrix.yaml');
@@ -355,6 +356,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   //     command since they aren't bound to a specific open file).
   context.subscriptions.push(
     vscode.commands.registerTextEditorCommand('transitrix.openPreview', openPreviewHandler),
+    vscode.commands.registerCommand(NEW_GOAL_ELEMENT_COMMAND, () => newGoalElementCommand()),
     vscode.commands.registerCommand('transitrix.exportSvg', () => notYet('SVG')),
     vscode.commands.registerCommand('transitrix.exportPng', () => preview.saveAsPng()),
     vscode.commands.registerCommand('transitrix.exportBpmn', () => notYet('.bpmn')),

--- a/extension/src/new-element-command.ts
+++ b/extension/src/new-element-command.ts
@@ -1,0 +1,78 @@
+// "Authoring a first element requires only its own content" (epic
+// vkgeorgia/strategy#919) — the editor/extension creation path. Mirrors the
+// CLI's `transitrix new goal` (`src/scaffold.ts`): the author supplies id +
+// name only, the admission record and lifecycle envelope are computed, not
+// hand-typed. Reuses the same scaffold functions the CLI calls so the two
+// paths cannot drift apart on what "computed" means.
+//
+// GOAL only for this first cut, matching what `transitrix new` supports on
+// `main` today — DRIVER/CONSTRAINT/REQUIREMENT scaffolding exists only on an
+// unmerged CLI branch as of this writing.
+
+import * as vscode from 'vscode';
+import * as path from 'node:path';
+import { scaffoldGoalElement, writeScaffoldedElement, gitUserName } from '../../src/scaffold.js';
+
+export const NEW_GOAL_ELEMENT_COMMAND = 'transitrixStudio.newGoalElement';
+
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export async function newGoalElementCommand(): Promise<void> {
+  const folder = vscode.workspace.workspaceFolders?.[0];
+  if (!folder) {
+    vscode.window.showErrorMessage('Transitrix: open a repository folder to create a new element.');
+    return;
+  }
+  const root = folder.uri.fsPath;
+
+  const id = await vscode.window.showInputBox({
+    title: 'New Goal — id',
+    prompt: 'Canonical id (GOAL-[<middle>-]<INTEGER>)',
+    placeHolder: 'GOAL-042',
+    ignoreFocusOut: true,
+  });
+  if (!id) return;
+
+  const name = await vscode.window.showInputBox({
+    title: 'New Goal — name',
+    prompt: 'Human-readable name',
+    ignoreFocusOut: true,
+  });
+  if (!name) return;
+
+  const admittedBy =
+    gitUserName(root) ??
+    (await vscode.window.showInputBox({
+      title: 'New Goal — admitted_by',
+      prompt: '`git config user.name` is not set — enter the name to record as admitted_by',
+      ignoreFocusOut: true,
+    }));
+  if (!admittedBy) {
+    vscode.window.showErrorMessage(
+      'Transitrix: no admitted_by identity available — set `git config user.name` or enter a name.',
+    );
+    return;
+  }
+
+  const outcome = scaffoldGoalElement({
+    root,
+    id: id.trim(),
+    name: name.trim(),
+    admittedBy,
+    today: todayIso(),
+  });
+
+  if (!outcome.ok) {
+    vscode.window.showErrorMessage(`Transitrix: cannot scaffold this element:\n${outcome.errors.join('\n')}`);
+    return;
+  }
+
+  const absPath = writeScaffoldedElement(root, outcome);
+  const doc = await vscode.workspace.openTextDocument(absPath);
+  await vscode.window.showTextDocument(doc);
+  vscode.window.showInformationMessage(
+    `Transitrix: wrote ${path.relative(root, absPath).replace(/\\/g, '/')} — filled envelope fields: ${outcome.filled.join(', ')}`,
+  );
+}

--- a/extension/src/new-element-command.ts
+++ b/extension/src/new-element-command.ts
@@ -1,9 +1,9 @@
-// "Authoring a first element requires only its own content" (epic
-// vkgeorgia/strategy#919) — the editor/extension creation path. Mirrors the
-// CLI's `transitrix new goal` (`src/scaffold.ts`): the author supplies id +
-// name only, the admission record and lifecycle envelope are computed, not
-// hand-typed. Reuses the same scaffold functions the CLI calls so the two
-// paths cannot drift apart on what "computed" means.
+// Authoring a first element should require only its own content — the
+// editor/extension creation path. Mirrors the CLI's `transitrix new goal`
+// (`src/scaffold.ts`): the author supplies id + name only, the admission
+// record and lifecycle envelope are computed, not hand-typed. Reuses the
+// same scaffold functions the CLI calls so the two paths cannot drift apart
+// on what "computed" means.
 //
 // GOAL only for this first cut, matching what `transitrix new` supports on
 // `main` today — DRIVER/CONSTRAINT/REQUIREMENT scaffolding exists only on an


### PR DESCRIPTION
## Summary
- The editor/extension had no element-creation command at all — only the CLI could scaffold a GOAL element with a computed admission record + lifecycle envelope.
- Adds a command-palette entry ("Transitrix: New Goal Element") that prompts for id/name and calls the same scaffold functions the CLI uses (`src/scaffold.ts`), so the two paths can't drift on what "computed" means.
- GOAL only, matching what `transitrix new` supports on `main` today.

## Test plan
- [x] `npm run compile:extension` (tsc, cross-directory import type-checks clean)
- [x] `npm run compile` (root build unaffected)
- [x] `npm run extension:bundle` (esbuild resolves the import, bundles clean)
- [x] `npm run test:core` — same 3 pre-existing failures reproduce on unmodified `main` (unrelated: a `.mjs` import in one test file, and migrate-fixture tests dependent on local methodology-repo state); no new failures
- [x] `tests/scaffold.test.ts` (19/19) — covers the reused scaffold functions this command calls
- [ ] Full VS Code Extension Development Host click-through — no existing harness in this repo (no `@vscode/test-electron` setup) to drive the real UI; verified via type-check + bundle + existing unit coverage of the underlying logic instead