### PR TITLE
feat(extension): register .ttrs as a language with syntax highlighting

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- **`.ttrs` document templates are now a recognized language** — file-icon, `.ttrs` extension association, and syntax highlighting for the four slot kinds (fixed text, model-object reference, figure, instruction slot). A `.trs` file (the one-keystroke-off near-miss) is not misidentified as `.ttrs`.
+
 ## 3.1.3 — 2026-07-29
 
 The CLI npm package now ships the same diagrams behavior as the extension (fixes false `BL-006` rejections on current element types), and internal legacy identifiers have been cleaned up.

--- a/extension/assets/ttrs-icon-mono.svg
+++ b/extension/assets/ttrs-icon-mono.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" role="img" aria-label="Transitrix Document Template">
+  <path d="M6 2.5h8.5L19 7v14.5a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1v-18a1 1 0 0 1 1-1z"/>
+  <path d="M14.5 2.5V7H19"/>
+  <path d="M9.2 12.2c-1 0-1.6.6-1.6 1.6v.4c0 .8-.3 1.2-.9 1.4.6.2.9.6.9 1.4v.4c0 1 .6 1.6 1.6 1.6"/>
+  <path d="M14.8 12.2c1 0 1.6.6 1.6 1.6v.4c0 .8.3 1.2.9 1.4-.6.2-.9.6-.9 1.4v.4c0 1-.6 1.6-1.6 1.6"/>
+</svg>

--- a/extension/package.json
+++ b/extension/package.json
@@ -74,7 +74,8 @@
     "workspaceContains:**/REQUIREMENT-*.yaml",
     "workspaceContains:**/CONSTRAINT-*.yaml",
     "workspaceContains:**/*.puml",
-    "workspaceContains:**/*.plantuml"
+    "workspaceContains:**/*.plantuml",
+    "workspaceContains:**/*.ttrs"
   ],
   "contributes": {
     "configuration": {
@@ -549,6 +550,28 @@
           ".puml",
           ".plantuml"
         ]
+      },
+      {
+        "id": "transitrix-ttrs",
+        "aliases": [
+          "Transitrix Document Template",
+          "TTRS"
+        ],
+        "extensions": [
+          ".ttrs"
+        ],
+        "configuration": "./language-configuration.json",
+        "icon": {
+          "light": "media/ttrs-icon-mono.svg",
+          "dark": "media/ttrs-icon-mono.svg"
+        }
+      }
+    ],
+    "grammars": [
+      {
+        "language": "transitrix-ttrs",
+        "scopeName": "text.ttrs",
+        "path": "./syntaxes/ttrs.tmLanguage.json"
       }
     ],
     "commands": [

--- a/extension/syntaxes/ttrs.tmLanguage.json
+++ b/extension/syntaxes/ttrs.tmLanguage.json
@@ -1,0 +1,123 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "Transitrix Document Template",
+  "scopeName": "text.ttrs",
+  "fileTypes": ["ttrs"],
+  "patterns": [
+    { "include": "#frontmatter" },
+    { "include": "#escape" },
+    { "include": "#instruction-slot" },
+    { "include": "#capability-reference" },
+    { "include": "#figure-view" },
+    { "include": "#figure-supplied" },
+    { "include": "#figure-reference" },
+    { "include": "#model-object-reference" }
+  ],
+  "repository": {
+    "frontmatter": {
+      "begin": "\\A(---)\\s*$",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.frontmatter.begin.ttrs" }
+      },
+      "end": "^(---)\\s*$",
+      "endCaptures": {
+        "1": { "name": "punctuation.definition.frontmatter.end.ttrs" }
+      },
+      "name": "meta.frontmatter.ttrs",
+      "patterns": [{ "include": "source.yaml" }]
+    },
+    "escape": {
+      "match": "\\\\\\{\\{",
+      "name": "constant.character.escape.ttrs"
+    },
+    "instruction-slot": {
+      "begin": "(\\{\\{#)\\s*(instruct)\\s+([a-z0-9][a-z0-9-]*)\\s*(\\}\\})",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.tag.begin.ttrs" },
+        "2": { "name": "keyword.control.instruct.ttrs" },
+        "3": { "name": "entity.name.tag.slot-id.ttrs" },
+        "4": { "name": "punctuation.definition.tag.end.ttrs" }
+      },
+      "end": "(\\{\\{/)\\s*(instruct)\\s*(\\}\\})",
+      "endCaptures": {
+        "1": { "name": "punctuation.definition.tag.begin.ttrs" },
+        "2": { "name": "keyword.control.instruct.ttrs" },
+        "3": { "name": "punctuation.definition.tag.end.ttrs" }
+      },
+      "name": "meta.instruction-slot.ttrs",
+      "patterns": [{ "include": "#instruction-slot-body" }]
+    },
+    "instruction-slot-body": {
+      "patterns": [
+        {
+          "match": "^\\s*(question|inputs|sufficient)\\s*(:)",
+          "captures": {
+            "1": { "name": "keyword.other.instruction-key.ttrs" },
+            "2": { "name": "punctuation.separator.key-value.ttrs" }
+          }
+        },
+        { "match": "[^\\n]+", "name": "string.unquoted.instruction-body.ttrs" }
+      ]
+    },
+    "capability-reference": {
+      "match": "(\\{\\{)\\s*(CAPABILITY-[VH][1-9][0-9]*(?:\\.[1-9][0-9]*){0,2})\\s*(\\}\\})",
+      "captures": {
+        "1": { "name": "punctuation.definition.tag.begin.ttrs" },
+        "2": { "name": "variable.other.model-reference.ttrs" },
+        "3": { "name": "punctuation.definition.tag.end.ttrs" }
+      },
+      "name": "meta.model-object-reference.ttrs"
+    },
+    "model-object-reference": {
+      "match": "(\\{\\{)\\s*([A-Z][A-Z0-9_]*(?:-[A-Za-z0-9]+)*-[1-9][0-9]*)((?:\\.[A-Za-z_][A-Za-z0-9_]*){0,3})\\s*(\\}\\})",
+      "captures": {
+        "1": { "name": "punctuation.definition.tag.begin.ttrs" },
+        "2": { "name": "variable.other.model-reference.ttrs" },
+        "3": { "name": "variable.other.field-path.ttrs" },
+        "4": { "name": "punctuation.definition.tag.end.ttrs" }
+      },
+      "name": "meta.model-object-reference.ttrs"
+    },
+    "figure-view": {
+      "match": "(\\{\\{)\\s*(view)\\s+(\\S+)([^}]*)(\\}\\})",
+      "captures": {
+        "1": { "name": "punctuation.definition.tag.begin.ttrs" },
+        "2": { "name": "keyword.control.figure.ttrs" },
+        "3": { "name": "string.unquoted.path.ttrs" },
+        "4": { "patterns": [{ "include": "#figure-attributes" }] },
+        "5": { "name": "punctuation.definition.tag.end.ttrs" }
+      },
+      "name": "meta.figure.derived.ttrs"
+    },
+    "figure-supplied": {
+      "match": "(\\{\\{)\\s*(figure)\\s+(\\S+)([^}]*)(\\}\\})",
+      "captures": {
+        "1": { "name": "punctuation.definition.tag.begin.ttrs" },
+        "2": { "name": "keyword.control.figure.ttrs" },
+        "3": { "name": "string.unquoted.path.ttrs" },
+        "4": { "patterns": [{ "include": "#figure-attributes" }] },
+        "5": { "name": "punctuation.definition.tag.end.ttrs" }
+      },
+      "name": "meta.figure.supplied.ttrs"
+    },
+    "figure-reference": {
+      "match": "(\\{\\{)\\s*(figref)\\s+([A-Za-z_][A-Za-z0-9_-]*)\\s*(\\}\\})",
+      "captures": {
+        "1": { "name": "punctuation.definition.tag.begin.ttrs" },
+        "2": { "name": "keyword.control.figure.ttrs" },
+        "3": { "name": "variable.other.figure-name.ttrs" },
+        "4": { "name": "punctuation.definition.tag.end.ttrs" }
+      },
+      "name": "meta.figure.reference.ttrs"
+    },
+    "figure-attributes": {
+      "patterns": [
+        { "match": "\\b(as|fit|caption)\\b(?=\\s*=)", "name": "variable.parameter.ttrs" },
+        { "match": "=", "name": "keyword.operator.assignment.ttrs" },
+        { "match": "\"(?:\\\\.|[^\"\\\\])*\"", "name": "string.quoted.double.ttrs" },
+        { "match": "\\b(width|page|none)\\b", "name": "constant.language.ttrs" },
+        { "match": "[A-Za-z0-9_-]+", "name": "string.unquoted.ttrs" }
+      ]
+    }
+  }
+}

--- a/scripts/build-webview.mjs
+++ b/scripts/build-webview.mjs
@@ -34,4 +34,11 @@ await fs.cp(
   path.join(mediaDir, 'transitrix-icon-mono.svg'),
 );
 
+// File-icon for the .ttrs language contribution — same tracked-source /
+// gitignored-build-output split as the mark above.
+await fs.cp(
+  path.join(extensionAssets, 'ttrs-icon-mono.svg'),
+  path.join(mediaDir, 'ttrs-icon-mono.svg'),
+);
+
 console.log('Webview bundled to extension/media');


### PR DESCRIPTION
## What changed

Registers `.ttrs` document templates as a VS Code language: `contributes.languages`/`grammars` entries, a TextMate grammar covering the four slot kinds (fixed text, model-object reference, figure, instruction slot), and a file-icon (source in `extension/assets/`, copied into the gitignored `extension/media/` build output by `scripts/build-webview.mjs`, same pattern as the existing Transitrix mark).

The grammar matches the `CAPABILITY-V/H` dotted-ID form ahead of the generic model-object-reference pattern (its own dots aren't a field-path separator), and `.ttrs`'s extension pattern doesn't match `.trs` (the one-keystroke near-miss).

Format spec: THQ-59 (settled and landed on methodology PR transitrix/methodology#461). Task: THQ-56.

Out of scope here (separate task, THQ-57): live preview of Pass 1 *resolved* content — this is syntax highlighting / file recognition only.

## How it is verified

- `node -e "JSON.parse(...)"` on `extension/package.json` and the new grammar file.
- `npm run compile:extension` (`tsc --noEmit`) — clean.
- Regex-tested the model-object-reference vs. CAPABILITY-reference patterns against the spec's own examples (`REQ-14`, `REQ-14.text`, `REQ-14.parent.title`, `CAPABILITY-V1.2.3`) — each matches exactly one pattern, no double-match.
- Smoke-tested the `extension/assets` → `extension/media` icon copy step in isolation (the same split as the existing Transitrix mark icon).