### PR TITLE
feat(cli): let the author set valid_from when an element is created

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -72,7 +72,9 @@ transitrix <input.yaml> <output.bpmn> [--no-metrics] [--no-validate]
 transitrix serve [--port 8765] [--host 127.0.0.1]
 transitrix metrics <input.yaml> [--json]
 transitrix validate <input.yaml> [--json] [--template <name>]
+transitrix validate <input.yaml> --fix [--author <name>] [--valid-from <YYYY-MM-DD>] [--root <dir>] [--dry-run]
 transitrix validate --scope=repo [--root <dir>] [--json] [--include-model]
+transitrix new <goal|driver|constraint|requirement> --id <ID> --name "<label>" [options]
 transitrix export-compliance [--format md|pdf] [--scope law:<ID>|product:<ID>|gap] [--output <path>] [--root <dir>]
 ```
 
@@ -82,6 +84,7 @@ transitrix export-compliance [--format md|pdf] [--scope law:<ID>|product:<ID>|ga
 | `serve` | Local web UI (run `npm run ui:build` once beforehand). |
 | `metrics` | Layout-quality metrics only (`--json` for CI). |
 | `validate` | Validation only, no XML output (`--json` for CI). Exit 1 on errors. Default scope is a single file; `--scope=repo` runs whole-`canon/` checks (referential integrity, atomicity, id uniqueness, policy) over `--root` (default cwd) — see [validation.md](validation.md#validation-scope-file-vs-repo). `--include-model` (with `--json`) also emits the resolved `canon/elements/**`/`canon/relations/**` records it parsed — see [validation.md](validation.md#resolved-model-output---include-model). `--template <name>` (file scope, `blocks` matrix-subset `grid:` documents only — e.g. `raci`) additionally enforces that template's own cell-value invariant (e.g. `RACI-001`) on top of the base `BL-02x` rules; the base notation does not fix a cell-value vocabulary, so this is opt-in per template. |
+| `new <type>` | Scaffolds a standalone motivation-layer element (`goal`, `driver`, `constraint`, `requirement`) with the admission record and lifecycle envelope computed rather than hand-typed — see [Envelope defaults](#envelope-defaults). `--dry-run` previews without writing. Run `transitrix new <type> --help` for the per-type fields. |
 | `export-compliance` | Markdown or PDF report of the compliance views (matrix by default; `law:` / `product:` / `gap` scopes). Scans `--root` (default cwd). PDF needs WeasyPrint on PATH (`pipx install weasyprint`). |
 
 Flags: `--no-metrics` suppresses the metrics report on compile; `--no-validate`
@@ -99,6 +102,59 @@ transitrix metrics order.bpmn.transitrix.yaml --json
 transitrix export-compliance --format md --scope gap --output gaps.md
 transitrix serve --port 9000
 ```
+
+## Envelope defaults
+
+Authoring an element requires only the fields that carry its own meaning:
+`notation`, `id`, `name`, and the per-TYPE fields. The rest of the canonical
+envelope — the admission record (`CONTRACT.md` §6) and the primitive lifecycle
+(`CONTRACT.md` §7) — is produced by whichever path creates the file.
+
+Two commands supply it:
+
+- **`transitrix new <type>`** — writes a brand-new element file with the
+  envelope already complete.
+- **`transitrix validate <file> --fix`** — completes the envelope on a file
+  that was hand-authored without one, inserting only what it can derive and
+  leaving every value already present untouched.
+
+The VS Code extension's **New … Element** commands take the third path and use
+the same defaults; see [`extension/README.md`](../extension/README.md).
+
+### The defaults, and how to override them
+
+| Field | Default | Override |
+|---|---|---|
+| `zone` | `canon` | — (the creation paths write into `canon/`) |
+| `admitted_at` | today | **none, by design** — see below |
+| `admitted_by` | `git config user.name` | `--author "<name>"` |
+| `gate_checks` | the result of the checks that actually ran | — (never a constant `pass`) |
+| `valid_from` | today | `--valid-from <YYYY-MM-DD>` |
+| `valid_to` | `null` (open-ended) | — (close a primitive by editing the file) |
+
+```bash
+# an element whose subject has been true since before it was written down
+transitrix new goal --id GOAL-042 --name "Reduce audit lead time" --valid-from 2026-01-01
+
+# same override when completing a hand-authored file
+transitrix validate canon/elements/01_motivation/goals/GOAL-042.yaml --fix --valid-from 2026-01-01
+```
+
+Dates are quoted `YYYY-MM-DD` (`CONTRACT.md` §4). A `--valid-from` that is not
+a calendar date in that form is rejected — the command fails rather than
+falling back to today, so a mistyped date can never be recorded silently.
+
+**Why `admitted_at` has no override.** `admitted_at` records when admission
+actually happened, so a caller-supplied value would falsify the admission
+record — the same reason `gate_checks` is never written as a constant `pass`.
+`valid_from` is different in kind: it is a statement about the subject, not
+about the tooling, and an author may legitimately know it to be earlier or
+later than the day they run the command.
+
+**What `--fix` will not do.** It fills only what it can derive. A field it
+cannot determine — most commonly `admitted_by`, when neither `--author` nor
+`git config user.name` supplies an identity — is reported as unresolved and
+the file still fails validation. `--fix` completes; it does not invent.
 
 ## Project config
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -65,6 +65,32 @@ Every notation in the table above follows the same pattern: `*.<notation>.transi
 
 > **Editors:** the extension ships to the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=transitrix.transitrix-studio) (VS Code) and to the [Open VSX Registry](https://open-vsx.org/extension/transitrix/transitrix-studio) (Cursor, VSCodium, Windsurf). The artefact is identical; pick whichever Extensions panel ships with your editor. **JetBrains IDEs** (IntelliJ IDEA and the rest) have a companion **Transitrix Studio** plugin — install it from **Settings → Plugins → Marketplace** and search for *Transitrix Studio*.
 
+## Creating a new element
+
+In a repository that follows the Transitrix methodology, the Command Palette
+carries **Transitrix: New Goal Element** and the matching **Driver**,
+**Constraint** and **Requirement** commands. Each asks only for what carries
+the element's own meaning — its id, its name, the one field its type requires —
+and writes the file into the folder that type belongs in.
+
+Everything else the file needs is computed rather than typed: the zone, the
+admission record (who admitted it, when, and the result of the checks that
+actually ran), and the lifecycle dates. Two of those values are yours to set
+rather than accept:
+
+| Prompt | Default | Notes |
+|---|---|---|
+| `admitted_by` | `git config user.name` | Asked only when git has no name configured. |
+| `valid_from` | today | Pre-filled — press Enter to accept, or type the date the element starts being true (`YYYY-MM-DD`). |
+
+The command refuses to write a file whose id already exists, or whose
+references do not resolve, rather than recording a check as passed when it
+did not.
+
+The same defaults, and the equivalent `--author` / `--valid-from` flags, are
+available from the CLI's `transitrix new` and `transitrix validate --fix` —
+see [`docs/cli.md`](../docs/cli.md#envelope-defaults).
+
 ## Settings
 
 Configure under **Settings → Transitrix Studio**. The canonical keys are `transitrix.*`.

--- a/extension/src/new-element-command.ts
+++ b/extension/src/new-element-command.ts
@@ -8,6 +8,7 @@
 
 import * as vscode from 'vscode';
 import * as path from 'node:path';
+import { isIsoDate } from '../../src/cli-parse.js';
 import {
   gitUserName,
   scaffoldConstraintElement,
@@ -39,16 +40,24 @@ function resolveRoot(): string | undefined {
   return folder.uri.fsPath;
 }
 
-/** Prompts for id, name, and admitted_by — the fields every element type
- *  requires, in the same order and with the same fallback-to-`git config
+/** Prompts for id, name, admitted_by and valid_from — the fields every element
+ *  type requires, in the same order and with the same fallback-to-`git config
  *  user.name` behaviour. Returns undefined if the author cancelled or no
- *  admitted_by identity is available. */
+ *  admitted_by identity is available.
+ *
+ *  `valid_from` is prompted pre-filled with today rather than filled silently:
+ *  it is the one envelope date an author may legitimately know to be earlier or
+ *  later than the day they create the file, and a pre-filled box is how they
+ *  find that out without reading the contract. Accepting it is one keypress.
+ *  `admitted_at` is deliberately not offered — it records when admission
+ *  actually happened, so an author-set value would falsify the admission
+ *  record; the CLI takes the same split. */
 async function promptCommonFields(
   root: string,
   label: string,
   idPrompt: string,
   idPlaceholder: string,
-): Promise<{ id: string; name: string; admittedBy: string } | undefined> {
+): Promise<{ id: string; name: string; admittedBy: string; validFrom: string } | undefined> {
   const id = await vscode.window.showInputBox({
     title: `New ${label} — id`,
     prompt: idPrompt,
@@ -78,7 +87,17 @@ async function promptCommonFields(
     return undefined;
   }
 
-  return { id: id.trim(), name: name.trim(), admittedBy };
+  const validFrom = await vscode.window.showInputBox({
+    title: `New ${label} — valid_from`,
+    prompt: 'Date the element starts being true (CONTRACT.md §7). Defaults to today.',
+    value: todayIso(),
+    ignoreFocusOut: true,
+    validateInput: (v) =>
+      isIsoDate(v.trim()) ? undefined : 'Enter a calendar date in YYYY-MM-DD form (CONTRACT.md §4).',
+  });
+  if (!validFrom) return undefined;
+
+  return { id: id.trim(), name: name.trim(), admittedBy, validFrom: validFrom.trim() };
 }
 
 /** Writes a successful scaffold outcome and opens it, or reports the

--- a/src/cli-parse.ts
+++ b/src/cli-parse.ts
@@ -12,6 +12,18 @@ export function normalizeExt(s: string): string {
   return t.startsWith('.') ? t : `.${t}`;
 }
 
+/** CONTRACT.md §4 — every date-typed field is a quoted `YYYY-MM-DD` string.
+ *  A caller-supplied date is checked against this before it can reach a
+ *  written file: an unparseable override is a hard failure, never a silent
+ *  fall back to today, which would record a lifecycle date nobody asked for.
+ *  The shape alone would accept `2026-02-31`, so the round-trip through `Date`
+ *  is what rejects a well-formed non-day. */
+export function isIsoDate(v: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(v)) return false;
+  const d = new Date(`${v}T00:00:00Z`);
+  return !Number.isNaN(d.getTime()) && d.toISOString().slice(0, 10) === v;
+}
+
 export type ParseCliFileArgvResult =
   | { ok: true; positional: string[]; extList: string[]; wantsHelp: boolean }
   | { ok: false; error: '--ext_requires_value' };
@@ -64,6 +76,7 @@ export type ParseValidateArgvResult =
       template: string | undefined;
       fix: boolean;
       author: string | undefined;
+      validFrom: string | undefined;
       dryRun: boolean;
       positional: string[];
       extList: string[];
@@ -77,6 +90,8 @@ export type ParseValidateArgvResult =
         | '--root_requires_value'
         | '--template_requires_value'
         | '--author_requires_value'
+        | '--valid-from_requires_value'
+        | 'bad_valid_from'
         | 'bad_scope';
       scope?: ValidateScope;
     };
@@ -86,8 +101,9 @@ export type ParseValidateArgvResult =
  * `--scope repo` form), `--root <dir>` for repo-scope, `--template <name>`
  * (matrix-subset `blocks` documents, §6a — e.g. `raci`) for file scope, and
  * `--fix` (file scope only — completes missing envelope fields; `--author`
- * overrides `git config user.name` for `admitted_by`, `--dry-run` previews
- * without writing); everything else is delegated to {@link parseCliFileArgv}.
+ * overrides `git config user.name` for `admitted_by`, `--valid-from`
+ * overrides today for `valid_from`, `--dry-run` previews without writing);
+ * everything else is delegated to {@link parseCliFileArgv}.
  * Default scope is `file`, preserving the existing per-file
  * `validate <input.yaml>` behaviour.
  */
@@ -97,6 +113,7 @@ export function parseValidateArgv(argv: string[]): ParseValidateArgvResult {
   let template: string | undefined;
   let fix = false;
   let author: string | undefined;
+  let validFrom: string | undefined;
   let dryRun = false;
   const rest: string[] = [];
 
@@ -153,6 +170,19 @@ export function parseValidateArgv(argv: string[]): ParseValidateArgvResult {
       author = a.slice('--author='.length);
       continue;
     }
+    if (a === '--valid-from') {
+      const v = argv[++i];
+      if (v === undefined) return { ok: false, error: '--valid-from_requires_value' };
+      if (!isIsoDate(v)) return { ok: false, error: 'bad_valid_from' };
+      validFrom = v;
+      continue;
+    }
+    if (a.startsWith('--valid-from=')) {
+      const v = a.slice('--valid-from='.length);
+      if (!isIsoDate(v)) return { ok: false, error: 'bad_valid_from' };
+      validFrom = v;
+      continue;
+    }
     rest.push(a);
   }
 
@@ -166,6 +196,7 @@ export function parseValidateArgv(argv: string[]): ParseValidateArgvResult {
     template,
     fix,
     author,
+    validFrom,
     dryRun,
     positional: parsed.positional,
     extList: parsed.extList,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -85,11 +85,11 @@ function printUsage(): void {
        transitrix metrics [--ext=.bpmn.transitrix.yaml] <input.yaml> [--json]
        transitrix validate <input.yaml> [--json]
        transitrix validate [--ext=.bpmn.transitrix.yaml] <input.yaml> [--json]
-       transitrix validate <input.yaml> --fix [--author <name>] [--root <dir>] [--dry-run]
+       transitrix validate <input.yaml> --fix [--author <name>] [--valid-from <YYYY-MM-DD>] [--root <dir>] [--dry-run]
        transitrix validate --scope=repo [--root <dir>] [--json] [--include-model]
        transitrix export-compliance [--format md|pdf] [--scope law:<ID>|product:<ID>|gap] [--output <path>] [--root <dir>]
        transitrix migrate [--from X.Y] [--to X.Y] [--dry-run] [--recipes <dir>] [target-dir]
-       transitrix new <goal|driver|constraint|requirement> --id <ID> --name "<label>" [--author <name>] [--root <dir>] [--dry-run]
+       transitrix new <goal|driver|constraint|requirement> --id <ID> --name "<label>" [--author <name>] [--valid-from <YYYY-MM-DD>] [--root <dir>] [--dry-run]
 
 
   serve     — local web UI (run npm run ui:build once beforehand).
@@ -118,7 +118,9 @@ function printUsage(): void {
               constraint, or requirement) with the admission record and
               lifecycle envelope computed (zone/admitted_at/admitted_by/
               gate_checks/valid_from/valid_to) rather than hand-typed.
-              --author sets admitted_by (default: git config user.name).
+              --author sets admitted_by (default: git config user.name);
+              --valid-from sets valid_from (default: today). admitted_at has no
+              override — it records when admission actually happened.
               Run 'transitrix new <type> --help' for type-specific options.
 
   --no-metrics  suppress quality metrics report on compile.
@@ -419,6 +421,7 @@ async function runValidateFixCommand(
       root,
       absFilePath,
       author: parsed.author,
+      validFrom: parsed.validFrom,
       catalog: ctx.catalog,
     });
 
@@ -465,6 +468,12 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
       console.error('transitrix validate: --template requires a value (e.g. raci).');
     } else if (parsed.error === '--author_requires_value') {
       console.error('transitrix validate: --author requires a value.');
+    } else if (parsed.error === '--valid-from_requires_value') {
+      console.error('transitrix validate: --valid-from requires a date (YYYY-MM-DD).');
+    } else if (parsed.error === 'bad_valid_from') {
+      console.error(
+        'transitrix validate: --valid-from must be a calendar date in YYYY-MM-DD form (CONTRACT.md §4).',
+      );
     } else {
       console.error('transitrix: --ext requires a comma-separated list of suffixes.');
     }
@@ -509,6 +518,8 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
     console.error('             by inserting only what it can derive — never a value it cannot');
     console.error('             determine, never a correction to a value already present.');
     console.error('             --author "<name>" overrides `git config user.name` for admitted_by;');
+    console.error('             --valid-from <YYYY-MM-DD> overrides today for valid_from (admitted_at');
+    console.error('             has no override — it records when admission actually happened);');
     console.error('             --root <dir> is the adopter repo root for the canon scan (default cwd);');
     console.error('             --dry-run previews the fix without writing.');
     console.error('repo scope — whole-canon checks (referential integrity, atomicity,');

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -28,6 +28,7 @@ import { execFileSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import * as path from 'node:path';
 import yaml from 'js-yaml';
+import { isIsoDate } from './cli-parse.js';
 
 const SKIP_SEGMENTS = new Set(['node_modules', '.templates', '.validators']);
 const GOAL_ELEM_ID_RE = /^GOAL-([A-Z0-9]+-)*[0-9]+$/;
@@ -102,10 +103,21 @@ export interface NewGoalOptions {
    *  handle here, never a tool id, keeps `admission_state`/`reviewer_authority`
    *  at their human-authored defaults: absent ⇒ active ⇒ expert_confirmed). */
   admittedBy: string;
-  /** ISO 8601 date (CONTRACT.md §4) used for `admitted_at` and `valid_from`.
+  /** ISO 8601 date (CONTRACT.md §4) used for `admitted_at`, and for
+   *  `valid_from` when {@link NewGoalOptions.validFrom} is absent.
    *  Caller-supplied rather than computed here so the function stays pure
    *  and testable without mocking the clock. */
   today: string;
+  /** Overrides `valid_from` (CONTRACT.md §7 — the date the primitive starts
+   *  being true). Defaults to `today`.
+   *
+   *  `admitted_at` has deliberately no counterpart override: it records when
+   *  admission actually happened, so a caller-set value would falsify the
+   *  admission record — the same reason `gate_checks` is never written as a
+   *  constant `pass`. `valid_from` is a modelling statement about the subject,
+   *  which the author may legitimately know to be earlier or later than the
+   *  day they type the command. */
+  validFrom?: string;
   type?: string;
   level?: number;
   parent?: string;
@@ -146,7 +158,7 @@ function renderGoalYaml(opts: NewGoalOptions): string {
   lines.push('  completeness: pass # required fields present');
   lines.push('');
   lines.push('# Primitive lifecycle (CONTRACT.md §7)');
-  lines.push(`valid_from: "${opts.today}"`);
+  lines.push(`valid_from: "${opts.validFrom ?? opts.today}"`);
   lines.push('valid_to: null');
   lines.push('');
   return lines.join('\n');
@@ -225,7 +237,12 @@ const DRIVER_ELEM_ID_RE = /^DRIVER-([A-Z0-9]+-)*[0-9]+$/;
 const CONSTRAINT_ELEM_ID_RE = /^CONSTRAINT-([A-Z0-9]+-)*[0-9]+$/;
 const REQUIREMENT_ELEM_ID_RE = /^REQUIREMENT-([A-Z0-9]+-)*[0-9]+$/;
 
-function renderEnvelopeSuffix(cmd: string, today: string, admittedBy: string): string {
+function renderEnvelopeSuffix(
+  cmd: string,
+  today: string,
+  admittedBy: string,
+  validFrom?: string,
+): string {
   return [
     '',
     `# Admission record (CONTRACT.md §6) — filled by \`transitrix new ${cmd}\``,
@@ -238,7 +255,7 @@ function renderEnvelopeSuffix(cmd: string, today: string, admittedBy: string): s
     '  completeness: pass # required fields present',
     '',
     '# Primitive lifecycle (CONTRACT.md §7)',
-    `valid_from: "${today}"`,
+    `valid_from: "${validFrom ?? today}"`,
     'valid_to: null',
     '',
   ].join('\n');
@@ -252,6 +269,8 @@ export interface NewDriverOptions {
   name: string;
   admittedBy: string;
   today: string;
+  /** Overrides `valid_from`; see {@link NewGoalOptions.validFrom}. */
+  validFrom?: string;
   driverType?: string;
   category?: string;
   description?: string;
@@ -269,7 +288,7 @@ function renderDriverYaml(opts: NewDriverOptions): string {
   if (opts.referencesConstraint && opts.referencesConstraint.length > 0) {
     lines.push(`references_constraint: [${opts.referencesConstraint.join(', ')}]`);
   }
-  return lines.join('\n') + '\n' + renderEnvelopeSuffix('driver', opts.today, opts.admittedBy);
+  return lines.join('\n') + '\n' + renderEnvelopeSuffix('driver', opts.today, opts.admittedBy, opts.validFrom);
 }
 
 export function scaffoldDriverElement(opts: NewDriverOptions): ScaffoldOutcome {
@@ -315,6 +334,8 @@ export interface NewConstraintOptions {
   name: string;
   admittedBy: string;
   today: string;
+  /** Overrides `valid_from`; see {@link NewGoalOptions.validFrom}. */
+  validFrom?: string;
   statement: string;
   /** Organisation-defined workflow state (envelope §3) — `active` | `proposed`
    *  | `deprecated` | `retired`. Not part of the methodology's own required
@@ -346,7 +367,7 @@ function renderConstraintYaml(opts: NewConstraintOptions): string {
   if (opts.rationale) lines.push(`rationale: "${opts.rationale.replace(/"/g, '\\"')}"`);
   if (opts.nextReviewAt) lines.push(`next_review_at: "${opts.nextReviewAt}"`);
   if (opts.parent) lines.push(`parent: ${opts.parent}`);
-  return lines.join('\n') + '\n' + renderEnvelopeSuffix('constraint', opts.today, opts.admittedBy);
+  return lines.join('\n') + '\n' + renderEnvelopeSuffix('constraint', opts.today, opts.admittedBy, opts.validFrom);
 }
 
 export function scaffoldConstraintElement(opts: NewConstraintOptions): ScaffoldOutcome {
@@ -392,6 +413,8 @@ export interface NewRequirementOptions {
   name: string;
   admittedBy: string;
   today: string;
+  /** Overrides `valid_from`; see {@link NewGoalOptions.validFrom}. */
+  validFrom?: string;
   description: string;
   origin?: string;
   severity?: string;
@@ -417,7 +440,7 @@ function renderRequirementYaml(opts: NewRequirementOptions): string {
   if (opts.nextReviewAt) lines.push(`next_review_at: "${opts.nextReviewAt}"`);
   if (opts.serves) lines.push(`serves: ${opts.serves}`);
   if (opts.derivedFrom && opts.derivedFrom.length > 0) lines.push(`derived_from: [${opts.derivedFrom.join(', ')}]`);
-  return lines.join('\n') + '\n' + renderEnvelopeSuffix('requirement', opts.today, opts.admittedBy);
+  return lines.join('\n') + '\n' + renderEnvelopeSuffix('requirement', opts.today, opts.admittedBy, opts.validFrom);
 }
 
 export function scaffoldRequirementElement(opts: NewRequirementOptions): ScaffoldOutcome {
@@ -469,6 +492,9 @@ export interface NewElementArgs {
   id: string | undefined;
   name: string | undefined;
   author: string | undefined;
+  /** `--valid-from` — raw, unvalidated; {@link handleNewCommand} rejects a
+   *  non-`YYYY-MM-DD` value rather than falling back to today. */
+  validFrom: string | undefined;
   root: string;
   typeValue: string | undefined;
   level: number | undefined;
@@ -510,6 +536,7 @@ export function parseNewArgv(argv: string[]): NewElementArgs {
     id: undefined,
     name: undefined,
     author: undefined,
+    validFrom: undefined,
     root: process.cwd(),
     typeValue: undefined,
     level: undefined,
@@ -546,6 +573,8 @@ export function parseNewArgv(argv: string[]): NewElementArgs {
     if (a.startsWith('--name=')) { args.name = a.slice('--name='.length); continue; }
     if (a === '--author') { args.author = rest[++i]; continue; }
     if (a.startsWith('--author=')) { args.author = a.slice('--author='.length); continue; }
+    if (a === '--valid-from') { args.validFrom = rest[++i]; continue; }
+    if (a.startsWith('--valid-from=')) { args.validFrom = a.slice('--valid-from='.length); continue; }
     if (a === '--root') { args.root = rest[++i]; continue; }
     if (a.startsWith('--root=')) { args.root = a.slice('--root='.length); continue; }
     if (a === '--type') { args.typeValue = rest[++i]; continue; }
@@ -616,6 +645,7 @@ function printTypeUsage(type: 'goal' | 'driver' | 'constraint' | 'requirement'):
     '  --id <…>             Required — canonical id.',
     '  --name "<label>"     Required — human-readable name.',
     '  --author "<name>"    Recorded as admitted_by. Default: `git config user.name`.',
+    '  --valid-from <date>  Recorded as valid_from (YYYY-MM-DD). Default: today.',
     '  --root <dir>         Adopter repo root containing canon/ (default: cwd).',
     '  --dry-run            Print what would be written; do not write the file.',
   ];
@@ -700,6 +730,13 @@ export async function handleNewCommand(argv: string[]): Promise<void> {
     process.exit(1);
   }
 
+  if (args.validFrom !== undefined && !isIsoDate(args.validFrom)) {
+    console.error(
+      `transitrix new ${args.type}: --valid-from "${args.validFrom}" is not a calendar date in YYYY-MM-DD form (CONTRACT.md §4).`,
+    );
+    process.exit(1);
+  }
+
   const root = path.resolve(args.root);
   const admittedBy = args.author ?? gitUserName(root);
   if (!admittedBy) {
@@ -709,29 +746,30 @@ export async function handleNewCommand(argv: string[]): Promise<void> {
   }
 
   const today = todayIso();
+  const validFrom = args.validFrom;
   let outcome: ScaffoldOutcome;
   if (args.type === 'goal') {
     outcome = scaffoldGoalElement({
-      root, id: args.id, name: args.name, admittedBy, today,
+      root, id: args.id, name: args.name, admittedBy, today, validFrom,
       type: args.typeValue, level: args.level, parent: args.parent,
       factors: args.factors, description: args.description, link: args.link,
     });
   } else if (args.type === 'driver') {
     outcome = scaffoldDriverElement({
-      root, id: args.id, name: args.name, admittedBy, today,
+      root, id: args.id, name: args.name, admittedBy, today, validFrom,
       driverType: args.typeValue, category: args.category,
       description: args.description, referencesConstraint: args.referencesConstraint,
     });
   } else if (args.type === 'constraint') {
     outcome = scaffoldConstraintElement({
-      root, id: args.id, name: args.name, admittedBy, today,
+      root, id: args.id, name: args.name, admittedBy, today, validFrom,
       statement: args.statement as string, status: args.status, appliesTo: args.appliesTo,
       source: args.source, ownerRole: args.ownerRole, severity: args.severity,
       rationale: args.rationale, nextReviewAt: args.nextReviewAt, parent: args.parent,
     });
   } else {
     outcome = scaffoldRequirementElement({
-      root, id: args.id, name: args.name, admittedBy, today,
+      root, id: args.id, name: args.name, admittedBy, today, validFrom,
       description: args.description as string, origin: args.origin, severity: args.severity,
       level: args.levelRaw, kind: args.kind, parent: args.parent,
       nextReviewAt: args.nextReviewAt, serves: args.serves, derivedFrom: args.derivedFrom,

--- a/src/validate-fix.ts
+++ b/src/validate-fix.ts
@@ -88,6 +88,16 @@ export interface ComputeFixPlanOptions {
   absFilePath: string;
   /** `--author`, else `git config user.name` (never invented). */
   author?: string;
+  /** `--valid-from` — overrides the `valid_from` fill (CONTRACT.md §7, the
+   *  date the primitive starts being true). Defaults to today.
+   *
+   *  `admitted_at` has no counterpart override on purpose: it records when
+   *  admission actually happened, so a caller-set value would falsify the
+   *  admission record — the same posture that keeps `gate_checks` from ever
+   *  being written as a constant `pass`. Callers validate the format before
+   *  passing it; an already-present `valid_from` is never touched, override
+   *  or not. */
+  validFrom?: string;
   /** Repo-wide catalogue, so the catalogue-aware notations (change,
    *  stakeholder, target-state) can actually resolve cross-references when
    *  deciding whether `gate_checks.consistency` truly holds. */
@@ -130,7 +140,7 @@ export function computeFixPlan(
     filled.push({ field: 'admitted_at', value: v });
   }
   if (missingSimple.has('valid_from')) {
-    const v = todayIso();
+    const v = opts.validFrom ?? todayIso();
     candidate.valid_from = v;
     filled.push({ field: 'valid_from', value: v });
   }

--- a/tests/cli-parse.test.ts
+++ b/tests/cli-parse.test.ts
@@ -5,6 +5,7 @@ import {
   parseCliFileArgv,
   parseValidateArgv,
   inputMatchesExtension,
+  isIsoDate,
 } from '../src/cli-parse.js';
 
 describe('cli-parse', () => {
@@ -115,6 +116,36 @@ describe('parseValidateArgv (#141 — validate scope)', () => {
 
   it('signals --author without a value', () => {
     expect(parseValidateArgv(['--author'])).toEqual({ ok: false, error: '--author_requires_value' });
+  });
+
+  it('parses --valid-from (both separate and = forms)', () => {
+    expect(parseValidateArgv(['model.yaml'])).toMatchObject({ ok: true, validFrom: undefined });
+    expect(parseValidateArgv(['model.yaml', '--fix', '--valid-from', '2026-01-01']))
+      .toMatchObject({ ok: true, validFrom: '2026-01-01' });
+    expect(parseValidateArgv(['model.yaml', '--fix', '--valid-from=2026-01-01']))
+      .toMatchObject({ ok: true, validFrom: '2026-01-01' });
+  });
+
+  it('signals --valid-from without a value, and rejects a non-calendar date', () => {
+    expect(parseValidateArgv(['--valid-from'])).toEqual({ ok: false, error: '--valid-from_requires_value' });
+    for (const bad of ['01/01/2026', '2026-1-1', '2026-02-31', 'yesterday', '']) {
+      expect(parseValidateArgv(['model.yaml', `--valid-from=${bad}`]), bad)
+        .toEqual({ ok: false, error: 'bad_valid_from' });
+    }
+  });
+});
+
+describe('isIsoDate', () => {
+  it('accepts a canonical calendar date and rejects everything else', () => {
+    expect(isIsoDate('2026-01-01')).toBe(true);
+    expect(isIsoDate('2024-02-29')).toBe(true);   // leap day
+    expect(isIsoDate('2026-02-29')).toBe(false);  // not a leap year
+    expect(isIsoDate('2026-02-31')).toBe(false);
+    expect(isIsoDate('2026-13-01')).toBe(false);
+    expect(isIsoDate('2026-1-1')).toBe(false);
+    expect(isIsoDate('01/01/2026')).toBe(false);
+    expect(isIsoDate('2026-01-01T00:00:00Z')).toBe(false);
+    expect(isIsoDate('')).toBe(false);
   });
 });
 

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -47,6 +47,12 @@ describe('parseNewArgv', () => {
     expect(r.author).toBe('a.b');
   });
 
+  it('parses --valid-from both as separate and = forms', () => {
+    expect(parseNewArgv(['goal', '--valid-from', '2026-01-01']).validFrom).toBe('2026-01-01');
+    expect(parseNewArgv(['goal', '--valid-from=2026-01-01']).validFrom).toBe('2026-01-01');
+    expect(parseNewArgv(['goal']).validFrom).toBeUndefined();
+  });
+
   it('parses --factors as a comma-split list', () => {
     const r = parseNewArgv(['goal', '--factors', 'DRIVER-A-1, DRIVER-B-2']);
     expect(r.factors).toEqual(['DRIVER-A-1', 'DRIVER-B-2']);
@@ -110,6 +116,23 @@ describe('scaffoldGoalElement', () => {
     expect(outcome.filled).toEqual(
       expect.arrayContaining(['zone', 'admitted_at', 'admitted_by', 'gate_checks', 'valid_from', 'valid_to']),
     );
+  });
+
+  it('honours a validFrom override without moving admitted_at', () => {
+    const root = makeRepo();
+    const outcome = scaffoldGoalElement({
+      root,
+      id: 'GOAL-REVENUE-1',
+      name: 'Grow revenue',
+      admittedBy: 'v.korobeinikov',
+      today: '2026-08-02',
+      validFrom: '2026-01-01',
+    });
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+    expect(outcome.content).toContain('valid_from: "2026-01-01"');
+    // admitted_at records when admission happened; the override must not reach it.
+    expect(outcome.content).toContain('admitted_at: "2026-08-02"');
   });
 
   it('rejects an id that does not match the GOAL grammar', () => {
@@ -204,6 +227,24 @@ describe('scaffoldDriverElement', () => {
     expect(outcome.content).toContain('type: external');
     expect(outcome.content).toContain('category: legal');
     expect(outcome.content).toContain('admitted_by: "v.korobeinikov"');
+  });
+
+  it('honours a validFrom override on the shared envelope suffix', () => {
+    const root = makeRepo();
+    // driver/constraint/requirement all render through renderEnvelopeSuffix,
+    // so one case covers the override reaching that shared path.
+    const outcome = scaffoldDriverElement({
+      root,
+      id: 'DRIVER-EU-REG-1',
+      name: 'EU regulatory window',
+      admittedBy: 'v.korobeinikov',
+      today: '2026-08-03',
+      validFrom: '2025-11-15',
+    });
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+    expect(outcome.content).toContain('valid_from: "2025-11-15"');
+    expect(outcome.content).toContain('admitted_at: "2026-08-03"');
   });
 
   it('rejects an id that does not match the DRIVER grammar', () => {
@@ -399,6 +440,43 @@ describe('transitrix new goal (CLI)', () => {
     expect(status).toBe(0);
     expect(stdout).toMatch(/Would write/);
     expect(existsSync(join(root, 'canon', 'elements', '01_motivation', 'goals', 'GOAL-PREVIEW-1.yaml'))).toBe(false);
+  });
+
+  it('--valid-from is written through to the file, leaving admitted_at at today', () => {
+    const root = makeRepo();
+    const { status } = runCli([
+      'new', 'goal',
+      '--id', 'GOAL-BACKDATED-1',
+      '--name', 'True before it was written down',
+      '--author', 'a.b',
+      '--valid-from', '2026-01-01',
+      '--root', root,
+    ]);
+    expect(status).toBe(0);
+    const written = readFileSync(
+      join(root, 'canon', 'elements', '01_motivation', 'goals', 'GOAL-BACKDATED-1.yaml'),
+      'utf-8',
+    );
+    expect(written).toContain('valid_from: "2026-01-01"');
+    expect(written).toMatch(/admitted_at: "\d{4}-\d{2}-\d{2}"/);
+    expect(written).not.toContain('admitted_at: "2026-01-01"');
+  });
+
+  it('exits 1 on a --valid-from that is not a calendar date, without writing', () => {
+    const root = makeRepo();
+    for (const bad of ['01/01/2026', '2026-1-1', '2026-02-31', 'yesterday']) {
+      const { status, stderr } = runCli([
+        'new', 'goal',
+        '--id', 'GOAL-BADDATE-1',
+        '--name', 'Bad date',
+        '--author', 'a.b',
+        '--valid-from', bad,
+        '--root', root,
+      ]);
+      expect(status, bad).toBe(1);
+      expect(stderr, bad).toMatch(/--valid-from/);
+    }
+    expect(existsSync(join(root, 'canon', 'elements', '01_motivation', 'goals', 'GOAL-BADDATE-1.yaml'))).toBe(false);
   });
 
   it('exits 1 and reports gate-check failures without writing', () => {

--- a/tests/validate-fix.test.ts
+++ b/tests/validate-fix.test.ts
@@ -62,6 +62,37 @@ describe('computeFixPlan', () => {
     expect(byField.gate_checks).toEqual({ uniqueness: 'pass', consistency: 'pass', completeness: 'pass' });
   });
 
+  it('fills valid_from from the override, leaving admitted_at at today', () => {
+    const root = makeRepo();
+    const absFilePath = join(root, 'ACTOR-OPS-1.yaml');
+    const data = { notation: 'actor', id: 'ACTOR-OPS-1', name: 'Ops', type: 'system' };
+
+    const plan = computeFixPlan('actor', data, {
+      root, absFilePath, author: 'a.b', validFrom: '2026-01-01',
+    });
+
+    const byField = Object.fromEntries(plan.filled.map((f) => [f.field, f.value]));
+    expect(byField.valid_from).toBe('2026-01-01');
+    // admitted_at records when admission happened — the override must not reach it.
+    expect(byField.admitted_at).not.toBe('2026-01-01');
+    expect(byField.admitted_at).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('does not touch a valid_from already present, override or not', () => {
+    const root = makeRepo();
+    const absFilePath = join(root, 'ACTOR-OPS-1.yaml');
+    const data = {
+      notation: 'actor', id: 'ACTOR-OPS-1', name: 'Ops', type: 'system',
+      valid_from: '2026-07-04',
+    };
+
+    const plan = computeFixPlan('actor', data, {
+      root, absFilePath, author: 'a.b', validFrom: '2026-01-01',
+    });
+
+    expect(plan.filled.map((f) => f.field)).not.toContain('valid_from');
+  });
+
   it('leaves admitted_by unresolved (and gate_checks uncertified) with no --author and no git identity', () => {
     const root = makeRepo();
     const absFilePath = join(root, 'ACTOR-OPS-1.yaml');


### PR DESCRIPTION
## What changed

The envelope creation paths computed every lifecycle date from the clock. `valid_from` states when the element's subject starts being true, which an author may know to be earlier or later than the day they write the file, so it is now settable on all three creation paths:

- `transitrix new <goal|driver|constraint|requirement> --valid-from <YYYY-MM-DD>`
- `transitrix validate <file> --fix --valid-from <YYYY-MM-DD>`
- the extension's **New … Element** commands prompt for it, pre-filled with today (one keypress to accept)

`admitted_at` deliberately gets no such override: it records when admission actually happened, so a caller-supplied value would falsify the admission record — the same reason `gate_checks` is never written as a constant `pass`.

A value that is not a calendar date in `YYYY-MM-DD` form (CONTRACT.md §4) is rejected rather than falling back to today, so a mistyped date cannot be recorded silently. The shared `isIsoDate` round-trips through `Date`, so a well-formed non-day such as `2026-02-31` fails too. An already-present `valid_from` is never touched by `--fix`, override or not.

Documented in `docs/cli.md` (new "Envelope defaults" section, covering the full default/override table) and `extension/README.md`.

## How it is verified

- `npm run compile` and `npm run compile:extension` — both clean.
- `npx vitest run tests/cli-parse.test.ts tests/scaffold.test.ts tests/validate-fix.test.ts` — 85/85 pass, including new cases for both flag forms, the missing-value error, and rejection of `01/01/2026`, `2026-1-1`, `2026-02-31`, `2026-13-01`, `2026-02-29`, an ISO timestamp, and the empty string.
- Full `npx vitest run` — 588/591. The 3 failures (`tests/cli-migrate.test.ts`) and the `ci-hygiene-hashrefs.test.ts` suite error reproduce identically on `main` with this change stashed; they need a methodology repo checkout and are unrelated.
- `packages/diagrams` is untouched, so no version bump applies.

Refs THQ-22