### PR TITLE
fix(diagrams): declare the node engines floor

### DIFF
--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -15,6 +15,9 @@
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "engines": {
+    "node": ">=20"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

- `packages/diagrams/package.json` was the one manifest in this repo without a `node` `engines` floor — root and `packages/cli` already declare `>=20`. `extension/package.json`'s `engines.vscode` is a different contract (VS Code API compatibility, not a Node runtime floor) and is unaffected.

Part of THQ-23 (Deliverable C, runtime floor).

## Test plan

- [x] `npm --workspace packages/diagrams run build` — clean
- [x] `npm --workspace packages/diagrams test` — 1660/1660 passed