### PR TITLE
feat(diagrams): VERSIONED-004 covers the applications catalogue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - **`REQUIREMENT` → `VERIFICATION` coverage surfaced as an obligation.** New `VERIFICATION` element (`canon/verifications/`, `VERIF-001..006`) — the engineering V&V analogue of `ASSERTION`. The reverse-trace completeness rules `REQ-VERIF-COVERAGE-001` (no verification targets a requirement) and `-002` (every verification against it is still unresolved) are computed cross-cuttingly and surfaced in `validate --scope=repo`'s `compliance` findings. The Requirement Trace preview renders a "Verification" section labelled "Not verified" / "Unresolved" for a gap rather than a blank section; the Compliance Gap Dashboard lists every affected requirement repo-wide (both re-scan on save of any `VERIFICATION-*.yaml` file).
+- **`VERSIONED-004` now covers the applications catalogue.** `owner_role`/`vendor`/`maturity` on an `applications[]` entry (`notations/views/10-applications.md` §5a) are rejected inline, same as capability's `current_maturity`. Unlike capability's element-file check, a catalogue entry has no file of its own to check, so this instance lives in the per-file `applications` notation validator rather than the repo-scope element sweep — see `docs/validation.md`. The `acme_corp` worked example's `eu-portfolio` catalogue and the two `APPLICATION-*` elements it references migrate their `owner_role`/`vendor`/`maturity` into `.history.yaml` sidecars; the standalone `notation-corpus` fixture (no element pairing to sidecar against) drops the fields instead. Not resolved here: neither `render-applications.ts` nor `render-capability-map.ts` reads a current value back from the sidecar at render time — both still read the field straight off the document.
 
 ### Changed
 
@@ -15,6 +16,8 @@
 
 - `@transitrix/diagrams` 1.8.21 → 1.9.0 — the V&V coverage rules; supersedes the interim 1.8.22 comment-only bump.
 - `@transitrix/cli` 2.3.0 → 2.4.0 — paired bump per `cli-diagrams-alignment`; supersedes the interim 2.3.1.
+- `@transitrix/diagrams` 1.9.4 → 1.9.5 — applications-catalogue `VERSIONED-004`.
+- `@transitrix/cli` 2.4.4 → 2.4.5 — paired bump per `cli-diagrams-alignment`.
 
 ## [3.1.3] — 2026-07-29
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -197,19 +197,39 @@ repo-scope wiring).
 | `VERSIONED-004` | error | A field declared `time_varying` is present inline on its primitive instead of only in the sidecar. |
 | `VERSIONED-005` | error | A version entry's `valid_from` falls outside `[target.valid_from, target.valid_to]`. |
 
-**`VERSIONED-004`'s field list is deliberately narrower than CONTRACT.md
-§9.4's full candidate table.** It enforces only the fields already
-`time_varying` on methodology's *currently-merged*
-`notations/views/05-capability-map.md`: capability `current_maturity`,
-`target_maturity`, `owner_role`, `target_date` (methodology PR #425, the
-2026-08-02 maturity ADR's remaining half, merged 2026-08-04 and brought
-`target_maturity` in — `organizations/acme_corp`'s capability fixtures
-migrated their inline values to sidecar form in the same pass). Applications-
-catalogue `maturity` is on the same CONTRACT.md §9.4 candidate row but is
-**not** enforced here: `check-versioned-attributes.ts` only walks
-`elements`, and `maturity` lives on the `applications[]` list inside a
-catalogue *view* document, not on a standalone element primitive — adding it
-needs the check to walk view documents too, not just a field-list edit.
+**`VERSIONED-004`'s element-level field list (`TIME_VARYING_FIELDS` in
+`check-versioned-attributes.ts`) enforces capability's `current_maturity`,
+`target_maturity`, `owner_role`, `target_date`** — every field methodology's
+merged `notations/views/05-capability-map.md` declares `time_varying`, now
+that PR #425 (the 2026-08-02 maturity ADR's remaining half) is on `main`;
+`organizations/acme_corp`'s capability fixtures migrated their inline
+`target_maturity` values to sidecar form in the same pass.
+
+**Applications-catalogue `owner_role`/`vendor`/`maturity` are covered too,
+but by a different mechanism.** DSM's importer-parity element-file check
+above walks standalone primitives under `canon/elements/**`; an
+applications-catalogue entry has no file of its own — the time-varying
+values, per `notations/views/10-applications.md` §5/§5a, are asserted
+inline on the catalogue *view* document's `applications[].{owner_role,
+vendor,maturity}`, not on a standalone `APPLICATION-*` element file. So this
+`VERSIONED-004` instance is ported into
+`packages/diagrams/src/applications/validate.ts` (the per-file notation
+validator, same as `HDR-001/002`/`LIFECYCLE-001/004` are for capability-map
+above) rather than into `check-versioned-attributes.ts`'s element sweep. The
+sidecar itself is still co-located with the referenced `APPLICATION-*`
+element file (`canon/elements/03_application/applications/<app_id>.
+history.yaml`) and its own shape (`VERSIONED-001/002/003/005`) is validated
+generically by the existing element-sweep `checkSidecars` — only the
+inline-vs-sidecar placement check needed a second home.
+
+**Not resolved here: rendering a current value from the sidecar.** Neither
+`render-applications.ts` (`a.maturity`/`a.vendor`/`a.owner_role`) nor
+`render-capability-map.ts` (`node.current_maturity`/`target_maturity`)
+resolves a sidecar at load — both still read the field directly off the
+document they're given. `versioned-attribute/resolve.ts`
+(`resolveAttributes`/`resolveAttributeValue`, CONTRACT.md §9.2) exists and is
+exercised by the validator, but nothing wires it into either preview yet.
+Flagged rather than silently left broken or silently worked around.
 
 **Not covered here: the native `capability-map` notation's own single-file
 view-document form** (`packages/diagrams/src/capability-map/{types,

--- a/organizations/acme_corp/.templates/elements/03_application_template.yaml
+++ b/organizations/acme_corp/.templates/elements/03_application_template.yaml
@@ -8,7 +8,7 @@
 #   INTEGRATION  notation: integration   folder integrations/  fields: §7.8 (view-defined/nested in v1; promotable)
 #
 # Worked examples: organizations/acme_corp/canon/elements/03_application/.
-# Time-varying fields (owner_role, vendor, lifecycle_stage, maturity) live in a
+# Time-varying fields (owner_role, vendor, maturity) live in a
 # <id>.history.yaml sidecar (CONTRACT.md §9), never inline (would trigger VERSIONED-004).
 
 notation: application                  # element TYPE short name (lowercased TYPE)

--- a/organizations/acme_corp/canon/elements/03_application/applications/APPLICATION-CRM-1.history.yaml
+++ b/organizations/acme_corp/canon/elements/03_application/applications/APPLICATION-CRM-1.history.yaml
@@ -1,0 +1,19 @@
+# Worked example — versioned-attribute sidecar.
+# Schema: notations/CONTRACT.md §9.1.
+#
+# Target: the APPLICATION-CRM-1.yaml primitive in this folder. Time-varying
+# attributes (owner_role, vendor, maturity — notations/views/10-applications.md
+# §5a) live here, not inline on the catalogue entry
+# (canon/views/applications/eu-portfolio.applications.transitrix.yaml).
+# Single-entry migration: valid_from = the primitive's own valid_from, per
+# §5a's migration note.
+
+target: APPLICATION-CRM-1
+
+attribute_versions:
+  owner_role:
+    - { valid_from: "2026-05-26", value: ROLE-SALES-1 }
+  vendor:
+    - { valid_from: "2026-05-26", value: "Salesforce" }
+  maturity:
+    - { valid_from: "2026-05-26", value: 2 }

--- a/organizations/acme_corp/canon/elements/03_application/applications/APPLICATION-CRM-1.yaml
+++ b/organizations/acme_corp/canon/elements/03_application/applications/APPLICATION-CRM-1.yaml
@@ -1,7 +1,8 @@
 # Worked example — APPLICATION element primitive (stable fields only).
 # Schema: notations/ELEMENT_PRIMITIVES.md §7.7 + envelope §3.
-# Time-varying fields (owner_role, vendor, lifecycle_stage, maturity) are
-# sidecar-bound per CONTRACT.md §9 — not inline here.
+# Time-varying fields (owner_role, vendor, maturity) are sidecar-bound per
+# CONTRACT.md §9 — not inline here; see APPLICATION-CRM-1.history.yaml in
+# this folder.
 
 notation: application
 id: APPLICATION-CRM-1

--- a/organizations/acme_corp/canon/elements/03_application/applications/APPLICATION-OMS-1.history.yaml
+++ b/organizations/acme_corp/canon/elements/03_application/applications/APPLICATION-OMS-1.history.yaml
@@ -1,0 +1,19 @@
+# Worked example — versioned-attribute sidecar.
+# Schema: notations/CONTRACT.md §9.1.
+#
+# Target: the APPLICATION-OMS-1.yaml primitive in this folder. Time-varying
+# attributes (owner_role, vendor, maturity — notations/views/10-applications.md
+# §5a) live here, not inline on the catalogue entry
+# (canon/views/applications/eu-portfolio.applications.transitrix.yaml).
+# Single-entry migration: valid_from = the primitive's own valid_from, per
+# §5a's migration note.
+
+target: APPLICATION-OMS-1
+
+attribute_versions:
+  owner_role:
+    - { valid_from: "2026-05-26", value: ROLE-TECH-1 }
+  vendor:
+    - { valid_from: "2026-05-26", value: "Internal" }
+  maturity:
+    - { valid_from: "2026-05-26", value: 3 }

--- a/organizations/acme_corp/canon/elements/03_application/applications/APPLICATION-OMS-1.yaml
+++ b/organizations/acme_corp/canon/elements/03_application/applications/APPLICATION-OMS-1.yaml
@@ -2,10 +2,10 @@
 # Schema: notations/ELEMENT_PRIMITIVES.md §7.7 + envelope §3.
 # Arranged by the applications-catalogue view (canon/views/applications/).
 #
-# Time-varying fields (owner_role, vendor, lifecycle_stage, maturity) are
-# sidecar-bound per CONTRACT.md §9 — kept out of this file (inline placement
-# would trigger VERSIONED-004). No sidecar is provided for this minimal
-# example; the catalogue view shows their current values.
+# Time-varying fields (owner_role, vendor, maturity) are sidecar-bound per
+# CONTRACT.md §9 — kept out of this file (inline placement would trigger
+# VERSIONED-004) and out of the catalogue view; see
+# APPLICATION-OMS-1.history.yaml in this folder.
 
 notation: application
 id: APPLICATION-OMS-1

--- a/organizations/acme_corp/canon/elements/03_application/applications/README.md
+++ b/organizations/acme_corp/canon/elements/03_application/applications/README.md
@@ -15,14 +15,14 @@ Defined in [`notations/ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEME
 - Identity + application fields: `notation: application`, `id`, `name`, `type` (`application` | `integration` | `platform` | `data_store`, required), `domain`, `description`, `capabilities: [CAPABILITY-…]`, `products: [PRODUCT-…]`.
 - Admission record ([`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §6) and primitive lifecycle ([`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §7).
 
-**Time-varying** fields — `owner_role`, `vendor`, `lifecycle_stage`, `maturity` — are sidecar-bound ([`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §9), **not** inline (inline placement triggers `VERSIONED-004`). `INTEGRATION` is view-defined (nested under its source application in the catalogue) in v1 and promotable to a standalone `../integrations/` file — see [`ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEMENT_PRIMITIVES.md) §7.8.
+**Time-varying** fields — `owner_role`, `vendor`, `maturity` — are sidecar-bound ([`CONTRACT.md`](../../../../../../notations/CONTRACT.md) §9), **not** inline (inline placement triggers `VERSIONED-004`, enforced both here and on the catalogue view's `applications[]` entries). `INTEGRATION` is view-defined (nested under its source application in the catalogue) in v1 and promotable to a standalone `../integrations/` file — see [`ELEMENT_PRIMITIVES.md`](../../../../../../notations/ELEMENT_PRIMITIVES.md) §7.8.
 
 ## Examples in this folder
 
 | File | Notes |
 |---|---|
-| `APPLICATION-OMS-1.yaml` | Order Management System — supports `CAPABILITY-V1`, used by `PRODUCT-ECOMM-1` |
-| `APPLICATION-CRM-1.yaml` | CRM System — supports `CAPABILITY-V2` |
+| `APPLICATION-OMS-1.yaml` (+ `.history.yaml` sidecar) | Order Management System — supports `CAPABILITY-V1`, used by `PRODUCT-ECOMM-1` |
+| `APPLICATION-CRM-1.yaml` (+ `.history.yaml` sidecar) | CRM System — supports `CAPABILITY-V2` |
 
 ## See also
 

--- a/organizations/acme_corp/canon/views/applications/eu-portfolio.applications.transitrix.yaml
+++ b/organizations/acme_corp/canon/views/applications/eu-portfolio.applications.transitrix.yaml
@@ -17,10 +17,9 @@ applications_catalogue:
       name: "Order Management System"
       type: "application"
       domain: "Operations"
-      owner_role: ROLE-TECH-1
-      vendor: "Internal"
       status: "Active"
-      maturity: 3
+      # owner_role, vendor, maturity are time-varying — they live in
+      # APPLICATION-OMS-1.history.yaml (CONTRACT.md §9), not inline.
       description: "Core system for order lifecycle management; holds active-order personal data."
       capabilities: ["CAPABILITY-V1"]
       products: ["PRODUCT-ECOMM-1"]
@@ -36,10 +35,9 @@ applications_catalogue:
       name: "CRM System"
       type: "application"
       domain: "Sales"
-      owner_role: ROLE-SALES-1
-      vendor: "Salesforce"
       status: "Active"
-      maturity: 2
+      # owner_role, vendor, maturity are time-varying — they live in
+      # APPLICATION-CRM-1.history.yaml (CONTRACT.md §9), not inline.
       description: "Customer relationship and consent management; holds contact and consent personal data."
       capabilities: ["CAPABILITY-V2"]
       products: ["PRODUCT-ECOMM-1"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -6981,7 +6981,7 @@
     },
     "packages/cli": {
       "name": "@transitrix/cli",
-      "version": "2.4.2",
+      "version": "2.4.5",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",
@@ -6999,7 +6999,7 @@
     },
     "packages/diagrams": {
       "name": "@transitrix/diagrams",
-      "version": "1.9.2",
+      "version": "1.9.5",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/cli",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "type": "module",
   "description": "Transitrix CLI — compile, validate, and report on Transitrix diagrams (BPMN, Goals, DGCA, …) from any shell or CI pipeline.",
   "license": "MIT",

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",

--- a/packages/diagrams/src/applications/__tests__/validate.test.ts
+++ b/packages/diagrams/src/applications/__tests__/validate.test.ts
@@ -8,7 +8,7 @@ const VALID_CATALOGUE = {
     name: 'Enterprise Applications',
     updated_at: '2026-05-14',
     applications: [
-      { app_id: 'APP-001', name: 'Order System', type: 'application', status: 'Active', maturity: 3 },
+      { app_id: 'APP-001', name: 'Order System', type: 'application', status: 'Active' },
       { app_id: 'INT-001', name: 'Event Bus', type: 'integration', status: 'Draft' },
     ],
   },
@@ -219,13 +219,47 @@ describe('validateApplicationsCatalogue', () => {
   it('accepts application with all optional fields', () => {
     const apps = [{
       app_id: 'A1', name: 'Full App', type: 'application', status: 'Active',
-      domain: 'Sales', owner_role: 'ROLE-001', vendor: 'Salesforce', maturity: 4,
+      domain: 'Sales',
       description: 'CRM system', capabilities: ['CAP-001'], products: ['PROD-001'],
       integrations: [{ target: 'A2', direction: 'outbound', protocol: 'REST', description: 'sends events' }],
     }];
     const cat = { ...VALID_CATALOGUE.applications_catalogue, applications: apps };
     const r = validateApplicationsCatalogue({ ...VALID_CATALOGUE, applications_catalogue: cat });
     expect(r.valid).toBe(true);
+  });
+
+  // VERSIONED-004 (CONTRACT.md §9.3) — owner_role/vendor/maturity are
+  // time_varying per notations/views/10-applications.md §5a; inline placement
+  // on the catalogue entry is rejected, same as CAPABILITY-*'s current_maturity.
+  it('VERSIONED-004: rejects inline owner_role', () => {
+    const apps = [{ app_id: 'A1', name: 'X', type: 'application', status: 'Active', owner_role: 'ROLE-001' }];
+    const cat = { ...VALID_CATALOGUE.applications_catalogue, applications: apps };
+    const r = validateApplicationsCatalogue({ ...VALID_CATALOGUE, applications_catalogue: cat });
+    expect(r.valid).toBe(false);
+    expect(r.errors.some(e => e.code === 'VERSIONED-004' && e.message.includes('owner_role'))).toBe(true);
+  });
+
+  it('VERSIONED-004: rejects inline vendor', () => {
+    const apps = [{ app_id: 'A1', name: 'X', type: 'application', status: 'Active', vendor: 'Salesforce' }];
+    const cat = { ...VALID_CATALOGUE.applications_catalogue, applications: apps };
+    const r = validateApplicationsCatalogue({ ...VALID_CATALOGUE, applications_catalogue: cat });
+    expect(r.valid).toBe(false);
+    expect(r.errors.some(e => e.code === 'VERSIONED-004' && e.message.includes('vendor'))).toBe(true);
+  });
+
+  it('VERSIONED-004: rejects inline maturity', () => {
+    const apps = [{ app_id: 'A1', name: 'X', type: 'application', status: 'Active', maturity: 4 }];
+    const cat = { ...VALID_CATALOGUE.applications_catalogue, applications: apps };
+    const r = validateApplicationsCatalogue({ ...VALID_CATALOGUE, applications_catalogue: cat });
+    expect(r.valid).toBe(false);
+    expect(r.errors.some(e => e.code === 'VERSIONED-004' && e.message.includes('A1.history.yaml'))).toBe(true);
+  });
+
+  it('VERSIONED-004: absent when none of owner_role/vendor/maturity is inline', () => {
+    const apps = [{ app_id: 'A1', name: 'X', type: 'application', status: 'Active', domain: 'Sales' }];
+    const cat = { ...VALID_CATALOGUE.applications_catalogue, applications: apps };
+    const r = validateApplicationsCatalogue({ ...VALID_CATALOGUE, applications_catalogue: cat });
+    expect(r.errors.some(e => e.code === 'VERSIONED-004')).toBe(false);
   });
 
   // Pre-release blocker regression (orchestrator review 2026-05-21).

--- a/packages/diagrams/src/applications/validate.ts
+++ b/packages/diagrams/src/applications/validate.ts
@@ -12,6 +12,17 @@ const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 const IFACE_CONDITIONAL = ['protocol', 'payload_class', 'sensitivity', 'directionality'] as const;
 
+// VERSIONED-004 (CONTRACT.md §9.3) — `owner_role`, `vendor`, `maturity` are
+// declared `time_varying` by notations/views/10-applications.md §5/§5a and
+// belong in the sidecar `<app_id>.history.yaml`, not inline on the catalogue
+// entry. Unlike capability's VERSIONED-004 (packages/diagrams/src/
+// repo-validate/check-versioned-attributes.ts), which walks standalone
+// element files under canon/elements/**, an applications-catalogue entry has
+// no file of its own to check inline-vs-sidecar on — the entry lives in this
+// view document — so the check runs here, at the per-file notation
+// validator, rather than in the repo-scope element sweep.
+const TIME_VARYING_FIELDS = ['owner_role', 'vendor', 'maturity'] as const;
+
 export function validateApplicationsCatalogue(input: unknown): ValidationResult {
   const errors: ValidationError[] = [];
   const warnings: ValidationWarning[] = [];
@@ -111,6 +122,18 @@ export function validateApplicationsCatalogue(input: unknown): ValidationResult 
       const m = a['maturity'];
       if (typeof m !== 'number' || !Number.isInteger(m) || m < 1 || m > 5) {
         errors.push({ code: 'APP-006', message: `${idx}: maturity must be an integer 1–5, got "${m}"` });
+      }
+    }
+
+    // VERSIONED-004: time_varying fields must live in the sidecar, not inline.
+    for (const field of TIME_VARYING_FIELDS) {
+      if (a[field] !== undefined) {
+        errors.push({
+          code: 'VERSIONED-004',
+          message:
+            `${idx}: '${field}' is time_varying (CONTRACT.md §9) and belongs in the sidecar ` +
+            `'${typeof a['app_id'] === 'string' ? a['app_id'] : idx}.history.yaml', not inline on the catalogue entry.`,
+        });
       }
     }
 

--- a/tests/fixtures/notation-corpus/applications/README.md
+++ b/tests/fixtures/notation-corpus/applications/README.md
@@ -37,9 +37,9 @@ notation: applications
 | Field | Description |
 |---|---|
 | `domain` | Business domain |
-| `owner_role` | Responsible role or team |
-| `vendor` | Vendor name or `Internal` |
-| `maturity` | Integer 1–5 (CMM level, displayed as ●●●○○ dots) |
+| `owner_role` | Responsible role or team. **Time-varying** — lives in the sidecar `<app_id>.history.yaml` (CONTRACT.md §9), not inline. Inline placement triggers `VERSIONED-004`. Omitted from this corpus example, which has no `canon/elements/03_application/` pairing to sidecar against. |
+| `vendor` | Vendor name or `Internal`. **Time-varying** — same as `owner_role`. |
+| `maturity` | Integer 1–5 (CMM level, displayed as ●●●○○ dots). **Time-varying** — same as `owner_role`. |
 | `description` | Short description |
 | `capabilities` | List of capability names |
 | `products` | List of product IDs this application supports |

--- a/tests/fixtures/notation-corpus/applications/portfolio-2026.applications.transitrix.yaml
+++ b/tests/fixtures/notation-corpus/applications/portfolio-2026.applications.transitrix.yaml
@@ -1,3 +1,7 @@
+# owner_role/vendor/maturity are time_varying (CONTRACT.md §9, notations/
+# views/10-applications.md §5a) — sidecar-bound, not inline. This corpus
+# example is self-contained (no canon/elements/03_application/ pairing), so
+# it omits them rather than fabricating a sidecar with no real target.
 notation: applications
 spec_version: "0.1"
 title: Enterprise Applications Portfolio 2026
@@ -16,9 +20,6 @@ applications_catalogue:
       type: application
       status: Active
       domain: Operations
-      owner_role: ROLE-ENG-001
-      vendor: Internal
-      maturity: 4
       description: Core system for end-to-end order lifecycle management.
       capabilities:
         - V1.2      # Order Fulfilment — order processing
@@ -42,9 +43,6 @@ applications_catalogue:
       type: application
       status: Active
       domain: Sales
-      owner_role: ROLE-SALES-001
-      vendor: Salesforce
-      maturity: 3
       description: Customer relationship and sales pipeline management.
       capabilities:
         - V2.1    # Customer Acquisition — lead management, opportunity tracking
@@ -55,9 +53,6 @@ applications_catalogue:
       type: platform
       status: Active
       domain: Engineering
-      owner_role: ROLE-PLATFORM-001
-      vendor: Internal
-      maturity: 5
       description: Centralised Kafka-based event streaming platform for domain event distribution.
       integrations:
         - target: APPLICATION-DWH-1
@@ -70,9 +65,6 @@ applications_catalogue:
       type: data_store
       status: Active
       domain: Data & Analytics
-      owner_role: ROLE-DATA-001
-      vendor: Snowflake
-      maturity: 4
       description: Central analytical data store for BI and reporting.
       capabilities:
         - V4.1    # Analytics — real-time reporting
@@ -84,8 +76,6 @@ applications_catalogue:
       type: application
       status: Deprecated
       domain: Customer
-      vendor: Internal
-      maturity: 2
       description: Original web portal for customer self-service. Being replaced by the mobile app.
 
     - app_id: APPLICATION-ERP-LEGACY-1
@@ -93,9 +83,6 @@ applications_catalogue:
       type: application
       status: Decommissioning
       domain: Finance
-      owner_role: ROLE-FIN-001
-      vendor: SAP
-      maturity: 1
       description: On-premise ERP module being decommissioned in Q3 2026. Migration to cloud ERP in progress.
 
     - app_id: INTEGRATION-OMS-CRM-1
@@ -103,7 +90,6 @@ applications_catalogue:
       type: integration
       status: Draft
       domain: Operations
-      owner_role: ROLE-INTARCH-001
       description: Event-driven integration forwarding order state changes from OMS to CRM.
       source: APPLICATION-OMS-1
       target: APPLICATION-CRM-1


### PR DESCRIPTION
## Summary
- Extends `VERSIONED-004` enforcement to the applications-catalogue notation: `owner_role`/`vendor`/`maturity` inline on an `applications[]` entry are rejected, matching the notation spec's existing "inline placement triggers VERSIONED-004" note (`notations/views/10-applications.md` §5/§5a).
- Unlike capability's element-file check (`check-versioned-attributes.ts`), a catalogue entry has no standalone file of its own to check inline-vs-sidecar on — the entry lives in the view document — so this instance is ported into the per-file `applications` notation validator (`packages/diagrams/src/applications/validate.ts`) instead. The referenced element's sidecar shape itself (`VERSIONED-001/002/003/005`) is still validated generically by the existing element-sweep `checkSidecars`, no change needed there.
- Migrates the acme_corp worked example: `eu-portfolio.applications.transitrix.yaml`'s two entries move `owner_role`/`vendor`/`maturity` into new `APPLICATION-OMS-1.history.yaml` / `APPLICATION-CRM-1.history.yaml` sidecars (single-entry, `valid_from` = the element's own `valid_from`, per the notation's migration note).
- Migrates the standalone `tests/fixtures/notation-corpus/applications/portfolio-2026...yaml` fixture by dropping the three fields — it has no `canon/elements/` pairing to sidecar against.
- Not resolved here (flagged in `docs/validation.md`): neither `render-applications.ts` nor `render-capability-map.ts` resolves a current value from the sidecar at render time — both still read the field directly off the document they're given.

## Test plan
- [x] `packages/diagrams` unit tests (full suite, 1604/1604) + new VERSIONED-004 cases in `applications/__tests__/validate.test.ts`
- [x] Root `vitest run` — same 2 pre-existing environment-dependent failures (`cli-migrate`, `ci-hygiene-hashrefs`) reproduce unchanged on `main`
- [x] `tsc --noEmit` clean
- [x] `transitrix validate --scope=repo --root organizations/acme_corp` — zero `VERSIONED-*` findings after migration

Do not merge without Valerii review.