### PR TITLE
feat(diagrams): resolve applications-catalogue maturity at render time

### DIFF
--- a/extension/src/applications-preview.ts
+++ b/extension/src/applications-preview.ts
@@ -1,10 +1,18 @@
+import * as path from 'node:path';
 import { escHtml } from '@transitrix/diagrams/webview/render-util.js';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { buildDiagramFrame, extractDiagramMeta, CATALOGUE_STYLES, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
 import { coerceDatesToIsoStrings } from '@transitrix/diagrams/yaml-normalize.js';
 import { validateApplicationsCatalogue } from '@transitrix/diagrams/applications/validate.js';
+import {
+  resolveApplicationAttributes,
+  withResolvedAttributes,
+  type ResolvedApplicationAttributes,
+} from '@transitrix/diagrams/applications/resolve-maturity.js';
 import { StaticPreview } from './static-preview.js';
+import { findCanonRoot, readYamlDocsUnder } from './canon-loader.js';
+import { todayIso } from './svg-title-block.js';
 
 // ── Types (used by render helpers) ───────────────────────────────────────────
 
@@ -87,8 +95,12 @@ function renderIntegrations(integrations: ApplicationIntegration[] | undefined):
   return `<details><summary>Integrations (${integrations.length})</summary><ul>${items}</ul></details>`;
 }
 
-function buildApplicationsTable(catalogue: ApplicationsCatalogueHeader): string {
-  const rows = catalogue.applications.map(a => {
+function buildApplicationsTable(
+  catalogue: ApplicationsCatalogueHeader,
+  resolved: Map<string, ResolvedApplicationAttributes>,
+): string {
+  const rows = catalogue.applications.map(raw => {
+    const a = withResolvedAttributes(raw, resolved);
     const extras = [
       renderIntegrations(a.integrations),
       disclosureList('Capabilities', a.capabilities),
@@ -145,7 +157,37 @@ export class ApplicationsPreview extends StaticPreview {
   protected readonly viewType = 'applicationsPreview';
   protected readonly enableCommandUris = ['transitrixStudio.changeTheme'];
 
-  protected renderHtml(yamlText: string, filename: string): string {
+  // Overridden (rather than the base's sync `renderHtml`) because resolving
+  // owner_role/vendor/maturity means reading canon/elements/** for the
+  // catalogue's sidecars (CONTRACT.md §9.4) before the table can be built —
+  // same async-loading shape as ActionsTreePreview's canon walk.
+  protected override async pushDocument(doc: vscode.TextDocument): Promise<void> {
+    if (!this.panel) return;
+    const resolved = await this.resolveMaturity(doc.uri);
+    this.panel.webview.html = this.buildHtml(doc.getText(), path.basename(doc.fileName), resolved);
+  }
+
+  /** Sidecar-bound fields (CONTRACT.md §9.4) never live inline on an admitted
+   *  catalogue entry (VERSIONED-004) — resolve them from canon/elements/**
+   *  so the preview isn't just blank cells for a compliant document. A read
+   *  model only: the result is never written anywhere. */
+  private async resolveMaturity(
+    fileUri: vscode.Uri,
+  ): Promise<{ byAppId: Map<string, ResolvedApplicationAttributes>; asOf: string }> {
+    const asOf = todayIso();
+    const canonRoot = findCanonRoot(fileUri);
+    if (!canonRoot) return { byAppId: new Map(), asOf };
+    const rawDocs: unknown[] = [];
+    const warnings: string[] = [];
+    await readYamlDocsUnder(vscode.Uri.joinPath(canonRoot, 'elements'), rawDocs, warnings);
+    return { byAppId: resolveApplicationAttributes(rawDocs, asOf), asOf };
+  }
+
+  private buildHtml(
+    yamlText: string,
+    filename: string,
+    resolved: { byAppId: Map<string, ResolvedApplicationAttributes>; asOf: string },
+  ): string {
     let bodyContent = '';
     let errorMsg = '';
     let title: string | undefined;
@@ -167,7 +209,10 @@ export class ApplicationsPreview extends StaticPreview {
       } else {
         const raw = parsed as Record<string, unknown>;
         const catalogue = raw['applications_catalogue'] as ApplicationsCatalogueHeader;
-        bodyContent = buildApplicationsTable(catalogue);
+        const resolvedNote = resolved.byAppId.size > 0
+          ? `<div class="resolved-note">Owner Role, Vendor, Maturity resolved as of ${escHtml(resolved.asOf)}</div>`
+          : '';
+        bodyContent = resolvedNote + buildApplicationsTable(catalogue, resolved.byAppId);
         if (!title) title = catalogue.name;
         if (!subtitle && catalogue.description) subtitle = catalogue.description;
         if (!version && catalogue.version) version = catalogue.version;
@@ -199,6 +244,11 @@ export class ApplicationsPreview extends StaticPreview {
 }
 
 const APPLICATIONS_STYLES = `
+  .resolved-note {
+    font-size: 11px;
+    color: var(--ts-text-muted, #64748b);
+    margin: 4px 0 10px;
+  }
   .applications-table {
     width: 100%;
     border-collapse: collapse;

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/cli",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "type": "module",
   "description": "Transitrix CLI — compile, validate, and report on Transitrix diagrams (BPMN, Goals, DGCA, …) from any shell or CI pipeline.",
   "license": "MIT",

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",

--- a/packages/diagrams/src/applications/__tests__/resolve-maturity.test.ts
+++ b/packages/diagrams/src/applications/__tests__/resolve-maturity.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { resolveApplicationAttributes, withResolvedAttributes } from '../resolve-maturity.js';
+import type { Application } from '../types.js';
+
+const SIDECAR_CRM = {
+  target: 'APPLICATION-CRM-1',
+  attribute_versions: {
+    owner_role: [{ valid_from: '2026-05-26', value: 'ROLE-SALES-1' }],
+    vendor: [{ valid_from: '2026-05-26', value: 'Salesforce' }],
+    maturity: [
+      { valid_from: '2026-05-26', value: 2 },
+      { valid_from: '2026-08-01', value: 3 },
+    ],
+  },
+};
+
+const NOT_A_SIDECAR = { notation: 'application', id: 'APPLICATION-CRM-1', name: 'CRM System' };
+
+describe('resolveApplicationAttributes', () => {
+  it('resolves owner_role/vendor/maturity from a sidecar at a date', () => {
+    const byAppId = resolveApplicationAttributes([SIDECAR_CRM, NOT_A_SIDECAR], '2026-08-05');
+    expect(byAppId.get('APPLICATION-CRM-1')).toEqual({
+      owner_role: 'ROLE-SALES-1',
+      vendor: 'Salesforce',
+      maturity: 3,
+    });
+  });
+
+  it('resolves the earlier value before a later entry takes effect', () => {
+    const byAppId = resolveApplicationAttributes([SIDECAR_CRM], '2026-06-01');
+    expect(byAppId.get('APPLICATION-CRM-1')?.maturity).toBe(2);
+  });
+
+  it('ignores docs that are not shaped like a sidecar', () => {
+    const byAppId = resolveApplicationAttributes([NOT_A_SIDECAR, null, 'not an object', 42], '2026-08-05');
+    expect(byAppId.size).toBe(0);
+  });
+
+  it('omits an app entirely when it has no matching sidecar', () => {
+    const byAppId = resolveApplicationAttributes([], '2026-08-05');
+    expect(byAppId.has('APPLICATION-CRM-1')).toBe(false);
+  });
+});
+
+describe('withResolvedAttributes', () => {
+  const app: Application = { app_id: 'APPLICATION-CRM-1', name: 'CRM System', type: 'application', status: 'Active' };
+
+  it('merges resolved values onto an application with none inline', () => {
+    const resolved = resolveApplicationAttributes([SIDECAR_CRM], '2026-08-05');
+    const merged = withResolvedAttributes(app, resolved);
+    expect(merged).toMatchObject({ owner_role: 'ROLE-SALES-1', vendor: 'Salesforce', maturity: 3 });
+    // Never mutates the source row.
+    expect(app.maturity).toBeUndefined();
+  });
+
+  it('returns the same app unchanged when there is no resolution for it', () => {
+    const resolved = resolveApplicationAttributes([], '2026-08-05');
+    expect(withResolvedAttributes(app, resolved)).toBe(app);
+  });
+});

--- a/packages/diagrams/src/applications/index.ts
+++ b/packages/diagrams/src/applications/index.ts
@@ -9,3 +9,6 @@ export type {
 } from './types.js';
 
 export { validateApplicationsCatalogue } from './validate.js';
+
+export type { ResolvedApplicationAttributes } from './resolve-maturity.js';
+export { resolveApplicationAttributes, withResolvedAttributes } from './resolve-maturity.js';

--- a/packages/diagrams/src/applications/resolve-maturity.ts
+++ b/packages/diagrams/src/applications/resolve-maturity.ts
@@ -1,0 +1,66 @@
+// Render-time resolution of the applications-catalogue's sidecar-bound
+// time_varying fields (owner_role, vendor, maturity — notations/views/
+// 10-applications.md §5a, CONTRACT.md §9.4). VERSIONED-004 rejects these
+// inline on an admitted catalogue entry, so a compliant document never
+// carries them — a renderer that only reads the document straight shows
+// blank cells for every field the maturity decision moved out.
+//
+// Pure: no I/O, no repo walk. The host (VS Code extension, IntelliJ/JCEF,
+// CLI) already owns loading canon/elements/** (canon-loader.ts's shared FS
+// layer) — this module only knows how to pick sidecars out of that pool and
+// resolve them at a date.
+//
+// Per the 2026-08-05 hub decision (proposal #1022): this is a read model,
+// never storage. Callers render an augmented, ephemeral copy of the
+// application row and must never serialise it back — the sidecar stays the
+// only place these fields are written.
+
+import { parseSidecar, resolveAttributes } from '../versioned-attribute/index.js';
+import type { Application } from './types.js';
+
+export interface ResolvedApplicationAttributes {
+  owner_role?: string;
+  vendor?: string;
+  maturity?: number;
+}
+
+/** Pick every sidecar out of a raw canon/elements/** doc pool and resolve
+ *  owner_role/vendor/maturity at `atDate`, keyed by the sidecar's target id
+ *  (== an application's `app_id`, per the notation's element-file pairing). */
+export function resolveApplicationAttributes(
+  rawElementDocs: unknown[],
+  atDate: string,
+): Map<string, ResolvedApplicationAttributes> {
+  const byAppId = new Map<string, ResolvedApplicationAttributes>();
+  for (const doc of rawElementDocs) {
+    if (!doc || typeof doc !== 'object' || Array.isArray(doc)) continue;
+    const sidecar = parseSidecar(doc as Record<string, unknown>);
+    if (!sidecar) continue;
+    const resolved = resolveAttributes(sidecar, atDate);
+    const entry: ResolvedApplicationAttributes = {};
+    if (typeof resolved['owner_role'] === 'string') entry.owner_role = resolved['owner_role'];
+    if (typeof resolved['vendor'] === 'string') entry.vendor = resolved['vendor'];
+    if (typeof resolved['maturity'] === 'number') entry.maturity = resolved['maturity'];
+    if (Object.keys(entry).length > 0) byAppId.set(sidecar.target, entry);
+  }
+  return byAppId;
+}
+
+/** Merge resolved sidecar values into a rendering copy of an application row.
+ *  An inline value would win if present, but VERSIONED-004 already forbids
+ *  that on an admitted document — this is a display fallback, not a
+ *  migration tool. The returned object is a plain copy; nothing here writes
+ *  it anywhere. */
+export function withResolvedAttributes(
+  app: Application,
+  resolved: Map<string, ResolvedApplicationAttributes>,
+): Application {
+  const r = resolved.get(app.app_id);
+  if (!r) return app;
+  return {
+    ...app,
+    owner_role: app.owner_role ?? r.owner_role,
+    vendor: app.vendor ?? r.vendor,
+    maturity: app.maturity ?? r.maturity,
+  };
+}

--- a/packages/diagrams/src/webview/__tests__/render-applications.test.ts
+++ b/packages/diagrams/src/webview/__tests__/render-applications.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { renderApplicationsHtml } from '../render-applications.js';
+import { resolveApplicationAttributes } from '../../applications/resolve-maturity.js';
+import type { ApplicationsCatalogueHeader } from '../../applications/types.js';
+
+const CATALOGUE: ApplicationsCatalogueHeader = {
+  id: 'APP-CAT-001',
+  name: 'Enterprise Applications',
+  updated_at: '2026-05-14',
+  applications: [
+    { app_id: 'APPLICATION-CRM-1', name: 'CRM System', type: 'application', status: 'Active' },
+  ],
+};
+
+const SIDECAR = {
+  target: 'APPLICATION-CRM-1',
+  attribute_versions: {
+    owner_role: [{ valid_from: '2026-05-26', value: 'ROLE-SALES-1' }],
+    vendor: [{ valid_from: '2026-05-26', value: 'Salesforce' }],
+    maturity: [{ valid_from: '2026-05-26', value: 2 }],
+  },
+};
+
+describe('renderApplicationsHtml — sidecar resolution', () => {
+  it('renders blank cells when no resolution is supplied (unchanged behaviour)', () => {
+    const html = renderApplicationsHtml(CATALOGUE);
+    expect(html).not.toContain('resolved as of');
+    expect(html).toContain('cell-empty');
+    expect(html).not.toContain('ROLE-SALES-1');
+  });
+
+  it('fills owner/vendor/maturity from a resolved sidecar and states the as-of date', () => {
+    const byAppId = resolveApplicationAttributes([SIDECAR], '2026-08-05');
+    const html = renderApplicationsHtml(CATALOGUE, { asOf: '2026-08-05', byAppId });
+    expect(html).toContain('ROLE-SALES-1');
+    expect(html).toContain('Salesforce');
+    expect(html).toContain('resolved as of 2026-08-05');
+  });
+
+  it('never mutates the source catalogue object', () => {
+    const byAppId = resolveApplicationAttributes([SIDECAR], '2026-08-05');
+    renderApplicationsHtml(CATALOGUE, { asOf: '2026-08-05', byAppId });
+    expect(CATALOGUE.applications[0].maturity).toBeUndefined();
+  });
+});

--- a/packages/diagrams/src/webview/render-applications.ts
+++ b/packages/diagrams/src/webview/render-applications.ts
@@ -12,6 +12,8 @@ import type {
   ApplicationIntegration,
   ApplicationsCatalogueHeader,
 } from '../applications/types.js';
+import type { ResolvedApplicationAttributes } from '../applications/resolve-maturity.js';
+import { withResolvedAttributes } from '../applications/resolve-maturity.js';
 import { escHtml } from './render-util.js';
 
 const TYPE_LABEL: Record<string, string> = {
@@ -86,8 +88,28 @@ function renderRow(a: Application): string {
 </tr>`;
 }
 
-export function renderApplicationsHtml(catalogue: ApplicationsCatalogueHeader): string {
-  const rows = catalogue.applications.map(renderRow).join('\n');
+/**
+ * Resolved values for owner_role/vendor/maturity — sidecar-bound
+ * (CONTRACT.md §9.4) and never inline on an admitted catalogue entry
+ * (VERSIONED-004). The host resolves these upstream (see
+ * `applications/resolve-maturity.ts`) and passes the result in; this
+ * function stays a pure renderer of whatever it's given — no I/O, no
+ * write-back. `asOf` is the date the resolution ran at, shown so the view
+ * never states an undated value.
+ */
+export interface ApplicationsMaturityResolution {
+  asOf: string;
+  byAppId: Map<string, ResolvedApplicationAttributes>;
+}
+
+export function renderApplicationsHtml(
+  catalogue: ApplicationsCatalogueHeader,
+  resolution?: ApplicationsMaturityResolution,
+): string {
+  const applications = resolution
+    ? catalogue.applications.map((a) => withResolvedAttributes(a, resolution.byAppId))
+    : catalogue.applications;
+  const rows = applications.map(renderRow).join('\n');
   const emptyRow = catalogue.applications.length === 0
     ? `<tr><td colspan="7" class="empty-catalogue">No applications defined.</td></tr>`
     : '';
@@ -99,6 +121,7 @@ export function renderApplicationsHtml(catalogue: ApplicationsCatalogueHeader): 
       ${catalogue.version ? `<span class="catalogue-version">v${escHtml(catalogue.version)}</span>` : ''}
     </div>
     ${catalogue.description ? `<div class="catalogue-subtitle">${escHtml(catalogue.description)}</div>` : ''}
+    ${resolution ? `<div class="catalogue-resolved-note">Owner Role, Vendor, Maturity resolved as of ${escHtml(resolution.asOf)}</div>` : ''}
   </header>`;
   return `<section class="tx-catalogue tx-applications">
 ${header}

--- a/packages/diagrams/src/webview/styles.css
+++ b/packages/diagrams/src/webview/styles.css
@@ -140,6 +140,12 @@ body {
   color: var(--tx-fg);
 }
 
+.catalogue-resolved-note {
+  margin-top: 6px;
+  color: var(--tx-muted);
+  font-size: 11px;
+}
+
 .catalogue-table {
   width: 100%;
   border-collapse: collapse;


### PR DESCRIPTION
## Summary

- VERSIONED-004 (merged in #472) already rejects `owner_role`/`vendor`/`maturity` inline on an admitted applications-catalogue entry — so today a compliant document renders blank cells for all three, since nothing resolves the sidecar at render time.
- Adds a pure resolution helper (`applications/resolve-maturity.ts`) that picks sidecars out of an already-loaded `canon/elements/**` doc pool and resolves the three fields at a date. No I/O of its own — the host supplies the doc pool.
- The VS Code preview (`applications-preview.ts`) now loads canon (reusing the existing shared FS layer, `canon-loader.ts`) before rendering and merges the resolved values into an ephemeral, augmented copy of each row — never written back anywhere — with an "as of `<date>`" note in the view.
- `renderApplicationsHtml` (the host-neutral webview module used by the IntelliJ/JCEF bundle) takes an optional resolution parameter for the same merge; unset, its behaviour is unchanged, so `webview/entry.ts`'s `render(kind, source)` stays a pure function of a document, per the design call decided on hub proposal #1022.

## Test plan

- [x] `packages/diagrams` suite: 1613/1613 passing (2 new test files, 9 new tests)
- [x] `npm run compile` (root) and `npm run compile:extension` — clean
- [x] `npm run extension:prep` — esbuild bundle succeeds
- [x] End-to-end check against the acme_corp worked example: resolves `APPLICATION-CRM-1`'s sidecar (`owner_role`, `vendor: Salesforce`, `maturity`) and renders it with the as-of note
- [x] Core `vitest run`: no new failures (3 pre-existing `cli-migrate.test.ts` failures + 1 pre-existing `ci-hygiene-hashrefs.test.ts` suite error reproduce identically on `main`, confirmed via stash-and-rerun)

Bumped `@transitrix/diagrams` 1.9.5→1.9.6 and `@transitrix/cli` 2.4.5→2.4.6 per the version-bump/alignment guards.

Capability-map's nested catalogue entries stay inline, unchanged — that half of the same design call is blocked on a methodology prerequisite question, filed separately.