### PR TITLE
feat(extension): live preview of .ttrs Pass 1 (resolved) output

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -848,7 +848,7 @@
     "menus": {
       "editor/title": [
         {
-          "when": "resourceFilename =~ /\\.(bpmn|goals|dgca|dga|action|action-card|actions-tree|blocks|products|applications|process-map|scenarios|capability-map|process-blueprint|compliance-impact|coverage-metric)\\.transitrix\\.yaml$/ || resourceFilename =~ /\\.compliance-impact\\.view\\.yaml$/ || resourceFilename =~ /^(LAW|REGULATION|POLICY|INTERNAL_STANDARD)-.*\\.yaml$/ || resourceFilename =~ /^PRODUCT-.*\\.yaml$/ || resourceFilename =~ /^(REQUIREMENT|CONSTRAINT)-.*\\.yaml$/ || resourceFilename =~ /\\.(puml|plantuml)$/",
+          "when": "resourceFilename =~ /\\.(bpmn|goals|dgca|dga|action|action-card|actions-tree|blocks|products|applications|process-map|scenarios|capability-map|process-blueprint|compliance-impact|coverage-metric)\\.transitrix\\.yaml$/ || resourceFilename =~ /\\.compliance-impact\\.view\\.yaml$/ || resourceFilename =~ /^(LAW|REGULATION|POLICY|INTERNAL_STANDARD)-.*\\.yaml$/ || resourceFilename =~ /^PRODUCT-.*\\.yaml$/ || resourceFilename =~ /^(REQUIREMENT|CONSTRAINT)-.*\\.yaml$/ || resourceFilename =~ /\\.(puml|plantuml)$/ || resourceFilename =~ /\\.ttrs$/",
           "command": "transitrix.openPreview",
           "group": "navigation@-10"
         },

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -25,6 +25,7 @@ import { RequirementTracePreview } from './requirement-trace-preview.js';
 import { GapDashboardPreview } from './gap-dashboard-preview.js';
 import { CoverageMetricPreview } from './coverage-metric-preview.js';
 import { PlantUMLPreview, isPumlFile } from './plantuml-preview.js';
+import { TtrsPreview, isTtrsFile } from './ttrs-preview.js';
 import { openComplianceFile } from './compliance-scan.js';
 import type { LayoutMetrics, ValidationReport } from './types.js';
 import { documentMatchesTransitrixSource } from './source-files.js';
@@ -247,6 +248,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   const gapDashboardPreview = new GapDashboardPreview(context.extensionUri);
   const coverageMetricPreview = new CoverageMetricPreview(context.extensionUri);
   const plantumlPreview = new PlantUMLPreview(context.extensionUri);
+  const ttrsPreview = new TtrsPreview();
 
   async function openBpmnPreviewForDocument(doc: vscode.TextDocument): Promise<void> {
     const renderer = vscode.workspace.getConfiguration('transitrix').get<string>('bpmnRenderer', 'custom');
@@ -272,6 +274,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   function resolveNotationPreview(doc: vscode.TextDocument): ResolvedPreview | undefined {
     if (isPumlFile(doc)) {
       return { id: 'puml', open: () => plantumlPreview.showOrReveal(doc), refresh: () => plantumlPreview.refreshSaved(doc) };
+    }
+    if (isTtrsFile(doc)) {
+      return { id: 'ttrs', open: () => ttrsPreview.showOrReveal(doc), refresh: () => ttrsPreview.refreshSaved(doc) };
     }
     if (isGoalsFile(doc)) {
       return { id: 'goals', open: () => goalsPreview.showOrReveal(doc), refresh: () => goalsPreview.refreshSaved(doc) };
@@ -506,6 +511,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       void capabilityMapPreview.refreshConfig();
       if (isThemeChange) {
         void plantumlPreview.refreshConfig();
+        void ttrsPreview.refreshConfig();
         void activityCardPreview.refreshConfig();
         void applicationsPreview.refreshConfig();
         void productsPreview.refreshConfig();

--- a/extension/src/ttrs-preview.ts
+++ b/extension/src/ttrs-preview.ts
@@ -1,0 +1,140 @@
+import * as path from 'node:path';
+import { readFileSync } from 'node:fs';
+import * as vscode from 'vscode';
+import yaml from 'js-yaml';
+import { buildDiagramFrame, type ThemeId, OPEN_THEME_COMMAND } from './diagram-frame.js';
+import { StaticPreview } from './static-preview.js';
+import { renderTtrsResult, TTRS_STYLES, type FigureEmbed } from './ttrs-render.js';
+import { coerceDatesToIsoStrings } from '@transitrix/diagrams/yaml-normalize.js';
+import {
+  validateBlocks,
+  layoutNestedBlocks,
+  layoutGrid,
+  type BlocksFile,
+  type GridFile,
+} from '@transitrix/diagrams/blocks';
+import { renderBlocksLayoutSvg, renderGridLayoutSvg } from '@transitrix/diagrams/webview/render-blocks.js';
+import { readBlocksLeafSize } from './node-size-config.js';
+
+// The vendored @transitrix/document-renderer pass-1 resolver
+// (vendor/methodology/README.md "document-renderer/"). A real library
+// import against the methodology-authored resolver — not a
+// reimplementation of its resolution logic. See tests/document-renderer-vendor.test.ts
+// for the integrity check that keeps this import target trustworthy.
+// Typed by the co-located pass1.d.mts (vendor/methodology/document-renderer/) —
+// Studio's own type contract for the vendored JS, not part of what's fetched.
+import { runPass1 } from '../../vendor/methodology/document-renderer/pass1.mjs';
+
+/** Detects `.ttrs` document-template files (transitrix-hq#56 registered the language). */
+export function isTtrsFile(doc: vscode.TextDocument): boolean {
+  return doc.fileName.endsWith('.ttrs');
+}
+
+/**
+ * Rasterises a resolved figure for the preview. Pass 1 leaves this to the
+ * output layer by design (its README: "Turning a view source into a raster
+ * is the output layer's job, reached through the optional rasterise hook so
+ * this module stays free of any renderer dependency") — this is that layer.
+ *
+ * Must be synchronous: pass 1 calls it without awaiting.
+ *
+ * Scope, stated rather than silently gapped: an `.svg` asset (a supplied
+ * figure, `{{ figure … }}`) is inlined verbatim. A derived figure
+ * (`{{ view … }}`) sourced from a `*.blocks.transitrix.yaml` file is
+ * rendered through the same `@transitrix/diagrams` blocks emitter the
+ * Blocks preview uses. Every other view notation is not yet wired into this
+ * preview — it renders as a clearly labelled "not rendered" note naming the
+ * source, never a broken image and never silently dropped.
+ */
+function rasteriseFigure(
+  input: { kind: 'view' | 'figure'; source: string; name: string; number: number; fit: string | null },
+  figureEmbeds: Map<number, FigureEmbed>,
+): string {
+  const embedPath = `#ttrs-fig-${input.number}`;
+  try {
+    if (/\.svg$/i.test(input.source)) {
+      figureEmbeds.set(input.number, { svg: readFileSync(input.source, 'utf8') });
+      return embedPath;
+    }
+    if (input.kind === 'view' && /\.blocks\.transitrix\.ya?ml$/i.test(input.source)) {
+      const raw = readFileSync(input.source, 'utf8');
+      const parsed = coerceDatesToIsoStrings(yaml.load(raw) as unknown);
+      const rawObj = (parsed && typeof parsed === 'object' ? parsed : {}) as Record<string, unknown>;
+      const hasGrid = rawObj['grid'] !== undefined && rawObj['grid'] !== null;
+      const v = validateBlocks(parsed);
+      if (!v.valid) {
+        figureEmbeds.set(input.number, {
+          unavailable: `diagram does not validate — ${v.errors.map((e) => e.code).join(', ')}`,
+        });
+      } else if (hasGrid) {
+        const layout = layoutGrid(parsed as GridFile);
+        figureEmbeds.set(input.number, { svg: renderGridLayoutSvg(layout, { topInset: 0, title: '' }) });
+      } else {
+        const leafSize = readBlocksLeafSize();
+        const layout = layoutNestedBlocks(parsed as BlocksFile, { leafWidth: leafSize.width, leafHeight: leafSize.height });
+        figureEmbeds.set(input.number, { svg: renderBlocksLayoutSvg(layout, { topInset: 0, title: '' }) });
+      }
+      return embedPath;
+    }
+    figureEmbeds.set(input.number, {
+      unavailable: `rendering not available in the editor preview for this notation (${path.basename(input.source)})`,
+    });
+    return embedPath;
+  } catch (e) {
+    figureEmbeds.set(input.number, { unavailable: (e as Error).message ?? 'figure failed to render' });
+    return embedPath;
+  }
+}
+
+/**
+ * Live preview of a `.ttrs` document's pass-1 (deterministic) output
+ * (transitrix-hq#57). Wired against the vendored @transitrix/document-renderer
+ * as a library call — model-object references, derived figures and the four
+ * resolver states are pass 1's own; this class only turns its result into
+ * webview HTML (extension/src/ttrs-render.ts) and supplies the rasterise hook
+ * above.
+ */
+export class TtrsPreview extends StaticPreview {
+  readonly panelTitle = 'Document Preview';
+  protected readonly viewType = 'ttrsPreview';
+  protected readonly enableCommandUris = [OPEN_THEME_COMMAND];
+
+  protected override async pushDocument(doc: vscode.TextDocument): Promise<void> {
+    if (!this.panel) return;
+    const filename = path.basename(doc.fileName);
+    const figureEmbeds = new Map<number, FigureEmbed>();
+    let bodyContent = '';
+    let errorMsg = '';
+
+    try {
+      const result = await runPass1({
+        text: doc.getText(),
+        templatePath: doc.fileName,
+        profile: 'review',
+        rasterise: (input) => rasteriseFigure(input, figureEmbeds),
+      });
+
+      if (result.header === null) {
+        // No `---` front matter at all — pass 1 never got as far as an AST.
+        errorMsg = result.errors.map((e) => `${e.code}: ${e.message}`).join('\n');
+      } else {
+        const rendered = renderTtrsResult(result, figureEmbeds);
+        bodyContent = rendered.bodyContent;
+        errorMsg = rendered.errorMsg;
+      }
+    } catch (e) {
+      errorMsg = (e as Error).message ?? 'Pass 1 failed';
+    }
+
+    const themeId = vscode.workspace.getConfiguration('transitrix').get<ThemeId>('theme', 'transitrix');
+    this.panel.webview.html = buildDiagramFrame({
+      filename,
+      notation: 'Document (.ttrs)',
+      bodyContent,
+      errorMsg,
+      themeId,
+      extraStyles: TTRS_STYLES,
+      themeCommand: OPEN_THEME_COMMAND,
+    });
+  }
+}

--- a/extension/src/ttrs-render.ts
+++ b/extension/src/ttrs-render.ts
@@ -1,0 +1,323 @@
+// Pure rendering: `.ttrs` pass-1 resolver output → preview HTML.
+//
+// No vscode import here — this module takes plain data (the object
+// `runPass1()` from the vendored @transitrix/document-renderer returns, plus
+// whatever figures the host already rasterised) and returns HTML strings.
+// ttrs-preview.ts owns the vscode-facing half (finding the document, calling
+// the vendored resolver, wiring the webview panel).
+//
+// The resolved Markdown from pass 1 is rendered as-is — this module never
+// re-decides what a reference resolved to. It only:
+//   - converts the Markdown pass 1 already produced to HTML (headings,
+//     paragraphs, bold — the format's document text has no italic content
+//     and this repo's rendered output never adds any, per the "no italic
+//     text in any rendered output" design rule),
+//   - style-marks the state markers and flags pass 1 already embedded in
+//     that Markdown («unresolved: ID», a trailing ⚑U/⚑A/⚑V, an instruction
+//     slot's raw byte-for-byte block),
+//   - and adds summary panels built from pass 1's own findings/errors/
+//     instructionSlots/suspicion fields, for the acceptance criteria that
+//     need distinct visibility rather than inline placement (the "each"/
+//     "trace" TTRS-004 case: pass 1 drops the construct from its Markdown
+//     entirely — no marker, no position — so it can only be surfaced as a
+//     summary entry, not inline).
+
+export interface Pass1Finding {
+  code: string;
+  state: string;
+  flag: string | null;
+  id: string | null;
+  file: string;
+}
+
+export interface Pass1Error {
+  code: string;
+  message: string;
+}
+
+export interface Pass1InstructionSlot {
+  slotId: string;
+  question: string;
+  inputs: string[];
+  sufficient: string;
+}
+
+export interface Pass1Figure {
+  number: number;
+  name: string;
+  kind: 'view' | 'figure';
+  source: string;
+  derived: boolean;
+  fit: string | null;
+  caption: string | null;
+  embedPath: string;
+}
+
+export interface Pass1Suspicion {
+  computed: boolean;
+  state: string;
+  reason: string;
+}
+
+/** The subset of runPass1()'s return value this module reads. */
+export interface Pass1Result {
+  ok: boolean;
+  markdown: string;
+  instructionSlots: Pass1InstructionSlot[];
+  figures: Pass1Figure[];
+  errors: Pass1Error[];
+  findings: Pass1Finding[];
+  states: Record<string, number>;
+  suspicion: Pass1Suspicion;
+  profile: 'strict' | 'review';
+}
+
+/** What the host resolved a figure to, keyed by its pass-1 figure `number`. */
+export interface FigureEmbed {
+  /** Inline SVG markup (no wrapping <img> — CSP on this frame has no img-src). */
+  svg?: string;
+  /** Set instead of `svg` when this figure's notation isn't rendered in the preview yet. */
+  unavailable?: string;
+}
+
+const STATE_LABEL: Record<string, string> = {
+  unresolved: 'unresolved',
+  'not-admitted': 'not admitted',
+  'out-of-validity': 'out of validity',
+};
+
+const STATE_CLASS: Record<string, string> = {
+  unresolved: 'ttrs-state-error',
+  'not-admitted': 'ttrs-state-error',
+  'out-of-validity': 'ttrs-state-warning',
+};
+
+const FLAG_CLASS: Record<string, string> = {
+  '⚑U': 'ttrs-state-error',
+  '⚑A': 'ttrs-state-error',
+  '⚑V': 'ttrs-state-warning',
+};
+
+function escHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+// Placeholder tokens carry only characters escHtml leaves untouched, so they
+// survive the escape pass on surrounding paragraph text intact.
+let placeholderSeq = 0;
+function nextPlaceholder(kind: string): string {
+  placeholderSeq += 1;
+  return `TTRS_${kind}_${placeholderSeq}`;
+}
+
+interface Extraction {
+  text: string;
+  replacements: Map<string, string>;
+}
+
+/** Pulls instruction-slot raw blocks and figure images out of the Markdown,
+ *  replacing each with a placeholder token, so the remaining text can go
+ *  through ordinary paragraph/heading/escaping without either construct
+ *  being mangled by it. */
+function extractBlocks(
+  markdown: string,
+  instructionSlots: Pass1InstructionSlot[],
+  figureEmbeds: Map<number, FigureEmbed>,
+): Extraction {
+  const replacements = new Map<string, string>();
+  const slotById = new Map(instructionSlots.map((s) => [s.slotId, s]));
+
+  let text = markdown.replace(
+    /\{\{#\s*instruct\s+([a-z0-9-]+)\s*\}\}[\s\S]*?\{\{\/\s*instruct\s*\}\}/g,
+    (_match, slotId: string) => {
+      const token = nextPlaceholder('INSTRUCT');
+      replacements.set(token, renderInstructionSlot(slotById.get(slotId), slotId));
+      return token;
+    },
+  );
+
+  text = text.replace(/!\[([^\]]*)\]\(([^)]*)\)/g, (_match, caption: string, src: string) => {
+    const token = nextPlaceholder('FIGURE');
+    const numberMatch = /^#ttrs-fig-(\d+)$/.exec(src);
+    const embed = numberMatch ? figureEmbeds.get(Number(numberMatch[1])) : undefined;
+    replacements.set(token, renderFigureEmbed(caption, embed));
+    return token;
+  });
+
+  return { text, replacements };
+}
+
+function renderInstructionSlot(slot: Pass1InstructionSlot | undefined, slotId: string): string {
+  if (!slot) {
+    return `<div class="ttrs-instruct">\n  <div class="ttrs-instruct-label">⧗ instruction slot "${escHtml(slotId)}" — pending, pass 2 not run in this preview</div>\n</div>`;
+  }
+  const inputs = slot.inputs.length > 0
+    ? `<div class="ttrs-instruct-row"><span class="ttrs-instruct-key">inputs</span> ${escHtml(slot.inputs.join(', '))}</div>`
+    : '';
+  return `<div class="ttrs-instruct">
+  <div class="ttrs-instruct-label">⧗ instruction slot "${escHtml(slot.slotId)}" — pending, pass 2 not run in this preview</div>
+  <div class="ttrs-instruct-row"><span class="ttrs-instruct-key">question</span> ${escHtml(slot.question)}</div>
+  ${inputs}
+  <div class="ttrs-instruct-row"><span class="ttrs-instruct-key">sufficient</span> ${escHtml(slot.sufficient)}</div>
+</div>`;
+}
+
+function renderFigureEmbed(caption: string, embed: FigureEmbed | undefined): string {
+  const captionHtml = caption ? `<div class="ttrs-figure-caption">${escHtml(caption)}</div>` : '';
+  if (embed?.svg) {
+    return `<div class="ttrs-figure">${embed.svg}${captionHtml}</div>`;
+  }
+  const reason = embed?.unavailable ?? 'figure source could not be resolved';
+  return `<div class="ttrs-figure ttrs-figure-unavailable">
+  <div class="ttrs-figure-note">⧗ not rendered in this preview — ${escHtml(reason)}</div>
+  ${captionHtml}
+</div>`;
+}
+
+function renderInlineMarkers(escaped: string): string {
+  let out = escaped.replace(
+    /«(unresolved|not admitted|out of validity): ([^»]*)»/g,
+    (_m, state: string, id: string) => {
+      const key = state.replace(/ /g, '-');
+      const cls = STATE_CLASS[key] ?? 'ttrs-state-error';
+      return `<span class="ttrs-ref-state ${cls}" title="${escHtml(STATE_LABEL[key] ?? state)}">⚑ ${escHtml(state)}: ${escHtml(id)}</span>`;
+    },
+  );
+  out = out.replace(/⚑[UAV]/g, (flag) => {
+    const cls = FLAG_CLASS[flag] ?? 'ttrs-state-error';
+    return `<span class="ttrs-flag ${cls}">${flag}</span>`;
+  });
+  return out;
+}
+
+function renderInlineBold(escaped: string): string {
+  return escaped.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+}
+
+function renderParagraphContent(text: string): string {
+  return renderInlineMarkers(renderInlineBold(escHtml(text)));
+}
+
+/** Converts pass 1's resolved Markdown to HTML. Headings, paragraphs and bold
+ *  only — this format's own body has no other inline styling, and this repo
+ *  renders no italics anywhere. */
+function markdownToHtml(text: string, replacements: Map<string, string>): string {
+  const blocks = text.split(/\n{2,}/).map((b) => b.trim()).filter((b) => b !== '');
+  const html = blocks.map((block) => {
+    const heading = /^(#{1,6})\s+(.*)$/s.exec(block);
+    if (heading) {
+      const level = heading[1].length;
+      return `<h${level}>${renderParagraphContent(heading[2].replace(/\n/g, ' '))}</h${level}>`;
+    }
+    // A block that is entirely one placeholder token (instruction slot or
+    // figure) is already its own HTML — don't wrap it in <p>.
+    if (/^TTRS_(INSTRUCT|FIGURE)_\d+$/.test(block)) {
+      return block;
+    }
+    return `<p>${renderParagraphContent(block.replace(/\n/g, ' '))}</p>`;
+  }).join('\n');
+
+  let out = html;
+  for (const [token, replacement] of replacements) {
+    out = out.split(token).join(replacement);
+  }
+  return out;
+}
+
+function renderNoRepositoryBanner(findings: Pass1Finding[]): string {
+  if (!findings.some((f) => f.state === 'no-repository')) return '';
+  return `<div class="ttrs-banner ttrs-banner-info">
+  ℹ No repository configured — every model-object reference below is shown unresolved because there is nothing to resolve against.
+</div>`;
+}
+
+function renderSuspicionBanner(suspicion: Pass1Suspicion): string {
+  return `<div class="ttrs-banner ttrs-banner-info">
+  ℹ Link suspicion (⚑S): <strong>not computed</strong> — ${escHtml(suspicion.reason)}
+</div>`;
+}
+
+function renderDeferredPanel(errors: Pass1Error[]): string {
+  const deferred = errors.filter((e) => e.code === 'TTRS-004');
+  if (deferred.length === 0) return '';
+  const items = deferred.map((e) => `<li>${escHtml(e.message)}</li>`).join('');
+  return `<div class="ttrs-panel ttrs-panel-deferred">
+  <div class="ttrs-panel-title">⧗ Recognised, not implemented in this pass</div>
+  <ul>${items}</ul>
+</div>`;
+}
+
+function renderReferenceIssuesPanel(findings: Pass1Finding[]): string {
+  const byState = findings.filter((f) => f.state !== 'no-repository');
+  if (byState.length === 0) return '';
+  const items = byState.map((f) => {
+    const cls = STATE_CLASS[f.state] ?? 'ttrs-state-error';
+    return `<li><span class="ttrs-ref-state ${cls}">${escHtml(STATE_LABEL[f.state] ?? f.state)}</span> <code>${escHtml(f.id ?? '')}</code> (${escHtml(f.code)})</li>`;
+  }).join('');
+  return `<div class="ttrs-panel ttrs-panel-issues">
+  <div class="ttrs-panel-title">Reference issues</div>
+  <ul>${items}</ul>
+</div>`;
+}
+
+export interface TtrsRenderOutput {
+  bodyContent: string;
+  errorMsg: string;
+  warnings: string[];
+}
+
+/** Builds the webview body for a pass-1 result. Pure — no vscode. */
+export function renderTtrsResult(
+  result: Pass1Result,
+  figureEmbeds: Map<number, FigureEmbed>,
+): TtrsRenderOutput {
+  const { text, replacements } = extractBlocks(result.markdown, result.instructionSlots, figureEmbeds);
+  const contentHtml = markdownToHtml(text, replacements);
+
+  const panels = [
+    renderNoRepositoryBanner(result.findings),
+    renderDeferredPanel(result.errors),
+    renderReferenceIssuesPanel(result.findings),
+    renderSuspicionBanner(result.suspicion),
+  ].filter(Boolean).join('\n');
+
+  const bodyContent = `<div class="ttrs-doc">${contentHtml}</div>\n${panels}`;
+
+  // Hard problems only — never the deferred-construct marker (its own panel
+  // above) and never the no-repository state (its own banner above).
+  const hardErrors = result.errors.filter((e) => e.code !== 'TTRS-004' && e.code !== 'TTRS-011');
+  const errorMsg = hardErrors.map((e) => `${e.code}: ${e.message}`).join('\n');
+
+  return { bodyContent, errorMsg, warnings: [] };
+}
+
+export const TTRS_STYLES = `
+.ttrs-doc { font-size: 13px; line-height: 1.6; color: var(--ts-text, #0f172a); font-family: var(--vscode-font-family, system-ui, sans-serif); }
+.ttrs-doc h1, .ttrs-doc h2, .ttrs-doc h3, .ttrs-doc h4, .ttrs-doc h5, .ttrs-doc h6 { color: var(--ts-header-text, #0f172a); margin: 20px 0 8px; }
+.ttrs-doc p { margin: 0 0 12px; }
+.ttrs-ref-state { display: inline-block; padding: 1px 6px; border-radius: 4px; font-size: 11px; font-weight: 600; white-space: nowrap; }
+.ttrs-flag { display: inline-block; padding: 0 3px; border-radius: 3px; font-weight: 700; }
+.ttrs-state-error { background: var(--ts-status-error-bg, #fee2e2); color: var(--ts-status-error-fg, #991b1b); }
+.ttrs-state-warning { background: var(--ts-status-warning-bg, #fef9c3); color: var(--ts-status-warning-fg, #854d0e); }
+.ttrs-instruct { margin: 12px 0; padding: 10px 12px; border-left: 3px solid var(--ts-status-info-fg, #0c4a6e); background: var(--ts-status-info-bg, #e0f2fe); border-radius: 4px; }
+.ttrs-instruct-label { font-weight: 600; color: var(--ts-status-info-fg, #0c4a6e); margin-bottom: 4px; }
+.ttrs-instruct-row { font-size: 12px; margin-top: 2px; }
+.ttrs-instruct-key { font-weight: 600; text-transform: uppercase; font-size: 10px; letter-spacing: 0.04em; color: var(--ts-text-muted, #64748b); margin-right: 6px; }
+.ttrs-figure { margin: 12px 0; }
+.ttrs-figure svg { max-width: 100%; height: auto; }
+.ttrs-figure-caption { font-size: 12px; color: var(--ts-text-muted, #64748b); margin-top: 4px; }
+.ttrs-figure-unavailable { padding: 10px 12px; border: 1px dashed var(--ts-border, #cbd5e1); border-radius: 4px; }
+.ttrs-figure-note { font-size: 12px; color: var(--ts-text-muted, #64748b); }
+.ttrs-banner { margin: 0 0 12px; padding: 8px 12px; border-radius: 4px; font-size: 12px; }
+.ttrs-banner-info { background: var(--ts-status-info-bg, #e0f2fe); color: var(--ts-status-info-fg, #0c4a6e); }
+.ttrs-panel { margin: 16px 0; padding: 10px 12px; border-radius: 6px; border: 1px solid var(--ts-border, #cbd5e1); }
+.ttrs-panel-title { font-weight: 600; font-size: 12px; margin-bottom: 6px; }
+.ttrs-panel ul { margin: 0; padding-left: 20px; }
+.ttrs-panel li { font-size: 12px; margin-bottom: 4px; }
+.ttrs-panel-deferred { background: var(--ts-bg-elevated, #f1f5f9); }
+`;

--- a/scripts/vendor-methodology-document-renderer.mjs
+++ b/scripts/vendor-methodology-document-renderer.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+/**
+ * Re-vendor @transitrix/document-renderer's pass-1 resolver into vendor/methodology/.
+ *
+ * Same contract as vendor-methodology-vocabulary.mjs: vendor a tagged release,
+ * never a local sibling checkout and never a branch, so what lands here is what
+ * shipped. The package's own README states this is the intended integration
+ * path — "Pass 1 ships as a unit callable on its own, so pass 2 and Studio's
+ * preview can both depend on it as a library."
+ *
+ * Five files make up the callable unit: pass1.mjs is the entry point;
+ * parse-template.mjs, repository.mjs, ids.mjs and syntax.mjs are what it
+ * imports. Vendored verbatim, with their relative imports intact, so
+ * pass1.mjs resolves the same way here as it does in methodology's own tree.
+ *
+ * Usage:
+ *   node scripts/vendor-methodology-document-renderer.mjs --ref v3.4.0
+ *   node scripts/vendor-methodology-document-renderer.mjs --ref v3.4.0 --check
+ *
+ * --check fetches and reports what would change without writing anything.
+ *
+ * Requires the GitHub CLI (`gh`) to be installed and authenticated.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const VENDOR_DIR = path.resolve(HERE, '..', 'vendor', 'methodology', 'document-renderer');
+
+const SOURCE_REPO = 'transitrix/methodology';
+const SOURCE_DIR = 'packages/document-renderer/src';
+const FILES = ['pass1.mjs', 'parse-template.mjs', 'repository.mjs', 'ids.mjs', 'syntax.mjs'];
+
+function parseArgs(argv) {
+  const out = { ref: null, check: false };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--ref') out.ref = argv[++i];
+    else if (argv[i] === '--check') out.check = true;
+    else die(`unknown argument: ${argv[i]}`);
+  }
+  if (!out.ref) die('--ref <tag> is required (a release tag, e.g. v3.4.0 — not a branch)');
+  if (!/^v\d+\.\d+\.\d+$/.test(out.ref)) die(`--ref must be a release tag like v3.4.0, got: ${out.ref}`);
+  return out;
+}
+
+function die(message) {
+  console.error(`vendor-methodology-document-renderer: ${message}`);
+  process.exit(1);
+}
+
+/** SHA-256 over LF-normalised bytes — matches tests/document-renderer-vendor.test.ts. */
+function hashArtefact(text) {
+  return createHash('sha256').update(text.replace(/\r\n/g, '\n'), 'utf8').digest('hex');
+}
+
+function fetchFile(ref, name) {
+  let raw;
+  try {
+    raw = execFileSync(
+      'gh',
+      ['api', '-H', 'Accept: application/vnd.github.raw', `repos/${SOURCE_REPO}/contents/${SOURCE_DIR}/${name}?ref=${ref}`],
+      { encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 },
+    );
+  } catch (err) {
+    die(`could not fetch ${SOURCE_DIR}/${name} at ${ref}: ${err.stderr?.toString().trim() || err.message}`);
+  }
+  return raw.replace(/\r\n/g, '\n');
+}
+
+function readCurrentPin() {
+  try {
+    return JSON.parse(readFileSync(path.join(VENDOR_DIR, 'VENDORED.json'), 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+const { ref, check } = parseArgs(process.argv.slice(2));
+const current = readCurrentPin();
+
+const fetched = {};
+for (const name of FILES) {
+  const text = fetchFile(ref, name);
+  fetched[name] = { text, sha256: hashArtefact(text) };
+}
+
+const unchanged = current
+  && current.source_ref === ref
+  && FILES.every((name) => current.files?.[name] === fetched[name].sha256);
+
+if (unchanged) {
+  console.log(`already vendored: ${SOURCE_REPO}@${ref}`);
+  process.exit(0);
+}
+
+console.log(`  from  ${current ? current.source_ref : '(nothing vendored)'}`);
+console.log(`  to    ${ref}`);
+for (const name of FILES) {
+  const before = current?.files?.[name];
+  const after = fetched[name].sha256;
+  console.log(`    ${name}: ${before === after ? 'unchanged' : `${before ?? '(new)'} -> ${after}`}`);
+}
+
+if (check) {
+  console.log('--check: nothing written.');
+  process.exit(0);
+}
+
+const pin = {
+  source_repo: SOURCE_REPO,
+  source_ref: ref,
+  source_path: SOURCE_DIR,
+  files: Object.fromEntries(FILES.map((name) => [name, fetched[name].sha256])),
+  vendored_on: new Date().toISOString().slice(0, 10),
+};
+
+mkdirSync(VENDOR_DIR, { recursive: true });
+for (const name of FILES) {
+  writeFileSync(path.join(VENDOR_DIR, name), fetched[name].text, 'utf8');
+}
+writeFileSync(path.join(VENDOR_DIR, 'VENDORED.json'), `${JSON.stringify(pin, null, 2)}\n`, 'utf8');
+console.log('written. Run `npx vitest run tests/document-renderer-vendor.test.ts` before committing.');

--- a/tests/document-renderer-vendor.test.ts
+++ b/tests/document-renderer-vendor.test.ts
@@ -1,0 +1,111 @@
+// Integrity check for vendor/methodology/document-renderer/ — the five source
+// files of @transitrix/document-renderer's pass-1 resolver, vendored so the
+// .ttrs preview (extension/src/ttrs-preview.ts) can call `runPass1` as a real
+// library import rather than reimplementing its resolution logic.
+//
+// Unlike vocabulary-drift.test.ts, this is not a divergence check against a
+// local reimplementation — there is no local copy of the resolution logic to
+// diverge. It is an integrity check: the vendored files must be exactly what
+// VENDORED.json says they are, and the vendored pass1.mjs must actually run.
+// It fails closed — a missing file, an unpinned file, or a hash mismatch is a
+// build failure, never a pass.
+
+import { describe, expect, it } from 'vitest';
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import path from 'node:path';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const VENDOR_DIR = path.join(repoRoot, 'vendor', 'methodology', 'document-renderer');
+
+function hashArtefact(text: string): string {
+  return createHash('sha256').update(text.replace(/\r\n/g, '\n'), 'utf8').digest('hex');
+}
+
+interface VendoredPin {
+  source_repo: string;
+  source_ref: string;
+  source_path: string;
+  files: Record<string, string>;
+  vendored_on: string;
+}
+
+function loadPin(): VendoredPin {
+  const text = readFileSync(path.join(VENDOR_DIR, 'VENDORED.json'), 'utf8');
+  const pin = JSON.parse(text) as VendoredPin;
+  if (!pin.source_ref || typeof pin.source_ref !== 'string') {
+    throw new Error('VENDORED.json carries no source_ref');
+  }
+  if (!pin.files || typeof pin.files !== 'object') {
+    throw new Error('VENDORED.json carries no files map');
+  }
+  return pin;
+}
+
+const EXPECTED_FILES = ['pass1.mjs', 'parse-template.mjs', 'repository.mjs', 'ids.mjs', 'syntax.mjs'];
+
+describe('vendor/methodology/document-renderer — integrity', () => {
+  it('VENDORED.json pins exactly the five files the resolver needs', () => {
+    const pin = loadPin();
+    expect(Object.keys(pin.files).sort()).toEqual([...EXPECTED_FILES].sort());
+  });
+
+  it.each(EXPECTED_FILES)('%s matches its pinned hash', (name) => {
+    const pin = loadPin();
+    const text = readFileSync(path.join(VENDOR_DIR, name), 'utf8');
+    expect(hashArtefact(text)).toBe(pin.files[name]);
+  });
+
+  it('is checked out with LF line endings, per .gitattributes', () => {
+    for (const name of EXPECTED_FILES) {
+      const raw = readFileSync(path.join(VENDOR_DIR, name), 'utf8');
+      expect(raw.includes('\r\n'), `${name} contains CRLF`).toBe(false);
+    }
+  });
+});
+
+describe('vendor/methodology/document-renderer — the resolver actually runs', () => {
+  it('runPass1 resolves a repository-optional template with no model references', async () => {
+    const mod = await import(pathToFileURL(path.join(VENDOR_DIR, 'pass1.mjs')).href) as {
+      runPass1: (opts: { text: string; profile?: 'strict' | 'review' }) => Promise<{
+        ok: boolean;
+        markdown: string;
+        suspicion: { computed: boolean };
+      }>;
+    };
+    const text = [
+      '---',
+      'document: Smoke Test',
+      'kind: mrd',
+      'template_id: smoke.mrd',
+      'template_version: "1.0"',
+      '---',
+      '# Fixed text only, no model references',
+    ].join('\n');
+    const result = await mod.runPass1({ text, profile: 'strict' });
+    expect(result.ok).toBe(true);
+    expect(result.markdown).toContain('# Fixed text only, no model references');
+    expect(result.suspicion.computed).toBe(false);
+  });
+
+  it('runPass1 reports TTRS-004 for a deferred `each` construct, distinct from TTRS-002', async () => {
+    const mod = await import(pathToFileURL(path.join(VENDOR_DIR, 'pass1.mjs')).href) as {
+      runPass1: (opts: { text: string; profile?: 'strict' | 'review' }) => Promise<{
+        errors: { code: string }[];
+      }>;
+    };
+    const text = [
+      '---',
+      'document: Smoke Test',
+      'kind: mrd',
+      'template_id: smoke.mrd',
+      'template_version: "1.0"',
+      '---',
+      '{{# each REQ }}{{ .title }}{{/ each }}',
+    ].join('\n');
+    const result = await mod.runPass1({ text, profile: 'review' });
+    expect(result.errors.some((e) => e.code === 'TTRS-004')).toBe(true);
+    expect(result.errors.some((e) => e.code === 'TTRS-002')).toBe(false);
+  });
+});

--- a/tests/ttrs-render.test.ts
+++ b/tests/ttrs-render.test.ts
@@ -1,0 +1,161 @@
+// Pure-rendering tests for extension/src/ttrs-render.ts — no vscode import in
+// that module, so no stub is needed here. Exercises the acceptance criteria
+// from transitrix-hq#57: the four resolver states surface distinctly, a
+// deferred `each`/`trace` construct reads as "recognised, not implemented"
+// rather than a generic error, suspicion is reported as not-computed rather
+// than omitted, an instruction slot is visibly pending, and the
+// no-repository case is bannered rather than folded into per-reference noise.
+
+import { describe, expect, it } from 'vitest';
+import { renderTtrsResult, type Pass1Result, type FigureEmbed } from '../extension/src/ttrs-render.js';
+
+function baseResult(overrides: Partial<Pass1Result> = {}): Pass1Result {
+  return {
+    ok: true,
+    markdown: '',
+    instructionSlots: [],
+    figures: [],
+    errors: [],
+    findings: [],
+    states: {},
+    suspicion: {
+      computed: false,
+      state: 'not-computed',
+      reason: 'link suspicion (⚑S) is not computed in pass 1',
+    },
+    profile: 'review',
+    ...overrides,
+  };
+}
+
+describe('renderTtrsResult — reference states', () => {
+  it('renders an unresolved reference marker with a distinct, named style', () => {
+    const result = baseResult({
+      markdown: '# Title\n\nSee «unresolved: REQ-99».',
+      findings: [{ code: 'TTRS-010', state: 'unresolved', flag: '⚑U', id: 'REQ-99', file: 'x.mrd.ttrs' }],
+    });
+    const { bodyContent } = renderTtrsResult(result, new Map());
+    expect(bodyContent).toContain('ttrs-state-error');
+    expect(bodyContent).toContain('REQ-99');
+    expect(bodyContent).toContain('unresolved');
+  });
+
+  it('renders an out-of-validity flag distinctly from unresolved/not-admitted', () => {
+    const result = baseResult({ markdown: 'Some value ⚑V here.' });
+    const { bodyContent } = renderTtrsResult(result, new Map());
+    expect(bodyContent).toContain('ttrs-state-warning');
+  });
+
+  it('lists every finding state in the reference-issues panel, not folded into one bucket', () => {
+    const result = baseResult({
+      markdown: '# Doc',
+      findings: [
+        { code: 'TTRS-010', state: 'unresolved', flag: '⚑U', id: 'A-1', file: 'x' },
+        { code: 'TTRS-014', state: 'not-admitted', flag: '⚑A', id: 'B-1', file: 'x' },
+        { code: 'TTRS-015', state: 'out-of-validity', flag: '⚑V', id: 'C-1', file: 'x' },
+      ],
+    });
+    const { bodyContent } = renderTtrsResult(result, new Map());
+    expect(bodyContent).toContain('unresolved');
+    expect(bodyContent).toContain('not admitted');
+    expect(bodyContent).toContain('out of validity');
+  });
+});
+
+describe('renderTtrsResult — no-repository case', () => {
+  it('shows a distinct banner rather than folding into per-reference findings', () => {
+    const result = baseResult({
+      markdown: 'See «unresolved: REQ-1».',
+      findings: [{ code: 'TTRS-011', state: 'no-repository', flag: null, id: null, file: 'x' }],
+      errors: [{ code: 'TTRS-011', message: 'x.mrd.ttrs: template references a model object but no repository is configured' }],
+    });
+    const { bodyContent, errorMsg } = renderTtrsResult(result, new Map());
+    expect(bodyContent).toContain('No repository configured');
+    // TTRS-011 is bannered, not repeated in the hard-error box.
+    expect(errorMsg).toBe('');
+  });
+});
+
+describe('renderTtrsResult — deferred constructs (each/trace)', () => {
+  it('surfaces TTRS-004 as "recognised, not implemented", distinct from a hard error', () => {
+    const result = baseResult({
+      markdown: '# Doc',
+      errors: [
+        { code: 'TTRS-004', message: '"{{ each REQ }}": the `each` block is a construct of the directive language that pass 1 does not implement — recognised, not implemented in this pass' },
+      ],
+    });
+    const { bodyContent, errorMsg } = renderTtrsResult(result, new Map());
+    expect(bodyContent).toContain('Recognised, not implemented in this pass');
+    expect(bodyContent).toContain('each');
+    // Never reported as a broken-syntax hard error.
+    expect(errorMsg).toBe('');
+  });
+
+  it('still reports a genuine syntax error (TTRS-002) as a hard error', () => {
+    const result = baseResult({
+      markdown: '# Doc',
+      ok: false,
+      errors: [{ code: 'TTRS-002', message: 'unrecognised directive "{{ nonsense }}"' }],
+    });
+    const { errorMsg } = renderTtrsResult(result, new Map());
+    expect(errorMsg).toContain('TTRS-002');
+  });
+});
+
+describe('renderTtrsResult — suspicion', () => {
+  it('always reports suspicion as not-computed, never omitted', () => {
+    const result = baseResult({ markdown: '# Doc' });
+    const { bodyContent } = renderTtrsResult(result, new Map());
+    expect(bodyContent).toContain('not computed');
+    expect(bodyContent).toContain('⚑S');
+  });
+});
+
+describe('renderTtrsResult — instruction slots', () => {
+  it('marks an instruction slot as pending, distinct from resolved content', () => {
+    const result = baseResult({
+      markdown: '# Doc\n\n{{# instruct market-size }}\nquestion: How big?\nsufficient: A number.\n{{/ instruct }}',
+      instructionSlots: [
+        { slotId: 'market-size', question: 'How big?', inputs: [], sufficient: 'A number.' },
+      ],
+    });
+    const { bodyContent } = renderTtrsResult(result, new Map());
+    expect(bodyContent).toContain('ttrs-instruct');
+    expect(bodyContent).toContain('pending');
+    expect(bodyContent).toContain('How big?');
+    // The raw directive syntax must not leak through unstyled.
+    expect(bodyContent).not.toContain('{{#');
+  });
+});
+
+describe('renderTtrsResult — figures', () => {
+  it('inlines rendered SVG when the host resolved one', () => {
+    const embeds = new Map<number, FigureEmbed>([[1, { svg: '<svg><rect/></svg>' }]]);
+    const result = baseResult({ markdown: '![context](#ttrs-fig-1)' });
+    const { bodyContent } = renderTtrsResult(result, embeds);
+    expect(bodyContent).toContain('<svg><rect/></svg>');
+  });
+
+  it('shows a labelled placeholder, never a broken image, when unavailable', () => {
+    const embeds = new Map<number, FigureEmbed>([[1, { unavailable: 'rendering not available for this notation' }]]);
+    const result = baseResult({ markdown: '![context](#ttrs-fig-1)' });
+    const { bodyContent } = renderTtrsResult(result, embeds);
+    expect(bodyContent).toContain('not rendered in this preview');
+    expect(bodyContent).not.toContain('<img');
+  });
+});
+
+describe('renderTtrsResult — headings and bold survive escaping', () => {
+  it('renders a heading and bold text as HTML, not literal Markdown', () => {
+    const result = baseResult({ markdown: '# Market Requirements\n\n**REQ-14** — the text.' });
+    const { bodyContent } = renderTtrsResult(result, new Map());
+    expect(bodyContent).toContain('<h1>Market Requirements</h1>');
+    expect(bodyContent).toContain('<strong>REQ-14</strong>');
+  });
+
+  it('escapes HTML-significant characters in document text', () => {
+    const result = baseResult({ markdown: 'Value < 5 & > 3 "quoted"' });
+    const { bodyContent } = renderTtrsResult(result, new Map());
+    expect(bodyContent).toContain('&lt; 5 &amp; &gt; 3');
+  });
+});

--- a/vendor/methodology/README.md
+++ b/vendor/methodology/README.md
@@ -36,3 +36,27 @@ The script fetches the artefact from the named tag via the GitHub API, writes bo
 files, and prints the new hash. Refreshing usually surfaces new drift — that is the
 point; resolve or re-date the affected `tests/vocabulary-drift/allowlist.ts` entries
 in the same change.
+
+## `document-renderer/`
+
+The five source files of `@transitrix/document-renderer`'s pass-1 resolver
+(`pass1.mjs` and the four modules it imports: `parse-template.mjs`,
+`repository.mjs`, `ids.mjs`, `syntax.mjs`). The package's own README states this
+is the intended integration path: "Pass 1 ships as a unit callable on its own,
+so pass 2 and Studio's preview can both depend on it as a library rather than
+on the whole renderer." Studio's `.ttrs` preview (`extension/src/ttrs-preview.ts`)
+imports `runPass1` from the vendored copy — a real library call against the
+methodology-authored resolver, not a reimplementation of its resolution logic.
+
+`VENDORED.json` records the source tag and a per-file SHA-256 (LF-normalised).
+`tests/document-renderer-vendor.test.ts` fails closed: a missing file, an
+unpinned file, or a hash mismatch is a build failure, never a pass.
+
+### Refreshing
+
+```
+node scripts/vendor-methodology-document-renderer.mjs --ref v3.4.0
+```
+
+Same fetch-from-tag contract as `vocabulary.yaml` above — never a sibling
+checkout, never a branch.

--- a/vendor/methodology/document-renderer/VENDORED.json
+++ b/vendor/methodology/document-renderer/VENDORED.json
@@ -1,0 +1,13 @@
+{
+  "source_repo": "transitrix/methodology",
+  "source_ref": "v3.3.0",
+  "source_path": "packages/document-renderer/src",
+  "files": {
+    "pass1.mjs": "10de90ea275d74680bbb8586136bbdb59485090cc263edc0d3dfa903a444abc7",
+    "parse-template.mjs": "0109b7ac5edc733e01bb3ec1cd1b8fff10127b06a3d3dc5e33d85a4674065ca0",
+    "repository.mjs": "4b90bfe47507205495ea297d7a666c718058ece3d5569a1403059b7f59260493",
+    "ids.mjs": "f007b6b1d266b661dcb2a47c91e61c61466af06add68e09f3d8576d05059b084",
+    "syntax.mjs": "b6d1f5bf74d705c262454202289e64475cbaad3e4924e2c89a64660c6de2fd97"
+  },
+  "vendored_on": "2026-08-08"
+}

--- a/vendor/methodology/document-renderer/ids.mjs
+++ b/vendor/methodology/document-renderer/ids.mjs
@@ -1,0 +1,29 @@
+// Canonical ID grammar (notations/IDS_AND_REFERENCES.md §1-2): `<TYPE>-[<middle>-]<INTEGER>`,
+// plus the CAPABILITY V/H diagram-address exception.
+//
+// One notation, one parser: this package owns the ID grammar for the document
+// notation, and @transitrix/document-view-engine imports it from here rather than
+// keeping a second copy. The copy it used to hold was byte-identical to this file's
+// core, which is the drift-in-waiting that consolidation removes.
+
+const GENERAL_ID = /^[A-Z][A-Z0-9_]*(-[A-Za-z0-9]+)*-[1-9][0-9]*$/;
+const CAPABILITY_ID = /^CAPABILITY-[VH][1-9][0-9]*(\.[1-9][0-9]*){0,2}$/;
+
+export function isValidId(id) {
+  if (typeof id !== 'string' || id === '') return false;
+  return GENERAL_ID.test(id) || CAPABILITY_ID.test(id);
+}
+
+// A CAPABILITY id embeds its own dots (the V/H diagram address, IDS_AND_REFERENCES.md
+// §2) — split it off first so those dots aren't mistaken for a field path separator.
+export const CAPABILITY_PREFIX = /^(CAPABILITY-[VH][1-9][0-9]*(?:\.[1-9][0-9]*){0,2})(?:\.(.*))?$/;
+
+// TYPE registry is open-ended (notations keep adding types) — an entity type is
+// validated as an uppercase TYPE-shaped token, not against a closed list. Used by
+// the `each` block's selection clause, which only document-view-engine implements
+// today; the check itself is generic to the ID grammar, so it lives here.
+const TYPE_NAME = /^[A-Z][A-Z0-9_]*$/;
+
+export function isValidTypeName(name) {
+  return typeof name === 'string' && TYPE_NAME.test(name);
+}

--- a/vendor/methodology/document-renderer/parse-template.mjs
+++ b/vendor/methodology/document-renderer/parse-template.mjs
@@ -1,0 +1,391 @@
+// `.ttrs` document-template parser — syntax only.
+//
+// A `.ttrs` file is prose with directives, not a mapping. It carries a YAML
+// front-matter header and a body made of four slot kinds:
+//
+//   fixed text              anything outside `{{ … }}` — copied verbatim
+//   model-object reference  `{{ REQ-14 }}` / `{{ REQ-14.text }}`
+//   figure                  `{{ view … }}` (derived) / `{{ figure … }}` (supplied)
+//                           / `{{ figref … }}` (cross-reference)
+//   instruction slot        `{{# instruct <slot-id> }} … {{/ instruct }}`
+//
+// Scope of this module: syntax. It turns a template's text into a header object
+// and a body AST. It resolves nothing against a repository and renders nothing —
+// that is pass1.mjs, built on top of this AST.
+//
+// The directive language is ONE language with more constructs than this pass
+// implements (DIRECTIVE_LANGUAGE.md, notations/views/documents/). Two failures
+// that look alike from a distance are kept apart on purpose:
+//
+//   TTRS-002  unknown or malformed syntax — not in the language at all
+//   TTRS-004  recognised, not implemented in this pass — `each`, `trace` and
+//             the `.field` row reference are defined constructs this parser
+//             names and declines, never silently drops and never reports as
+//             though the author mistyped something
+//
+// Folding the second into the first would tell an author their valid template
+// is a typo.
+//
+// Zero runtime dependencies outside this package. The grammar itself — front
+// matter, header scalars, the id/field-path split — lives in syntax.mjs, shared
+// with the view engine's skeleton parser: one notation, one parser. What stays
+// here is what pass 1 alone decides: its construct set and its error codes.
+
+import { isValidId } from './ids.mjs';
+import {
+  FRONT_MATTER,
+  IDENTIFIER,
+  parseHeaderFields,
+  splitIdAndFields,
+} from './syntax.mjs';
+
+// `<basename>.<kind>.ttrs` — the middle segment is the document kind, so the
+// existing extension/parent-folder lint applies to it unchanged.
+const TEMPLATE_FILENAME = /^[^.]+\.([a-z0-9-]+)\.ttrs$/;
+
+const SLOT_ID = /^[a-z0-9][a-z0-9-]*$/;
+
+const REQUIRED_HEADER_FIELDS = ['document', 'kind', 'template_id', 'template_version'];
+
+// Returns the document kind declared by a `.ttrs` filename, or undefined when the
+// name is not of that shape. Exported so a caller can check it against the header's
+// `kind:` without re-deriving the pattern.
+export function templateKindFromFilename(name) {
+  const m = TEMPLATE_FILENAME.exec(String(name));
+  return m ? m[1] : undefined;
+}
+
+// ── Header ───────────────────────────────────────────────────────────────
+// `canon:` is deliberately optional — the repository is an optional input. A
+// template naming no model object and no derived figure renders standalone.
+
+function parseHeader(headerText) {
+  const errors = [];
+  const fields = parseHeaderFields(headerText);
+
+  for (const name of REQUIRED_HEADER_FIELDS) {
+    if (!fields[name]) {
+      errors.push({ code: 'TTRS-001', message: `header: \`${name}\` is required` });
+    }
+  }
+  if (fields.kind && !/^[a-z0-9-]+$/.test(fields.kind)) {
+    errors.push({
+      code: 'TTRS-001',
+      message: `header: \`kind\` must be lower-case letters, digits and hyphens, got "${fields.kind}"`,
+    });
+  }
+
+  return {
+    header: {
+      document: fields.document,
+      kind: fields.kind,
+      template_id: fields.template_id,
+      template_version: fields.template_version,
+      canon: fields.canon ?? null,
+    },
+    errors,
+  };
+}
+
+// ── Tokenizer ────────────────────────────────────────────────────────────
+// Walks the body, splitting it into literal-text runs and `{{ … }}` directives.
+// `\{{` is the one defined escape — renders as a literal `{{`.
+//
+// An instruction slot's body is opaque: on `{{# instruct … }}` the tokenizer
+// scans straight to the matching `{{/ instruct }}` and keeps everything between
+// as raw text. No slot kind nests inside another, by design.
+
+const INSTRUCT_OPEN = /^#\s*instruct(?:\s+([^\s}]+))?\s*$/;
+const INSTRUCT_CLOSE = '{{/ instruct }}';
+const INSTRUCT_CLOSE_RE = /\{\{\/\s*instruct\s*\}\}/;
+
+// `{{# each TYPE where … order by … }} … {{/ each }}` — a construct of the
+// language this pass does not implement. Scanned to its close and reported
+// once, so an author gets one honest "not implemented here" rather than a
+// cascade of syntax errors from the block's own contents.
+const EACH_OPEN = /^#\s*each(\s|$)/;
+const EACH_CLOSE = '{{/ each }}';
+const EACH_CLOSE_RE = /\{\{\/\s*each\s*\}\}/;
+
+function tokenize(body) {
+  const tokens = [];
+  const errors = [];
+  let buf = '';
+  let i = 0;
+
+  const flushText = () => {
+    if (buf !== '') { tokens.push({ type: 'text', value: buf }); buf = ''; }
+  };
+
+  while (i < body.length) {
+    if (body.startsWith('\\{{', i)) { buf += '{{'; i += 3; continue; }
+    if (body.startsWith('{{', i)) {
+      const close = body.indexOf('}}', i + 2);
+      if (close === -1) {
+        errors.push({ code: 'TTRS-002', message: `unterminated "{{" at offset ${i} — no matching "}}"` });
+        i = body.length;
+        break;
+      }
+      const content = body.slice(i + 2, close);
+      const openMatch = INSTRUCT_OPEN.exec(content.trim());
+      if (openMatch) {
+        flushText();
+        const afterOpen = close + 2;
+        const closeMatch = INSTRUCT_CLOSE_RE.exec(body.slice(afterOpen));
+        if (!closeMatch) {
+          errors.push({
+            code: 'TTRS-002',
+            message: `instruction slot "${content.trim()}" is never closed — expected a matching "${INSTRUCT_CLOSE}"`,
+          });
+          i = body.length;
+          break;
+        }
+        const bodyStart = afterOpen;
+        const bodyEnd = afterOpen + closeMatch.index;
+        const rawSource = body.slice(i, bodyEnd + closeMatch[0].length);
+        tokens.push(parseInstruct(openMatch[1], body.slice(bodyStart, bodyEnd), rawSource, errors));
+        i = bodyEnd + closeMatch[0].length;
+        continue;
+      }
+      if (EACH_OPEN.test(content.trim())) {
+        flushText();
+        const afterOpen = close + 2;
+        const eachClose = EACH_CLOSE_RE.exec(body.slice(afterOpen));
+        if (!eachClose) {
+          errors.push({
+            code: 'TTRS-004',
+            message: `"{{ ${content.trim()} }}" is recognised, not implemented in this pass — and it is never closed either (expected a matching "${EACH_CLOSE}")`,
+          });
+          i = body.length;
+          break;
+        }
+        errors.push({
+          code: 'TTRS-004',
+          message: `"{{ ${content.trim()} }}": the \`each\` block is a construct of the directive language that pass 1 does not implement — recognised, not implemented in this pass`,
+        });
+        tokens.push({ type: 'unimplemented', construct: 'each' });
+        i = afterOpen + eachClose.index + eachClose[0].length;
+        continue;
+      }
+      flushText();
+      tokens.push(classify(content, errors));
+      i = close + 2;
+      continue;
+    }
+    buf += body[i];
+    i++;
+  }
+  flushText();
+  return { tokens, errors };
+}
+
+// ── Instruction slot ─────────────────────────────────────────────────────
+// Pass 1 never fills one of these; it copies the slot through untouched so the
+// unresolved section is visible in the Markdown and pass 2 can find it. The
+// three body keys are the epic's shape: the question the section answers, the
+// inputs it may read, and what makes an answer sufficient.
+
+function parseInstruct(slotId, bodyText, rawSource, errors) {
+  const label = slotId ? `instruction slot "${slotId}"` : 'instruction slot';
+
+  if (!slotId) {
+    errors.push({ code: 'TTRS-002', message: '"{{# instruct … }}": missing slot id' });
+  } else if (!SLOT_ID.test(slotId)) {
+    errors.push({
+      code: 'TTRS-002',
+      message: `${label}: slot id must be lower-case letters, digits and hyphens`,
+    });
+  }
+
+  const fields = {};
+  for (const line of bodyText.split(/\r?\n/)) {
+    const m = line.match(/^\s*(question|inputs|sufficient):[ \t]*(.*)$/);
+    if (m) fields[m[1]] = m[2].trim();
+  }
+
+  if (!fields.question) {
+    errors.push({ code: 'TTRS-002', message: `${label}: \`question:\` is required` });
+  }
+  if (!fields.sufficient) {
+    errors.push({ code: 'TTRS-002', message: `${label}: \`sufficient:\` is required` });
+  }
+
+  const inputs = fields.inputs
+    ? fields.inputs.split(',').map((s) => s.trim()).filter(Boolean)
+    : [];
+
+  return {
+    type: 'instruct',
+    slotId,
+    question: fields.question,
+    inputs,
+    sufficient: fields.sufficient,
+    raw: rawSource,
+  };
+}
+
+// ── Model-object reference and figures ───────────────────────────────────
+
+function splitFieldPath(raw, errors, context) {
+  const segments = raw.split('.').filter((s) => s !== '');
+  if (segments.length === 0) {
+    errors.push({ code: 'TTRS-002', message: `${context}: empty field path` });
+    return [];
+  }
+  if (segments.length > 3) {
+    errors.push({ code: 'TTRS-002', message: `${context}: field path "${raw}" exceeds max traversal depth 3` });
+  }
+  for (const seg of segments) {
+    if (!IDENTIFIER.test(seg)) {
+      errors.push({ code: 'TTRS-002', message: `${context}: "${seg}" in field path "${raw}" is not a valid field name` });
+    }
+  }
+  return segments;
+}
+
+// `key = value` attribute list, values optionally double-quoted.
+function parseAttrs(rest) {
+  const attrs = {};
+  const re = /([a-z_][a-z0-9_]*)\s*=\s*("(?:[^"\\]|\\.)*"|\S+)/gi;
+  let m;
+  while ((m = re.exec(rest)) !== null) {
+    let value = m[2];
+    if (value.startsWith('"')) {
+      try { value = JSON.parse(value); } catch { value = value.slice(1, -1); }
+    }
+    attrs[m[1]] = value;
+  }
+  return attrs;
+}
+
+// The leading path argument: everything before the first `key =` attribute.
+function splitPathAndAttrs(rest) {
+  const attrStart = rest.search(/[a-z_][a-z0-9_]*\s*=/i);
+  if (attrStart === -1) return { path: rest.trim(), attrRest: '' };
+  return { path: rest.slice(0, attrStart).trim(), attrRest: rest.slice(attrStart) };
+}
+
+const FIT_VALUES = new Set(['width', 'page', 'none']);
+
+function parseView(trimmed, errors) {
+  const { path, attrRest } = splitPathAndAttrs(trimmed.replace(/^view\s*/, ''));
+  const attrs = parseAttrs(attrRest);
+  if (!path) {
+    errors.push({ code: 'TTRS-002', message: `"{{ ${trimmed} }}": missing view source path` });
+  }
+  const fit = attrs.fit ?? 'width';
+  if (!FIT_VALUES.has(fit)) {
+    errors.push({ code: 'TTRS-002', message: `"{{ ${trimmed} }}": fit must be width, page or none — got "${fit}"` });
+  }
+  return { type: 'view', path, as: attrs.as ?? null, fit };
+}
+
+function parseFigure(trimmed, errors) {
+  const { path, attrRest } = splitPathAndAttrs(trimmed.replace(/^figure\s*/, ''));
+  const attrs = parseAttrs(attrRest);
+  if (!path) {
+    errors.push({ code: 'TTRS-002', message: `"{{ ${trimmed} }}": missing figure asset path` });
+  }
+  return { type: 'figure', path, caption: attrs.caption ?? null, as: attrs.as ?? null };
+}
+
+function parseFigref(trimmed, errors) {
+  const name = trimmed.replace(/^figref\s*/, '').trim();
+  if (!name) {
+    errors.push({ code: 'TTRS-002', message: `"{{ ${trimmed} }}": missing figure name` });
+  }
+  return { type: 'figref', name };
+}
+
+function classify(rawContent, errors) {
+  const trimmed = rawContent.trim();
+
+  if (trimmed.startsWith('/')) {
+    errors.push({
+      code: 'TTRS-002',
+      message: `unexpected closing directive "{{${trimmed}}}" — no block is open here`,
+    });
+    return { type: 'error' };
+  }
+
+  if (trimmed.startsWith('#')) {
+    errors.push({
+      code: 'TTRS-002',
+      message: `unknown block directive "{{${trimmed}}}" — "{{# instruct <slot-id> }}" and "{{# each … }}" are the language's only block forms`,
+    });
+    return { type: 'error' };
+  }
+
+  if (/^view(\s|$)/.test(trimmed)) return parseView(trimmed, errors);
+  if (/^figure(\s|$)/.test(trimmed)) return parseFigure(trimmed, errors);
+  if (/^figref(\s|$)/.test(trimmed)) return parseFigref(trimmed, errors);
+
+  // Recognised constructs of the language that pass 1 declines by name.
+  if (/^trace(\s|$)/.test(trimmed)) {
+    errors.push({
+      code: 'TTRS-004',
+      message: `"{{ ${trimmed} }}": \`trace\` is a construct of the directive language that pass 1 does not implement — recognised, not implemented in this pass`,
+    });
+    return { type: 'unimplemented', construct: 'trace' };
+  }
+
+  // `{{ .field }}` — the row reference, meaningful only inside an `each` block.
+  // Reported as unimplemented rather than as a malformed id: it is in the
+  // language, and its own block form is what pass 1 does not implement.
+  if (trimmed.startsWith('.')) {
+    errors.push({
+      code: 'TTRS-004',
+      message: `"{{ ${trimmed} }}": a field reference belongs to an \`each\` block — recognised, not implemented in this pass`,
+    });
+    return { type: 'unimplemented', construct: 'field-ref' };
+  }
+
+  if (/\s/.test(trimmed)) {
+    errors.push({ code: 'TTRS-002', message: `unrecognised directive "{{ ${trimmed} }}"` });
+    return { type: 'error' };
+  }
+
+  const { id, fieldsRaw } = splitIdAndFields(trimmed);
+  if (!isValidId(id)) {
+    errors.push({
+      code: 'TTRS-002',
+      message: `model-object reference "{{ ${trimmed} }}": "${id}" is not a valid ID (IDS_AND_REFERENCES.md §1)`,
+    });
+  }
+  const fields = fieldsRaw === ''
+    ? []
+    : splitFieldPath(fieldsRaw, errors, `model-object reference "{{ ${trimmed} }}"`);
+  return { type: 'reference', id, fields };
+}
+
+// ── Entry point ──────────────────────────────────────────────────────────
+
+export function parseTemplate(text) {
+  const errors = [];
+  const m = FRONT_MATTER.exec(String(text));
+  if (!m) {
+    return {
+      header: null,
+      ast: [],
+      errors: [{ code: 'TTRS-001', message: 'template has no `---` front-matter header' }],
+    };
+  }
+
+  const { header, errors: headerErrors } = parseHeader(m[1]);
+  errors.push(...headerErrors);
+
+  const { tokens, errors: bodyErrors } = tokenize(m[2]);
+  errors.push(...bodyErrors);
+
+  // A slot id names a section in the run record, so two slots may not share one.
+  const seen = new Set();
+  for (const node of tokens) {
+    if (node.type !== 'instruct' || !node.slotId) continue;
+    if (seen.has(node.slotId)) {
+      errors.push({ code: 'TTRS-003', message: `duplicate instruction slot id "${node.slotId}"` });
+    }
+    seen.add(node.slotId);
+  }
+
+  return { header, ast: tokens, errors };
+}

--- a/vendor/methodology/document-renderer/pass1.d.mts
+++ b/vendor/methodology/document-renderer/pass1.d.mts
@@ -1,0 +1,85 @@
+// Type contract for the vendored pass1.mjs — Studio's own, not part of what
+// vendor-methodology-document-renderer.mjs fetches from methodology (that
+// script only writes the five .mjs files; this file is untouched by it).
+// Kept intentionally narrow: only the shape extension/src/ttrs-preview.ts and
+// tests/document-renderer-vendor.test.ts actually read. The source of truth
+// for the full contract is pass1.mjs's own JSDoc and
+// methodology/notations/views/documents/DIRECTIVE_LANGUAGE.md.
+
+export interface Pass1Header {
+  document: string;
+  kind: string;
+  template_id: string;
+  template_version: string;
+  canon: string | null;
+}
+
+export interface Pass1InstructionSlot {
+  slotId: string;
+  question: string;
+  inputs: string[];
+  sufficient: string;
+}
+
+export interface Pass1Figure {
+  number: number;
+  name: string;
+  kind: 'view' | 'figure';
+  source: string;
+  derived: boolean;
+  fit: string | null;
+  caption: string | null;
+  embedPath: string;
+}
+
+export interface Pass1Error {
+  code: string;
+  message: string;
+}
+
+export interface Pass1Finding {
+  code: string;
+  state: string;
+  flag: string | null;
+  id: string | null;
+  file: string;
+}
+
+export interface Pass1Suspicion {
+  computed: boolean;
+  state: string;
+  reason: string;
+}
+
+export interface RasteriseInput {
+  kind: 'view' | 'figure';
+  source: string;
+  name: string;
+  number: number;
+  fit: string | null;
+}
+
+export interface RunPass1Options {
+  text: string;
+  templatePath?: string;
+  repositoryRoot?: string | null;
+  rasterise?: (input: RasteriseInput) => string;
+  profile?: 'strict' | 'review';
+  renderDate?: string;
+}
+
+export interface Pass1Result {
+  ok: boolean;
+  markdown: string;
+  header: Pass1Header | null;
+  instructionSlots: Pass1InstructionSlot[];
+  figures: Pass1Figure[];
+  errors: Pass1Error[];
+  findings: Pass1Finding[];
+  states: Record<string, number>;
+  suspicion: Pass1Suspicion;
+  profile: 'strict' | 'review';
+  renderDate: string;
+}
+
+export function runPass1(options: RunPass1Options): Promise<Pass1Result>;

--- a/vendor/methodology/document-renderer/pass1.mjs
+++ b/vendor/methodology/document-renderer/pass1.mjs
@@ -1,0 +1,402 @@
+// Pass 1 — the deterministic half of the document renderer.
+//
+// Resolves every model-object reference and every derived figure in a `.ttrs`
+// template. Runs and is testable with NO agent present: nothing in this module
+// calls a model, and nothing in it may. Instruction slots are pass 2's job and
+// are copied through untouched, so an unfilled section is visible in the output
+// rather than silently blank.
+//
+// This module ships as a unit callable on its own, so pass 2 and Studio's
+// preview can both depend on it as a library rather than on the whole renderer.
+//
+// Two invariants worth stating outright:
+//
+//   * It writes nothing into the model. Every filesystem touch here is a read.
+//   * It is re-run-stable. Given unchanged inputs the Markdown is byte-identical —
+//     no timestamps, no filesystem-order dependence, no counters that reset.
+//
+// Failure discipline: an unresolvable reference FAILS the run by name. It never
+// renders as empty text. The distinct codes matter — a caller must be able to
+// tell "you have no repository configured" (TTRS-011) apart from "your
+// repository does not contain this id" (TTRS-010).
+//
+// The language names FIVE non-ok reference states (DIRECTIVE_LANGUAGE.md §5).
+// This pass computes four of them and reports the fifth (⚑S) as not computed.
+// The three canon-side ones are @transitrix/document-view-engine's own
+// (resolveReference()'s ⚑U / ⚑A / ⚑V), deliberately reused rather than
+// re-invented — one notation must not grow two classifications of the same
+// failure. The fourth is this pass's, and is about configuration, not canon:
+//
+//   unresolved         ⚑U  TTRS-010  no object with that id in the repository
+//   not-admitted       ⚑A  TTRS-014  it exists, but admission_state isn't active
+//   out-of-validity    ⚑V  TTRS-015  [valid_from, valid_to] misses the render date
+//   no-repository      —   TTRS-011  the template cites canon; none is configured
+//
+// The worst defect this guards against is not a missing reference — it is a
+// reference that resolves and renders as plainly correct text when the object
+// behind it was never admitted, or stopped being valid. So a non-ok state is
+// never rendered as its bare value.
+//
+// ⚑S (suspect) is NOT computed in this pass, and is reported as "not computed"
+// rather than omitted. DIRECTIVE_LANGUAGE.md §5.1 requires three distinguishable
+// outcomes and not two — suspect, checked-and-clean, and never-checked — because
+// a render that never checked must not look like one that came back clean. That
+// is the one failure mode which reads as success. Three standing reasons for
+// declining, none of them a time-box — see the `suspicion` field of the result.
+
+import { existsSync } from 'node:fs';
+import { dirname, isAbsolute, join, resolve as resolvePath } from 'node:path';
+
+import { parseTemplate, templateKindFromFilename } from './parse-template.mjs';
+import { buildRepositoryIndex } from './repository.mjs';
+
+// Rendered in place of a reference that did not land in `ok`. The run has already
+// failed by the time this is visible; it exists so the failure is never a blank,
+// and never a value that reads as correct.
+const UNRESOLVED_MARKER = (id) => `«unresolved: ${id}»`;
+const STATE_MARKER = (state, id) => `«${STATES[state].label}: ${id}»`;
+
+// The one place a state's code, flag and wording live together.
+const STATES = {
+  unresolved: { code: 'TTRS-010', flag: '⚑U', label: 'unresolved' },
+  'not-admitted': { code: 'TTRS-014', flag: '⚑A', label: 'not admitted' },
+  'out-of-validity': { code: 'TTRS-015', flag: '⚑V', label: 'out of validity' },
+};
+
+// Why ⚑S is absent, carried in the result so a caller never has to guess
+// whether suspicion was clean or simply never run.
+const SUSPICION_NOT_COMPUTED = {
+  computed: false,
+  state: 'not-computed',
+  reason:
+    'link suspicion (⚑S) is not computed in pass 1: it is out of scope by the '
+    + 'rendered-documents decision, it is derived from commit history rather than '
+    + 'read from a file, and CONTRACT.md §16.2 scopes it to REL/claim records '
+    + 'rather than the element references a template cites.',
+};
+
+// Field consulted, in order, when a reference names no field path of its own.
+const DEFAULT_FIELDS = ['name', 'title', 'id'];
+
+function todayIso() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function coversDate(validFrom, validTo, renderDate) {
+  if (validFrom === null || validFrom === undefined) return true; // nothing to check against
+  if (renderDate < validFrom) return false;
+  if (validTo !== null && validTo !== undefined && renderDate > validTo) return false;
+  return true;
+}
+
+// The §3 classification, in document-view-engine's order: existence, then
+// admission, then validity. Returns 'ok' when the object is usable.
+function classifyReference(entry, renderDate) {
+  if (!entry) return 'unresolved';
+  if (entry.admissionState !== 'active') return 'not-admitted';
+  if (!coversDate(entry.validFrom, entry.validTo, renderDate)) return 'out-of-validity';
+  return 'ok';
+}
+
+function needsRepository(ast) {
+  return ast.some((node) => node.type === 'reference' || node.type === 'view');
+}
+
+function traverse(entry, fields, index) {
+  let current = entry;
+  for (let i = 0; i < fields.length; i++) {
+    const value = current.fields[fields[i]];
+    if (value === undefined) return undefined;
+    // A middle segment must name another object to keep walking into.
+    if (i < fields.length - 1) {
+      const next = index.get(value);
+      if (!next) return undefined;
+      current = next;
+      continue;
+    }
+    return value;
+  }
+  return undefined;
+}
+
+// Records one non-ok reference state: always as a finding, and — in the strict
+// profile — as an error that fails the run. The message names the file, the id
+// and the state, in that order, because that is the order someone fixing it
+// needs them in.
+function recordState(node, state, ctx) {
+  const { code, label, flag } = STATES[state];
+  ctx.findings.push({ code, state, flag, id: node.id, file: ctx.templateLabel });
+  ctx.states[state] = (ctx.states[state] ?? 0) + 1;
+  if (ctx.profile === 'strict') {
+    ctx.errors.push({
+      code,
+      message: `${ctx.templateLabel}: model-object reference "${node.id}" is ${label}`,
+    });
+  }
+}
+
+function renderReference(node, index, ctx) {
+  const entry = index.get(node.id);
+  const state = classifyReference(entry, ctx.renderDate);
+
+  if (state !== 'ok') {
+    recordState(node, state, ctx);
+    // In review the value is shown WITH its flag, so a reader sees both what the
+    // template meant and that it is not usable. In strict it never renders as
+    // its bare value — a wrong-but-plausible render is the defect being guarded
+    // against, and it is worse than a visibly missing one.
+    if (ctx.profile === 'review' && entry) {
+      const value = readValue(node, entry, index);
+      if (value !== undefined) return `${value} ${STATES[state].flag}`;
+    }
+    return STATE_MARKER(state, node.id);
+  }
+
+  ctx.states.ok = (ctx.states.ok ?? 0) + 1;
+
+  const value = readValue(node, entry, index);
+  if (value !== undefined) return value;
+
+  // The object is admitted and in validity; it is the field path that is absent.
+  const path = node.fields.length === 0
+    ? node.id
+    : `${node.id}.${node.fields.join('.')}`;
+  const detail = node.fields.length === 0
+    ? `resolves, but the object carries none of: ${DEFAULT_FIELDS.join(', ')}`
+    : 'does not resolve — the field path is not present on that object';
+  ctx.errors.push({
+    code: 'TTRS-010',
+    message: `${ctx.templateLabel}: model-object reference "${path}" ${detail}`,
+  });
+  return UNRESOLVED_MARKER(path);
+}
+
+// The value a reference substitutes: its own field path, or the first of the
+// default fields the object carries. `undefined` when neither is present.
+function readValue(node, entry, index) {
+  if (!entry) return undefined;
+  if (node.fields.length === 0) {
+    for (const name of DEFAULT_FIELDS) {
+      if (entry.fields[name] !== undefined) return entry.fields[name];
+    }
+    return undefined;
+  }
+  return traverse(entry, node.fields, index);
+}
+
+function resolveAssetPath(baseDir, path) {
+  if (!baseDir) return path;
+  return isAbsolute(path) ? path : resolvePath(join(baseDir, path));
+}
+
+// A derived figure (`{{ view … }}`) is authored as text in the existing view
+// notation; a supplied figure (`{{ figure … }}`) is an asset and is never
+// generated. Pass 1 resolves both to a stable, numbered embed. Turning a view
+// source into a raster is the output layer's job, reached through the optional
+// `rasterise` hook so this module stays free of any renderer dependency.
+function renderFigure(node, ctx, errors) {
+  const kind = node.type === 'view' ? 'view' : 'figure';
+  const abs = resolveAssetPath(ctx.baseDir, node.path);
+
+  if (!ctx.exists(abs)) {
+    errors.push({
+      code: 'TTRS-012',
+      message: `${kind} source "${node.path}" does not exist${ctx.baseDir ? ` (looked in ${ctx.baseDir})` : ''}`,
+    });
+    return UNRESOLVED_MARKER(node.path);
+  }
+
+  const number = ctx.figures.length + 1;
+  const name = node.as ?? `figure-${number}`;
+  const embedPath = ctx.rasterise
+    ? ctx.rasterise({ kind, source: abs, name, number, fit: node.fit ?? null })
+    : node.path;
+
+  ctx.figures.push({
+    number,
+    name,
+    kind,
+    source: node.path,
+    derived: kind === 'view',
+    fit: node.fit ?? null,
+    caption: node.caption ?? null,
+    embedPath,
+  });
+  ctx.figureNumbers.set(name, number);
+
+  const caption = node.caption ?? `Figure ${number}`;
+  return `![${caption}](${embedPath})`;
+}
+
+function renderFigref(node, ctx, errors) {
+  const number = ctx.figureNumbers.get(node.name);
+  if (number === undefined) {
+    errors.push({
+      code: 'TTRS-012',
+      message: `figref "${node.name}" names no figure declared earlier in this template`,
+    });
+    return UNRESOLVED_MARKER(node.name);
+  }
+  return `Figure ${number}`;
+}
+
+/**
+ * Run pass 1 over a `.ttrs` template.
+ *
+ * @param {object} options
+ * @param {string} options.text            template source
+ * @param {string} [options.templatePath]  path the source came from — enables the
+ *                                         filename/`kind:` cross-check and gives
+ *                                         figure paths a base directory
+ * @param {string} [options.repositoryRoot] canon root; overrides the header's `canon:`.
+ *                                          Pass `null` to force the no-repository case.
+ * @param {Function} [options.rasterise]   hook turning a resolved figure source into
+ *                                         the path to embed; omitted, the source path
+ *                                         is embedded as-is
+ * @param {'strict'|'review'} [options.profile] `strict` (default) fails the run on
+ *                                         every non-ok reference state; `review`
+ *                                         renders each one flagged and does not fail.
+ *                                         Corresponds to @transitrix/document-view-engine's
+ *                                         `clean` / `review` pair.
+ * @param {string} [options.renderDate]    ISO date validity is resolved at; defaults to
+ *                                         today. Pin it to keep runs on different days
+ *                                         byte-identical — the date is an input.
+ * @returns {Promise<{ok, markdown, header, instructionSlots, figures, errors, findings, states, suspicion, profile, renderDate}>}
+ */
+export async function runPass1({
+  text, templatePath, repositoryRoot, rasterise, profile = 'strict', renderDate,
+} = {}) {
+  if (profile !== 'strict' && profile !== 'review') {
+    throw new Error(`runPass1: profile must be "strict" or "review", got "${profile}"`);
+  }
+  const date = renderDate ?? todayIso();
+  const { header, ast, errors } = parseTemplate(text);
+
+  const emptyResult = (hdr) => ({
+    ok: false,
+    markdown: '',
+    header: hdr,
+    instructionSlots: [],
+    figures: [],
+    errors,
+    findings: [],
+    states: {},
+    suspicion: SUSPICION_NOT_COMPUTED,
+    profile,
+    renderDate: date,
+  });
+
+  if (header === null) return emptyResult(null);
+
+  if (templatePath) {
+    const kindFromName = templateKindFromFilename(basename(templatePath));
+    if (kindFromName === undefined) {
+      errors.push({
+        code: 'TTRS-013',
+        message: `"${templatePath}" is not named <basename>.<kind>.ttrs`,
+      });
+    } else if (header.kind && kindFromName !== header.kind) {
+      errors.push({
+        code: 'TTRS-013',
+        message: `filename declares kind "${kindFromName}" but the header declares "${header.kind}"`,
+      });
+    }
+  }
+
+  // The repository is an optional input. Resolve which root we have, if any.
+  const explicit = repositoryRoot !== undefined;
+  let canonRoot = explicit ? repositoryRoot : header.canon;
+  if (canonRoot && !explicit && templatePath) {
+    canonRoot = resolvePath(join(dirname(templatePath), canonRoot));
+  }
+
+  // The fourth state, and the only one that is about configuration rather than
+  // canon. Named in the same breath as the other three so a caller reading the
+  // findings never has to look in two places for "why did nothing resolve".
+  const templateLabel = templatePath ? basename(templatePath) : '<template>';
+  const noRepository = !canonRoot && needsRepository(ast);
+  if (noRepository) {
+    errors.push({
+      code: 'TTRS-011',
+      message: `${templateLabel}: template references a model object but no repository is configured`,
+    });
+  }
+
+  const index = await buildRepositoryIndex(canonRoot);
+
+  const ctx = {
+    baseDir: templatePath ? dirname(templatePath) : null,
+    exists: (p) => existsSync(p),
+    rasterise: rasterise ?? null,
+    figures: [],
+    figureNumbers: new Map(),
+    profile,
+    renderDate: date,
+    templateLabel,
+    errors,
+    findings: noRepository
+      ? [{ code: 'TTRS-011', state: 'no-repository', flag: null, id: null, file: templateLabel }]
+      : [],
+    states: noRepository ? { 'no-repository': 1 } : {},
+  };
+
+  const instructionSlots = [];
+  const out = [];
+
+  for (const node of ast) {
+    switch (node.type) {
+      case 'text':
+        out.push(node.value);
+        break;
+      case 'reference':
+        // With no repository the run has already failed as TTRS-011; the id is
+        // still marked in the output rather than left blank.
+        out.push(canonRoot ? renderReference(node, index, ctx) : UNRESOLVED_MARKER(node.id));
+        break;
+      case 'view':
+      case 'figure':
+        out.push(canonRoot || node.type === 'figure'
+          ? renderFigure(node, ctx, errors)
+          : UNRESOLVED_MARKER(node.path));
+        break;
+      case 'figref':
+        out.push(renderFigref(node, ctx, errors));
+        break;
+      case 'instruct':
+        // Pass 2's job. Copied through byte-for-byte — an unfilled section stays
+        // visible, and pass 2 finds it by the same syntax that put it here.
+        instructionSlots.push({
+          slotId: node.slotId,
+          question: node.question,
+          inputs: node.inputs,
+          sufficient: node.sufficient,
+        });
+        out.push(node.raw);
+        break;
+      default:
+        break; // a node the parser already reported on
+    }
+  }
+
+  return {
+    ok: errors.length === 0,
+    markdown: out.join(''),
+    header,
+    instructionSlots,
+    figures: ctx.figures,
+    errors,
+    // Every non-ok reference state, in document order, whatever the profile —
+    // `review` reports exactly what `strict` fails on.
+    findings: ctx.findings,
+    states: ctx.states,
+    // Never omitted. "Clean" and "never checked" must not look alike.
+    suspicion: SUSPICION_NOT_COMPUTED,
+    profile,
+    renderDate: date,
+  };
+}
+
+function basename(p) {
+  const parts = String(p).split(/[\\/]/);
+  return parts[parts.length - 1];
+}

--- a/vendor/methodology/document-renderer/repository.mjs
+++ b/vendor/methodology/document-renderer/repository.mjs
@@ -1,0 +1,115 @@
+// Repository index — the deterministic half of what pass 1 resolves against.
+//
+// A template's `canon:` header names a `canon/` directory. This module walks it
+// once into an id → object map so every reference in one render pass shares a
+// single index. Top-level scalars only: a model-object reference substitutes a
+// field's text, it does not traverse into nested structure.
+//
+// The repository is an OPTIONAL input. `buildRepositoryIndex(null)` is not an
+// error — it yields an empty index, and pass 1 decides whether the template
+// actually needed one.
+//
+// Own hand-rolled field extraction, no shared cross-package runtime import —
+// same convention as this repo's other packages.
+
+import { readFile, readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+// Record folders carrying ids alongside `elements/`. Kept in one place so a new
+// record kind is a one-line addition.
+const RECORD_DIRS = ['elements', 'relations', 'assertions', 'verifications', 'validations'];
+
+async function walkYaml(dir) {
+  const out = [];
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  // Sort so an index built twice over unchanged inputs is byte-identical —
+  // readdir order is filesystem-dependent and must not leak into the output.
+  entries.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+  for (const entry of entries) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...(await walkYaml(p)));
+    else if (entry.isFile() && entry.name.endsWith('.yaml')) out.push(p);
+  }
+  return out;
+}
+
+// Every top-level `key: scalar` in the document. Block scalars (`|`, `>`) are
+// folded to their content so `{{ REQ-14.text }}` picks up multi-line prose.
+export function topLevelFields(text) {
+  const fields = {};
+  const lines = String(text).split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(/^([A-Za-z_][A-Za-z0-9_]*):[ \t]*(.*)$/);
+    if (!m) continue;
+    const [, key, rawValue] = m;
+    const value = rawValue.trim();
+
+    if (value === '|' || value === '>' || value === '|-' || value === '>-') {
+      const block = [];
+      for (let j = i + 1; j < lines.length; j++) {
+        if (lines[j].trim() === '') { block.push(''); continue; }
+        if (!/^\s/.test(lines[j])) break;
+        block.push(lines[j].replace(/^\s+/, ''));
+      }
+      fields[key] = (value.startsWith('|') ? block.join('\n') : block.join(' ')).trim();
+      continue;
+    }
+    if (value === '') continue; // a nested mapping or sequence — not a scalar field
+    fields[key] = stripScalar(value);
+  }
+  return fields;
+}
+
+function stripScalar(value) {
+  let s = value;
+  const hash = s.indexOf(' #');
+  if (hash >= 0) s = s.slice(0, hash).trim();
+  if (s.startsWith('"') && s.endsWith('"') && s.length >= 2) {
+    try { return JSON.parse(s); } catch { return s.slice(1, -1); }
+  }
+  if (s.startsWith("'") && s.endsWith("'") && s.length >= 2) return s.slice(1, -1).replace(/''/g, "'");
+  return s;
+}
+
+// A `valid_to:` of literal `null` means "no end" — an open interval, not the
+// string "null". Read as a scalar it arrives as text, so it is normalised here
+// rather than at every use site.
+function dateOrNull(value) {
+  if (value === undefined || value === '' || value === 'null' || value === '~') return null;
+  return value;
+}
+
+// Walks `canonRoot` into an id → entry index. A null/undefined root yields an
+// empty index — the no-repository-configured case, which is legitimate input.
+//
+// Each entry carries the fields a reference substitutes AND the three envelope
+// values the four-state classification is decided from. An object with no
+// `admission_state:` is `active`, matching @transitrix/document-view-engine's
+// buildCanonIndex(): absence is the ordinary case, not an unknown one.
+//
+// Proposed and rejected drafts are indexed, never skipped — telling "does not
+// exist" apart from "exists, not admitted" is the whole point of the split.
+export async function buildRepositoryIndex(canonRoot) {
+  const index = new Map();
+  if (!canonRoot) return index;
+
+  for (const dir of RECORD_DIRS) {
+    for (const file of await walkYaml(join(canonRoot, dir))) {
+      const text = await readFile(file, 'utf8');
+      const fields = topLevelFields(text);
+      if (!fields.id) continue;
+      index.set(fields.id, {
+        fields,
+        admissionState: fields.admission_state ?? 'active',
+        validFrom: dateOrNull(fields.valid_from),
+        validTo: dateOrNull(fields.valid_to),
+      });
+    }
+  }
+  return index;
+}

--- a/vendor/methodology/document-renderer/syntax.mjs
+++ b/vendor/methodology/document-renderer/syntax.mjs
@@ -1,0 +1,56 @@
+// Shared syntax primitives of the document directive language.
+//
+// `.ttrs` templates and the view engine's skeleton files are one notation with two
+// current implementations (parse-template.mjs here, parse-skeleton.mjs in
+// @transitrix/document-view-engine). The two differ in which constructs they
+// implement and in how they report errors — but the pieces below are the grammar
+// itself, and were carried as byte-identical copies in both. One notation, one
+// parser: they are defined once, here, and imported by both.
+//
+// What deliberately stays with each parser: the construct set it implements, its
+// error shape (this package's codes vs. the engine's bare messages), and its AST
+// node names. Those are implementation surface, not grammar.
+
+import { CAPABILITY_PREFIX } from './ids.mjs';
+
+// A document file is YAML front matter followed by a body.
+export const FRONT_MATTER = /^---\r?\n([\s\S]*?)\r?\n---[ \t]*\r?\n?([\s\S]*)$/;
+
+// A field-path segment / header key.
+export const IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+// Header scalars are the flat subset both headers use: an optional trailing ` #`
+// comment, and optional single or double quoting.
+export function cleanScalar(raw) {
+  let s = String(raw).trim();
+  const hash = s.indexOf(' #');
+  if (hash >= 0) s = s.slice(0, hash).trim();
+  if (s.startsWith('"') && s.endsWith('"') && s.length >= 2) {
+    try { return JSON.parse(s); } catch { return s.slice(1, -1); }
+  }
+  if (s.startsWith("'") && s.endsWith("'") && s.length >= 2) return s.slice(1, -1).replace(/''/g, "'");
+  return s;
+}
+
+// Reads a front-matter block into a flat field map. Which fields are required, and
+// what a missing one costs, is each parser's own business — this only reads.
+export function parseHeaderFields(headerText) {
+  const fields = {};
+  for (const line of headerText.split(/\r?\n/)) {
+    if (line.trim() === '' || line.trim().startsWith('#')) continue;
+    const m = line.match(/^([A-Za-z_][A-Za-z0-9_]*):[ \t]*(.*)$/);
+    if (!m) continue;
+    fields[m[1]] = cleanScalar(m[2]);
+  }
+  return fields;
+}
+
+// Splits `REQ-14.text` into its id and the raw field path after it. A CAPABILITY id
+// embeds its own dots (the V/H diagram address), so that form is matched first.
+export function splitIdAndFields(trimmed) {
+  const capMatch = CAPABILITY_PREFIX.exec(trimmed);
+  if (capMatch) return { id: capMatch[1], fieldsRaw: capMatch[2] ?? '' };
+  const dot = trimmed.indexOf('.');
+  if (dot === -1) return { id: trimmed, fieldsRaw: '' };
+  return { id: trimmed.slice(0, dot), fieldsRaw: trimmed.slice(dot + 1) };
+}


### PR DESCRIPTION
## Summary

- Vendors `@transitrix/document-renderer`'s pass-1 resolver from methodology v3.3.0 into `vendor/methodology/document-renderer/` (tagged release, no sibling-checkout read, no cross-repo package dependency — same contract as the existing `vocabulary.yaml` vendoring), integrity-checked by `tests/document-renderer-vendor.test.ts`.
- Adds `TtrsPreview` (`extension/src/ttrs-preview.ts`), wired into the shared `transitrix.openPreview` dispatch for `.ttrs` files, calling the vendored `runPass1` as a real library call rather than reimplementing resolution.
- Adds `extension/src/ttrs-render.ts` (pure, no vscode import) turning a pass-1 result into preview HTML: all four resolver states named distinctly (unresolved / not admitted / out of validity / no repository), `each`/`trace` reported as "recognised, not implemented in this pass" (not folded into a syntax error), link suspicion always shown as not-computed with its reason, and instruction slots marked visibly pending.
- Figures: an `.svg` supplied asset and a `*.blocks.transitrix.yaml` derived figure render inline (reusing the same `@transitrix/diagrams` blocks emitter the Blocks preview uses). Other view notations show a clearly labelled "not rendered in this preview" note rather than a broken image — a stated scope boundary, not a silent gap.

Closes THQ-57.

## Scope note for the reviewer

Full rasterisation across every view notation (~18) that a `.ttrs` document could cite is a larger follow-up than this task's acceptance criteria required to land safely in one change. Blocks-notation figures and SVG assets are fully wired and tested; anything else is an honest placeholder, not a broken render.

## Test plan

- [x] `npx vitest run tests/document-renderer-vendor.test.ts` — 9/9 (vendored artefact integrity + the resolver actually runs)
- [x] `npx vitest run tests/ttrs-render.test.ts` — 12/12 (state markers, no-repo banner, deferred-construct panel, suspicion banner, instruction-slot marker, figure embed/placeholder, heading/bold/escaping)
- [x] `npx tsc --noEmit -p extension/tsconfig.json` — clean except one pre-existing, unrelated `@resvg/resvg-js` type error
- [x] `node scripts/build-extension-bundle.mjs` — bundles cleanly (validates the vendored `.mjs` import resolves through esbuild)
- [x] `npx vitest run` (full suite) — 713 passed; only 2 pre-existing failures unrelated to this change (a schema-file-copy fixture and a hygiene-pattern test, both failing before this branch touched anything)