### PR TITLE
feat(extension): highlight each, trace and row references in .ttrs

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- **`.ttrs` document templates are now a recognized language** — file-icon, `.ttrs` extension association, and syntax highlighting for the four slot kinds (fixed text, model-object reference, figure, instruction slot). A `.trs` file (the one-keystroke-off near-miss) is not misidentified as `.ttrs`.
+- **`.ttrs` document templates are now a recognized language** — file-icon, `.ttrs` extension association, and syntax highlighting for the whole directive language: references (including the `CAPABILITY-V1.2.3` dotted-id form and field paths), figures (`view`, `figure`, `figref`), `each` blocks with their `where` / `order by` clauses and row references, `trace`, and `instruct` blocks whose body stays opaque. A `.trs` file (the one-keystroke-off near-miss) is not misidentified as `.ttrs`.
 
 ## 3.1.3 — 2026-07-29
 

--- a/extension/syntaxes/ttrs.tmLanguage.json
+++ b/extension/syntaxes/ttrs.tmLanguage.json
@@ -7,6 +7,8 @@
     { "include": "#frontmatter" },
     { "include": "#escape" },
     { "include": "#instruction-slot" },
+    { "include": "#each-block" },
+    { "include": "#trace" },
     { "include": "#capability-reference" },
     { "include": "#figure-view" },
     { "include": "#figure-supplied" },
@@ -57,6 +59,83 @@
           }
         },
         { "match": "[^\\n]+", "name": "string.unquoted.instruction-body.ttrs" }
+      ]
+    },
+    "each-block": {
+      "begin": "(\\{\\{#)\\s*(each)\\s+([A-Z][A-Z0-9_]*)([^}]*)(\\}\\})",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.tag.begin.ttrs" },
+        "2": { "name": "keyword.control.each.ttrs" },
+        "3": { "name": "entity.name.type.element-type.ttrs" },
+        "4": { "patterns": [{ "include": "#each-clauses" }] },
+        "5": { "name": "punctuation.definition.tag.end.ttrs" }
+      },
+      "end": "(\\{\\{/)\\s*(each)\\s*(\\}\\})",
+      "endCaptures": {
+        "1": { "name": "punctuation.definition.tag.begin.ttrs" },
+        "2": { "name": "keyword.control.each.ttrs" },
+        "3": { "name": "punctuation.definition.tag.end.ttrs" }
+      },
+      "name": "meta.block.each.ttrs",
+      "patterns": [{ "include": "#each-body" }]
+    },
+    "each-clauses": {
+      "patterns": [
+        {
+          "match": "\\b(order)\\s+(by)\\b",
+          "captures": {
+            "1": { "name": "keyword.control.each.ttrs" },
+            "2": { "name": "keyword.control.each.ttrs" }
+          }
+        },
+        { "match": "\\b(where|and)\\b", "name": "keyword.control.each.ttrs" },
+        {
+          "match": "(!=|=)\\s*(\"(?:\\\\.|[^\"\\\\])*\"|[A-Za-z0-9_.-]+)",
+          "captures": {
+            "1": { "name": "keyword.operator.comparison.ttrs" },
+            "2": { "name": "string.unquoted.literal.ttrs" }
+          }
+        },
+        { "match": "[A-Za-z_][A-Za-z0-9_.-]*", "name": "variable.other.field.ttrs" }
+      ]
+    },
+    "each-body": {
+      "patterns": [
+        { "include": "#escape" },
+        { "include": "#instruction-slot" },
+        { "include": "#trace" },
+        { "include": "#capability-reference" },
+        { "include": "#figure-view" },
+        { "include": "#figure-supplied" },
+        { "include": "#figure-reference" },
+        { "include": "#row-reference" },
+        { "include": "#model-object-reference" }
+      ]
+    },
+    "row-reference": {
+      "match": "(\\{\\{)\\s*(\\.[A-Za-z_][A-Za-z0-9_]*)\\s*(\\}\\})",
+      "captures": {
+        "1": { "name": "punctuation.definition.tag.begin.ttrs" },
+        "2": { "name": "variable.other.row-field.ttrs" },
+        "3": { "name": "punctuation.definition.tag.end.ttrs" }
+      },
+      "name": "meta.row-reference.ttrs"
+    },
+    "trace": {
+      "match": "(\\{\\{)\\s*(trace)\\s+([^}]*)(\\}\\})",
+      "captures": {
+        "1": { "name": "punctuation.definition.tag.begin.ttrs" },
+        "2": { "name": "keyword.control.trace.ttrs" },
+        "3": { "patterns": [{ "include": "#trace-attributes" }] },
+        "4": { "name": "punctuation.definition.tag.end.ttrs" }
+      },
+      "name": "meta.trace.ttrs"
+    },
+    "trace-attributes": {
+      "patterns": [
+        { "match": "\\b(from|to|via)\\b(?=\\s*=)", "name": "variable.parameter.ttrs" },
+        { "match": "=", "name": "keyword.operator.assignment.ttrs" },
+        { "match": "[A-Za-z_][A-Za-z0-9_]*", "name": "entity.name.type.element-type.ttrs" }
       ]
     },
     "capability-reference": {

--- a/tests/ttrs-grammar.test.ts
+++ b/tests/ttrs-grammar.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+const grammar = JSON.parse(
+  readFileSync(path.join(repoRoot, 'extension/syntaxes/ttrs.tmLanguage.json'), 'utf8'),
+) as {
+  patterns: { include: string }[];
+  repository: Record<string, Record<string, unknown>>;
+};
+
+const extensionManifest = JSON.parse(
+  readFileSync(path.join(repoRoot, 'extension/package.json'), 'utf8'),
+) as {
+  contributes: {
+    languages: { id: string; extensions?: string[] }[];
+    grammars: { language: string; scopeName: string; path: string }[];
+  };
+};
+
+/**
+ * The grammar's patterns are written in the subset of the regex syntax that
+ * JS and Oniguruma share, so a rule can be exercised directly here. Anchored
+ * both ends: a rule that only matches part of a directive would still leave
+ * the rest unhighlighted.
+ */
+function rule(name: string): RegExp {
+  const entry = grammar.repository[name];
+  const source = (entry.match ?? entry.begin) as string;
+  return new RegExp(`^(?:${source})$`);
+}
+
+function ruleUnanchored(name: string): RegExp {
+  const entry = grammar.repository[name];
+  return new RegExp((entry.match ?? entry.begin) as string);
+}
+
+const included = (patterns: { include: string }[]) => patterns.map((p) => p.include);
+
+describe('.ttrs language contribution', () => {
+  it('associates only the .ttrs extension, so the .trs near-miss is not claimed', () => {
+    const language = extensionManifest.contributes.languages.find(
+      (l) => l.id === 'transitrix-ttrs',
+    );
+    expect(language).toBeDefined();
+    expect(language?.extensions).toEqual(['.ttrs']);
+  });
+
+  it('points the grammar at the scope the grammar file declares', () => {
+    const contribution = extensionManifest.contributes.grammars.find(
+      (g) => g.language === 'transitrix-ttrs',
+    );
+    expect(contribution?.scopeName).toBe('text.ttrs');
+    expect(contribution?.path).toBe('./syntaxes/ttrs.tmLanguage.json');
+  });
+});
+
+describe('each — DIRECTIVE_LANGUAGE.md §4.1', () => {
+  const each = rule('each-block');
+
+  it('recognises the bare form', () => {
+    const m = '{{# each REQ }}'.match(each);
+    expect(m?.[3]).toBe('REQ');
+  });
+
+  it('recognises a multi-word element type', () => {
+    expect('{{# each BUSINESS_SERVICE }}'.match(each)?.[3]).toBe('BUSINESS_SERVICE');
+  });
+
+  it('recognises where, and, and order by together', () => {
+    const source = '{{# each REQ where status = approved and priority != low order by id }}';
+    const m = source.match(each);
+    expect(m?.[3]).toBe('REQ');
+    expect(m?.[4]).toContain('order by id');
+  });
+
+  it('recognises the closing tag', () => {
+    expect(
+      new RegExp(`^(?:${grammar.repository['each-block'].end as string})$`).test('{{/ each }}'),
+    ).toBe(true);
+  });
+
+  it('scopes where / and / order by as keywords, and the right-hand side as a literal', () => {
+    const clauses = grammar.repository['each-clauses'].patterns as {
+      match: string;
+      name?: string;
+    }[];
+    const keywordSources = clauses
+      .filter((p) => (p.name ?? '').startsWith('keyword') || p.match.includes('order'))
+      .map((p) => p.match);
+    expect(keywordSources.some((s) => new RegExp(s).test('where'))).toBe(true);
+    expect(keywordSources.some((s) => new RegExp(s).test('and'))).toBe(true);
+    expect(keywordSources.some((s) => new RegExp(s).test('order by'))).toBe(true);
+  });
+
+  it('carries the inline constructs into its body, including the row reference', () => {
+    const body = included(grammar.repository['each-body'].patterns as { include: string }[]);
+    expect(body).toContain('#row-reference');
+    expect(body).toContain('#model-object-reference');
+    expect(body).toContain('#capability-reference');
+    expect(body).toContain('#trace');
+  });
+});
+
+describe('row reference — §3.3', () => {
+  const row = rule('row-reference');
+
+  it('recognises a current-row field', () => {
+    expect('{{ .title }}'.match(row)?.[2]).toBe('.title');
+  });
+
+  it('does not claim an ordinary reference', () => {
+    expect(row.test('{{ REQ-14 }}')).toBe(false);
+  });
+});
+
+describe('trace — §3.4', () => {
+  const trace = rule('trace');
+
+  it('recognises the three required attributes', () => {
+    const m = '{{ trace from = REQUIREMENT to = CAPABILITY via = realises }}'.match(trace);
+    expect(m?.[2]).toBe('trace');
+    expect(m?.[3]).toContain('via = realises');
+  });
+
+  it('recognises the whitespace-tight spelling', () => {
+    expect(trace.test('{{ trace from=REQUIREMENT to=CAPABILITY via=realises }}')).toBe(true);
+  });
+});
+
+describe('references — §2.1, §3.2', () => {
+  it('splits the CAPABILITY V/H prefix off before any field path', () => {
+    const m = '{{ CAPABILITY-V1.2.3 }}'.match(rule('capability-reference'));
+    expect(m?.[2]).toBe('CAPABILITY-V1.2.3');
+  });
+
+  it('reads a field path off an ordinary id', () => {
+    const m = '{{ REQ-14.parent.title }}'.match(rule('model-object-reference'));
+    expect(m?.[2]).toBe('REQ-14');
+    expect(m?.[3]).toBe('.parent.title');
+  });
+
+  it('does not match a field path deeper than three segments', () => {
+    expect(rule('model-object-reference').test('{{ REQ-14.a.b.c.d }}')).toBe(false);
+  });
+});
+
+describe('rule precedence', () => {
+  const top = included(grammar.patterns);
+
+  it('matches each and trace before the generic reference rule', () => {
+    expect(top.indexOf('#each-block')).toBeGreaterThan(-1);
+    expect(top.indexOf('#trace')).toBeGreaterThan(-1);
+    expect(top.indexOf('#each-block')).toBeLessThan(top.indexOf('#model-object-reference'));
+    expect(top.indexOf('#trace')).toBeLessThan(top.indexOf('#model-object-reference'));
+  });
+
+  it('matches the CAPABILITY form before the generic reference rule', () => {
+    expect(top.indexOf('#capability-reference')).toBeLessThan(
+      top.indexOf('#model-object-reference'),
+    );
+  });
+
+  it('leaves an each opener alone for the generic reference rule', () => {
+    expect(ruleUnanchored('model-object-reference').test('{{# each REQ }}')).toBe(false);
+    expect(ruleUnanchored('model-object-reference').test('{{ trace from = REQ to = CAP via = r }}')).toBe(
+      false,
+    );
+  });
+
+  it('keeps an instruct body opaque — no reference rule reaches inside one', () => {
+    const body = grammar.repository['instruction-slot-body'].patterns as { include?: string }[];
+    expect(body.every((p) => p.include === undefined)).toBe(true);
+  });
+});


### PR DESCRIPTION
## What changed

The `.ttrs` TextMate grammar covered references, figures and `instruct` blocks, but had no rule for two constructs the directive language also defines (`notations/views/documents/DIRECTIVE_LANGUAGE.md`, stable/1.0). Without a rule they fall through as unstyled plain text. Added:

- **`each` blocks** — `{{# each TYPE [where … and …] [order by field] }} … {{/ each }}`, with the clause keywords, `=` / `!=`, and the right-hand literal each scoped, and the inline constructs carried into the block body.
- **Row references** — `{{ .field }}`, §3.3. Meaningful only inside an `each` body, so the rule is reachable only there.
- **`trace`** — `{{ trace from = TYPE to = TYPE via = relation }}`, §3.4.

`each` and `trace` are part of the language regardless of whether a given renderer implements them yet, so they get ordinary valid-syntax scopes rather than an implementation-status scope that a later change would have to rename. A preview that marks them "recognised, not implemented" is a separate surface from syntax highlighting.

Both new rules precede the generic reference rule in the pattern list; neither opener can be matched by it (`{{#` is not an id start, and `trace` is lower-case).

## How it is verified

`tests/ttrs-grammar.test.ts` (new, 19 cases) exercises the grammar's own patterns against the spec's examples:

- `each` in bare, multi-word-type, and full `where … and … order by` forms, plus its closing tag, its clause scoping, and its body pattern list.
- `{{ .title }}` matches the row rule; `{{ REQ-14 }}` does not.
- `trace` in spaced and tight spellings.
- `CAPABILITY-V1.2.3` reads as one id, not id + field path (§2.1).
- `REQ-14.parent.title` splits into id and field path; a fourth segment does not match, per the depth-3 cap (§3.2).
- Rule order: `each` and `trace` precede the generic reference rule, which matches neither opener.
- The `instruct` body pattern list includes no reference rule, so a directive written inside a slot stays prose (§4.2).
- The language contributes exactly `.ttrs`, so `.trs` is not claimed.

Run: `npx vitest run tests/ttrs-grammar.test.ts` · `npm run compile`

THQ-56
