### PR TITLE
fix: declare the methodology release this build targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 - **Work-item references use the neutral `HUB-NNN` form** across comments, READMEs and docstrings (54 files). Not the hash form — a bare `#84` auto-links to this repository's own issue 84, rendering as a working link to an unrelated item.
 - **Public-surface hygiene gains a pattern slot and a full-tree pass** (`scripts/ci-hygiene-tree.mjs`). The diff check only sees what a PR adds, so anything already committed was invisible to it; the tree pass reads every tracked text file. Scoped to the new slot alone so it fails on the change under review, not on pre-existing content. Patterns stay in repository secrets; output is `file:line` only.
+- **The declared methodology version now names the release this build actually targets.** `transitrix.methodologyVersion` (`package.json`) and the `SCHEMA_VERSION` constant it is pinned to both read `0.5.0` — a release this repository moved past long ago, left behind because nothing but their own lockstep test read either value. Both now read `3.1.0`: the notation vocabulary and rule coverage on this branch implement that release's additions in full (`RISK-001..004`, `METRIC-001..004`, `NEED-001..002`, `VALID-001..006`, `REQ-005`/`REQ-006`) and none of the additions from the release after it. The accompanying comments no longer restate "the current methodology release" as a literal — that was the fact that went stale, and the constant does not track it. Two hardcoded vocabulary literals are known to lag `3.1.0` and are deliberately not changed here: `target-state/types.ts` carries no `type: base | target` field, and the cross-reference id grammar in `blocks/validate.ts` diverges from the one in `typed-id.ts` — its terminal `\d+` admits the leading-zero ids that `IDS_AND_REFERENCES.md` §1 rejects, and its uppercase-only middle segments miss the mixed-case ids that do occur in canon. Correcting the declaration is what makes those two visible as drift rather than as a wrong baseline.
 
 ### Packages
 
@@ -46,6 +47,8 @@
 - `@transitrix/cli` 2.4.12 → 2.4.13 — paired bump per `cli-diagrams-alignment`.
 - `@transitrix/diagrams` 1.9.13 → 1.9.14 — `INTEGRATION` envelope validation wired in.
 - `@transitrix/cli` 2.4.13 → 2.4.14 — paired bump per `cli-diagrams-alignment`.
+- `@transitrix/diagrams` 1.9.14 → 1.9.15 — `SCHEMA_VERSION` corrected to the targeted methodology release.
+- `@transitrix/cli` 2.4.14 → 2.4.15 — paired bump per `cli-diagrams-alignment`.
 
 ## [3.1.3] — 2026-07-29
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6468,7 +6468,7 @@
     },
     "packages/cli": {
       "name": "@transitrix/cli",
-      "version": "2.4.14",
+      "version": "2.4.15",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",
@@ -6486,7 +6486,7 @@
     },
     "packages/diagrams": {
       "name": "@transitrix/diagrams",
-      "version": "1.9.14",
+      "version": "1.9.15",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "type": "module",
   "transitrix": {
-    "methodologyVersion": "0.5.0"
+    "methodologyVersion": "3.1.0"
   },
   "engines": {
     "node": ">=20"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/cli",
-  "version": "2.4.14",
+  "version": "2.4.15",
   "type": "module",
   "description": "Transitrix CLI ΓÇö compile, validate, and report on Transitrix diagrams (BPMN, Goals, DGCA, ΓÇª) from any shell or CI pipeline.",
   "license": "MIT",

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.9.14",
+  "version": "1.9.15",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",

--- a/packages/diagrams/src/schema-version.ts
+++ b/packages/diagrams/src/schema-version.ts
@@ -4,13 +4,16 @@
  *
  * Source of truth: the methodology `methodology_version`, declared in an adopter
  * repository's `transitrix.yaml` per the methodology `notations/MANIFEST.md`
- * (single source of truth for a repo's conformance). The current methodology
- * release is **0.5.0**.
+ * (single source of truth for a repo's conformance).
+ *
+ * This is the release this build *targets*, not the newest release that exists —
+ * the methodology may be ahead. Raise it only together with the vocabulary and
+ * rule coverage that release requires, so the two never disagree. Individual
+ * hardcoded vocabulary literals may still lag the declared release; the
+ * per-module drift check is what makes such a gap visible, not this constant.
  *
  * This constant is kept in lockstep with the project manifest's
  * `transitrix.methodologyVersion` (`package.json`); the
- * `tests/schema-version.test.ts` unit test asserts the two are equal. A CI guard
- * that additionally asserts both equal the methodology's published SoT lands
- * separately (SV-1 PR2) — do not bundle it here.
+ * `tests/schema-version.test.ts` unit test asserts the two are equal.
  */
-export const SCHEMA_VERSION = '0.5.0';
+export const SCHEMA_VERSION = '3.1.0';

--- a/tests/schema-version.test.ts
+++ b/tests/schema-version.test.ts
@@ -8,7 +8,8 @@ import { SCHEMA_VERSION } from '../packages/diagrams/src/schema-version.js';
 // SV-1: the @transitrix/diagrams SCHEMA_VERSION constant and the project
 // manifest's `transitrix.methodologyVersion` must stay in lockstep — both pin the
 // methodology release this build conforms to (SoT: methodology
-// notations/MANIFEST.md `methodology_version`, currently 0.5.0).
+// notations/MANIFEST.md `methodology_version`). The pinned release is the one
+// this build targets; the methodology itself may be further ahead.
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const pkg = JSON.parse(readFileSync(path.join(repoRoot, 'package.json'), 'utf-8')) as {
   transitrix?: { methodologyVersion?: string };


### PR DESCRIPTION
## What changed

`transitrix.methodologyVersion` (`package.json`) and the `SCHEMA_VERSION`
constant it is pinned to both declared `0.5.0`. Both now declare `3.1.0`.

Paired version bumps come with it, per `cli-diagrams-alignment`:
`@transitrix/diagrams` 1.9.14 → 1.9.15, `@transitrix/cli` 2.4.14 → 2.4.15.

## Why 3.1.0 and not the newest release

The declared value is the methodology release this build *targets*, so it was
chosen by checking which release's vocabulary and rules this branch actually
implements:

- Every addition in 3.1.0 is implemented here — `RISK-001..004`,
  `METRIC-001..004`, `NEED-001..002`, `VALID-001..006`, and
  `REQUIREMENT.level` / `REQUIREMENT.kind` (`REQ-005` / `REQ-006`).
- None of the additions from the release after it are implemented on this
  branch — no `RELEASE` element, no `required_for`, no `depends_on`
  (`REL-005` / `REL-006`), no agreement axis (`AGREE-001..003`), no
  `ASSERT-010` / `VERIF-007`.

Declaring the newest release instead would make the field read as current
while the code behind it is not.

## Two literals that lag the declared release

Both are left unchanged on purpose — this change corrects the declaration, not
the vocabulary. Correcting the baseline first is what lets these read as drift
rather than as a wrong starting point:

- `packages/diagrams/src/target-state/types.ts` carries no
  `type: base | target` field, which `ELEMENT_PRIMITIVES.md` §7.18 defines.
- The cross-reference id grammar in `packages/diagrams/src/blocks/validate.ts`
  diverges from the one in `typed-id.ts`: its terminal `\d+` admits the
  leading-zero ids that `IDS_AND_REFERENCES.md` §1 rejects, and its
  uppercase-only middle segments miss the mixed-case ids that occur in canon.

## How it is verified

`tests/schema-version.test.ts` asserts the constant and the manifest field are
equal and semver-shaped; it passes. Full `npm test` and `npm run build` run
clean apart from two failures that reproduce identically on `main` without
this change (`tests/cli-migrate.test.ts`, which needs a local methodology
checkout, and a load-time failure in `tests/ci-hygiene-hashrefs.test.ts`).
