### PR TITLE
feat: contribute changelog entries as per-change fragments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,20 @@ After changes that touch compilation or layout, run **`npm test`**.
 
 Skim **[`docs/repo-layout.md`](docs/repo-layout.md)** for a directory-level map of the repository. Adopter-facing docs: [`docs/README.md`](docs/README.md). Maintainer runbooks: [`docs/internal/README.md`](docs/internal/README.md).
 
+## Changelog entries — add a fragment, don't edit `CHANGELOG.md`
+
+If a change is user-visible enough to note, add a fragment file instead of
+editing `CHANGELOG.md`'s `## Unreleased` section directly:
+
+```bash
+node scripts/new-changelog-fragment.mjs Added your-change-slug
+```
+
+See **[`changelog/fragments/README.md`](changelog/fragments/README.md)** for
+the format. Fragments are folded into `CHANGELOG.md` as a release-prep step,
+not per PR — two PRs that each add their own fragment file never collide,
+even from the same base commit.
+
 ## Web UI vs "mandatory chrome" (`roadmap`: RD-043)
 
 The file-prep web app under **`ui/`** (served by `transitrix serve`) is intentionally minimal: a header with actions, an optional layout drawer, a YAML pane, a BPMN preview, and a single **status** line in the footer. It does not implement a full status bar with user/DB/AI blocks, LED-style indicators, or dedicated system log. The footer is the only system feedback channel for compile/export state.

--- a/changelog/fragments/README.md
+++ b/changelog/fragments/README.md
@@ -1,0 +1,47 @@
+# Changelog fragments
+
+A PR that wants a `CHANGELOG.md` entry adds one file here instead of editing
+`CHANGELOG.md`'s `## Unreleased` section directly. Two PRs that each add
+their own fragment file never collide, even opened from the same base
+commit and touching unrelated code — the old failure mode, where every PR
+edited the same lines at the head of the same file.
+
+## Adding one
+
+```bash
+node scripts/new-changelog-fragment.mjs <section> <slug>
+# e.g.
+node scripts/new-changelog-fragment.mjs Added wire-node-validator
+```
+
+This writes `changelog/fragments/<slug>-<random-suffix>.md` with a template
+to fill in. `<section>` is one of `Added`, `Changed`, `Fixed`, `Removed`,
+`Deprecated`, `Security`, `Packages` — the same sections `CHANGELOG.md`
+already uses.
+
+A fragment file's content is exactly the block that would otherwise have
+been hand-inserted:
+
+```markdown
+### Added
+
+- **Short bold title.** The rest of the entry, same voice and detail level
+  as any existing `CHANGELOG.md` entry.
+```
+
+Multiple bullets under one header are fine if the change genuinely has more
+than one line-item.
+
+## What happens to it
+
+Fragments are **not** meant to be assembled into `CHANGELOG.md` by every
+PR. They accumulate here across PRs and are folded in as a release-prep
+step (`node scripts/assemble-changelog.mjs`, see
+`docs/internal/release-runbook.md`), which appends each fragment's bullets
+under the matching `### <Section>` heading in `## Unreleased` — creating
+the heading if it doesn't exist yet — and deletes the fragment files it
+consumed. Sections are ordered the same way `CHANGELOG.md` already orders
+them; already-released version sections are never touched.
+
+Do not hand-edit `CHANGELOG.md`'s `## Unreleased` section in a regular PR —
+add a fragment instead.

--- a/changelog/fragments/changelog-entries-as-fragments-64059f3e.md
+++ b/changelog/fragments/changelog-entries-as-fragments-64059f3e.md
@@ -1,0 +1,3 @@
+### Changed
+
+- **A PR contributes its `CHANGELOG.md` entry as its own fragment file, not a hand-edit of the shared `## Unreleased` section.** Two PRs to `diagrams/src` that each edited the head of `CHANGELOG.md` collided by construction, whatever their code touched. `node scripts/new-changelog-fragment.mjs <section> <slug>` scaffolds a fragment under `changelog/fragments/`; `node scripts/assemble-changelog.mjs` — run as the first step of release prep (`docs/internal/release-runbook.md`) — folds every fragment into `## Unreleased` in the same section/order/wording convention a hand-edit would have produced, then deletes the fragments it consumed. Existing `CHANGELOG.md` history is untouched; the mechanism applies going forward only.

--- a/docs/internal/release-runbook.md
+++ b/docs/internal/release-runbook.md
@@ -30,9 +30,14 @@ releases that bump only one package (or neither) stay green.
 One PR against `main` — the pattern of the 2.8.0 (#339) and 2.9.0 (#344)
 notes PRs:
 
-- `CHANGELOG.md`: retitle `[Unreleased]` to `[X.Y.Z] — <date>`; make sure
-  every PR merged since the previous notes PR has an entry (fixes merged
-  after the notes PR are the usual gap).
+- `CHANGELOG.md`: first run `node scripts/assemble-changelog.mjs` to fold
+  every `changelog/fragments/*.md` file accumulated since the previous
+  release into `## Unreleased` (it deletes the fragments it consumes — see
+  [`changelog/fragments/README.md`](../../changelog/fragments/README.md)).
+  Then retitle `## Unreleased` to `## [X.Y.Z] — <date>`; make sure every PR
+  merged since the previous notes PR has an entry (a PR that predates the
+  fragment mechanism, or whose author forgot to add one, is the usual gap —
+  add it by hand).
 - Versions:
   - root `package.json` + `extension/package.json` — bump together via
     `node scripts/bump-extension-version.mjs minor|patch|major`;

--- a/scripts/assemble-changelog.mjs
+++ b/scripts/assemble-changelog.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+// Release-time step: fold changelog/fragments/*.md into CHANGELOG.md's
+// Unreleased section, then delete the fragments it consumed.
+//
+// Run this as the first step of preparing a release PR (docs/internal/release-runbook.md
+// step 1), before retitling "## Unreleased" to the release version. Safe to
+// run with zero fragments present (no-op).
+
+import { readdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import path from 'node:path';
+
+import { assembleChangelog, groupFragments, parseFragment } from './changelog-fragments.mjs';
+
+const ROOT = process.cwd();
+const FRAGMENTS_DIR = path.join(ROOT, 'changelog', 'fragments');
+const CHANGELOG_PATH = path.join(ROOT, 'CHANGELOG.md');
+
+function loadFragmentFiles() {
+  let names;
+  try {
+    names = readdirSync(FRAGMENTS_DIR);
+  } catch (err) {
+    if (err.code === 'ENOENT') return [];
+    throw err;
+  }
+  return names.filter((name) => name.endsWith('.md') && name !== 'README.md').sort();
+}
+
+const files = loadFragmentFiles();
+if (files.length === 0) {
+  console.log('[assemble-changelog] no fragments in changelog/fragments/ — nothing to do.');
+  process.exit(0);
+}
+
+const fragments = files.map((file) => {
+  const content = readFileSync(path.join(FRAGMENTS_DIR, file), 'utf8');
+  const { section, body } = parseFragment(file, content);
+  return { file, section, body };
+});
+
+const grouped = groupFragments(fragments);
+const changelogText = readFileSync(CHANGELOG_PATH, 'utf8');
+const updated = assembleChangelog(changelogText, grouped);
+
+writeFileSync(CHANGELOG_PATH, updated);
+for (const file of files) {
+  rmSync(path.join(FRAGMENTS_DIR, file));
+}
+
+console.log(`[assemble-changelog] folded ${files.length} fragment(s) into CHANGELOG.md:`);
+for (const file of files) console.log(`  ${file}`);

--- a/scripts/changelog-fragments.mjs
+++ b/scripts/changelog-fragments.mjs
@@ -1,0 +1,135 @@
+// Pure logic for the changelog-fragment mechanism.
+//
+// A PR contributes its changelog entry as its own fragment file under
+// changelog/fragments/ instead of editing CHANGELOG.md's Unreleased section
+// directly, so two unrelated PRs never collide on the same lines.
+// assembleChangelog() is the release-time step that folds fragments back
+// into CHANGELOG.md, producing what a hand-edit would have produced.
+
+export const SECTION_ORDER = ['Added', 'Changed', 'Fixed', 'Removed', 'Deprecated', 'Security', 'Packages'];
+
+const SECTION_HEADER_RE = /^###\s+(.+?)\s*$/;
+const UNRELEASED_HEADER_RE = /^##\s+Unreleased\s*$/;
+const RELEASE_HEADER_RE = /^##\s+/;
+const TITLE_RE = /^#\s+/;
+
+// A fragment file is "### <Section>" followed by one or more bullet lines —
+// exactly the block a contributor would otherwise have hand-inserted.
+export function parseFragment(filename, content) {
+  const lines = content.split('\n');
+  const headerIdx = lines.findIndex((line) => SECTION_HEADER_RE.test(line));
+  if (headerIdx === -1) {
+    throw new Error(`${filename}: no "### <Section>" header found`);
+  }
+  const section = lines[headerIdx].match(SECTION_HEADER_RE)[1];
+  const body = lines
+    .slice(headerIdx + 1)
+    .join('\n')
+    .trim();
+  if (!body) {
+    throw new Error(`${filename}: no bullet content under "### ${section}"`);
+  }
+  return { section, body };
+}
+
+// fragments: [{ file, section, body }] — pass already sorted by `file` for a
+// deterministic, reviewable assembly order.
+export function groupFragments(fragments) {
+  const bySection = new Map();
+  for (const { section, body } of fragments) {
+    if (!bySection.has(section)) bySection.set(section, []);
+    bySection.get(section).push(body);
+  }
+  const ordered = new Map();
+  for (const section of SECTION_ORDER) {
+    if (bySection.has(section)) ordered.set(section, bySection.get(section));
+  }
+  for (const [section, bodies] of bySection) {
+    if (!ordered.has(section)) ordered.set(section, bodies);
+  }
+  return ordered;
+}
+
+function trimTrailingBlank(lines) {
+  while (lines.length && lines[lines.length - 1].trim() === '') lines.pop();
+}
+
+function trimLeadingBlank(lines) {
+  while (lines.length && lines[0].trim() === '') lines.shift();
+}
+
+// Folds `grouped` (section -> bodies, from groupFragments) into the
+// "## Unreleased" block of `changelogText`. Everything outside that block —
+// every already-released version section — is left byte-for-byte alone.
+export function assembleChangelog(changelogText, grouped) {
+  if (grouped.size === 0) return changelogText;
+
+  let lines = changelogText.split('\n');
+  let unreleasedIdx = lines.findIndex((line) => UNRELEASED_HEADER_RE.test(line));
+
+  if (unreleasedIdx === -1) {
+    const titleIdx = lines.findIndex((line) => TITLE_RE.test(line));
+    const insertAt = titleIdx === -1 ? 0 : titleIdx + 1;
+    lines = [...lines.slice(0, insertAt), '', '## Unreleased', ...lines.slice(insertAt)];
+    unreleasedIdx = lines.findIndex((line) => UNRELEASED_HEADER_RE.test(line));
+  }
+
+  const blockStart = unreleasedIdx + 1;
+  let blockEnd = lines.length;
+  for (let i = blockStart; i < lines.length; i++) {
+    if (RELEASE_HEADER_RE.test(lines[i])) {
+      blockEnd = i;
+      break;
+    }
+  }
+
+  const existing = new Map();
+  const order = [];
+  let cur = null;
+  for (const line of lines.slice(blockStart, blockEnd)) {
+    const match = line.match(SECTION_HEADER_RE);
+    if (match) {
+      cur = match[1];
+      if (!existing.has(cur)) {
+        existing.set(cur, []);
+        order.push(cur);
+      }
+      continue;
+    }
+    if (cur !== null) existing.get(cur).push(line);
+  }
+  for (const sectionLines of existing.values()) {
+    trimLeadingBlank(sectionLines);
+    trimTrailingBlank(sectionLines);
+  }
+
+  for (const [section, bodies] of grouped) {
+    if (!existing.has(section)) {
+      existing.set(section, []);
+      order.push(section);
+    }
+    const sectionLines = existing.get(section);
+    trimTrailingBlank(sectionLines);
+    for (const body of bodies) {
+      // Bullets within a section sit on adjacent lines, no blank separator —
+      // matches the existing hand-edited CHANGELOG.md convention.
+      sectionLines.push(...body.split('\n'));
+    }
+  }
+
+  const canonicalOrder = [
+    ...SECTION_ORDER.filter((section) => order.includes(section)),
+    ...order.filter((section) => !SECTION_ORDER.includes(section)),
+  ];
+
+  const rebuilt = [];
+  for (const section of canonicalOrder) {
+    const sectionLines = existing.get(section);
+    trimTrailingBlank(sectionLines);
+    rebuilt.push(`### ${section}`, '', ...sectionLines, '');
+  }
+  trimTrailingBlank(rebuilt);
+
+  const newLines = [...lines.slice(0, blockStart), '', ...rebuilt, '', ...lines.slice(blockEnd)];
+  return newLines.join('\n');
+}

--- a/scripts/new-changelog-fragment.mjs
+++ b/scripts/new-changelog-fragment.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+// Scaffold a new changelog/fragments/<slug>-<random>.md file for the current
+// change. Usage: node scripts/new-changelog-fragment.mjs <section> <slug>
+//   section — one of Added, Changed, Fixed, Removed, Deprecated, Security, Packages
+//   slug    — short kebab-case description, e.g. "wire-node-validator"
+
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { randomBytes } from 'node:crypto';
+import path from 'node:path';
+
+import { SECTION_ORDER } from './changelog-fragments.mjs';
+
+const [section, slug] = process.argv.slice(2);
+
+if (!section || !slug) {
+  console.error('usage: node scripts/new-changelog-fragment.mjs <section> <slug>');
+  console.error(`  section: one of ${SECTION_ORDER.join(', ')}`);
+  process.exit(1);
+}
+
+if (!SECTION_ORDER.includes(section)) {
+  console.error(`[new-changelog-fragment] unknown section "${section}" — expected one of ${SECTION_ORDER.join(', ')}`);
+  process.exit(1);
+}
+
+const dir = path.join(process.cwd(), 'changelog', 'fragments');
+mkdirSync(dir, { recursive: true });
+
+const suffix = randomBytes(4).toString('hex');
+const filename = `${slug}-${suffix}.md`;
+const filePath = path.join(dir, filename);
+
+if (existsSync(filePath)) {
+  console.error(`[new-changelog-fragment] ${filename} already exists — re-run for a fresh suffix.`);
+  process.exit(1);
+}
+
+writeFileSync(filePath, `### ${section}\n\n- **Title.** Description.\n`);
+console.log(`[new-changelog-fragment] wrote changelog/fragments/${filename}`);

--- a/tests/changelog-fragments.test.ts
+++ b/tests/changelog-fragments.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+
+import { assembleChangelog, groupFragments, parseFragment } from '../scripts/changelog-fragments.mjs';
+
+describe('parseFragment', () => {
+  it('extracts the section and bullet body', () => {
+    const content = '### Added\n\n- **Thing.** Description.\n';
+    expect(parseFragment('a.md', content)).toEqual({
+      section: 'Added',
+      body: '- **Thing.** Description.',
+    });
+  });
+
+  it('supports a multi-line bullet body', () => {
+    const content = '### Fixed\n\n- **Bug.** First line.\n  Second line.\n';
+    expect(parseFragment('a.md', content)).toEqual({
+      section: 'Fixed',
+      body: '- **Bug.** First line.\n  Second line.',
+    });
+  });
+
+  it('throws when no "### <Section>" header is present', () => {
+    expect(() => parseFragment('bad.md', '- just a bullet\n')).toThrow(/no "### <Section>" header/);
+  });
+
+  it('throws when the header has no bullet content under it', () => {
+    expect(() => parseFragment('empty.md', '### Added\n\n')).toThrow(/no bullet content/);
+  });
+});
+
+describe('groupFragments', () => {
+  it('groups fragments by section in canonical order regardless of input order', () => {
+    const grouped = groupFragments([
+      { file: 'b.md', section: 'Packages', body: '- pkg bump' },
+      { file: 'a.md', section: 'Added', body: '- new thing' },
+      { file: 'c.md', section: 'Fixed', body: '- fixed thing' },
+    ]);
+    expect([...grouped.keys()]).toEqual(['Added', 'Fixed', 'Packages']);
+  });
+
+  it('concatenates multiple fragments under the same section, preserving input order', () => {
+    const grouped = groupFragments([
+      { file: 'a.md', section: 'Added', body: '- first' },
+      { file: 'b.md', section: 'Added', body: '- second' },
+    ]);
+    expect(grouped.get('Added')).toEqual(['- first', '- second']);
+  });
+
+  it('appends an unrecognized section after the canonical ones', () => {
+    const grouped = groupFragments([
+      { file: 'a.md', section: 'Added', body: '- new' },
+      { file: 'b.md', section: 'Experimental', body: '- odd' },
+    ]);
+    expect([...grouped.keys()]).toEqual(['Added', 'Experimental']);
+  });
+});
+
+describe('assembleChangelog', () => {
+  it('is a no-op when there is nothing to assemble', () => {
+    const text = '# Changelog\n\n## Unreleased\n\n## [1.0.0] — 2026-01-01\n';
+    expect(assembleChangelog(text, new Map())).toBe(text);
+  });
+
+  it('creates a new section under an already-present Unreleased heading', () => {
+    const text = '# Changelog\n\n## Unreleased\n\n## [1.0.0] — 2026-01-01\n\nold stuff\n';
+    const grouped = groupFragments([{ file: 'a.md', section: 'Added', body: '- new thing' }]);
+    const out = assembleChangelog(text, grouped);
+
+    expect(out).toContain('## Unreleased\n\n### Added\n\n- new thing');
+    expect(out).toContain('## [1.0.0] — 2026-01-01\n\nold stuff');
+  });
+
+  it('appends to an existing ### subsection already under Unreleased, after its current bullets', () => {
+    const text = '# Changelog\n\n## Unreleased\n\n### Added\n\n- existing bullet\n\n## [1.0.0] — 2026-01-01\n';
+    const grouped = groupFragments([{ file: 'a.md', section: 'Added', body: '- new bullet' }]);
+    const out = assembleChangelog(text, grouped);
+
+    const unreleasedBlock = out.slice(out.indexOf('## Unreleased'), out.indexOf('## [1.0.0]'));
+    expect(unreleasedBlock).toContain('- existing bullet');
+    expect(unreleasedBlock).toContain('- new bullet');
+    expect(unreleasedBlock.indexOf('- existing bullet')).toBeLessThan(unreleasedBlock.indexOf('- new bullet'));
+  });
+
+  it('orders newly created sections canonically alongside pre-existing ones', () => {
+    const text = '# Changelog\n\n## Unreleased\n\n### Packages\n\n- pkg bump\n\n## [1.0.0] — 2026-01-01\n';
+    const grouped = groupFragments([{ file: 'a.md', section: 'Fixed', body: '- a fix' }]);
+    const out = assembleChangelog(text, grouped);
+
+    const unreleasedBlock = out.slice(out.indexOf('## Unreleased'), out.indexOf('## [1.0.0]'));
+    expect(unreleasedBlock.indexOf('### Fixed')).toBeLessThan(unreleasedBlock.indexOf('### Packages'));
+  });
+
+  it('creates the Unreleased section when none exists yet', () => {
+    const text = '# Changelog\n\n## [1.0.0] — 2026-01-01\n\nold stuff\n';
+    const grouped = groupFragments([{ file: 'a.md', section: 'Added', body: '- new thing' }]);
+    const out = assembleChangelog(text, grouped);
+
+    expect(out.indexOf('## Unreleased')).toBeLessThan(out.indexOf('## [1.0.0]'));
+    expect(out).toContain('### Added\n\n- new thing');
+    expect(out).toContain('## [1.0.0] — 2026-01-01\n\nold stuff');
+  });
+
+  it('leaves already-released version sections byte-for-byte untouched', () => {
+    const text =
+      '# Changelog\n\n## Unreleased\n\n## [1.0.0] — 2026-01-01\n\n### Fixed\n\n- historic fix, keep exactly as written\n';
+    const grouped = groupFragments([{ file: 'a.md', section: 'Added', body: '- new thing' }]);
+    const out = assembleChangelog(text, grouped);
+
+    expect(out).toContain('## [1.0.0] — 2026-01-01\n\n### Fixed\n\n- historic fix, keep exactly as written');
+  });
+
+  it('merges two independently-ordered fragments into the same new section deterministically by file order', () => {
+    const text = '# Changelog\n\n## Unreleased\n\n## [1.0.0] — 2026-01-01\n';
+    const grouped = groupFragments([
+      { file: 'aaa.md', section: 'Added', body: '- from aaa' },
+      { file: 'bbb.md', section: 'Added', body: '- from bbb' },
+    ]);
+    const out = assembleChangelog(text, grouped);
+    const unreleasedBlock = out.slice(out.indexOf('## Unreleased'), out.indexOf('## [1.0.0]'));
+
+    expect(unreleasedBlock.indexOf('- from aaa')).toBeLessThan(unreleasedBlock.indexOf('- from bbb'));
+  });
+});


### PR DESCRIPTION
## Summary
- A PR contributes its CHANGELOG.md entry as its own fragment file under `changelog/fragments/` instead of editing the shared `## Unreleased` section, so two PRs never collide there regardless of what code they touch.
- `node scripts/new-changelog-fragment.mjs <section> <slug>` scaffolds a uniquely-named fragment; `node scripts/assemble-changelog.mjs` (release-prep step, wired into `docs/internal/release-runbook.md`) folds every fragment into `CHANGELOG.md`'s Unreleased section in the same section/order/wording convention a hand-edit produces, then deletes the fragments it consumed.
- Existing `CHANGELOG.md` history is untouched — verified byte-for-byte identical for every already-released section when assembling against the real repo's current CHANGELOG.md.

## Test plan
- [x] `npx vitest run tests/changelog-fragments.test.ts` — 14 new unit tests covering fragment parsing, section grouping/ordering, and assembly (new section, existing section append, no pre-existing Unreleased heading, released sections left untouched).
- [x] `npm test` — full suite green except `tests/cli-migrate.test.ts` (3 failures pre-existing on `main`, unrelated — depend on external methodology repo state).
- [x] `npm run compile` green.
- [x] Manual smoke test of `new-changelog-fragment.mjs` + `assemble-changelog.mjs` against a copy of this repo's actual `CHANGELOG.md`.