### PR TITLE
feat(vocabulary): drift check against the vendored vocabulary artefact

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,7 @@
 # Shell scripts must keep LF line endings even when checked out on Windows
 # (otherwise bash fails to parse them on macOS/Linux).
 *.sh text eol=lf
+
+# Vendored artefacts are verbatim copies of a tagged upstream release, pinned by
+# content hash. Keep them byte-identical to the source on every platform.
+vendor/** text eol=lf

--- a/scripts/vendor-methodology-vocabulary.mjs
+++ b/scripts/vendor-methodology-vocabulary.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+/**
+ * Re-vendor the methodology closed-vocabulary artefact into vendor/methodology/.
+ *
+ * The artefact's own contract for consumers outside the methodology repository
+ * is: vendor the tagged release and read the vendored path. No cross-repo
+ * package dependency, no sibling-checkout read, no runtime fetch. This script is
+ * the maintainer-side half of that — it fetches from a *tag*, never from a local
+ * clone and never from a branch, so what lands here is what shipped.
+ *
+ * It writes vocabulary.yaml verbatim and rewrites VENDORED.json with the tag,
+ * the artefact's own methodology_version, and a SHA-256 over LF-normalised
+ * bytes. `tests/vocabulary-drift.test.ts` verifies all three on every run.
+ *
+ * Usage:
+ *   node scripts/vendor-methodology-vocabulary.mjs --ref v3.4.0
+ *   node scripts/vendor-methodology-vocabulary.mjs --ref v3.4.0 --check
+ *
+ * --check fetches and reports what would change without writing anything.
+ *
+ * Requires the GitHub CLI (`gh`) to be installed and authenticated.
+ *
+ * Re-vendoring usually surfaces new drift — that is the point. Resolve or
+ * re-date the affected tests/vocabulary-drift/allowlist.ts entries in the same
+ * change; do not land a refresh that leaves the check red.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const VENDOR_DIR = path.resolve(HERE, '..', 'vendor', 'methodology');
+
+const SOURCE_REPO = 'transitrix/methodology';
+const SOURCE_PATH = 'notations/vocabulary.yaml';
+
+function parseArgs(argv) {
+  const out = { ref: null, check: false };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--ref') out.ref = argv[++i];
+    else if (argv[i] === '--check') out.check = true;
+    else die(`unknown argument: ${argv[i]}`);
+  }
+  if (!out.ref) die('--ref <tag> is required (a release tag, e.g. v3.4.0 — not a branch)');
+  if (!/^v\d+\.\d+\.\d+$/.test(out.ref)) die(`--ref must be a release tag like v3.4.0, got: ${out.ref}`);
+  return out;
+}
+
+function die(message) {
+  console.error(`vendor-methodology-vocabulary: ${message}`);
+  process.exit(1);
+}
+
+/** SHA-256 over LF-normalised bytes — matches tests/vocabulary-drift/artefact.ts. */
+function hashArtefact(text) {
+  return createHash('sha256').update(text.replace(/\r\n/g, '\n'), 'utf8').digest('hex');
+}
+
+function fetchArtefact(ref) {
+  let raw;
+  try {
+    raw = execFileSync(
+      'gh',
+      ['api', '-H', 'Accept: application/vnd.github.raw', `repos/${SOURCE_REPO}/contents/${SOURCE_PATH}?ref=${ref}`],
+      { encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 },
+    );
+  } catch (err) {
+    die(`could not fetch ${SOURCE_PATH} at ${ref}: ${err.stderr?.toString().trim() || err.message}`);
+  }
+  const text = raw.replace(/\r\n/g, '\n');
+  const declared = /^methodology_version:\s*"?(\d+\.\d+\.\d+)"?\s*$/m.exec(text);
+  if (!declared) die(`the artefact at ${ref} carries no semver methodology_version`);
+  if (`v${declared[1]}` !== ref) {
+    die(`the artefact at ${ref} declares methodology_version ${declared[1]} — tag and artefact disagree`);
+  }
+  return { text, methodologyVersion: declared[1] };
+}
+
+function readCurrentPin() {
+  try {
+    return JSON.parse(readFileSync(path.join(VENDOR_DIR, 'VENDORED.json'), 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+const { ref, check } = parseArgs(process.argv.slice(2));
+const { text, methodologyVersion } = fetchArtefact(ref);
+const sha256 = hashArtefact(text);
+const current = readCurrentPin();
+
+if (current && current.sha256 === sha256 && current.source_ref === ref) {
+  console.log(`already vendored: ${SOURCE_REPO}@${ref} (${methodologyVersion}), sha256 ${sha256}`);
+  process.exit(0);
+}
+
+console.log(`  from  ${current ? `${current.source_ref} (${current.methodology_version}), sha256 ${current.sha256}` : '(nothing vendored)'}`);
+console.log(`  to    ${ref} (${methodologyVersion}), sha256 ${sha256}`);
+
+if (check) {
+  console.log('--check: nothing written.');
+  process.exit(0);
+}
+
+const pin = {
+  source_repo: SOURCE_REPO,
+  source_ref: ref,
+  source_path: SOURCE_PATH,
+  methodology_version: methodologyVersion,
+  sha256,
+  vendored_on: new Date().toISOString().slice(0, 10),
+};
+
+writeFileSync(path.join(VENDOR_DIR, 'vocabulary.yaml'), text, 'utf8');
+writeFileSync(path.join(VENDOR_DIR, 'VENDORED.json'), `${JSON.stringify(pin, null, 2)}\n`, 'utf8');
+console.log('written. Run `npx vitest run tests/vocabulary-drift.test.ts` and settle the allowlist before committing.');

--- a/tests/vocabulary-drift.test.ts
+++ b/tests/vocabulary-drift.test.ts
@@ -1,0 +1,276 @@
+// Vocabulary drift check — this repo's closed sets against the vendored
+// methodology artefact (`vendor/methodology/vocabulary.yaml`).
+//
+// Drift check first, migration on contact. The scattered per-module vocabulary
+// literals are not replaced in one sweep; this check makes every divergence
+// visible at once and keeps the set from growing, and each module migrates to
+// reading the artefact when it is next touched for other reasons.
+//
+// It fails closed. A missing, unparseable, unpinned or tampered artefact fails
+// the build — it never passes because it could not evaluate its input.
+
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, it, expect, afterEach } from 'vitest';
+
+import { ALLOWLIST } from './vocabulary-drift/allowlist.js';
+import { loadVendoredVocabulary, hashArtefact, VENDOR_DIR } from './vocabulary-drift/artefact.js';
+import { compareVocabulary, describeDivergence, divergenceKey } from './vocabulary-drift/compare.js';
+import type { RepoSurface } from './vocabulary-drift/compare.js';
+import { declaredMethodologyVersion, repoSurface } from './vocabulary-drift/surface.js';
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+const scratch: string[] = [];
+
+function fixtureDir(files: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), 'vocab-drift-'));
+  scratch.push(dir);
+  for (const [name, content] of Object.entries(files)) writeFileSync(join(dir, name), content);
+  return dir;
+}
+
+function pinFor(yaml: string, overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    source_repo: 'transitrix/methodology',
+    source_ref: 'v9.9.9',
+    source_path: 'notations/vocabulary.yaml',
+    methodology_version: '9.9.9',
+    sha256: hashArtefact(yaml),
+    vendored_on: '2026-08-08',
+    ...overrides,
+  });
+}
+
+/** A minimal but structurally complete artefact — every section the loader
+ *  requires, small enough to reason about a diff by eye. */
+const FIXTURE_YAML = [
+  'methodology_version: "9.9.9"',
+  'element_types:',
+  '  GOAL: { mode: standalone }',
+  '  DRIVER: { mode: standalone }',
+  'deprecated_element_types:',
+  '  FACTOR: { replaced_by: DRIVER }',
+  'relation_types:',
+  '  goal_parent: { from: [GOAL], to: [GOAL] }',
+  'deprecated_relation_types:',
+  '  activity_goal: { replaced_by: action_goal }',
+  'value_vocabularies:',
+  '  agreement:',
+  '    values: [draft, agreed, disputed]',
+  'rule_codes:',
+  '  AGREE-001: { severity: error }',
+  '',
+].join('\n');
+
+/** The surface that exactly matches FIXTURE_YAML — the clean-pass baseline. */
+function fixtureSurface(overrides: Partial<RepoSurface> = {}): RepoSurface {
+  return {
+    declaredMethodologyVersion: '9.9.9',
+    bindings: [
+      { key: 'element_types', values: ['GOAL', 'DRIVER', 'FACTOR'], origin: 'fixture' },
+      { key: 'relation_types', values: ['goal_parent', 'activity_goal'], origin: 'fixture' },
+      { key: 'rule_codes', values: ['AGREE-001'], origin: 'fixture' },
+      { key: 'value_vocabularies.agreement', values: ['draft', 'agreed', 'disputed'], origin: 'fixture' },
+    ],
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  while (scratch.length) rmSync(scratch.pop()!, { recursive: true, force: true });
+});
+
+describe('the vendored artefact loads and is pinned', () => {
+  it('loads the repo’s own vendored copy', () => {
+    const { pin, artefact } = loadVendoredVocabulary();
+    expect(pin.source_repo).toBe('transitrix/methodology');
+    expect(artefact.methodologyVersion).toBe(pin.methodology_version);
+    expect(artefact.elementTypes.length).toBeGreaterThan(0);
+    expect(artefact.relationTypes.length).toBeGreaterThan(0);
+    expect(artefact.valueVocabularies.size).toBeGreaterThan(0);
+    expect(artefact.ruleCodes.length).toBeGreaterThan(0);
+  });
+
+  it('reads package.json’s declared methodology version', () => {
+    expect(declaredMethodologyVersion()).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+});
+
+describe('it fails closed on input it cannot trust', () => {
+  it('a missing artefact fails', () => {
+    const dir = fixtureDir({ 'VENDORED.json': pinFor(FIXTURE_YAML) });
+    expect(() => loadVendoredVocabulary(dir)).toThrow(/vocabulary artefact not found/);
+  });
+
+  it('a missing pin fails', () => {
+    const dir = fixtureDir({ 'vocabulary.yaml': FIXTURE_YAML });
+    expect(() => loadVendoredVocabulary(dir)).toThrow(/vendor pin not found/);
+  });
+
+  it('an unpinned artefact fails', () => {
+    const yaml = FIXTURE_YAML;
+    const pin = JSON.parse(pinFor(yaml)) as Record<string, unknown>;
+    delete pin.methodology_version;
+    const dir = fixtureDir({ 'vocabulary.yaml': yaml, 'VENDORED.json': JSON.stringify(pin) });
+    expect(() => loadVendoredVocabulary(dir)).toThrow(/missing `methodology_version`/);
+  });
+
+  it('a corrupted artefact fails — unparseable YAML', () => {
+    const yaml = `${FIXTURE_YAML}\n  : : not yaml [\n`;
+    const dir = fixtureDir({ 'vocabulary.yaml': yaml, 'VENDORED.json': pinFor(yaml) });
+    expect(() => loadVendoredVocabulary(dir)).toThrow(/not parseable YAML/);
+  });
+
+  it('a corrupted artefact fails — content that does not match its hash', () => {
+    const dir = fixtureDir({
+      'vocabulary.yaml': FIXTURE_YAML.replace('GOAL:', 'TAMPERED:'),
+      'VENDORED.json': pinFor(FIXTURE_YAML),
+    });
+    expect(() => loadVendoredVocabulary(dir)).toThrow(/does not match its pin/);
+  });
+
+  it('a truncated artefact fails — a required section is gone', () => {
+    const yaml = FIXTURE_YAML.split('rule_codes:')[0];
+    const dir = fixtureDir({ 'vocabulary.yaml': yaml, 'VENDORED.json': pinFor(yaml) });
+    expect(() => loadVendoredVocabulary(dir)).toThrow(/`rule_codes` is missing/);
+  });
+
+  it('an artefact whose version contradicts its pin fails', () => {
+    const dir = fixtureDir({
+      'vocabulary.yaml': FIXTURE_YAML,
+      'VENDORED.json': pinFor(FIXTURE_YAML, { methodology_version: '1.2.3' }),
+    });
+    expect(() => loadVendoredVocabulary(dir)).toThrow(/does not match the vendor pin/);
+  });
+
+  it('a hash stable across CRLF checkout, unstable across content change', () => {
+    expect(hashArtefact(FIXTURE_YAML.replace(/\n/g, '\r\n'))).toBe(hashArtefact(FIXTURE_YAML));
+    expect(hashArtefact(`${FIXTURE_YAML} `)).not.toBe(hashArtefact(FIXTURE_YAML));
+  });
+
+  it('a vendor directory that does not exist fails', () => {
+    const dir = join(tmpdir(), 'vocab-drift-absent-dir');
+    rmSync(dir, { recursive: true, force: true });
+    expect(() => loadVendoredVocabulary(dir)).toThrow(/vendor pin not found/);
+  });
+});
+
+describe('the comparison', () => {
+  it('reports nothing when the surface matches the artefact', () => {
+    const dir = fixtureDir({ 'vocabulary.yaml': FIXTURE_YAML, 'VENDORED.json': pinFor(FIXTURE_YAML) });
+    const { artefact } = loadVendoredVocabulary(dir);
+    expect(compareVocabulary(artefact, fixtureSurface())).toEqual([]);
+  });
+
+  it('reports a value the artefact defines and the repo does not', () => {
+    const dir = fixtureDir({ 'vocabulary.yaml': FIXTURE_YAML, 'VENDORED.json': pinFor(FIXTURE_YAML) });
+    const { artefact } = loadVendoredVocabulary(dir);
+    const surface = fixtureSurface();
+    const bindings = surface.bindings.map((b) =>
+      b.key === 'element_types' ? { ...b, values: ['GOAL', 'FACTOR'] } : b,
+    );
+    const found = compareVocabulary(artefact, { ...surface, bindings });
+    expect(found.map(divergenceKey)).toEqual(['element_types:missing:DRIVER']);
+  });
+
+  it('reports a value the repo carries and the artefact does not', () => {
+    const dir = fixtureDir({ 'vocabulary.yaml': FIXTURE_YAML, 'VENDORED.json': pinFor(FIXTURE_YAML) });
+    const { artefact } = loadVendoredVocabulary(dir);
+    const surface = fixtureSurface();
+    const bindings = surface.bindings.map((b) =>
+      b.key === 'value_vocabularies.agreement'
+        ? { ...b, values: ['draft', 'agreed', 'disputed', 'withdrawn'] }
+        : b,
+    );
+    const found = compareVocabulary(artefact, { ...surface, bindings });
+    expect(found.map(divergenceKey)).toEqual(['value_vocabularies.agreement:extra:withdrawn']);
+  });
+
+  it('reports a whole set no constant here expresses', () => {
+    const dir = fixtureDir({ 'vocabulary.yaml': FIXTURE_YAML, 'VENDORED.json': pinFor(FIXTURE_YAML) });
+    const { artefact } = loadVendoredVocabulary(dir);
+    const surface = fixtureSurface();
+    const bindings = surface.bindings.map((b) => (b.key === 'rule_codes' ? { ...b, values: null } : b));
+    const found = compareVocabulary(artefact, { ...surface, bindings });
+    expect(found.map(divergenceKey)).toEqual(['rule_codes:unbound']);
+  });
+
+  it('reports a declared version that does not name the vendored artefact', () => {
+    const dir = fixtureDir({ 'vocabulary.yaml': FIXTURE_YAML, 'VENDORED.json': pinFor(FIXTURE_YAML) });
+    const { artefact } = loadVendoredVocabulary(dir);
+    const found = compareVocabulary(artefact, fixtureSurface({ declaredMethodologyVersion: '1.0.0' }));
+    expect(found.map(divergenceKey)).toEqual(['methodology_version:mismatch']);
+  });
+
+  it('refuses a surface that leaves an artefact vocabulary unaccounted for', () => {
+    const dir = fixtureDir({ 'vocabulary.yaml': FIXTURE_YAML, 'VENDORED.json': pinFor(FIXTURE_YAML) });
+    const { artefact } = loadVendoredVocabulary(dir);
+    const surface = fixtureSurface();
+    const bindings = surface.bindings.filter((b) => b.key !== 'relation_types');
+    expect(() => compareVocabulary(artefact, { ...surface, bindings })).toThrow(/does not account for/);
+  });
+
+  it('refuses a surface that binds a vocabulary the artefact no longer defines', () => {
+    const dir = fixtureDir({ 'vocabulary.yaml': FIXTURE_YAML, 'VENDORED.json': pinFor(FIXTURE_YAML) });
+    const { artefact } = loadVendoredVocabulary(dir);
+    const surface = fixtureSurface();
+    const bindings = [...surface.bindings, { key: 'value_vocabularies.GONE.field', values: [], origin: 'fixture' }];
+    expect(() => compareVocabulary(artefact, { ...surface, bindings })).toThrow(/does not define/);
+  });
+});
+
+describe('the allowlist is time-boxed', () => {
+  it('every entry carries an ISO review date and a reason', () => {
+    for (const entry of ALLOWLIST) {
+      expect(entry.review_by, `${entry.key} has no ISO review_by date`).toMatch(ISO_DATE);
+      expect(entry.reason.trim(), `${entry.key} has no reason`).not.toBe('');
+    }
+  });
+
+  it('has no duplicate keys', () => {
+    const keys = ALLOWLIST.map((e) => e.key);
+    expect(keys.length).toBe(new Set(keys).size);
+  });
+
+  it('has no entry whose review date has passed', () => {
+    const today = new Date().toISOString().slice(0, 10);
+    const expired = ALLOWLIST.filter((e) => e.review_by <= today);
+    expect(
+      expired.map((e) => `${e.key} (review_by ${e.review_by})`),
+      'allowlist entries are past their review date — resolve the divergence or re-date the entry',
+    ).toEqual([]);
+  });
+});
+
+describe('this repo does not diverge from the vendored vocabulary', () => {
+  const { artefact } = loadVendoredVocabulary();
+  const divergences = compareVocabulary(artefact, repoSurface());
+  const allowed = new Map(ALLOWLIST.map((e) => [e.key, e]));
+
+  it('reports no divergence that is not allowlisted', () => {
+    const unallowed = divergences.filter((d) => !allowed.has(divergenceKey(d)));
+    expect(
+      unallowed.map((d) => `${divergenceKey(d)} — ${describeDivergence(d)}`),
+      'new vocabulary drift against the vendored artefact',
+    ).toEqual([]);
+  });
+
+  it('carries no allowlist entry for a divergence that no longer occurs', () => {
+    const live = new Set(divergences.map(divergenceKey));
+    const stale = ALLOWLIST.filter((e) => !live.has(e.key)).map((e) => e.key);
+    expect(stale, 'allowlist entries whose divergence is resolved — delete them').toEqual([]);
+  });
+
+  it('states the divergence it is standing over', () => {
+    // Not an assertion about the number: it is the count made visible, so a run
+    // of this check reports the gap rather than reading as a clean bill.
+    console.log(
+      `vocabulary drift vs ${artefact.methodologyVersion}: ${divergences.length} divergence(s), all allowlisted\n` +
+        divergences.map((d) => `  - ${describeDivergence(d)}`).join('\n'),
+    );
+    expect(divergences.length).toBe(ALLOWLIST.length);
+  });
+});

--- a/tests/vocabulary-drift/allowlist.ts
+++ b/tests/vocabulary-drift/allowlist.ts
@@ -1,0 +1,160 @@
+// Time-boxed allowlist for vocabulary drift.
+//
+// Every entry names a date by which it is resolved or renewed, and the check
+// fails once that date passes — an undated allowlist is the silent gap this
+// check exists to remove, reintroduced one entry at a time. An entry narrows the
+// check to exactly one divergence key; there is no way to exempt a whole
+// vocabulary or the whole check.
+//
+// A stale entry (one whose divergence no longer occurs) also fails, so the file
+// cannot accumulate resolved exemptions that read as outstanding work.
+//
+// Adding an entry is not the way to land a vocabulary change. It is the way to
+// land the *check* over a gap that already exists, so the gap stops widening
+// while each module migrates on contact.
+
+export interface AllowlistEntry {
+  /** Divergence key, exactly as `divergenceKey()` produces it. */
+  key: string;
+  /** ISO date; the check fails from this date on. */
+  review_by: string;
+  reason: string;
+}
+
+/** Shared review date for the divergences this check found on its first run —
+ *  they were measured together and are re-measured together. */
+const FIRST_RUN = '2026-11-08';
+
+export const ALLOWLIST: readonly AllowlistEntry[] = [
+  {
+    key: 'methodology_version:mismatch',
+    review_by: FIRST_RUN,
+    reason:
+      'The declared version is the methodology release this build targets, not the newest that exists. ' +
+      'The artefact first ships in a release later than that target, so the vendored copy is necessarily ' +
+      'ahead until the rule and vocabulary coverage of the intervening releases lands here.',
+  },
+
+  // --- element_types: TYPEs the artefact defines and this repo does not ------
+  {
+    key: 'element_types:missing:NEED',
+    review_by: FIRST_RUN,
+    reason: 'NEED is modelled and validated here but is not in the block-grid TYPE registry.',
+  },
+  {
+    key: 'element_types:missing:METRIC',
+    review_by: FIRST_RUN,
+    reason: 'METRIC is modelled and validated here but is not in the block-grid TYPE registry.',
+  },
+  {
+    key: 'element_types:missing:RISK',
+    review_by: FIRST_RUN,
+    reason: 'RISK is modelled and validated here but is not in the block-grid TYPE registry.',
+  },
+  {
+    key: 'element_types:missing:RELEASE',
+    review_by: FIRST_RUN,
+    reason: 'RELEASE arrived with a methodology release later than the one this build targets.',
+  },
+  {
+    key: 'element_types:missing:INFORMATION_ENTITY',
+    review_by: FIRST_RUN,
+    reason:
+      'Retired name kept in the artefact for its alias window; this repo never registered it, so there is ' +
+      'nothing here to warn on. Resolves when the alias window closes.',
+  },
+
+  // --- element_types: TYPEs this repo registers and the artefact does not ----
+  {
+    key: 'element_types:extra:HAZARD',
+    review_by: FIRST_RUN,
+    reason: 'Registered for cross-reference resolution in block grids; not a registered TYPE in the artefact.',
+  },
+  {
+    key: 'element_types:extra:RISK_CONTROL',
+    review_by: FIRST_RUN,
+    reason: 'Registered for cross-reference resolution in block grids; not a registered TYPE in the artefact.',
+  },
+  {
+    key: 'element_types:extra:REL',
+    review_by: FIRST_RUN,
+    reason: 'The relation-record id prefix, not an element TYPE — the registry conflates the two.',
+  },
+  {
+    key: 'element_types:extra:MILESTONE',
+    review_by: FIRST_RUN,
+    reason: 'Registered for cross-reference resolution in block grids; not a registered TYPE in the artefact.',
+  },
+  {
+    key: 'element_types:extra:VERIFICATION',
+    review_by: FIRST_RUN,
+    reason:
+      'VERIFICATION is a modelled element here with its own notation, but the artefact does not register it ' +
+      'as an element TYPE.',
+  },
+
+  // --- value vocabularies ----------------------------------------------------
+  {
+    key: 'value_vocabularies.ASSERTION.status:extra:pending_owner',
+    review_by: FIRST_RUN,
+    reason: 'A status this repo renders and admits that the artefact does not define.',
+  },
+  {
+    key: 'value_vocabularies.REQUIREMENT.origin:unbound',
+    review_by: FIRST_RUN,
+    reason: '`origin` is scaffolded but not modelled or validated; binding it means adding the field first.',
+  },
+  {
+    key: 'value_vocabularies.REQUIREMENT.severity:unbound',
+    review_by: FIRST_RUN,
+    reason: 'Type-only union; binding it means promoting it to a runtime array at the same time.',
+  },
+  {
+    key: 'value_vocabularies.rule.severity:unbound',
+    review_by: FIRST_RUN,
+    reason:
+      'The severity ladder here stops at error/warning/info and is a type-only union; binding it means ' +
+      'promoting it to a runtime array and deciding what `deprecation` means for this repo.',
+  },
+  {
+    key: 'value_vocabularies.target_state_satisfies_goal.degree:unbound',
+    review_by: FIRST_RUN,
+    reason: 'Per-relation attributes are not modelled here; binding follows a relation model.',
+  },
+  {
+    key: 'value_vocabularies.assessment_influences_goal.sign:unbound',
+    review_by: FIRST_RUN,
+    reason: 'Per-relation attributes are not modelled here; binding follows a relation model.',
+  },
+  {
+    key: 'value_vocabularies.assessment_influences_goal.magnitude:unbound',
+    review_by: FIRST_RUN,
+    reason: 'Per-relation attributes are not modelled here; binding follows a relation model.',
+  },
+  {
+    key: 'value_vocabularies.candidate.kind:unbound',
+    review_by: FIRST_RUN,
+    reason: 'The ingest candidate contract has no consumer here; it may never need one.',
+  },
+  {
+    key: 'value_vocabularies.candidate.extraction_confidence:unbound',
+    review_by: FIRST_RUN,
+    reason: 'The ingest candidate contract has no consumer here; it may never need one.',
+  },
+
+  // --- whole sets with no expression here ------------------------------------
+  {
+    key: 'relation_types:unbound',
+    review_by: FIRST_RUN,
+    reason:
+      'Relation kinds are handled by an inline branch in repo-scope validation rather than a registry, so ' +
+      'no constant can be compared. Binding means introducing the registry.',
+  },
+  {
+    key: 'rule_codes:unbound',
+    review_by: FIRST_RUN,
+    reason:
+      'Rule codes are string literals at their emission sites with no registry to compare. Binding means ' +
+      'introducing one, which is a change of a different size from this check.',
+  },
+];

--- a/tests/vocabulary-drift/artefact.ts
+++ b/tests/vocabulary-drift/artefact.ts
@@ -1,0 +1,176 @@
+// Loader for the vendored methodology vocabulary artefact.
+//
+// The artefact is the authored source for every closed set the methodology
+// defines; this repo vendors a tagged copy under `vendor/methodology/` (see the
+// README there) and never reads a sibling checkout or fetches at runtime.
+//
+// Everything here **fails closed**. A missing file, an unparseable one, a
+// missing or mismatched pin, a hash that does not match, or a section that is
+// absent or the wrong shape throws. There is no fallback vocabulary and no
+// "could not evaluate, so pass" path: a consumer that cannot read the artefact
+// must fail, or the drift check silently stops checking.
+
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { load as parseYaml } from 'js-yaml';
+
+/** `vendor/methodology/VENDORED.json` — where the copy came from, and its hash. */
+export interface VendorPin {
+  source_repo: string;
+  source_ref: string;
+  source_path: string;
+  methodology_version: string;
+  sha256: string;
+  vendored_on: string;
+}
+
+/** The closed sets the artefact carries, flattened to what the check compares. */
+export interface VocabularyArtefact {
+  methodologyVersion: string;
+  /** Live element TYPEs — `element_types`. */
+  elementTypes: string[];
+  /** Retired TYPE names still accepted through their alias window. */
+  deprecatedElementTypes: string[];
+  relationTypes: string[];
+  deprecatedRelationTypes: string[];
+  /** `<owner>.<field>` (or a bare axis name) → its closed set. */
+  valueVocabularies: Map<string, string[]>;
+  ruleCodes: string[];
+}
+
+export const VENDOR_DIR = fileURLToPath(new URL('../../vendor/methodology/', import.meta.url));
+
+const SEMVER_RE = /^\d+\.\d+\.\d+$/;
+
+class ArtefactError extends Error {}
+
+function fail(message: string): never {
+  throw new ArtefactError(message);
+}
+
+/** SHA-256 over LF-normalised bytes, so a CRLF checkout on Windows does not
+ *  read as a tampered artefact while a real content change still does. */
+export function hashArtefact(bytes: Buffer | string): string {
+  const text = (typeof bytes === 'string' ? bytes : bytes.toString('utf8')).replace(/\r\n/g, '\n');
+  return createHash('sha256').update(text, 'utf8').digest('hex');
+}
+
+function readPin(dir: string): VendorPin {
+  const path = join(dir, 'VENDORED.json');
+  let raw: string;
+  try {
+    raw = readFileSync(path, 'utf8');
+  } catch {
+    fail(`vendor pin not found: ${path}. The vocabulary artefact must be vendored and pinned.`);
+  }
+
+  let pin: unknown;
+  try {
+    pin = JSON.parse(raw);
+  } catch (err) {
+    fail(`vendor pin is not valid JSON: ${path} (${(err as Error).message})`);
+  }
+  if (typeof pin !== 'object' || pin === null) fail(`vendor pin is not an object: ${path}`);
+
+  const p = pin as Record<string, unknown>;
+  for (const field of ['source_repo', 'source_ref', 'source_path', 'methodology_version', 'sha256', 'vendored_on']) {
+    const value = p[field];
+    if (typeof value !== 'string' || value.trim() === '') {
+      fail(`vendor pin is missing \`${field}\`: ${path}. An unpinned artefact is a failure, never a pass.`);
+    }
+  }
+  if (!SEMVER_RE.test(p.methodology_version as string)) {
+    fail(`vendor pin \`methodology_version\` is not semver-shaped: ${String(p.methodology_version)}`);
+  }
+  if (!/^[0-9a-f]{64}$/.test(p.sha256 as string)) {
+    fail(`vendor pin \`sha256\` is not a SHA-256 digest: ${String(p.sha256)}`);
+  }
+  return pin as VendorPin;
+}
+
+function requireMapping(doc: Record<string, unknown>, section: string, path: string): Record<string, unknown> {
+  const value = doc[section];
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    fail(`vocabulary artefact section \`${section}\` is missing or not a mapping: ${path}`);
+  }
+  const mapping = value as Record<string, unknown>;
+  if (Object.keys(mapping).length === 0) {
+    fail(`vocabulary artefact section \`${section}\` is empty: ${path}`);
+  }
+  return mapping;
+}
+
+/**
+ * Reads, verifies and flattens the vendored artefact. `dir` defaults to the
+ * repository's own `vendor/methodology/`; the fixtures pass their own.
+ */
+export function loadVendoredVocabulary(dir: string = VENDOR_DIR): { pin: VendorPin; artefact: VocabularyArtefact } {
+  const pin = readPin(dir);
+  const path = join(dir, 'vocabulary.yaml');
+
+  let bytes: Buffer;
+  try {
+    bytes = readFileSync(path);
+  } catch {
+    fail(`vocabulary artefact not found: ${path} (pinned at ${pin.source_repo}@${pin.source_ref})`);
+  }
+
+  const actual = hashArtefact(bytes);
+  if (actual !== pin.sha256) {
+    fail(
+      `vocabulary artefact does not match its pin.\n` +
+        `  expected sha256 ${pin.sha256}\n` +
+        `  actual   sha256 ${actual}\n` +
+        `The vendored copy is verbatim; re-vendor with scripts/vendor-methodology-vocabulary.mjs rather than editing it.`,
+    );
+  }
+
+  let doc: unknown;
+  try {
+    doc = parseYaml(bytes.toString('utf8'));
+  } catch (err) {
+    fail(`vocabulary artefact is not parseable YAML: ${path} (${(err as Error).message})`);
+  }
+  if (typeof doc !== 'object' || doc === null || Array.isArray(doc)) {
+    fail(`vocabulary artefact is not a YAML mapping: ${path}`);
+  }
+  const root = doc as Record<string, unknown>;
+
+  const declared = root.methodology_version;
+  if (typeof declared !== 'string' || !SEMVER_RE.test(declared)) {
+    fail(`vocabulary artefact carries no semver \`methodology_version\`: ${path}`);
+  }
+  if (declared !== pin.methodology_version) {
+    fail(
+      `vocabulary artefact version ${declared} does not match the vendor pin ${pin.methodology_version}: ${path}`,
+    );
+  }
+
+  const valueVocabularies = new Map<string, string[]>();
+  for (const [key, entry] of Object.entries(requireMapping(root, 'value_vocabularies', path))) {
+    const values = (entry as Record<string, unknown> | null)?.values;
+    if (!Array.isArray(values) || values.length === 0) {
+      fail(`vocabulary artefact \`value_vocabularies.${key}\` carries no \`values\` list: ${path}`);
+    }
+    valueVocabularies.set(
+      key,
+      values.map((v) => String(v)),
+    );
+  }
+
+  return {
+    pin,
+    artefact: {
+      methodologyVersion: declared,
+      elementTypes: Object.keys(requireMapping(root, 'element_types', path)),
+      deprecatedElementTypes: Object.keys(requireMapping(root, 'deprecated_element_types', path)),
+      relationTypes: Object.keys(requireMapping(root, 'relation_types', path)),
+      deprecatedRelationTypes: Object.keys(requireMapping(root, 'deprecated_relation_types', path)),
+      valueVocabularies,
+      ruleCodes: Object.keys(requireMapping(root, 'rule_codes', path)),
+    },
+  };
+}

--- a/tests/vocabulary-drift/compare.ts
+++ b/tests/vocabulary-drift/compare.ts
@@ -1,0 +1,144 @@
+// Vocabulary drift — the comparison itself.
+//
+// Pure: it takes an artefact, this repo's declared surface, and the declared
+// methodology version, and returns every divergence between them. No file
+// access, so the fixtures drive it directly.
+//
+// Four kinds of divergence, each with a stable key the allowlist is written
+// against:
+//
+//   missing           a value the artefact defines that this repo's constant
+//                     does not carry
+//   extra             a value this repo's constant carries that the artefact
+//                     does not define
+//   unbound           a closed set in the artefact that no runtime constant in
+//                     this repo expresses at all — the widest kind of drift,
+//                     and the one a member-by-member diff cannot see
+//   version-mismatch  `transitrix.methodologyVersion` does not name the
+//                     vendored artefact's version
+//
+// A divergence is reported, never repaired. Migration is per-module and happens
+// when a module is next touched for other reasons; this check only makes the gap
+// visible and keeps it from widening unnoticed.
+
+import type { VocabularyArtefact } from './artefact.js';
+
+/**
+ * One closed set of the artefact, and where (if anywhere) this repo holds it.
+ *
+ * `values: null` is the honest declaration that no runtime constant carries the
+ * set — not an omission. Every artefact vocabulary must appear in the surface,
+ * bound or not, so a newly published one cannot pass unnoticed.
+ */
+export interface SurfaceBinding {
+  /** Artefact vocabulary key: `element_types`, `relation_types`, `rule_codes`,
+   *  or `value_vocabularies.<owner>.<field>`. */
+  key: string;
+  /** The values this repo's constant carries, or `null` when none does. */
+  values: readonly string[] | null;
+  /** Where the values live (or, when unbound, why nothing does). */
+  origin: string;
+}
+
+export interface RepoSurface {
+  declaredMethodologyVersion: string;
+  bindings: readonly SurfaceBinding[];
+}
+
+export type Divergence =
+  | { kind: 'missing'; vocabulary: string; value: string; origin: string }
+  | { kind: 'extra'; vocabulary: string; value: string; origin: string }
+  | { kind: 'unbound'; vocabulary: string; size: number; origin: string }
+  | { kind: 'version-mismatch'; declared: string; vendored: string };
+
+/** Stable identity of a divergence — what an allowlist entry is written against. */
+export function divergenceKey(d: Divergence): string {
+  switch (d.kind) {
+    case 'missing':
+    case 'extra':
+      return `${d.vocabulary}:${d.kind}:${d.value}`;
+    case 'unbound':
+      return `${d.vocabulary}:unbound`;
+    case 'version-mismatch':
+      return 'methodology_version:mismatch';
+  }
+}
+
+/** One line, readable in a CI log without the surrounding context. */
+export function describeDivergence(d: Divergence): string {
+  switch (d.kind) {
+    case 'missing':
+      return `${d.vocabulary}: artefact defines \`${d.value}\`, ${d.origin} does not carry it`;
+    case 'extra':
+      return `${d.vocabulary}: ${d.origin} carries \`${d.value}\`, the artefact does not define it`;
+    case 'unbound':
+      return `${d.vocabulary}: ${d.size} value(s) in the artefact, no constant in this repo expresses the set (${d.origin})`;
+    case 'version-mismatch':
+      return `methodology_version: package.json declares ${d.declared}, the vendored artefact is ${d.vendored}`;
+  }
+}
+
+/** Every closed set the artefact carries, keyed as the surface keys them. */
+function artefactVocabularies(a: VocabularyArtefact): Map<string, string[]> {
+  const out = new Map<string, string[]>();
+  // Retired names stay part of the surface: a consumer must still recognise one
+  // to warn on it, so dropping it is drift in the same way adding a live TYPE is.
+  out.set('element_types', [...a.elementTypes, ...a.deprecatedElementTypes]);
+  out.set('relation_types', [...a.relationTypes, ...a.deprecatedRelationTypes]);
+  out.set('rule_codes', [...a.ruleCodes]);
+  for (const [key, values] of a.valueVocabularies) out.set(`value_vocabularies.${key}`, values);
+  return out;
+}
+
+export function compareVocabulary(artefact: VocabularyArtefact, surface: RepoSurface): Divergence[] {
+  const expected = artefactVocabularies(artefact);
+  const bound = new Map(surface.bindings.map((b) => [b.key, b]));
+
+  const unknown = surface.bindings.filter((b) => !expected.has(b.key));
+  if (unknown.length > 0) {
+    // Not drift — a broken surface. A binding for a set the artefact no longer
+    // has would otherwise sit there comparing against nothing and always pass.
+    throw new Error(
+      `repo surface binds vocabularies the artefact does not define: ${unknown.map((b) => b.key).join(', ')}`,
+    );
+  }
+  const unbindable = [...expected.keys()].filter((k) => !bound.has(k));
+  if (unbindable.length > 0) {
+    throw new Error(
+      `repo surface does not account for artefact vocabularies: ${unbindable.join(', ')}. ` +
+        `Add a binding (or an explicitly unbound one) in tests/vocabulary-drift/surface.ts.`,
+    );
+  }
+
+  const divergences: Divergence[] = [];
+
+  if (surface.declaredMethodologyVersion !== artefact.methodologyVersion) {
+    divergences.push({
+      kind: 'version-mismatch',
+      declared: surface.declaredMethodologyVersion,
+      vendored: artefact.methodologyVersion,
+    });
+  }
+
+  for (const [key, artefactValues] of expected) {
+    const binding = bound.get(key)!;
+    if (binding.values === null) {
+      divergences.push({ kind: 'unbound', vocabulary: key, size: artefactValues.length, origin: binding.origin });
+      continue;
+    }
+    const repoValues = new Set(binding.values);
+    for (const value of artefactValues) {
+      if (!repoValues.has(value)) {
+        divergences.push({ kind: 'missing', vocabulary: key, value, origin: binding.origin });
+      }
+    }
+    const artefactSet = new Set(artefactValues);
+    for (const value of binding.values) {
+      if (!artefactSet.has(value)) {
+        divergences.push({ kind: 'extra', vocabulary: key, value, origin: binding.origin });
+      }
+    }
+  }
+
+  return divergences;
+}

--- a/tests/vocabulary-drift/surface.ts
+++ b/tests/vocabulary-drift/surface.ts
@@ -1,0 +1,162 @@
+// This repo's vocabulary surface — one binding per closed set the artefact
+// defines, naming the runtime constant that carries it here.
+//
+// This file is the *only* hand-maintained mirror in the check, and it deliberately
+// holds no vocabulary values of its own: every binding points at the constant the
+// product code already uses, so a value added or removed there moves the check
+// with it. A binding that copied the values would be a fourth place for the same
+// list to drift.
+//
+// `values: null` declares that no runtime constant expresses the set. That is a
+// divergence like any other, reported and allowlisted with a date — not a way to
+// exclude a set from the check.
+//
+// Adding a binding is not a migration. The scattered per-module literals move to
+// reading the artefact when each module is next touched for other reasons; until
+// then this file is how the gap stays visible.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { AGREEMENT_VALUES } from '../../packages/diagrams/src/agreement.js';
+import { ASSERTION_STATUSES, ASSERTION_SUBJECT_TYPES } from '../../packages/diagrams/src/assertion/types.js';
+import { REGISTERED_ELEMENT_TYPES } from '../../packages/diagrams/src/blocks/validate.js';
+import { REQUIREMENT_KINDS, REQUIREMENT_LEVELS } from '../../packages/diagrams/src/requirement/types.js';
+import { VALIDATION_METHODS, VALIDATION_OUTCOMES } from '../../packages/diagrams/src/validation/types.js';
+import { VERIFICATION_METHODS, VERIFICATION_OUTCOMES } from '../../packages/diagrams/src/verification/types.js';
+
+import type { RepoSurface, SurfaceBinding } from './compare.js';
+
+const PACKAGE_JSON = fileURLToPath(new URL('../../package.json', import.meta.url));
+
+/** `transitrix.methodologyVersion` — the methodology release this build targets.
+ *  Read, never defaulted: an absent declaration is a failure, not a pass. */
+export function declaredMethodologyVersion(path: string = PACKAGE_JSON): string {
+  const pkg = JSON.parse(readFileSync(path, 'utf8')) as { transitrix?: { methodologyVersion?: unknown } };
+  const declared = pkg.transitrix?.methodologyVersion;
+  if (typeof declared !== 'string' || !/^\d+\.\d+\.\d+$/.test(declared)) {
+    throw new Error(`package.json declares no semver \`transitrix.methodologyVersion\`: ${path}`);
+  }
+  return declared;
+}
+
+export const BINDINGS: readonly SurfaceBinding[] = [
+  {
+    key: 'element_types',
+    values: [...REGISTERED_ELEMENT_TYPES],
+    origin: 'REGISTERED_ELEMENT_TYPES (packages/diagrams/src/blocks/validate.ts)',
+  },
+  {
+    key: 'relation_types',
+    values: null,
+    origin: 'no relation-type registry exists; repo-scope validation branches on the kind inline',
+  },
+  {
+    key: 'rule_codes',
+    values: null,
+    origin: 'no rule-code registry exists; every code is a string literal at its emission site',
+  },
+
+  // --- REQUIREMENT ---------------------------------------------------------
+  {
+    key: 'value_vocabularies.REQUIREMENT.origin',
+    values: null,
+    origin: '`origin` is not on the Requirement model and is not validated',
+  },
+  {
+    key: 'value_vocabularies.REQUIREMENT.level',
+    values: REQUIREMENT_LEVELS,
+    origin: 'REQUIREMENT_LEVELS (packages/diagrams/src/requirement/types.ts)',
+  },
+  {
+    key: 'value_vocabularies.REQUIREMENT.kind',
+    values: REQUIREMENT_KINDS,
+    origin: 'REQUIREMENT_KINDS (packages/diagrams/src/requirement/types.ts)',
+  },
+  {
+    key: 'value_vocabularies.REQUIREMENT.severity',
+    values: null,
+    origin: 'RequirementSeverity is a type-only union with no runtime array to validate against',
+  },
+
+  // --- ASSERTION -----------------------------------------------------------
+  {
+    key: 'value_vocabularies.ASSERTION.status',
+    values: ASSERTION_STATUSES,
+    origin: 'ASSERTION_STATUSES (packages/diagrams/src/assertion/types.ts)',
+  },
+  {
+    key: 'value_vocabularies.ASSERTION.subject_type',
+    values: ASSERTION_SUBJECT_TYPES,
+    origin: 'ASSERTION_SUBJECT_TYPES (packages/diagrams/src/assertion/types.ts)',
+  },
+
+  // --- VERIFICATION / VALIDATION -------------------------------------------
+  {
+    key: 'value_vocabularies.VERIFICATION.method',
+    values: VERIFICATION_METHODS,
+    origin: 'VERIFICATION_METHODS (packages/diagrams/src/verification/types.ts)',
+  },
+  {
+    key: 'value_vocabularies.VERIFICATION.outcome',
+    values: VERIFICATION_OUTCOMES,
+    origin: 'VERIFICATION_OUTCOMES (packages/diagrams/src/verification/types.ts)',
+  },
+  {
+    key: 'value_vocabularies.VALIDATION.method',
+    values: VALIDATION_METHODS,
+    origin: 'VALIDATION_METHODS (packages/diagrams/src/validation/types.ts)',
+  },
+  {
+    key: 'value_vocabularies.VALIDATION.outcome',
+    values: VALIDATION_OUTCOMES,
+    origin: 'VALIDATION_OUTCOMES (packages/diagrams/src/validation/types.ts)',
+  },
+
+  // --- Agreement axis ------------------------------------------------------
+  {
+    key: 'value_vocabularies.agreement',
+    values: AGREEMENT_VALUES,
+    origin: 'AGREEMENT_VALUES (packages/diagrams/src/agreement.ts)',
+  },
+
+  // --- Per-relation attributes ---------------------------------------------
+  {
+    key: 'value_vocabularies.target_state_satisfies_goal.degree',
+    values: null,
+    origin: 'relation attributes are not modelled here',
+  },
+  {
+    key: 'value_vocabularies.assessment_influences_goal.sign',
+    values: null,
+    origin: 'relation attributes are not modelled here',
+  },
+  {
+    key: 'value_vocabularies.assessment_influences_goal.magnitude',
+    values: null,
+    origin: 'relation attributes are not modelled here',
+  },
+
+  // --- Ingest candidate contract -------------------------------------------
+  {
+    key: 'value_vocabularies.candidate.kind',
+    values: null,
+    origin: 'the ingest candidate contract has no consumer in this repo',
+  },
+  {
+    key: 'value_vocabularies.candidate.extraction_confidence',
+    values: null,
+    origin: 'the ingest candidate contract has no consumer in this repo',
+  },
+
+  // --- Rule severities -----------------------------------------------------
+  {
+    key: 'value_vocabularies.rule.severity',
+    values: null,
+    origin: 'ValidationSeverity is a type-only union with no runtime array to validate against',
+  },
+];
+
+export function repoSurface(): RepoSurface {
+  return { declaredMethodologyVersion: declaredMethodologyVersion(), bindings: BINDINGS };
+}

--- a/vendor/methodology/README.md
+++ b/vendor/methodology/README.md
@@ -1,0 +1,38 @@
+# Vendored methodology artefacts
+
+Files here are **copies, not sources**. Nothing in this folder is authored in this
+repository, and an edit made here is not a change to the methodology — it is a
+divergence from it, which is exactly what the drift check exists to catch.
+
+## `vocabulary.yaml`
+
+The Transitrix closed-vocabulary artefact — the authored source for every closed
+set (element TYPEs, relation kinds, closed field value vocabularies, rule codes and
+their severities). Its own header states the contract for consumers outside the
+methodology repository: vendor the tagged release and read this path. No cross-repo
+package dependency, no sibling-checkout read, no runtime fetch.
+
+`VENDORED.json` records where the copy came from and pins its content:
+
+| Field | Meaning |
+|---|---|
+| `source_repo` / `source_ref` / `source_path` | the tagged release and path the copy was taken from |
+| `methodology_version` | the artefact's own `methodology_version`, restated so a swapped file cannot pass |
+| `sha256` | SHA-256 of `vocabulary.yaml` with line endings normalised to LF |
+| `vendored_on` | the date the copy was taken |
+
+`tests/vocabulary-drift.test.ts` reads both and fails closed: a missing file, an
+unparseable one, a missing or mismatched pin, or a hash that does not match is a
+build failure, never a pass. It then compares this repo's own vocabulary constants
+against the artefact and reports every divergence.
+
+## Refreshing
+
+```
+node scripts/vendor-methodology-vocabulary.mjs --ref v3.4.0
+```
+
+The script fetches the artefact from the named tag via the GitHub API, writes both
+files, and prints the new hash. Refreshing usually surfaces new drift — that is the
+point; resolve or re-date the affected `tests/vocabulary-drift/allowlist.ts` entries
+in the same change.

--- a/vendor/methodology/VENDORED.json
+++ b/vendor/methodology/VENDORED.json
@@ -1,0 +1,8 @@
+{
+  "source_repo": "transitrix/methodology",
+  "source_ref": "v3.3.0",
+  "source_path": "notations/vocabulary.yaml",
+  "methodology_version": "3.3.0",
+  "sha256": "48498d79106b22d95229862e628aef083a51842c3475d01f0cb06e686eb48d87",
+  "vendored_on": "2026-08-08"
+}

--- a/vendor/methodology/vocabulary.yaml
+++ b/vendor/methodology/vocabulary.yaml
@@ -1,0 +1,1290 @@
+# Transitrix closed-vocabulary source of truth.
+#
+# THIS FILE IS THE SOURCE. The Markdown specs describe, motivate, and give
+# examples; this artefact fixes the closed sets. Nothing here is recovered by
+# parsing Markdown — the artefact is authored, and `scripts/check-notations.mjs`
+# cross-checks it against a spec table so the two cannot drift apart unnoticed.
+# VOC1 (element_types vs ELEMENT_PRIMITIVES.md §4), VOC2 (relation_types vs
+# elements/17-relations.md §3), VOC3 (value_vocabularies vs their owning
+# specs), and VOC4 (rule_codes vs the codes specs actually use) are all
+# implemented in scripts/check-notations.mjs.
+#
+# Inclusion test (mechanical): if code anywhere holds a literal list of it, it
+# belongs here. Semantics, rationale, and worked examples stay in the specs.
+#
+# Consumers
+#   - packages/ingest-cli — `src/vocabulary.mjs` loads this file; `placement.mjs`
+#     and `validate.mjs` derive their sets from it and hold no literal lists.
+#   - Out-of-repo consumers vendor the tagged release and read this path
+#     (`notations/vocabulary.yaml`). No cross-repo package dependency, no
+#     sibling-checkout read, no runtime fetch.
+#
+# Fails closed. A consumer that cannot find, parse, or version-match this file
+# must fail — never fall back to a built-in default and never pass silently.
+#
+# Changing a closed set: edit this file, then update the spec table that prints
+# it in the same commit. Adding an element TYPE or a relation kind here is all
+# the ingest CLI needs to place and validate it.
+
+# Must equal notations/CURRENT_VERSION.yaml (enforced by check V1).
+methodology_version: "3.3.0"
+
+# ---------------------------------------------------------------------------
+# Element TYPE registry — ELEMENT_PRIMITIVES.md §4 (mode table) and §6 (layer
+# and folder placement); TYPE registration in IDS_AND_REFERENCES.md §3.1.
+#
+#   mode        standalone   — own element file in its per-TYPE folder
+#               contained    — inline in a host element (e.g. STEP in PROCESS.flow)
+#               view-defined — authored inline in a view/catalogue document
+#   layer       the numbered layer folder; `null` for a TYPE with no catalogue home
+#   folder      relative to the elements root, no `elements/`/`canon/` prefix;
+#               `null` means no own catalogue folder (document-local)
+#   promotable  the TYPE starts inline and gains a standalone file only when a
+#               SECOND document references it (§1 promotion rule); id never changes
+#
+# 30 live TYPEs. Retired names are under `deprecated_element_types` below and are
+# NOT part of that count.
+# ---------------------------------------------------------------------------
+element_types:
+
+  # --- 01_motivation -------------------------------------------------------
+  DRIVER:
+    mode: standalone
+    layer: 01_motivation
+    folder: 01_motivation/factors/
+    promotable: false
+  GOAL:
+    mode: standalone
+    layer: 01_motivation
+    folder: 01_motivation/goals/
+    promotable: false
+  CONSTRAINT:
+    mode: standalone
+    layer: 01_motivation
+    folder: 01_motivation/constraints/
+    promotable: false
+  REQUIREMENT:
+    mode: standalone
+    layer: 01_motivation
+    folder: 01_motivation/requirements/
+    promotable: false
+  STAKEHOLDER:
+    mode: standalone
+    layer: 01_motivation
+    folder: 01_motivation/stakeholders/
+    promotable: false
+  ASSESSMENT:
+    mode: standalone
+    layer: 01_motivation
+    folder: 01_motivation/assessments/
+    promotable: false
+  NEED:
+    mode: standalone
+    layer: 01_motivation
+    folder: 01_motivation/needs/
+    promotable: false
+  METRIC:
+    mode: standalone
+    layer: 01_motivation
+    folder: 01_motivation/metrics/
+    promotable: false
+  RISK:
+    mode: standalone
+    layer: 01_motivation
+    folder: 01_motivation/risks/
+    promotable: false
+
+  # --- 02_business ---------------------------------------------------------
+  CAPABILITY:
+    mode: standalone
+    layer: 02_business
+    folder: 02_business/capabilities/
+    promotable: false
+  PROCESS:
+    mode: standalone
+    layer: 02_business
+    folder: 02_business/processes/
+    promotable: false
+  STEP:
+    mode: contained
+    layer: 02_business
+    folder: 02_business/steps/
+    promotable: true
+  PRODUCT:
+    mode: standalone
+    layer: 02_business
+    folder: 02_business/products/
+    promotable: false
+  ROLE:
+    mode: standalone
+    layer: 02_business
+    folder: 02_business/roles/
+    promotable: false
+  ACTOR:
+    mode: standalone
+    layer: 02_business
+    folder: 02_business/actors/
+    promotable: false
+  LOCATION:
+    mode: standalone
+    layer: 02_business
+    folder: 02_business/locations/
+    promotable: false
+  BUSINESS_SERVICE:
+    mode: standalone
+    layer: 02_business
+    folder: 02_business/business-services/
+    promotable: false
+  RULE:
+    mode: standalone
+    layer: 02_business
+    folder: 02_business/rules/
+    promotable: false
+  REGISTRY:
+    # Rows are inline and canonical-by-containment; a row is promoted to its own
+    # standalone TYPE when a second document references it (§7.19).
+    mode: standalone
+    layer: 02_business
+    folder: 02_business/registries/
+    promotable: true
+  BUSINESS_OBJECT:
+    # Catalogued 2026-06-08 (EQUIPMENT/BUSINESS_OBJECT ADR); replaces the
+    # view-defined INFORMATION_ENTITY. Schema: ELEMENT_PRIMITIVES.md §7.15.
+    mode: standalone
+    layer: 02_business
+    folder: 02_business/business-objects/
+    promotable: false
+
+  # --- 03_application ------------------------------------------------------
+  APPLICATION:
+    mode: standalone
+    layer: 03_application
+    folder: 03_application/applications/
+    promotable: false
+  INTEGRATION:
+    mode: view-defined
+    layer: 03_application
+    folder: 03_application/integrations/
+    promotable: true
+
+  # --- 04_technology -------------------------------------------------------
+  EQUIPMENT:
+    # Catalogued 2026-06-08 (EQUIPMENT/BUSINESS_OBJECT ADR) — first catalogued
+    # TYPE in this layer. Schema: ELEMENT_PRIMITIVES.md §7.14.
+    mode: standalone
+    layer: 04_technology
+    folder: 04_technology/equipment/
+    promotable: false
+  NODE:
+    mode: standalone
+    layer: 04_technology
+    folder: 04_technology/nodes/
+    promotable: false
+  TECHNOLOGY_SERVICE:
+    mode: standalone
+    layer: 04_technology
+    folder: 04_technology/services/
+    promotable: false
+
+  # --- 05_implementation ---------------------------------------------------
+  ACTION:
+    mode: standalone
+    layer: 05_implementation
+    folder: 05_implementation/actions/
+    promotable: false
+  CHANGE:
+    mode: standalone
+    layer: 05_implementation
+    folder: 05_implementation/changes/
+    promotable: false
+  TARGET_STATE:
+    mode: standalone
+    layer: 05_implementation
+    folder: 05_implementation/target-states/
+    promotable: false
+  SCENARIO:
+    mode: standalone
+    layer: 05_implementation
+    folder: 05_implementation/scenarios/
+    promotable: false
+  RELEASE:
+    # Catalogued only when something references it (§7.29) — the same restraint
+    # as the STEP promotion rule.
+    mode: standalone
+    layer: 05_implementation
+    folder: 05_implementation/releases/
+    promotable: false
+
+# ---------------------------------------------------------------------------
+# Retired element TYPE names. Each resolves to the placement of its replacement
+# so existing files keep resolving through the alias window. Not counted among
+# the 30 live TYPEs; a consumer SHOULD warn (never silently rewrite) on one.
+# ---------------------------------------------------------------------------
+deprecated_element_types:
+  FACTOR:
+    replaced_by: DRIVER
+    # Grandfathered: existing FACTOR-… ids stay valid, no forced migration
+    # (IDS_AND_REFERENCES.md §6).
+    rule: null
+  ACTIVITY:
+    replaced_by: ACTION
+    # Deprecated 2026-06-25; accepted until the 1.0 cut (24-action.md §1).
+    rule: ACTION-005
+  INFORMATION_ENTITY:
+    replaced_by: BUSINESS_OBJECT
+    # One-release alias window; hard error in the following release
+    # (ADR 2026-06-08, ELEMENT_PRIMITIVES.md §7.15).
+    rule: BOBJ-D001
+
+# ---------------------------------------------------------------------------
+# Relation `type` enum — elements/17-relations.md §3. Closed for a given
+# methodology release; new kinds land as additive MINOR revisions.
+#
+#   from / to        allowed endpoint element TYPEs
+#   from_subtype /
+#   to_subtype       ACTOR `type` values the endpoint is narrowed to, when the
+#                    spec narrows it; `null` when unrestricted
+#
+# 19 live kinds. Endpoint TYPE constraints are enforced once the catalogue is
+# loaded (REL-002); the candidate stage checks enum membership and ID grammar.
+# ---------------------------------------------------------------------------
+relation_types:
+
+  parent:
+    from: [CAPABILITY]
+    to: [CAPABILITY]
+  goal_parent:
+    from: [GOAL]
+    to: [GOAL]
+  target_state_satisfies_goal:
+    from: [TARGET_STATE]
+    to: [GOAL]
+  assessment_influences_goal:
+    from: [ASSESSMENT]
+    to: [GOAL]
+  action_goal:
+    from: [ACTION]
+    to: [GOAL]
+  unit_parent:
+    from: [ACTOR]
+    from_subtype: [business_unit]
+    to: [ACTOR]
+    to_subtype: [business_unit]
+  employment:
+    from: [ACTOR]
+    from_subtype: [person]
+    to: [ACTOR]
+    to_subtype: [business_unit]
+  candidacy:
+    from: [ACTOR]
+    from_subtype: [person]
+    to: [ACTOR]
+    to_subtype: [business_unit]
+  alumni_membership:
+    from: [ACTOR]
+    from_subtype: [person]
+    to: [ACTOR]
+    to_subtype: [business_unit]
+  community_membership:
+    from: [ACTOR]
+    from_subtype: [person]
+    to: [ACTOR]
+    to_subtype: [business_unit]
+  contracting:
+    from: [ACTOR]
+    from_subtype: [person, business_unit]
+    to: [ACTOR]
+    to_subtype: [business_unit]
+  located_at:
+    from: [ACTOR]
+    from_subtype: [person, business_unit]
+    to: [LOCATION]
+  stakeholding:
+    from: [STAKEHOLDER]
+    to: [GOAL, ACTION, CAPABILITY]
+  offers:
+    from: [ACTOR, ROLE]
+    from_subtype: [business_unit]
+    to: [BUSINESS_SERVICE]
+  realizes:
+    from: [BUSINESS_SERVICE]
+    to: [CAPABILITY]
+  hosts:
+    from: [NODE]
+    to: [TECHNOLOGY_SERVICE]
+  uses:
+    from: [APPLICATION]
+    to: [TECHNOLOGY_SERVICE]
+  depends_on:
+    from: [REQUIREMENT]
+    to: [REQUIREMENT]
+  required_for:
+    from: [REQUIREMENT]
+    to: [RELEASE]
+
+# Retired relation kind names — accepted, warned on, never silently rewritten.
+deprecated_relation_types:
+  activity_goal:
+    replaced_by: action_goal
+    rule: ACTION-005
+
+# ---------------------------------------------------------------------------
+# Closed value vocabularies. Keyed `<owner>.<field>` where `<owner>` is the
+# element TYPE, relation kind, or artefact that carries the field. A field whose
+# enum is explicitly open (e.g. BUSINESS_OBJECT.type, §7.15) is NOT listed here —
+# absence from this block means the field is not closed.
+#
+#   values  the closed set
+#   spec    the spec that prints it, or `null` when no spec does (a pipeline-
+#           internal set, not cross-checked). VOC3 verifies every value
+#           appears there as (part of) a code span.
+#   rule    the code whose row states the enum, or `null`. When that row says
+#           "one of …" / "not in …", VOC3 additionally requires the row's own
+#           values to match `values` exactly — catching a value dropped from
+#           or added to the spec without the artefact moving.
+# ---------------------------------------------------------------------------
+value_vocabularies:
+
+  # REQUIREMENT — elements/15-requirement.md
+  REQUIREMENT.origin:
+    values: [legislative, process-product, project-product]
+    spec: notations/elements/15-requirement.md
+    rule: REQ-004
+  REQUIREMENT.level:
+    values: [stakeholder, system, software]
+    spec: notations/elements/15-requirement.md
+    rule: REQ-005
+  REQUIREMENT.kind:
+    values: [functional, quality]
+    spec: notations/elements/15-requirement.md
+    rule: REQ-006
+  REQUIREMENT.severity:
+    # Organisation-defined planning priority; distinct from obligation_level.
+    values: [high, medium, low]
+    spec: notations/elements/15-requirement.md
+    rule: null
+
+  # ASSERTION — elements/16-assertion.md §2/§3
+  ASSERTION.status:
+    values: [compliant, partial, non_compliant, under_review, n_a]
+    spec: notations/elements/16-assertion.md
+    rule: ASSERT-006
+  ASSERTION.subject_type:
+    values: [PRODUCT, PROCESS, CAPABILITY]
+    spec: notations/elements/16-assertion.md
+    rule: ASSERT-003
+
+  # VERIFICATION — elements/27-verification.md §3
+  VERIFICATION.method:
+    values: [test, analysis, inspection, demonstration]
+    spec: notations/elements/27-verification.md
+    rule: VERIF-003
+  VERIFICATION.outcome:
+    values: [pass, fail, inconclusive, not_yet_run]
+    spec: notations/elements/27-verification.md
+    rule: VERIF-004
+
+  # VALIDATION — elements/28-validation.md §3
+  VALIDATION.method:
+    values: [user_acceptance, field_trial, stakeholder_review, usability_study]
+    spec: notations/elements/28-validation.md
+    rule: VALID-003
+  VALIDATION.outcome:
+    values: [pass, fail, inconclusive, not_yet_run]
+    spec: notations/elements/28-validation.md
+    rule: VALID-004
+
+  # Agreement axis — CONTRACT.md §6.3 (REQUIREMENT / CONSTRAINT / NEED)
+  agreement:
+    values: [draft, agreed, disputed]
+    spec: notations/CONTRACT.md
+    rule: AGREE-001
+
+  # Per-relation attributes — elements/17-relations.md §3
+  target_state_satisfies_goal.degree:
+    values: [partial, full]
+    spec: notations/elements/17-relations.md
+    rule: null
+  assessment_influences_goal.sign:
+    values: [positive, negative]
+    spec: notations/elements/17-relations.md
+    rule: null
+  assessment_influences_goal.magnitude:
+    values: [low, medium, high]
+    spec: notations/elements/17-relations.md
+    rule: null
+
+  # Ingest candidate contract — the bundle's candidate.schema.json, not a spec.
+  candidate.kind:
+    values: [element, relation, assertion]
+    spec: null
+    rule: null
+  candidate.extraction_confidence:
+    values: [high, medium, low]
+    spec: null
+    rule: null
+
+  # Rule severities — the closed set a `rule_codes` entry may carry.
+  rule.severity:
+    values: [error, warning, info, deprecation]
+    spec: null
+    rule: null
+
+# ---------------------------------------------------------------------------
+# Time-boxed exemptions. Every entry names a date by which it is resolved or
+# renewed. An entry here narrows a check to exactly the named item — never a
+# whole check, never a whole file.
+# ---------------------------------------------------------------------------
+deferred:
+  rule_codes:
+    COMPIMP-010:
+      review_by: "2026-11-07"
+      reason: >-
+        views/reports/21-compliance-impact.md numbers two distinct rules
+        COMPIMP-010 — one `warning` (a legacy empty-cell label) and one `error`
+        (a subject-type column-header mismatch). The artefact cannot carry one
+        code at two severities. Renumbering a code that shipped in 3.2.0 is a
+        versioned canon change with downstream validator consumers, so it is
+        raised rather than decided here; COMPIMP-014 is the next free number in
+        the family. Narrows VOC4 (rule_codes vs the codes specs actually use,
+        scripts/check-notations.mjs) to exactly this code until resolved or
+        renewed.
+
+# ---------------------------------------------------------------------------
+# Validation rule codes and their severities. The code and its severity are the
+# closed part and live here; the rule's description stays in the spec named by
+# `spec` (the element/view spec that owns the family — CONTRACT.md restates many
+# of these, and a restatement is not ownership).
+# ---------------------------------------------------------------------------
+rule_codes:
+  ACT-001:
+    severity: error
+    spec: notations/views/diagrams/07-action.md
+  ACT-002:
+    severity: error
+    spec: notations/views/diagrams/07-action.md
+  ACT-003:
+    severity: error
+    spec: notations/views/diagrams/07-action.md
+  ACT-004:
+    severity: error
+    spec: notations/views/diagrams/07-action.md
+  ACT-005:
+    severity: error
+    spec: notations/views/diagrams/07-action.md
+  ACT-006:
+    severity: error
+    spec: notations/views/diagrams/07-action.md
+  ACT-007:
+    severity: error
+    spec: notations/views/diagrams/07-action.md
+  ACT-008:
+    severity: error
+    spec: notations/views/diagrams/07-action.md
+  ACTION-001:
+    severity: error
+    spec: notations/elements/24-action.md
+  ACTION-002:
+    severity: error
+    spec: notations/elements/24-action.md
+  ACTION-003:
+    severity: warning
+    spec: notations/elements/24-action.md
+  ACTION-004:
+    severity: error
+    spec: notations/elements/24-action.md
+  ACTION-005:
+    severity: warning
+    spec: notations/elements/24-action.md
+  ACTOR-001:
+    severity: error
+    spec: notations/elements/19-actors.md
+  ACTOR-002:
+    severity: error
+    spec: notations/elements/19-actors.md
+  ACTOR-003:
+    severity: error
+    spec: notations/elements/19-actors.md
+  ADMIT-001:
+    severity: error
+    spec: notations/CONTRACT.md
+  ADMIT-002:
+    severity: error
+    spec: notations/CONTRACT.md
+  ADMIT-003:
+    severity: error
+    spec: notations/CONTRACT.md
+  ADMIT-004:
+    severity: error
+    spec: notations/CONTRACT.md
+  ADMIT-005:
+    severity: warning
+    spec: notations/CONTRACT.md
+  ADMIT-006:
+    severity: error
+    spec: notations/CONTRACT.md
+  ADMIT-007:
+    severity: error
+    spec: notations/CONTRACT.md
+  ADMIT-008:
+    severity: warning
+    spec: notations/CONTRACT.md
+  AGREE-001:
+    severity: error
+    spec: notations/CONTRACT.md
+  AGREE-002:
+    severity: error
+    spec: notations/CONTRACT.md
+  AGREE-003:
+    severity: error
+    spec: notations/CONTRACT.md
+  AMENDMENT-001:
+    severity: error
+    spec: notations/elements/22-amendment.md
+  AMENDMENT-002:
+    severity: error
+    spec: notations/elements/22-amendment.md
+  AMENDMENT-003:
+    severity: error
+    spec: notations/elements/22-amendment.md
+  AMENDMENT-004:
+    severity: error
+    spec: notations/elements/22-amendment.md
+  AMENDMENT-005:
+    severity: warning
+    spec: notations/elements/22-amendment.md
+  AMENDMENT-006:
+    severity: warning
+    spec: notations/elements/22-amendment.md
+  AMENDMENT-007:
+    severity: error
+    spec: notations/elements/22-amendment.md
+  ASSERT-001:
+    severity: error
+    spec: notations/elements/16-assertion.md
+  ASSERT-002:
+    severity: error
+    spec: notations/elements/16-assertion.md
+  ASSERT-003:
+    severity: error
+    spec: notations/elements/16-assertion.md
+  ASSERT-004:
+    severity: error
+    spec: notations/elements/16-assertion.md
+  ASSERT-005:
+    severity: error
+    spec: notations/elements/16-assertion.md
+  ASSERT-006:
+    severity: error
+    spec: notations/elements/16-assertion.md
+  ASSERT-007:
+    severity: warning
+    spec: notations/elements/16-assertion.md
+  ASSERT-008:
+    severity: warning
+    spec: notations/elements/16-assertion.md
+  ASSERT-009:
+    severity: warning
+    spec: notations/elements/16-assertion.md
+  ASSERT-010:
+    severity: error
+    spec: notations/elements/16-assertion.md
+  ASSERT-DEAD-LINK-001:
+    severity: warning
+    spec: notations/elements/16-assertion.md
+  ATREE-001:
+    severity: error
+    spec: notations/views/reports/23-actions-tree.md
+  ATREE-002:
+    severity: error
+    spec: notations/views/reports/23-actions-tree.md
+  ATREE-003:
+    severity: error
+    spec: notations/views/reports/23-actions-tree.md
+  ATREE-007:
+    severity: error
+    spec: notations/views/reports/23-actions-tree.md
+  BL-001:
+    severity: error
+    spec: notations/views/diagrams/08-blocks.md
+  BL-002:
+    severity: error
+    spec: notations/views/diagrams/08-blocks.md
+  BL-003:
+    severity: error
+    spec: notations/views/diagrams/08-blocks.md
+  BL-004:
+    severity: error
+    spec: notations/views/diagrams/08-blocks.md
+  BL-005:
+    severity: error
+    spec: notations/views/diagrams/08-blocks.md
+  BL-006:
+    severity: error
+    spec: notations/views/diagrams/08-blocks.md
+  BL-007:
+    severity: error
+    spec: notations/views/diagrams/08-blocks.md
+  BL-020:
+    severity: error
+    spec: notations/views/diagrams/08-blocks.md
+  BL-021:
+    severity: error
+    spec: notations/views/diagrams/08-blocks.md
+  BL-022:
+    severity: error
+    spec: notations/views/diagrams/08-blocks.md
+  BL-023:
+    severity: error
+    spec: notations/views/diagrams/08-blocks.md
+  BL-024:
+    severity: error
+    spec: notations/views/diagrams/08-blocks.md
+  BL-025:
+    severity: error
+    spec: notations/views/diagrams/08-blocks.md
+  BOBJ-001:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  BOBJ-D001:
+    severity: warning
+    spec: notations/ELEMENT_PRIMITIVES.md
+  BP-001:
+    severity: error
+    spec: notations/views/diagrams/13-process-blueprint.md
+  BP-002:
+    severity: error
+    spec: notations/views/diagrams/13-process-blueprint.md
+  BP-003:
+    severity: error
+    spec: notations/views/diagrams/13-process-blueprint.md
+  BP-004:
+    severity: error
+    spec: notations/views/diagrams/13-process-blueprint.md
+  BP-005:
+    severity: error
+    spec: notations/views/diagrams/13-process-blueprint.md
+  BP-006:
+    severity: error
+    spec: notations/views/diagrams/13-process-blueprint.md
+  BP-007:
+    severity: error
+    spec: notations/views/diagrams/13-process-blueprint.md
+  BP-008:
+    severity: error
+    spec: notations/views/diagrams/13-process-blueprint.md
+  BP-009:
+    severity: error
+    spec: notations/views/diagrams/13-process-blueprint.md
+  BP-010:
+    severity: error
+    spec: notations/views/diagrams/13-process-blueprint.md
+  BSV-001:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  BSV-002:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  BSV-003:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  BSV-004:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  CODEX-001:
+    severity: error
+    spec: notations/elements/14-codex.md
+  CODEX-002:
+    severity: error
+    spec: notations/elements/14-codex.md
+  CODEX-004:
+    severity: warning
+    spec: notations/elements/14-codex.md
+  CODEX-005:
+    severity: info
+    spec: notations/elements/14-codex.md
+  COMPIMP-001:
+    severity: error
+    spec: notations/views/reports/21-compliance-impact.md
+  COMPIMP-002:
+    severity: error
+    spec: notations/views/reports/21-compliance-impact.md
+  COMPIMP-003:
+    severity: error
+    spec: notations/views/reports/21-compliance-impact.md
+  COMPIMP-004:
+    severity: error
+    spec: notations/views/reports/21-compliance-impact.md
+  COMPIMP-005:
+    severity: error
+    spec: notations/views/reports/21-compliance-impact.md
+  COMPIMP-006:
+    severity: error
+    spec: notations/views/reports/21-compliance-impact.md
+  COMPIMP-007:
+    severity: warning
+    spec: notations/views/reports/21-compliance-impact.md
+  COMPIMP-008:
+    severity: warning
+    spec: notations/views/reports/21-compliance-impact.md
+  COMPIMP-009:
+    severity: warning
+    spec: notations/views/reports/21-compliance-impact.md
+  COMPIMP-011:
+    severity: error
+    spec: notations/views/reports/21-compliance-impact.md
+  COMPIMP-012:
+    severity: error
+    spec: notations/views/reports/21-compliance-impact.md
+  COMPIMP-013:
+    severity: error
+    spec: notations/views/reports/21-compliance-impact.md
+  COVMET-001:
+    severity: error
+    spec: notations/views/reports/22-coverage-metric.md
+  COVMET-002:
+    severity: error
+    spec: notations/views/reports/22-coverage-metric.md
+  COVMET-003:
+    severity: error
+    spec: notations/views/reports/22-coverage-metric.md
+  COVMET-004:
+    severity: error
+    spec: notations/views/reports/22-coverage-metric.md
+  COVMET-005:
+    severity: error
+    spec: notations/views/reports/22-coverage-metric.md
+  COVMET-006:
+    severity: warning
+    spec: notations/views/reports/22-coverage-metric.md
+  COVMET-007:
+    severity: warning
+    spec: notations/views/reports/22-coverage-metric.md
+  COVMET-008:
+    severity: warning
+    spec: notations/views/reports/22-coverage-metric.md
+  COVMET-009:
+    severity: warning
+    spec: notations/views/reports/22-coverage-metric.md
+  CP-001:
+    severity: error
+    spec: notations/COVERAGE_PROFILES.md
+  CP-002:
+    severity: error
+    spec: notations/COVERAGE_PROFILES.md
+  CP-003:
+    severity: error
+    spec: notations/COVERAGE_PROFILES.md
+  CP-004:
+    severity: error
+    spec: notations/COVERAGE_PROFILES.md
+  CP-005:
+    severity: warning
+    spec: notations/COVERAGE_PROFILES.md
+  DGCA-001:
+    severity: error
+    spec: notations/views/diagrams/02-dgca.md
+  DGCA-002:
+    severity: error
+    spec: notations/views/diagrams/02-dgca.md
+  DGCA-003:
+    severity: error
+    spec: notations/views/diagrams/02-dgca.md
+  DGCA-004:
+    severity: error
+    spec: notations/views/diagrams/02-dgca.md
+  DGCA-005:
+    severity: error
+    spec: notations/views/diagrams/02-dgca.md
+  DGCA-006:
+    severity: error
+    spec: notations/views/diagrams/02-dgca.md
+  DGCA-007:
+    severity: error
+    spec: notations/views/diagrams/02-dgca.md
+  DGCA-008:
+    severity: error
+    spec: notations/views/diagrams/02-dgca.md
+  DGCA-009:
+    severity: error
+    spec: notations/views/diagrams/02-dgca.md
+  DGCA-010:
+    severity: error
+    spec: notations/views/diagrams/02-dgca.md
+  DGCA-011:
+    severity: error
+    spec: notations/views/diagrams/02-dgca.md
+  DGCA-012:
+    severity: warning
+    spec: notations/views/diagrams/02-dgca.md
+  DGCA-013:
+    severity: warning
+    spec: notations/views/diagrams/02-dgca.md
+  DGCA-014:
+    severity: warning
+    spec: notations/views/diagrams/02-dgca.md
+  DGCA-015:
+    severity: error
+    spec: notations/views/diagrams/02-dgca.md
+  DGCA-016:
+    severity: warning
+    spec: notations/views/diagrams/02-dgca.md
+  DGCA-017:
+    severity: warning
+    spec: notations/views/diagrams/02-dgca.md
+  DGCA-018:
+    severity: warning
+    spec: notations/views/diagrams/02-dgca.md
+  ELEM-001:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  ELEM-002:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  ELEM-003:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  ELEM-004:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  ELEM-005:
+    severity: warning
+    spec: notations/ELEMENT_PRIMITIVES.md
+  ELEM-ALIAS-001:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  ELEM-FORMER-ID-001:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  EQUIP-001:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  EXT-002:
+    severity: warning
+    spec: notations/CONTRACT.md
+  FRESHNESS-001:
+    severity: warning
+    spec: notations/CONTRACT.md
+  GOALS-001:
+    severity: error
+    spec: notations/views/diagrams/04-goals.md
+  GOALS-002:
+    severity: error
+    spec: notations/views/diagrams/04-goals.md
+  GOALS-003:
+    severity: error
+    spec: notations/views/diagrams/04-goals.md
+  GOALS-004:
+    severity: error
+    spec: notations/views/diagrams/04-goals.md
+  GOALS-005:
+    severity: error
+    spec: notations/views/diagrams/04-goals.md
+  GOALS-006:
+    severity: error
+    spec: notations/views/diagrams/04-goals.md
+  GOALS-007:
+    severity: error
+    spec: notations/views/diagrams/04-goals.md
+  HDR-001:
+    severity: error
+    spec: notations/CONTRACT.md
+  HDR-002:
+    severity: error
+    spec: notations/CONTRACT.md
+  HDR-003:
+    severity: error
+    spec: notations/CONTRACT.md
+  INT-001:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  INT-002:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  INT-003:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  INT-004:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  JURISDICTION-CONSISTENCY-001:
+    severity: warning
+    spec: notations/views/diagrams/13-process-blueprint.md
+  LIFECYCLE-001:
+    severity: error
+    spec: notations/CONTRACT.md
+  LIFECYCLE-002:
+    severity: error
+    spec: notations/CONTRACT.md
+  LIFECYCLE-003:
+    severity: error
+    spec: notations/CONTRACT.md
+  LIFECYCLE-004:
+    severity: warning
+    spec: notations/CONTRACT.md
+  LOC-001:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  LOC-002:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  LOC-003:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  MECH-001:
+    severity: info
+    spec: notations/CONTRACT.md
+  METRIC-001:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  METRIC-002:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  METRIC-003:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  METRIC-004:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  MRD-001:
+    severity: error
+    spec: notations/views/documents/29-mrd.md
+  MRD-002:
+    severity: error
+    spec: notations/views/documents/29-mrd.md
+  MRD-003:
+    severity: error
+    spec: notations/views/documents/29-mrd.md
+  MRD-004:
+    severity: warning
+    spec: notations/views/documents/29-mrd.md
+  MRD-005:
+    severity: warning
+    spec: notations/views/documents/29-mrd.md
+  MRD-006:
+    severity: error
+    spec: notations/views/documents/29-mrd.md
+  NEED-001:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  NEED-002:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  NEED-COVERAGE-001:
+    severity: warning
+    spec: notations/ELEMENT_PRIMITIVES.md
+  NEED-VALIDATION-COVERAGE-001:
+    severity: warning
+    spec: notations/ELEMENT_PRIMITIVES.md
+  NEED-VALIDATION-COVERAGE-002:
+    severity: warning
+    spec: notations/ELEMENT_PRIMITIVES.md
+  NOD-001:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  NOD-002:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  PC-001:
+    severity: error
+    spec: notations/views/diagrams/18-action-card.md
+  PC-002:
+    severity: error
+    spec: notations/views/diagrams/18-action-card.md
+  PC-003:
+    severity: error
+    spec: notations/views/diagrams/18-action-card.md
+  PC-004:
+    severity: warning
+    spec: notations/views/diagrams/18-action-card.md
+  PC-005:
+    severity: warning
+    spec: notations/views/diagrams/18-action-card.md
+  PKG-001:
+    severity: error
+    spec: notations/PACKAGES.md
+  PKG-002:
+    severity: error
+    spec: notations/PACKAGES.md
+  PROCESS-COVERAGE-001:
+    severity: warning
+    spec: notations/elements/16-assertion.md
+  REG-001:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  REL-001:
+    severity: error
+    spec: notations/elements/17-relations.md
+  REL-002:
+    severity: error
+    spec: notations/elements/17-relations.md
+  REL-003:
+    severity: error
+    spec: notations/elements/17-relations.md
+  REL-004:
+    severity: error
+    spec: notations/elements/17-relations.md
+  REL-005:
+    severity: error
+    spec: notations/elements/17-relations.md
+  REL-006:
+    severity: warning
+    spec: notations/elements/17-relations.md
+  RELEASE-001:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  RELEASE-002:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  RELEASE-003:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  RELEASE-005:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  REQ-001:
+    severity: error
+    spec: notations/elements/15-requirement.md
+  REQ-002:
+    severity: error
+    spec: notations/elements/15-requirement.md
+  REQ-003:
+    severity: error
+    spec: notations/elements/15-requirement.md
+  REQ-004:
+    severity: error
+    spec: notations/elements/15-requirement.md
+  REQ-005:
+    severity: error
+    spec: notations/elements/15-requirement.md
+  REQ-006:
+    severity: error
+    spec: notations/elements/15-requirement.md
+  REQ-COVERAGE-001:
+    severity: warning
+    spec: notations/elements/15-requirement.md
+  REQ-SERVES-001:
+    severity: error
+    spec: notations/elements/15-requirement.md
+  REQ-STALE-001:
+    severity: warning
+    spec: notations/elements/15-requirement.md
+  REQ-VERIF-COVERAGE-001:
+    severity: warning
+    spec: notations/elements/15-requirement.md
+  REQ-VERIF-COVERAGE-002:
+    severity: warning
+    spec: notations/elements/15-requirement.md
+  REQIF-001:
+    severity: error
+    spec: notations/packages/reqif.md
+  REQIF-002:
+    severity: error
+    spec: notations/packages/reqif.md
+  REQIF-003:
+    severity: error
+    spec: notations/packages/reqif.md
+  REQIF-004:
+    severity: error
+    spec: notations/packages/reqif.md
+  REQIF-005:
+    severity: error
+    spec: notations/packages/reqif.md
+  REQIF-006:
+    severity: error
+    spec: notations/packages/reqif.md
+  REQIF-007:
+    severity: error
+    spec: notations/packages/reqif.md
+  REQIF-008:
+    severity: error
+    spec: notations/packages/reqif.md
+  REQIF-009:
+    severity: error
+    spec: notations/packages/reqif.md
+  RISK-001:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  RISK-002:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  RISK-003:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  RISK-004:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  RISK-COVERAGE-001:
+    severity: warning
+    spec: notations/ELEMENT_PRIMITIVES.md
+  SDD-001:
+    severity: error
+    spec: notations/views/documents/31-sdd.md
+  SDD-002:
+    severity: error
+    spec: notations/views/documents/31-sdd.md
+  SDD-003:
+    severity: error
+    spec: notations/views/documents/31-sdd.md
+  SDD-004:
+    severity: error
+    spec: notations/views/documents/31-sdd.md
+  SDD-005:
+    severity: warning
+    spec: notations/views/documents/31-sdd.md
+  SDD-006:
+    severity: warning
+    spec: notations/views/documents/31-sdd.md
+  SDD-007:
+    severity: error
+    spec: notations/views/documents/31-sdd.md
+  SEGMENT-001:
+    severity: error
+    spec: notations/elements/23-segment.md
+  SEGMENT-002:
+    severity: error
+    spec: notations/elements/23-segment.md
+  SEGMENT-003:
+    severity: error
+    spec: notations/elements/23-segment.md
+  SEGMENT-004:
+    severity: error
+    spec: notations/elements/23-segment.md
+  SEGMENT-005:
+    severity: error
+    spec: notations/elements/23-segment.md
+  SEGMENT-006:
+    severity: warning
+    spec: notations/elements/23-segment.md
+  SEGMENT-007:
+    severity: warning
+    spec: notations/elements/23-segment.md
+  SEGMENT-008:
+    severity: warning
+    spec: notations/elements/23-segment.md
+  SNAP-001:
+    severity: error
+    spec: notations/CONTRACT.md
+  SNAP-002:
+    severity: error
+    spec: notations/CONTRACT.md
+  SNAP-003:
+    severity: error
+    spec: notations/CONTRACT.md
+  SNAP-004:
+    severity: warning
+    spec: notations/CONTRACT.md
+  SNAP-005:
+    severity: warning
+    spec: notations/CONTRACT.md
+  SRS-001:
+    severity: error
+    spec: notations/views/documents/30-srs.md
+  SRS-002:
+    severity: error
+    spec: notations/views/documents/30-srs.md
+  SRS-003:
+    severity: error
+    spec: notations/views/documents/30-srs.md
+  SRS-004:
+    severity: warning
+    spec: notations/views/documents/30-srs.md
+  SRS-005:
+    severity: warning
+    spec: notations/views/documents/30-srs.md
+  SRS-006:
+    severity: error
+    spec: notations/views/documents/30-srs.md
+  STAKE-001:
+    severity: error
+    spec: notations/elements/20-stakeholders.md
+  STAKE-002:
+    severity: error
+    spec: notations/elements/20-stakeholders.md
+  STAKE-003:
+    severity: error
+    spec: notations/elements/20-stakeholders.md
+  TSVC-001:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  TSVC-002:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  TSVC-003:
+    severity: error
+    spec: notations/ELEMENT_PRIMITIVES.md
+  UNRES-001:
+    severity: error
+    spec: notations/CONTRACT.md
+  UNRES-002:
+    severity: error
+    spec: notations/CONTRACT.md
+  UNRES-003:
+    severity: warning
+    spec: notations/CONTRACT.md
+  UNRES-004:
+    severity: error
+    spec: notations/CONTRACT.md
+  VALID-001:
+    severity: error
+    spec: notations/elements/28-validation.md
+  VALID-002:
+    severity: error
+    spec: notations/elements/28-validation.md
+  VALID-003:
+    severity: error
+    spec: notations/elements/28-validation.md
+  VALID-004:
+    severity: error
+    spec: notations/elements/28-validation.md
+  VALID-005:
+    severity: error
+    spec: notations/elements/28-validation.md
+  VALID-006:
+    severity: warning
+    spec: notations/elements/28-validation.md
+  VC-001:
+    severity: error
+    spec: notations/CONTRACT.md
+  VC-002:
+    severity: error
+    spec: notations/CONTRACT.md
+  VC-003:
+    severity: warning
+    spec: notations/CONTRACT.md
+  VERIF-001:
+    severity: error
+    spec: notations/elements/27-verification.md
+  VERIF-002:
+    severity: error
+    spec: notations/elements/27-verification.md
+  VERIF-003:
+    severity: error
+    spec: notations/elements/27-verification.md
+  VERIF-004:
+    severity: error
+    spec: notations/elements/27-verification.md
+  VERIF-005:
+    severity: error
+    spec: notations/elements/27-verification.md
+  VERIF-006:
+    severity: warning
+    spec: notations/elements/27-verification.md
+  VERIF-007:
+    severity: error
+    spec: notations/elements/27-verification.md
+  VERSIONED-001:
+    severity: error
+    spec: notations/CONTRACT.md
+  VERSIONED-002:
+    severity: error
+    spec: notations/CONTRACT.md
+  VERSIONED-003:
+    severity: warning
+    spec: notations/CONTRACT.md
+  VERSIONED-004:
+    severity: error
+    spec: notations/CONTRACT.md
+  VERSIONED-005:
+    severity: error
+    spec: notations/CONTRACT.md


### PR DESCRIPTION
## What changed

The methodology closed-vocabulary artefact is now vendored under
`vendor/methodology/`, and a build-time check compares this repo's own
vocabulary constants against it.

**`vendor/methodology/`** — `vocabulary.yaml` is a verbatim copy of the artefact
from a tagged release. `VENDORED.json` pins it: source repo, source tag, source
path, the artefact's own `methodology_version`, a SHA-256 over LF-normalised
bytes, and the date the copy was taken. `.gitattributes` keeps the tree at LF so
the copy stays byte-identical to its source on every platform.

**`scripts/vendor-methodology-vocabulary.mjs`** — refreshes the copy from a
release tag through the GitHub API, rejects a branch ref, rejects a tag whose
artefact declares a different version, and rewrites both files. `--check`
reports what would change without writing.

**`tests/vocabulary-drift.test.ts`** — the check. It fails closed: a missing
artefact, a missing or malformed pin, a pin without a version, YAML that does not
parse, a required section that is absent or the wrong shape, content whose hash
does not match the pin, or an artefact whose version contradicts its pin all
throw. There is no fallback vocabulary and no path where an unreadable input
reads as a pass.

## How the comparison works

`tests/vocabulary-drift/compare.ts` is pure — artefact plus surface in,
divergences out — so fixtures drive it directly. Four kinds, each with a stable
key:

| kind | meaning |
|---|---|
| `missing` | the artefact defines a value this repo's constant does not carry |
| `extra` | this repo's constant carries a value the artefact does not define |
| `unbound` | the artefact defines a closed set no runtime constant here expresses |
| `version-mismatch` | `transitrix.methodologyVersion` does not name the vendored artefact's version |

`tests/vocabulary-drift/surface.ts` binds every artefact vocabulary to the
constant that already carries it in product code (`REGISTERED_ELEMENT_TYPES`,
`ASSERTION_STATUSES`, `REQUIREMENT_LEVELS`, `AGREEMENT_VALUES`, …). It holds no
vocabulary values of its own, so a value added or removed at the real site moves
the check with it rather than needing a matching edit here. `values: null` is an
explicit declaration that nothing here expresses the set — reported as drift, not
excluded from the check. A binding for a set the artefact no longer defines, and
an artefact set with no binding at all, are both hard errors, so the surface
cannot quietly stop comparing.

## The first run

The check reports **22 divergences**, all of them pre-existing and all recorded
in `tests/vocabulary-drift/allowlist.ts`:

- 5 element TYPEs the artefact defines and `REGISTERED_ELEMENT_TYPES` does not
  carry (`NEED`, `METRIC`, `RISK`, `RELEASE`, `INFORMATION_ENTITY`);
- 5 it carries that the artefact does not define (`HAZARD`, `RISK_CONTROL`,
  `REL`, `MILESTONE`, `VERIFICATION`);
- 1 extra assertion status (`pending_owner`);
- 10 closed sets no constant here expresses — `relation_types`, `rule_codes`,
  and 8 value vocabularies;
- 1 version mismatch between the declaration and the vendored artefact.

The run prints all 22 with their origins, so the check reports the gap rather
than reading as a clean bill. The scattered per-module literals are not replaced
in this PR; each migrates to reading the artefact when it is next touched for
other reasons.

## The allowlist is time-boxed

Every entry carries a `review_by` date written into the file, and the check fails
from that date on. It also fails on an entry whose divergence no longer occurs,
so resolved exemptions cannot sit there reading as outstanding work, and on a
duplicate key. An entry narrows the check to exactly one divergence key — there
is no way to exempt a whole vocabulary or the whole check.

## Verification

`npx vitest run tests/vocabulary-drift.test.ts` — 24 tests, all passing.
Fixture coverage: a clean pass, each of the four divergence kinds reported
individually, both surface-integrity errors, and seven fail-closed cases
(missing artefact, missing pin, unpinned pin, unparseable YAML, hash mismatch,
truncated section, pin/artefact version disagreement), plus a hash that is stable
across a CRLF checkout and unstable across a content change.

Full `npm test`: 711 passing. `npm run build` and `npm run compile` clean. Two
test files fail identically on `main` without this change
(`tests/cli-migrate.test.ts`, `tests/ci-hygiene-hashrefs.test.ts`).

Refs THQ-52
