### PR TITLE
feat(extension): New Driver/Constraint/Requirement Element commands

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -567,6 +567,21 @@
         "category": "Transitrix"
       },
       {
+        "command": "transitrixStudio.newDriverElement",
+        "title": "Transitrix: New Driver Element",
+        "category": "Transitrix"
+      },
+      {
+        "command": "transitrixStudio.newConstraintElement",
+        "title": "Transitrix: New Constraint Element",
+        "category": "Transitrix"
+      },
+      {
+        "command": "transitrixStudio.newRequirementElement",
+        "title": "Transitrix: New Requirement Element",
+        "category": "Transitrix"
+      },
+      {
         "command": "transitrix.exportSvg",
         "title": "Transitrix: Export as SVG",
         "category": "Transitrix",

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -40,7 +40,16 @@ import {
   VIEW_CONFIG_SECTION,
 } from './spacing-config.js';
 import { OPEN_THEME_COMMAND } from './diagram-frame.js';
-import { NEW_GOAL_ELEMENT_COMMAND, newGoalElementCommand } from './new-element-command.js';
+import {
+  NEW_GOAL_ELEMENT_COMMAND,
+  newGoalElementCommand,
+  NEW_DRIVER_ELEMENT_COMMAND,
+  newDriverElementCommand,
+  NEW_CONSTRAINT_ELEMENT_COMMAND,
+  newConstraintElementCommand,
+  NEW_REQUIREMENT_ELEMENT_COMMAND,
+  newRequirementElementCommand,
+} from './new-element-command.js';
 
 function isGoalsFile(doc: vscode.TextDocument): boolean {
   return doc.fileName.endsWith('.goals.transitrix.yaml');
@@ -357,6 +366,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   context.subscriptions.push(
     vscode.commands.registerTextEditorCommand('transitrix.openPreview', openPreviewHandler),
     vscode.commands.registerCommand(NEW_GOAL_ELEMENT_COMMAND, () => newGoalElementCommand()),
+    vscode.commands.registerCommand(NEW_DRIVER_ELEMENT_COMMAND, () => newDriverElementCommand()),
+    vscode.commands.registerCommand(NEW_CONSTRAINT_ELEMENT_COMMAND, () => newConstraintElementCommand()),
+    vscode.commands.registerCommand(NEW_REQUIREMENT_ELEMENT_COMMAND, () => newRequirementElementCommand()),
     vscode.commands.registerCommand('transitrix.exportSvg', () => notYet('SVG')),
     vscode.commands.registerCommand('transitrix.exportPng', () => preview.saveAsPng()),
     vscode.commands.registerCommand('transitrix.exportBpmn', () => notYet('.bpmn')),

--- a/extension/src/new-element-command.ts
+++ b/extension/src/new-element-command.ts
@@ -1,51 +1,73 @@
 // Authoring a first element should require only its own content — the
-// editor/extension creation path. Mirrors the CLI's `transitrix new goal`
-// (`src/scaffold.ts`): the author supplies id + name only, the admission
-// record and lifecycle envelope are computed, not hand-typed. Reuses the
-// same scaffold functions the CLI calls so the two paths cannot drift apart
-// on what "computed" means.
-//
-// GOAL only for this first cut, matching what `transitrix new` supports on
-// `main` today — DRIVER/CONSTRAINT/REQUIREMENT scaffolding exists only on an
-// unmerged CLI branch as of this writing.
+// editor/extension creation path. Mirrors the CLI's `transitrix new
+// <goal|driver|constraint|requirement>` (`src/scaffold.ts`): the author
+// supplies id + name (+ the one per-type required field) only, the
+// admission record and lifecycle envelope are computed, not hand-typed.
+// Reuses the same scaffold functions the CLI calls so the two paths cannot
+// drift apart on what "computed" means.
 
 import * as vscode from 'vscode';
 import * as path from 'node:path';
-import { scaffoldGoalElement, writeScaffoldedElement, gitUserName } from '../../src/scaffold.js';
+import {
+  gitUserName,
+  scaffoldConstraintElement,
+  scaffoldDriverElement,
+  scaffoldGoalElement,
+  scaffoldRequirementElement,
+  writeScaffoldedElement,
+  type ScaffoldOutcome,
+} from '../../src/scaffold.js';
 
 export const NEW_GOAL_ELEMENT_COMMAND = 'transitrixStudio.newGoalElement';
+export const NEW_DRIVER_ELEMENT_COMMAND = 'transitrixStudio.newDriverElement';
+export const NEW_CONSTRAINT_ELEMENT_COMMAND = 'transitrixStudio.newConstraintElement';
+export const NEW_REQUIREMENT_ELEMENT_COMMAND = 'transitrixStudio.newRequirementElement';
 
 function todayIso(): string {
   return new Date().toISOString().slice(0, 10);
 }
 
-export async function newGoalElementCommand(): Promise<void> {
+/** Resolves the adopter repo root, or reports the error and returns
+ *  undefined — the shared precondition every `new <type>` command starts
+ *  with. */
+function resolveRoot(): string | undefined {
   const folder = vscode.workspace.workspaceFolders?.[0];
   if (!folder) {
     vscode.window.showErrorMessage('Transitrix: open a repository folder to create a new element.');
-    return;
+    return undefined;
   }
-  const root = folder.uri.fsPath;
+  return folder.uri.fsPath;
+}
 
+/** Prompts for id, name, and admitted_by — the fields every element type
+ *  requires, in the same order and with the same fallback-to-`git config
+ *  user.name` behaviour. Returns undefined if the author cancelled or no
+ *  admitted_by identity is available. */
+async function promptCommonFields(
+  root: string,
+  label: string,
+  idPrompt: string,
+  idPlaceholder: string,
+): Promise<{ id: string; name: string; admittedBy: string } | undefined> {
   const id = await vscode.window.showInputBox({
-    title: 'New Goal — id',
-    prompt: 'Canonical id (GOAL-[<middle>-]<INTEGER>)',
-    placeHolder: 'GOAL-042',
+    title: `New ${label} — id`,
+    prompt: idPrompt,
+    placeHolder: idPlaceholder,
     ignoreFocusOut: true,
   });
-  if (!id) return;
+  if (!id) return undefined;
 
   const name = await vscode.window.showInputBox({
-    title: 'New Goal — name',
+    title: `New ${label} — name`,
     prompt: 'Human-readable name',
     ignoreFocusOut: true,
   });
-  if (!name) return;
+  if (!name) return undefined;
 
   const admittedBy =
     gitUserName(root) ??
     (await vscode.window.showInputBox({
-      title: 'New Goal — admitted_by',
+      title: `New ${label} — admitted_by`,
       prompt: '`git config user.name` is not set — enter the name to record as admitted_by',
       ignoreFocusOut: true,
     }));
@@ -53,17 +75,16 @@ export async function newGoalElementCommand(): Promise<void> {
     vscode.window.showErrorMessage(
       'Transitrix: no admitted_by identity available — set `git config user.name` or enter a name.',
     );
-    return;
+    return undefined;
   }
 
-  const outcome = scaffoldGoalElement({
-    root,
-    id: id.trim(),
-    name: name.trim(),
-    admittedBy,
-    today: todayIso(),
-  });
+  return { id: id.trim(), name: name.trim(), admittedBy };
+}
 
+/** Writes a successful scaffold outcome and opens it, or reports the
+ *  gate-check failures — the shared tail every `new <type>` command ends
+ *  with. */
+async function finishScaffold(root: string, outcome: ScaffoldOutcome): Promise<void> {
   if (!outcome.ok) {
     vscode.window.showErrorMessage(`Transitrix: cannot scaffold this element:\n${outcome.errors.join('\n')}`);
     return;
@@ -75,4 +96,72 @@ export async function newGoalElementCommand(): Promise<void> {
   vscode.window.showInformationMessage(
     `Transitrix: wrote ${path.relative(root, absPath).replace(/\\/g, '/')} — filled envelope fields: ${outcome.filled.join(', ')}`,
   );
+}
+
+export async function newGoalElementCommand(): Promise<void> {
+  const root = resolveRoot();
+  if (!root) return;
+
+  const common = await promptCommonFields(root, 'Goal', 'Canonical id (GOAL-[<middle>-]<INTEGER>)', 'GOAL-042');
+  if (!common) return;
+
+  const outcome = scaffoldGoalElement({ root, ...common, today: todayIso() });
+  await finishScaffold(root, outcome);
+}
+
+export async function newDriverElementCommand(): Promise<void> {
+  const root = resolveRoot();
+  if (!root) return;
+
+  const common = await promptCommonFields(root, 'Driver', 'Canonical id (DRIVER-[<middle>-]<INTEGER>)', 'DRIVER-042');
+  if (!common) return;
+
+  const outcome = scaffoldDriverElement({ root, ...common, today: todayIso() });
+  await finishScaffold(root, outcome);
+}
+
+export async function newConstraintElementCommand(): Promise<void> {
+  const root = resolveRoot();
+  if (!root) return;
+
+  const common = await promptCommonFields(
+    root,
+    'Constraint',
+    'Canonical id (CONSTRAINT-[<middle>-]<INTEGER>)',
+    'CONSTRAINT-042',
+  );
+  if (!common) return;
+
+  const statement = await vscode.window.showInputBox({
+    title: 'New Constraint — statement',
+    prompt: 'The normative restriction sentence',
+    ignoreFocusOut: true,
+  });
+  if (!statement) return;
+
+  const outcome = scaffoldConstraintElement({ root, ...common, today: todayIso(), statement: statement.trim() });
+  await finishScaffold(root, outcome);
+}
+
+export async function newRequirementElementCommand(): Promise<void> {
+  const root = resolveRoot();
+  if (!root) return;
+
+  const common = await promptCommonFields(
+    root,
+    'Requirement',
+    'Canonical id (REQUIREMENT-[<middle>-]<INTEGER>)',
+    'REQUIREMENT-042',
+  );
+  if (!common) return;
+
+  const description = await vscode.window.showInputBox({
+    title: 'New Requirement — description',
+    prompt: 'The obligation, its scope, and its conditions',
+    ignoreFocusOut: true,
+  });
+  if (!description) return;
+
+  const outcome = scaffoldRequirementElement({ root, ...common, today: todayIso(), description: description.trim() });
+  await finishScaffold(root, outcome);
 }


### PR DESCRIPTION
## Summary
- Adds three command-palette entries (New Driver / Constraint / Requirement Element) alongside the existing New Goal Element command.
- Reuses the same `src/scaffold.ts` functions the CLI's `transitrix new driver|constraint|requirement` already calls, so both paths compute the admission record and lifecycle envelope identically.
- Factored the id/name/admitted_by prompt flow and the write/report tail into shared helpers so the four per-type commands stay thin.

## Test plan
- [x] `npm run compile:extension` — clean
- [x] `npm run compile` (root tsc + diagrams build) — clean
- [x] `npm run extension:prep` (webview + compiler bundle + esbuild extension bundle) — succeeds
- [x] `npx vitest run tests/scaffold.test.ts` — 38/38 passing (scaffold logic itself is unchanged)
- [x] Full `npx vitest run` — no new failures (3 pre-existing `cli-migrate.test.ts` failures reproduce identically on unmodified `main`, unrelated to this change)
- No VS Code Extension Development Host harness exists in this repo (same gap noted on the prior GOAL-only PR), so this is verified via type-check + bundle + the shared scaffold unit-test suite rather than a UI click-through.