### PR TITLE
feat(cli): transitrix impact — name views a staged canon change makes stale

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -76,6 +76,7 @@ transitrix validate <input.yaml> --fix [--author <name>] [--valid-from <YYYY-MM-
 transitrix validate --scope=repo [--root <dir>] [--json] [--include-model]
 transitrix new <goal|driver|constraint|requirement> --id <ID> --name "<label>" [options]
 transitrix export-compliance [--format md|pdf] [--scope law:<ID>|product:<ID>|gap] [--output <path>] [--root <dir>]
+transitrix impact [--root <dir>] [--json]
 ```
 
 | Command | Purpose |
@@ -86,6 +87,7 @@ transitrix export-compliance [--format md|pdf] [--scope law:<ID>|product:<ID>|ga
 | `validate` | Validation only, no XML output (`--json` for CI). Exit 1 on errors. Default scope is a single file; `--scope=repo` runs whole-`canon/` checks (referential integrity, atomicity, id uniqueness, policy) over `--root` (default cwd) — see [validation.md](validation.md#validation-scope-file-vs-repo). `--include-model` (with `--json`) also emits the resolved `canon/elements/**`/`canon/relations/**` records it parsed — see [validation.md](validation.md#resolved-model-output---include-model). `--template <name>` (file scope, `blocks` matrix-subset `grid:` documents only — e.g. `raci`) additionally enforces that template's own cell-value invariant (e.g. `RACI-001`) on top of the base `BL-02x` rules; the base notation does not fix a cell-value vocabulary, so this is opt-in per template. |
 | `new <type>` | Scaffolds a standalone motivation-layer element (`goal`, `driver`, `constraint`, `requirement`) with the admission record and lifecycle envelope computed rather than hand-typed — see [Envelope defaults](#envelope-defaults). `--dry-run` previews without writing. Run `transitrix new <type> --help` for the per-type fields. |
 | `export-compliance` | Markdown or PDF report of the compliance views (matrix by default; `law:` / `product:` / `gap` scopes). Scans `--root` (default cwd). PDF needs WeasyPrint on PATH (`pipx install weasyprint`). |
+| `impact` | Names which `canon/views/**` documents a *staged* (`git add`, not yet committed) `canon/elements/**` change makes stale. Silent when nothing is staged, or when nothing this can resolve is affected. Resolves the three canon-projection view notations with a static resolver (`goals`, `dgca`/`fgca`, `action`); every other view (inline-form views, `blocks`, `applications`, `capability-map`, `compliance-impact`, `coverage-metric`, `bpmn`) is reported as coverage not determined, never as unaffected. Document (`.ttrs`) coverage is not yet included. `--root` sets the repo to check (default cwd). |
 
 Flags: `--no-metrics` suppresses the metrics report on compile; `--no-validate`
 suppresses validation **warnings** (errors always run). Input files must use a

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,6 +43,7 @@ import {
   type FixFieldResult,
 } from './validate-fix.js';
 import { handleExportComplianceCommand } from './export-compliance.js';
+import { computeStagedImpact, reportImpact } from './impact.js';
 import { transitrixPackageVersion } from './package-version.js';
 import { bundledDiagramsVersion } from './diagrams-version.js';
 import { isActionViewDoc } from '@transitrix/diagrams/activities';
@@ -88,6 +89,7 @@ function printUsage(): void {
        transitrix validate <input.yaml> --fix [--author <name>] [--valid-from <YYYY-MM-DD>] [--root <dir>] [--dry-run]
        transitrix validate --scope=repo [--root <dir>] [--json] [--include-model]
        transitrix export-compliance [--format md|pdf] [--scope law:<ID>|product:<ID>|gap] [--output <path>] [--root <dir>]
+       transitrix impact [--root <dir>] [--json]
        transitrix migrate [--from X.Y] [--to X.Y] [--dry-run] [--recipes <dir>] [target-dir]
        transitrix new <goal|driver|constraint|requirement> --id <ID> --name "<label>" [--author <name>] [--valid-from <YYYY-MM-DD>] [--root <dir>] [--dry-run]
 
@@ -110,6 +112,14 @@ function printUsage(): void {
               default; law:/product:/gap scopes). Scans --root (default cwd) for
               requirement/assertion/product/codex canon. PDF rendering requires
               WeasyPrint on PATH (pipx install weasyprint).
+  impact    — names which canon/views/** documents a *staged* (git add, not
+              yet committed) canon/elements/** change makes stale. Silent
+              when nothing is staged, or when nothing this can resolve is
+              affected. A view this cannot yet resolve (inline-form views,
+              blocks, applications, capability-map, compliance-impact,
+              coverage-metric, bpmn) is reported as coverage not determined,
+              never as unaffected. Document (.ttrs) coverage is not yet
+              included. --root sets the repo to check (default cwd).
   migrate   — migrate an adopter repo to a newer methodology version by running
               the ordered recipes from the methodology repo. Reads the current
               version from transitrix.yaml (or --from X.Y); --dry-run previews
@@ -721,6 +731,23 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
   }
 }
 
+async function handleImpactCommand(argv: string[]): Promise<void> {
+  if (argv.includes('--help') || argv.includes('-h')) {
+    console.error('usage: transitrix impact [--root <dir>] [--json]');
+    process.exit(0);
+  }
+  const rootIdx = argv.indexOf('--root');
+  if (rootIdx !== -1 && !argv[rootIdx + 1]) {
+    console.error('transitrix impact: --root requires a directory path.');
+    process.exit(1);
+  }
+  const root = rootIdx !== -1 ? argv[rootIdx + 1] : process.cwd();
+  const useJson = argv.includes('--json');
+
+  const result = computeStagedImpact(root);
+  reportImpact(result, useJson);
+}
+
 async function handleMetricsCommand(argv: string[]): Promise<void> {
   const parsed = parseCliFileArgv(argv);
   if (!parsed.ok) {
@@ -814,6 +841,8 @@ try {
     await handleValidateCommand(process.argv.slice(3));
   } else if (subcommand === 'export-compliance') {
     await handleExportComplianceCommand(process.argv.slice(3));
+  } else if (subcommand === 'impact') {
+    await handleImpactCommand(process.argv.slice(3));
   } else if (subcommand === 'migrate') {
     await handleMigrateCommand(process.argv.slice(3));
   } else if (subcommand === 'new') {

--- a/src/impact.ts
+++ b/src/impact.ts
@@ -1,0 +1,215 @@
+// `transitrix impact` — names which derived views a *staged* canon/elements/**
+// change makes stale (transitrix-hq#89, "a change to the model names what it
+// just made untrue"). First slice: the three canon-projection view notations
+// with a static resolver (goals, dgca/fgca, action) checked against the
+// staged (git index) content of canon/elements/**. Everything else under
+// canon/views/** — inline-form views, blocks, applications, capability-map,
+// compliance-impact, coverage-metric, bpmn/process-blueprint — is reported as
+// "coverage not determined", never silently treated as unaffected (the
+// epic's acceptance requirement 6). Document (`.ttrs`) coverage is a
+// separate, later slice: the Pass 1 resolver it needs is not yet merged to
+// `main` (transitrix-hq#57).
+
+import { execFileSync } from 'node:child_process';
+import yaml from 'js-yaml';
+import { coerceDatesToIsoStrings } from '@transitrix/diagrams/yaml-normalize.js';
+import { resolveGoals, isGoalsViewDoc } from '@transitrix/diagrams/goals/resolver.js';
+import { resolveFGCA, isFGCAViewDoc } from '@transitrix/diagrams/fgca';
+import { resolveAction, isActionViewDoc } from '@transitrix/diagrams/activities';
+import { loadRepoModel, loadViewDocs } from './repo-validate.js';
+import { loadNotationYaml, notationOf } from './validate-notation.js';
+
+export interface ImpactFinding {
+  file: string;
+  notation: string;
+}
+
+export interface ImpactResult {
+  /** Staged canon/elements/** ids (added, modified or deleted) this run checked against. */
+  changedIds: string[];
+  /** Views a resolver could check, and that read at least one changed id. */
+  affected: ImpactFinding[];
+  /** Views under canon/views/** whose derivation this cannot yet resolve —
+   *  reported explicitly rather than assumed unaffected. */
+  notDetermined: ImpactFinding[];
+}
+
+function isYamlPath(p: string): boolean {
+  return /\.ya?ml$/i.test(p);
+}
+
+/** The staged (index) content of `relPath`, or `undefined` when it has none
+ *  (deleted in the index, or nothing staged). */
+function gitShowStaged(root: string, relPath: string): string | undefined {
+  try {
+    return execFileSync('git', ['show', `:${relPath}`], {
+      cwd: root,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+/** The `HEAD` content of `relPath` — used for a path staged as deleted, since
+ *  its id has to come from what is being removed, not from the (empty) index. */
+function gitShowHead(root: string, relPath: string): string | undefined {
+  try {
+    return execFileSync('git', ['show', `HEAD:${relPath}`], {
+      cwd: root,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+function elementIdOf(text: string | undefined): string | undefined {
+  if (!text) return undefined;
+  try {
+    const data = coerceDatesToIsoStrings(yaml.load(text));
+    const id = data && typeof data === 'object' && !Array.isArray(data)
+      ? (data as Record<string, unknown>)['id']
+      : undefined;
+    return typeof id === 'string' && id ? id : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Ids of every `canon/elements/**` file staged for commit — additions,
+ *  modifications and deletions alike, since a removed element can make a
+ *  view stale exactly as a changed one can. Reads the staged (index) blob for
+ *  a live path and the `HEAD` blob for a path staged as deleted, never the
+ *  working tree, so the check reflects what is actually about to be
+ *  committed. Returns an empty set for anything that isn't a git repository
+ *  (or has no staged changes) — the caller treats that the same as "nothing
+ *  staged", not as an error. */
+export function stagedCanonElementIds(root: string): Set<string> {
+  let out: string;
+  try {
+    out = execFileSync(
+      'git',
+      ['diff', '--cached', '--name-status', '--diff-filter=ACMRD', '--', 'canon/elements'],
+      { cwd: root, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] },
+    );
+  } catch {
+    return new Set();
+  }
+
+  const ids = new Set<string>();
+  for (const line of out.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const fields = trimmed.split('\t');
+    const status = fields[0];
+    // A rename reports as `R100\told\tnew` — the new path is what changed.
+    const file = fields[fields.length - 1];
+    if (!file || !isYamlPath(file)) continue;
+    const text = status.startsWith('D') ? gitShowHead(root, file) : gitShowStaged(root, file);
+    const id = elementIdOf(text);
+    if (id) ids.add(id);
+  }
+  return ids;
+}
+
+/** Every element id a resolved canon-projection view actually reads, across
+ *  the given top-level array fields of the resolver's output. */
+function idsIn(resolved: Record<string, unknown>, ...fields: string[]): Set<string> {
+  const ids = new Set<string>();
+  for (const field of fields) {
+    const arr = resolved[field];
+    if (!Array.isArray(arr)) continue;
+    for (const item of arr) {
+      if (item && typeof item === 'object' && !Array.isArray(item)) {
+        const id = (item as Record<string, unknown>)['id'];
+        if (typeof id === 'string' && id) ids.add(id);
+      }
+    }
+  }
+  return ids;
+}
+
+/** Which `canon/views/**` documents a staged `canon/elements/**` change makes
+ *  stale. Silent (all three arrays empty) when nothing is staged under
+ *  `canon/elements` — there is nothing yet to have made untrue. */
+export function computeStagedImpact(root: string): ImpactResult {
+  const changedIds = stagedCanonElementIds(root);
+  const affected: ImpactFinding[] = [];
+  const notDetermined: ImpactFinding[] = [];
+
+  if (changedIds.size === 0) {
+    return { changedIds: [], affected, notDetermined };
+  }
+
+  const model = loadRepoModel(root);
+  const elements = model.elements.map((d) => d.data).filter((d): d is Record<string, unknown> => d != null);
+  const relations = model.relations.map((d) => d.data).filter((d): d is Record<string, unknown> => d != null);
+
+  for (const doc of loadViewDocs(root)) {
+    let data: unknown;
+    try {
+      data = loadNotationYaml(doc.text);
+    } catch {
+      continue; // a YAML/structural error is `validate`'s concern, not impact's
+    }
+    const notation = notationOf(data);
+    if (!notation) continue;
+
+    let resolvedIds: Set<string> | undefined;
+    if (notation === 'goals' && isGoalsViewDoc(data)) {
+      resolvedIds = idsIn(resolveGoals(data, { elements }), 'goals');
+    } else if ((notation === 'dgca' || notation === 'fgca') && isFGCAViewDoc(data)) {
+      resolvedIds = idsIn(
+        resolveFGCA(data, { elements, relations }),
+        'factors',
+        'goals',
+        'changes',
+        'actions',
+      );
+    } else if (notation === 'action' && isActionViewDoc(data)) {
+      resolvedIds = idsIn(resolveAction(data, { elements, relations }), 'actions');
+    }
+
+    if (!resolvedIds) {
+      notDetermined.push({ file: doc.path, notation });
+      continue;
+    }
+    if ([...changedIds].some((id) => resolvedIds!.has(id))) {
+      affected.push({ file: doc.path, notation });
+    }
+  }
+
+  return { changedIds: [...changedIds], affected, notDetermined };
+}
+
+/** Print the result (human or JSON). Human output is silent — no lines at
+ *  all — when nothing is staged, or when everything staged resolves cleanly
+ *  to no affected and no undetermined view (epic acceptance requirement 5).
+ *  JSON output is unconditional: a script caller needs the empty case to be
+ *  distinguishable from a run that never happened. */
+export function reportImpact(result: ImpactResult, useJson: boolean): void {
+  if (useJson) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+  if (result.affected.length === 0 && result.notDetermined.length === 0) {
+    return;
+  }
+  if (result.affected.length > 0) {
+    console.log('Staged change affects:');
+    for (const a of result.affected) {
+      console.log(`  • ${a.file} [${a.notation}]`);
+    }
+    console.log();
+  }
+  if (result.notDetermined.length > 0) {
+    console.log('Coverage not determined — derivation not yet resolvable, not claimed unaffected:');
+    for (const n of result.notDetermined) {
+      console.log(`  • ${n.file} [${n.notation}]`);
+    }
+    console.log();
+  }
+}

--- a/src/repo-validate.ts
+++ b/src/repo-validate.ts
@@ -242,8 +242,11 @@ export function buildRepoValidateContext(root: string): RepoValidateContext {
   };
 }
 
-/** Collect the raw text of every YAML doc under `<root>/canon/views/**`. */
-function loadViewDocs(root: string): Array<{ path: string; text: string }> {
+/** Collect the raw text of every YAML doc under `<root>/canon/views/**`.
+ *  Exported for `impact.ts` (transitrix-hq#89), which needs the same raw
+ *  per-file walk to classify each view document's resolvability without
+ *  duplicating this directory walk. */
+export function loadViewDocs(root: string): Array<{ path: string; text: string }> {
   const docs: Array<{ path: string; text: string }> = [];
   let entries: string[] = [];
   try {

--- a/tests/impact.test.ts
+++ b/tests/impact.test.ts
@@ -1,0 +1,181 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+
+import { afterEach, describe, it, expect, vi } from 'vitest';
+
+import { computeStagedImpact, stagedCanonElementIds, reportImpact } from '../src/impact.js';
+
+// A staged canon/elements/** change is only meaningful against a real git
+// index (git diff --cached), so — same pattern as
+// tests/repo-validate-link-suspicion.test.ts — these fixtures are real
+// (throwaway) git repos, not plain tmpdirs.
+
+let root: string | undefined;
+
+afterEach(() => {
+  if (root) rmSync(root, { recursive: true, force: true });
+  root = undefined;
+});
+
+function git(args: string[], cwd: string): void {
+  execFileSync('git', args, { cwd, stdio: 'ignore' });
+}
+
+function write(base: string, rel: string, body: string): void {
+  const p = join(base, rel);
+  mkdirSync(dirname(p), { recursive: true });
+  writeFileSync(p, body, 'utf8');
+}
+
+function initRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'tx-impact-'));
+  git(['init', '-q'], dir);
+  git(['config', 'user.email', 'test@example.com'], dir);
+  git(['config', 'user.name', 'Test'], dir);
+  return dir;
+}
+
+function commitAll(dir: string, message: string): void {
+  git(['add', '-A'], dir);
+  git(['commit', '-q', '-m', message], dir);
+}
+
+/** A DGCA canon-projection view (`view_config`, no inline factors/goals/…) —
+ *  one of the three notations `computeStagedImpact` can resolve. `goals:
+ *  filter: all` means every GOAL element in the store is in scope. */
+const DGCA_VIEW = [
+  'notation: dgca',
+  'id: DGCA-STRAT-1',
+  'name: "Strategy chain"',
+  'view_config:',
+  '  goals:',
+  '    filter: all',
+  '  factors:',
+  '    surface: derived',
+  '  changes:',
+  '    surface: derived',
+  '  activities:',
+  '    surface: derived',
+  '',
+].join('\n');
+
+function goalYaml(id: string, name: string): string {
+  return `notation: goal\nid: ${id}\nname: "${name}"\n`;
+}
+
+function requirementYaml(id: string, description: string): string {
+  return [
+    'notation: requirement',
+    `id: ${id}`,
+    `description: "${description}"`,
+    'zone: canon',
+    'admitted_at: "2026-08-04"',
+    'admitted_by: "v.korobeinikov"',
+    'gate_checks:',
+    '  uniqueness: pass',
+    '  consistency: pass',
+    '  completeness: pass',
+    'valid_from: "2026-08-04"',
+    'valid_to: null',
+    '',
+  ].join('\n');
+}
+
+function seedBaseline(dir: string): void {
+  write(dir, 'canon/elements/goals/GOAL-1.yaml', goalYaml('GOAL-1', 'Grow revenue'));
+  write(dir, 'canon/elements/requirements/REQ-1.yaml', requirementYaml('REQ-1', 'Original wording'));
+  write(dir, 'canon/views/strategy/dgca.dgca.transitrix.yaml', DGCA_VIEW);
+  commitAll(dir, 'seed baseline');
+}
+
+describe('stagedCanonElementIds (transitrix-hq#89)', () => {
+  it('is empty for a repo with nothing staged', () => {
+    root = initRepo();
+    seedBaseline(root);
+    expect(stagedCanonElementIds(root)).toEqual(new Set());
+  });
+
+  it('reads the staged (index) content of a modified element, not the working tree', () => {
+    root = initRepo();
+    seedBaseline(root);
+    write(root, 'canon/elements/goals/GOAL-1.yaml', goalYaml('GOAL-1', 'Grow revenue by 20%'));
+    git(['add', 'canon/elements/goals/GOAL-1.yaml'], root);
+    expect(stagedCanonElementIds(root)).toEqual(new Set(['GOAL-1']));
+  });
+
+  it('reads the ids of an id-bearing file staged for deletion from HEAD, not the (missing) index', () => {
+    root = initRepo();
+    seedBaseline(root);
+    git(['rm', '-q', 'canon/elements/goals/GOAL-1.yaml'], root);
+    expect(stagedCanonElementIds(root)).toEqual(new Set(['GOAL-1']));
+  });
+
+  it('ignores an unstaged working-tree edit', () => {
+    root = initRepo();
+    seedBaseline(root);
+    write(root, 'canon/elements/goals/GOAL-1.yaml', goalYaml('GOAL-1', 'Edited but never staged'));
+    expect(stagedCanonElementIds(root)).toEqual(new Set());
+  });
+});
+
+describe('computeStagedImpact (transitrix-hq#89)', () => {
+  it('names the view that reads a staged, changed element', () => {
+    root = initRepo();
+    seedBaseline(root);
+    write(root, 'canon/elements/goals/GOAL-1.yaml', goalYaml('GOAL-1', 'Grow revenue by 20%'));
+    git(['add', 'canon/elements/goals/GOAL-1.yaml'], root);
+
+    const result = computeStagedImpact(root);
+    expect(result.changedIds).toEqual(['GOAL-1']);
+    expect(result.affected).toEqual([
+      { file: 'canon/views/strategy/dgca.dgca.transitrix.yaml', notation: 'dgca' },
+    ]);
+  });
+
+  it('produces no notice at all for a change nothing reads (acceptance: second case)', () => {
+    root = initRepo();
+    seedBaseline(root);
+    write(root, 'canon/elements/requirements/REQ-1.yaml', requirementYaml('REQ-1', 'Reworded wording'));
+    git(['add', 'canon/elements/requirements/REQ-1.yaml'], root);
+
+    const result = computeStagedImpact(root);
+    expect(result.changedIds).toEqual(['REQ-1']);
+    expect(result.affected).toEqual([]);
+    expect(result.notDetermined).toEqual([]);
+  });
+
+  it('is silent (no console output) when nothing is staged', () => {
+    root = initRepo();
+    seedBaseline(root);
+    const result = computeStagedImpact(root);
+    expect(result).toEqual({ changedIds: [], affected: [], notDetermined: [] });
+
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    reportImpact(result, false);
+    expect(log).not.toHaveBeenCalled();
+    log.mockRestore();
+  });
+
+  it('reports an unresolvable view as coverage-not-determined, never as unaffected', () => {
+    root = initRepo();
+    seedBaseline(root);
+    write(
+      root,
+      'canon/views/portfolio/apps.applications.transitrix.yaml',
+      'notation: applications\nid: APP-1\nname: "Portfolio"\napplications: []\n',
+    );
+    commitAll(root, 'add an unresolvable view');
+    write(root, 'canon/elements/goals/GOAL-1.yaml', goalYaml('GOAL-1', 'Grow revenue by 20%'));
+    git(['add', 'canon/elements/goals/GOAL-1.yaml'], root);
+
+    const result = computeStagedImpact(root);
+    expect(result.affected).toEqual([
+      { file: 'canon/views/strategy/dgca.dgca.transitrix.yaml', notation: 'dgca' },
+    ]);
+    expect(result.notDetermined).toEqual([
+      { file: 'canon/views/portfolio/apps.applications.transitrix.yaml', notation: 'applications' },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- First slice of THQ-89 ("a change to the model names what it just made untrue"): a new `transitrix impact [--root <dir>] [--json]` command that checks a *staged* (`git add`, not committed) `canon/elements/**` change against the three canon-projection view notations with a static resolver — `goals`, `dgca`/`fgca`, `action`.
- Named notice when a resolvable view reads a changed/deleted element id; total silence when nothing is staged or nothing resolvable is affected (epic acceptance requirement 5).
- Every other `canon/views/**` document (inline-form views, `blocks`, `applications`, `capability-map`, `compliance-impact`, `coverage-metric`, `bpmn`) is reported under a distinct "coverage not determined" line — never silently claimed unaffected (requirement 6).
- Deliberately out of scope for this slice, and called out on the epic: document (`.ttrs`) coverage (its Pass 1 resolver isn't merged to `main` yet — #505), and regeneration wiring (which surfaces raise the notice, and whether regeneration is per-artefact or batched, are both explicitly left open by the epic body).

## Test plan
- [x] `npx vitest run tests/impact.test.ts` — 8 new tests, all passing (real throwaway git repos, same pattern as `tests/repo-validate-link-suspicion.test.ts`): staged-vs-working-tree distinction, deletion handling, named-notice case, true silent no-op case, and the coverage-not-determined case.
- [x] `npm run compile` — clean typecheck.
- [x] `npx vitest run` — full suite green aside from 3 pre-existing `cli-migrate.test.ts` failures and 1 pre-existing `ci-hygiene-hashrefs.test.ts` syntax error, confirmed present on `main` before this change (unrelated to this diff).

THQ-89