### PR TITLE
feat(diagrams): VERSIONED-004 enforces target_maturity time-varying

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -201,15 +201,15 @@ repo-scope wiring).
 §9.4's full candidate table.** It enforces only the fields already
 `time_varying` on methodology's *currently-merged*
 `notations/views/05-capability-map.md`: capability `current_maturity`,
-`owner_role`, `target_date`. `target_maturity` (capability) and `maturity`
-(application) become `time_varying` only once methodology PR #425 (the
-2026-08-02 maturity ADR's remaining half) merges — enforcing them today would
-fail `organizations/acme_corp`'s `CAPABILITY-V1.yaml`, which correctly still
-carries `target_maturity` inline under the spec merged today. Extend
-`TIME_VARYING_FIELDS` in `check-versioned-attributes.ts` once #425 lands, and
-add the applications-catalogue field list at the same time (out of scope
-here — its `maturity` field isn't declared `time_varying` at the CONTRACT.md
-level until that PR merges).
+`target_maturity`, `owner_role`, `target_date` (methodology PR #425, the
+2026-08-02 maturity ADR's remaining half, merged 2026-08-04 and brought
+`target_maturity` in — `organizations/acme_corp`'s capability fixtures
+migrated their inline values to sidecar form in the same pass). Applications-
+catalogue `maturity` is on the same CONTRACT.md §9.4 candidate row but is
+**not** enforced here: `check-versioned-attributes.ts` only walks
+`elements`, and `maturity` lives on the `applications[]` list inside a
+catalogue *view* document, not on a standalone element primitive — adding it
+needs the check to walk view documents too, not just a field-list edit.
 
 **Not covered here: the native `capability-map` notation's own single-file
 view-document form** (`packages/diagrams/src/capability-map/{types,

--- a/organizations/acme_corp/.templates/elements/02_business_template.yaml
+++ b/organizations/acme_corp/.templates/elements/02_business_template.yaml
@@ -14,8 +14,8 @@
 #
 # Worked examples: organizations/acme_corp/canon/elements/02_business/.
 # CAPABILITY uses the V/H ID sub-grammar (IDS §2); its time-varying attributes
-# (current_maturity, owner_role, target_date) live in a <id>.history.yaml sidecar
-# (CONTRACT.md §9), never inline.
+# (current_maturity, target_maturity, owner_role, target_date) live in a
+# <id>.history.yaml sidecar (CONTRACT.md §9), never inline.
 
 notation: process                      # element TYPE short name (lowercased TYPE)
 id: PROCESS-EXAMPLE-1                   # canonical ID — IDS_AND_REFERENCES.md §1

--- a/organizations/acme_corp/canon/elements/02_business/capabilities/CAPABILITY-H1.history.yaml
+++ b/organizations/acme_corp/canon/elements/02_business/capabilities/CAPABILITY-H1.history.yaml
@@ -1,0 +1,12 @@
+# Worked example — versioned-attribute sidecar.
+# Schema: notations/CONTRACT.md §9.1.
+#
+# Target: the CAPABILITY-H1.yaml primitive in this folder. Single-entry
+# series — the migration pattern for an inline value with no prior history:
+# valid_from set to the primitive's own valid_from (CONTRACT.md §9.4).
+
+target: CAPABILITY-H1
+
+attribute_versions:
+  target_maturity:
+    - { valid_from: "2026-05-26", value: 3 }

--- a/organizations/acme_corp/canon/elements/02_business/capabilities/CAPABILITY-H1.yaml
+++ b/organizations/acme_corp/canon/elements/02_business/capabilities/CAPABILITY-H1.yaml
@@ -1,6 +1,9 @@
 # Cross-cutting compliance capability — referenced by products, scenarios,
 # and the process landscape. Diagram address H1 in the capability-map view.
 # Schema: notations/views/05-capability-map.md §13 + CONTRACT.md §6–§7.
+#
+# target_maturity is time-varying — it lives in the sidecar
+# CAPABILITY-H1.history.yaml per CONTRACT.md §9, not inline.
 
 notation: capability
 id: CAPABILITY-H1
@@ -11,7 +14,6 @@ description: >
   rights, breach reporting, and data residency. Lowest current maturity —
   the focus of the 2026 remediation programme.
 
-target_maturity: 3
 business_process: PROCESS-DSR-HANDLE-1
 
 zone: canon

--- a/organizations/acme_corp/canon/elements/02_business/capabilities/CAPABILITY-V1.1.history.yaml
+++ b/organizations/acme_corp/canon/elements/02_business/capabilities/CAPABILITY-V1.1.history.yaml
@@ -1,0 +1,12 @@
+# Worked example — versioned-attribute sidecar.
+# Schema: notations/CONTRACT.md §9.1.
+#
+# Target: the CAPABILITY-V1.1.yaml primitive in this folder. Single-entry
+# series — the migration pattern for an inline value with no prior history:
+# valid_from set to the primitive's own valid_from (CONTRACT.md §9.4).
+
+target: CAPABILITY-V1.1
+
+attribute_versions:
+  target_maturity:
+    - { valid_from: "2024-01-01", value: 4 }

--- a/organizations/acme_corp/canon/elements/02_business/capabilities/CAPABILITY-V1.1.yaml
+++ b/organizations/acme_corp/canon/elements/02_business/capabilities/CAPABILITY-V1.1.yaml
@@ -2,8 +2,8 @@
 # Schema: notations/views/05-capability-map.md §13 + admission record
 # (CONTRACT.md §6) + primitive lifecycle (CONTRACT.md §7).
 #
-# Time-varying attributes live in the sidecar CAPABILITY-V1.1.history.yaml
-# per CONTRACT.md §9 (not provided for this minimal example).
+# Time-varying attributes (target_maturity) live in the sidecar
+# CAPABILITY-V1.1.history.yaml per CONTRACT.md §9 — not inline here.
 # Parent relationship lives in REL files under canon/relations/ — see
 # REL-CAP-V11-PARENT-1.yaml (initial; ended 2026-04-01) and
 # REL-CAP-V11-PARENT-2.yaml (current). The re-parenting demonstrates
@@ -17,8 +17,6 @@ description: >
   Capture and validate customer order requests across all channels.
   Sits at the very top of the order-management value chain — touches
   the customer first, then hands off to the fulfilment side.
-
-target_maturity: 4
 
 # Admission record (CONTRACT.md §6)
 zone: canon

--- a/organizations/acme_corp/canon/elements/02_business/capabilities/CAPABILITY-V1.2.history.yaml
+++ b/organizations/acme_corp/canon/elements/02_business/capabilities/CAPABILITY-V1.2.history.yaml
@@ -1,0 +1,12 @@
+# Worked example — versioned-attribute sidecar.
+# Schema: notations/CONTRACT.md §9.1.
+#
+# Target: the CAPABILITY-V1.2.yaml primitive in this folder. Single-entry
+# series — the migration pattern for an inline value with no prior history:
+# valid_from set to the primitive's own valid_from (CONTRACT.md §9.4).
+
+target: CAPABILITY-V1.2
+
+attribute_versions:
+  target_maturity:
+    - { valid_from: "2026-05-26", value: 3 }

--- a/organizations/acme_corp/canon/elements/02_business/capabilities/CAPABILITY-V1.2.yaml
+++ b/organizations/acme_corp/canon/elements/02_business/capabilities/CAPABILITY-V1.2.yaml
@@ -2,10 +2,10 @@
 # Schema: notations/views/05-capability-map.md §13 + admission record
 # (CONTRACT.md §6) + primitive lifecycle (CONTRACT.md §7).
 #
-# Time-varying attributes (current_maturity, owner_role, target_date) live
-# in the sidecar CAPABILITY-V1.2.history.yaml per CONTRACT.md §9 (not
-# provided for this minimal example). Parent (CAPABILITY-V1.2 -> CAPABILITY-V1)
-# is carried inline by the capability-map view's children[] in v0.x.
+# Time-varying attributes (target_maturity, current_maturity, owner_role,
+# target_date) live in the sidecar CAPABILITY-V1.2.history.yaml per
+# CONTRACT.md §9. Parent (CAPABILITY-V1.2 -> CAPABILITY-V1) is carried
+# inline by the capability-map view's children[] in v0.x.
 
 notation: capability
 id: CAPABILITY-V1.2
@@ -14,8 +14,6 @@ type: domain                            # domain | supporting
 description: >
   Pick, pack, route, and close out customer orders. Sits beneath Order
   Management alongside Order Intake (CAPABILITY-V1.1).
-
-target_maturity: 3
 
 # Admission record (CONTRACT.md §6)
 zone: canon

--- a/organizations/acme_corp/canon/elements/02_business/capabilities/CAPABILITY-V1.history.yaml
+++ b/organizations/acme_corp/canon/elements/02_business/capabilities/CAPABILITY-V1.history.yaml
@@ -2,11 +2,12 @@
 # Schema: notations/CONTRACT.md §9.1.
 #
 # Target: the CAPABILITY-V1.yaml primitive in this folder. Time-varying
-# attributes (current_maturity, owner_role, target_date) live here, not
-# inline on the primitive. Three patterns demonstrated:
+# attributes (current_maturity, target_maturity, owner_role, target_date)
+# live here, not inline on the primitive. Four patterns demonstrated:
 #   1. current_maturity — monotonic progression over three years.
-#   2. owner_role       — handover from one role to another.
-#   3. target_date      — re-aiming the planning target (moved earlier).
+#   2. target_maturity  — the aspiration itself revised upward.
+#   3. owner_role       — handover from one role to another.
+#   4. target_date      — re-aiming the planning target (moved earlier).
 #
 # Current-value resolution: pick the entry with the largest
 # valid_from <= today (CONTRACT.md §9.2). Validation rules
@@ -22,6 +23,13 @@ attribute_versions:
     - { valid_from: "2024-01-01", value: 1 }
     - { valid_from: "2025-06-01", value: 2 }
     - { valid_from: "2026-09-15", value: 3 }
+
+  # Target itself revised upward once the 2024 target was reached ahead
+  # of schedule — a target is a statement made on a date, so this is a
+  # separate series from current_maturity, never merged into it.
+  target_maturity:
+    - { valid_from: "2024-01-01", value: 3 }
+    - { valid_from: "2026-09-15", value: 4 }
 
   # Owner-role handover when the Order Management team split out of
   # Operations into its own product unit.

--- a/organizations/acme_corp/canon/elements/02_business/capabilities/CAPABILITY-V1.yaml
+++ b/organizations/acme_corp/canon/elements/02_business/capabilities/CAPABILITY-V1.yaml
@@ -2,9 +2,10 @@
 # Schema: notations/views/05-capability-map.md §13 + admission record
 # (CONTRACT.md §6) + primitive lifecycle (CONTRACT.md §7).
 #
-# Time-varying attributes (current_maturity, owner_role, target_date)
-# live in the sidecar CAPABILITY-V1.history.yaml per CONTRACT.md §9 —
-# NOT inline here. Inline placement would trigger VERSIONED-004.
+# Time-varying attributes (current_maturity, target_maturity, owner_role,
+# target_date) live in the sidecar CAPABILITY-V1.history.yaml per
+# CONTRACT.md §9 — NOT inline here. Inline placement would trigger
+# VERSIONED-004.
 
 notation: capability
 id: CAPABILITY-V1
@@ -14,9 +15,6 @@ description: >
   End-to-end management of customer orders, from intake through
   fulfilment. The capability spans receiving, validating, routing, and
   closing out customer purchase requests across all channels.
-
-# Stable forward-looking aspiration — not time-varying
-target_maturity: 3
 
 # Relations — stay inline in v1 (Wave 3 may promote to first-class
 # time-aware relation files)

--- a/organizations/acme_corp/canon/elements/02_business/capabilities/CAPABILITY-V2.history.yaml
+++ b/organizations/acme_corp/canon/elements/02_business/capabilities/CAPABILITY-V2.history.yaml
@@ -1,0 +1,12 @@
+# Worked example — versioned-attribute sidecar.
+# Schema: notations/CONTRACT.md §9.1.
+#
+# Target: the CAPABILITY-V2.yaml primitive in this folder. Single-entry
+# series — the migration pattern for an inline value with no prior history:
+# valid_from set to the primitive's own valid_from (CONTRACT.md §9.4).
+
+target: CAPABILITY-V2
+
+attribute_versions:
+  target_maturity:
+    - { valid_from: "2024-01-01", value: 4 }

--- a/organizations/acme_corp/canon/elements/02_business/capabilities/CAPABILITY-V2.yaml
+++ b/organizations/acme_corp/canon/elements/02_business/capabilities/CAPABILITY-V2.yaml
@@ -6,6 +6,9 @@
 # REL-CAP-V11-PARENT-1.yaml. It is now Order Intake's ex-parent after
 # the 2026-04 re-org; the canonical Order Intake parent today is V1
 # (Order Management), captured in REL-CAP-V11-PARENT-2.yaml.
+#
+# target_maturity is time-varying — it lives in the sidecar
+# CAPABILITY-V2.history.yaml per CONTRACT.md §9, not inline.
 
 notation: capability
 id: CAPABILITY-V2
@@ -15,8 +18,6 @@ description: >
   Manage long-term relationships with customers — segmentation,
   loyalty, communications, lifetime value. Sits parallel to Order
   Management (V1) in the post-2026-04 hierarchy.
-
-target_maturity: 4
 
 # Admission record (CONTRACT.md §6)
 zone: canon

--- a/organizations/acme_corp/canon/elements/02_business/capabilities/README.md
+++ b/organizations/acme_corp/canon/elements/02_business/capabilities/README.md
@@ -2,7 +2,7 @@
 
 Capability element primitives — each file is one capability the organisation can perform, sitting on the ArchiMate 3.2 **business** layer. The hierarchical view over these elements (with CMM maturity overlay) lives at [`../../../views/capabilities/`](../../../views/capabilities/).
 
-Time-varying attributes (`current_maturity`, `owner_role`, `target_date`) live in a co-located sidecar (`<id>.history.yaml`) per [`notations/CONTRACT.md`](../../../../../../notations/CONTRACT.md) §9. They are **not** stored inline on the element file; inline placement triggers `VERSIONED-004`.
+Time-varying attributes (`current_maturity`, `target_maturity`, `owner_role`, `target_date`) live in a co-located sidecar (`<id>.history.yaml`) per [`notations/CONTRACT.md`](../../../../../../notations/CONTRACT.md) §9. They are **not** stored inline on the element file; inline placement triggers `VERSIONED-004`.
 
 TYPE registry: [`notations/IDS_AND_REFERENCES.md`](../../../../../../notations/IDS_AND_REFERENCES.md) §3.1 (`CAPABILITY`), §2 (V/H sub-grammar), §4 (uniqueness scope).
 
@@ -16,18 +16,19 @@ For each capability, an optional sidecar `<id>.history.yaml` carries the time-va
 
 Stable fields live on the element file. Defined in [`notations/views/05-capability-map.md`](../../../../../../notations/views/05-capability-map.md) §13 (fields table) with the inline/sidecar split annotated. Each capability element carries:
 
-- The capability-specific stable fields: `notation: capability`, `id`, `name`, `type`, `description`, optional `target_maturity`, `business_process`, `applications`, `children`.
+- The capability-specific stable fields: `notation: capability`, `id`, `name`, `type`, `description`, `business_process`, `applications`, `children`.
 - The admission record per [`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §6: `zone: canon`, `admitted_at`, `admitted_by`, `gate_checks`.
 - The primitive lifecycle per [`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §7: `valid_from`, `valid_to`.
 
-Time-varying fields (`current_maturity`, `owner_role`, `target_date`) live in the sidecar — not inline.
+Time-varying fields (`current_maturity`, `target_maturity`, `owner_role`, `target_date`) live in the sidecar — not inline.
 
 ## Examples in this folder
 
 | File | Notes |
 |---|---|
 | `CAPABILITY-V1.yaml` | Order Management — stable fields only; time-varying attributes in the sibling sidecar |
-| `CAPABILITY-V1.history.yaml` | Sidecar with three time-varying attributes (`current_maturity` / `owner_role` / `target_date`) demonstrating the CONTRACT.md §9 pattern, including a maturity progression over three years and an owner-role handover |
+| `CAPABILITY-V1.history.yaml` | Sidecar with four time-varying attributes (`current_maturity` / `target_maturity` / `owner_role` / `target_date`) demonstrating the CONTRACT.md §9 pattern, including a maturity progression over three years, a target revised upward, and an owner-role handover |
+| `CAPABILITY-H1.yaml`, `CAPABILITY-V1.1.yaml`, `CAPABILITY-V1.2.yaml`, `CAPABILITY-V2.yaml` | Minimal examples — each pairs with a single-entry `<id>.history.yaml` sidecar for `target_maturity`, the mechanical migration pattern (§9.4) for a value with no prior history |
 
 ## See also
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/cli",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "type": "module",
   "description": "Transitrix CLI — compile, validate, and report on Transitrix diagrams (BPMN, Goals, DGCA, …) from any shell or CI pipeline.",
   "license": "MIT",

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",

--- a/packages/diagrams/src/repo-validate/__tests__/check-versioned-attributes.test.ts
+++ b/packages/diagrams/src/repo-validate/__tests__/check-versioned-attributes.test.ts
@@ -42,9 +42,11 @@ describe('checkVersionedAttributes — VERSIONED-004 (inline time_varying field)
     expect(flagged.some((m) => m.includes('target_date'))).toBe(true);
   });
 
-  it('does not flag target_maturity — not yet time_varying on the merged spec', () => {
+  it('flags target_maturity present inline on a capability element', () => {
     const findings = validateRepoModel(model([capability({ target_maturity: 3 })]));
-    expect(findings.filter((f) => f.ruleId === 'VERSIONED-004')).toEqual([]);
+    const flagged = findings.filter((f) => f.ruleId === 'VERSIONED-004');
+    expect(flagged.length).toBe(1);
+    expect(flagged[0].message).toContain('target_maturity');
   });
 
   it('produces no findings for a capability with no inline time_varying fields', () => {
@@ -135,12 +137,16 @@ describe('checkVersionedAttributes — acme_corp-shaped worked example stays cle
   it('the CAPABILITY-V1 + sidecar pairing from organizations/acme_corp produces zero findings', () => {
     const findings = validateRepoModel(
       model([
-        capability({ target_maturity: 3, valid_from: '2024-01-01', valid_to: null }),
+        capability({ valid_from: '2024-01-01', valid_to: null }),
         sidecar({
           current_maturity: [
             { valid_from: '2024-01-01', value: 1 },
             { valid_from: '2025-06-01', value: 2 },
             { valid_from: '2026-09-15', value: 3 },
+          ],
+          target_maturity: [
+            { valid_from: '2024-01-01', value: 3 },
+            { valid_from: '2026-09-15', value: 4 },
           ],
           owner_role: [
             { valid_from: '2024-01-01', value: 'ROLE-OPS-1' },

--- a/packages/diagrams/src/repo-validate/check-versioned-attributes.ts
+++ b/packages/diagrams/src/repo-validate/check-versioned-attributes.ts
@@ -15,14 +15,13 @@
 //
 // `TIME_VARYING_FIELDS` is deliberately narrower than the full candidate
 // list in CONTRACT.md §9.4: it only enforces fields already `time_varying`
-// on methodology's *currently-merged* `notations/views/05-capability-map.md`
-// (`current_maturity`, `owner_role`, `target_date`). `target_maturity`
-// (capability) and `maturity` (application) become time_varying only once
-// methodology PR #425 (the other half of the 2026-08-02 maturity ADR)
-// merges — enforcing VERSIONED-004 on those now would fail the acme_corp
-// worked example (`CAPABILITY-V1.yaml` still carries `target_maturity`
-// inline, correctly, under the spec merged today) against a spec that isn't
-// canon yet. Extend this table once #425 lands.
+// on methodology's *currently-merged* notation specs. `capability` covers
+// `current_maturity`, `target_maturity`, `owner_role`, `target_date` per
+// `05-capability-map.md` §13/§14. Applications-catalogue `maturity` (and its
+// sibling `owner_role`/`vendor`) is on the same 2026-08-02 maturity ADR but
+// is not enforced here yet — it lives on the `applications[]` list inside a
+// catalogue view document, not on a standalone element primitive, and this
+// check only walks `elements`.
 
 import { parseSidecar, validateSidecar } from '../versioned-attribute/index.js';
 import { docId } from './validate-repo.js';
@@ -31,7 +30,7 @@ import type { RepoDoc, RepoFinding, RepoModelInput } from './types.js';
 const PScope: RepoFinding['scope'] = 'repo';
 
 const TIME_VARYING_FIELDS: Record<string, string[]> = {
-  capability: ['current_maturity', 'owner_role', 'target_date'],
+  capability: ['current_maturity', 'target_maturity', 'owner_role', 'target_date'],
 };
 
 function readString(data: Record<string, unknown>, key: string): string | undefined {


### PR DESCRIPTION
## Summary
- Extends `VERSIONED-004`'s capability field list to include `target_maturity`, now that the maturity spec's remaining half is on `main` — a target is a statement made on a date and revised on a later date, so it lives in the sidecar alongside `current_maturity`, not inline.
- Migrates the acme_corp worked example's inline `target_maturity` values to their `<id>.history.yaml` sidecars (mechanical single-entry migration for the four capabilities with no prior history; `CAPABILITY-V1` gets a two-entry series matching the upstream spec's own worked example).
- Applications-catalogue `maturity` stays unaddressed — it lives on a catalogue *view* document's `applications[]` list, not a standalone element primitive, and this check only walks elements; documented as a distinct follow-on in `docs/validation.md`.

## Test plan
- [x] `packages/diagrams` unit tests (full suite, 1600/1600) + `tsc --noEmit`
- [x] `npm run build` / `npm run compile` clean
- [x] `npm test` — same 3 pre-existing failures reproduce on `main` (environment-dependent `cli-migrate`/`ci-hygiene-hashrefs` tests, unrelated to this change)
- [x] `transitrix validate --scope=repo --root organizations/acme_corp` — zero `VERSIONED-*` findings after migration