### PR TITLE
fix(ci): keep full history when resolving hygiene base SHA

### DIFF
--- a/scripts/ci-hygiene-check.mjs
+++ b/scripts/ci-hygiene-check.mjs
@@ -71,10 +71,17 @@ if (!baseSha || !headSha) {
   process.exit(2);
 }
 
+// Ensure base is present. Never use `--depth=1` here: on a full checkout
+// (fetch-depth: 0) it converts the clone to shallow and breaks `base..head`
+// ancestry, so merge commits list unrelated history already on main.
 try {
-  execSync(`git fetch --no-tags --depth=1 origin ${baseSha}`, { stdio: 'pipe' });
+  execSync(`git cat-file -e ${baseSha}^{commit}`, { stdio: 'pipe' });
 } catch {
-  // Fallback: rely on existing fetch depth from checkout step.
+  try {
+    execSync(`git fetch --no-tags origin ${baseSha}`, { stdio: 'pipe' });
+  } catch {
+    // Fallback: rely on existing fetch from the checkout step.
+  }
 }
 
 let diff;


### PR DESCRIPTION
## Summary
- After a full PR checkout, the hygiene check fetched the base SHA with `--depth=1`, which shallowed the clone.
- That broke `base..head` ancestry on merge commits, so the blocklist scanned unrelated history already on main and false-failed clean PRs.
- Ensure the base commit is present without shallowing.

## Test plan
- [ ] Open or re-run hygiene on a PR that has merged `main` (merge commit); Diff + PR-metadata blocklist should pass when the branch tip itself is clean
- [ ] Confirm a linear single-commit PR still passes the same check