### PR TITLE
feat(cli): transitrix impact — document (.ttrs) coverage

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -112,14 +112,16 @@ function printUsage(): void {
               default; law:/product:/gap scopes). Scans --root (default cwd) for
               requirement/assertion/product/codex canon. PDF rendering requires
               WeasyPrint on PATH (pipx install weasyprint).
-  impact    — names which canon/views/** documents a *staged* (git add, not
-              yet committed) canon/elements/** change makes stale. Silent
-              when nothing is staged, or when nothing this can resolve is
-              affected. A view this cannot yet resolve (inline-form views,
-              blocks, applications, capability-map, compliance-impact,
-              coverage-metric, bpmn) is reported as coverage not determined,
-              never as unaffected. Document (.ttrs) coverage is not yet
-              included. --root sets the repo to check (default cwd).
+  impact    — names which canon/views/** documents and canon/views/documents/**
+              .ttrs sources a *staged* (git add, not yet committed)
+              canon/elements/** change makes stale. Silent when nothing is
+              staged, or when nothing this can resolve is affected. A view
+              this cannot yet resolve (inline-form views, blocks,
+              applications, capability-map, compliance-impact,
+              coverage-metric, bpmn) or a .ttrs document holding an
+              each/trace/row-field construct is reported as coverage not
+              determined, never as unaffected. --root sets the repo to check
+              (default cwd).
   migrate   — migrate an adopter repo to a newer methodology version by running
               the ordered recipes from the methodology repo. Reads the current
               version from transitrix.yaml (or --from X.Y); --dry-run previews

--- a/src/impact.ts
+++ b/src/impact.ts
@@ -6,9 +6,20 @@
 // canon/views/** — inline-form views, blocks, applications, capability-map,
 // compliance-impact, coverage-metric, bpmn/process-blueprint — is reported as
 // "coverage not determined", never silently treated as unaffected (the
-// epic's acceptance requirement 6). Document (`.ttrs`) coverage is a
-// separate, later slice: the Pass 1 resolver it needs is not yet merged to
-// `main` (transitrix-hq#57).
+// epic's acceptance requirement 6).
+//
+// Second slice: document (`.ttrs`) coverage, unblocked now that
+// @transitrix/document-renderer is vendored on `main` (originally for the
+// `.ttrs` preview, extension/src/ttrs-preview.ts). This reads a document's
+// model-object references (`{{ ID }}` / `{{ ID.field }}` / an instruction
+// slot's `inputs:` list) directly off the parse AST rather than running Pass
+// 1's full resolution — Pass 1 needs a `renderDate` and a resolvable
+// repository index to classify a reference as ok/unresolved/etc., none of
+// which this check has any use for: it only wants *which ids a document
+// cites*, not whether they currently resolve. A document whose AST contains
+// `each`/`trace`/a row `.field` (parsed as `unimplemented` — this pass does
+// not know which ids such a construct would touch) is reported as
+// coverage-not-determined, same honesty rule as an unresolvable view.
 
 import { execFileSync } from 'node:child_process';
 import yaml from 'js-yaml';
@@ -16,8 +27,19 @@ import { coerceDatesToIsoStrings } from '@transitrix/diagrams/yaml-normalize.js'
 import { resolveGoals, isGoalsViewDoc } from '@transitrix/diagrams/goals/resolver.js';
 import { resolveFGCA, isFGCAViewDoc } from '@transitrix/diagrams/fgca';
 import { resolveAction, isActionViewDoc } from '@transitrix/diagrams/activities';
-import { loadRepoModel, loadViewDocs } from './repo-validate.js';
+import { loadRepoModel, loadViewDocs, loadDocumentSources } from './repo-validate.js';
 import { loadNotationYaml, notationOf } from './validate-notation.js';
+import { DOCUMENT_SOURCE_EXTENSION } from './validate-document-source.js';
+// Vendored from methodology — see scripts/vendor-methodology-document-renderer.mjs
+// and tests/document-renderer-vendor.test.ts for the integrity check that
+// keeps this import target trustworthy. Only the syntax half (parseTemplate)
+// is needed here; this check never resolves a reference against a repository.
+import {
+  parseTemplate,
+  type TemplateNode,
+  type TemplateReferenceNode,
+  type TemplateInstructNode,
+} from '../vendor/methodology/document-renderer/parse-template.mjs';
 
 export interface ImpactFinding {
   file: string;
@@ -182,7 +204,59 @@ export function computeStagedImpact(root: string): ImpactResult {
     }
   }
 
+  for (const doc of loadDocumentSources(root)) {
+    // The `.trs` near-miss is never a parseable document — `validate` already
+    // names it as a naming defect; it has nothing for this check to read.
+    if (!doc.path.toLowerCase().endsWith(DOCUMENT_SOURCE_EXTENSION)) continue;
+
+    const { ids: referencedIds, determined } = documentReferencedIds(doc.text);
+    if (!determined) {
+      notDetermined.push({ file: doc.path, notation: 'documents' });
+      continue;
+    }
+    if ([...changedIds].some((id) => referencedIds.has(id))) {
+      affected.push({ file: doc.path, notation: 'documents' });
+    }
+  }
+
   return { changedIds: [...changedIds], affected, notDetermined };
+}
+
+/** The model-object ids a `.ttrs` document's parsed AST cites directly —
+ *  inline references (`{{ ID }}` / `{{ ID.field }}`) and an instruction
+ *  slot's own `inputs:` list — and whether that is the *whole* story.
+ *  `determined` is false when the AST holds an `each`/`trace`/row-`.field`
+ *  node (parsed as `unimplemented`) — this check does not know which ids such
+ *  a construct would touch, so it cannot claim the document unaffected on the
+ *  strength of the plain references alone (epic acceptance requirement 6). A
+ *  parse error carries no reference information either — same fallback. */
+function isReferenceNode(node: TemplateNode): node is TemplateReferenceNode {
+  return node.type === 'reference';
+}
+
+function isInstructNode(node: TemplateNode): node is TemplateInstructNode {
+  return node.type === 'instruct';
+}
+
+function documentReferencedIds(text: string): { ids: Set<string>; determined: boolean } {
+  const ids = new Set<string>();
+  let parsed: ReturnType<typeof parseTemplate>;
+  try {
+    parsed = parseTemplate(text);
+  } catch {
+    return { ids, determined: false };
+  }
+  let determined = true;
+  for (const node of parsed.ast) {
+    if (isReferenceNode(node)) {
+      ids.add(node.id);
+    } else if (isInstructNode(node)) {
+      for (const input of node.inputs) ids.add(input);
+    } else if (node.type === 'unimplemented') {
+      determined = false;
+    }
+  }
+  return { ids, determined };
 }
 
 /** Print the result (human or JSON). Human output is silent — no lines at

--- a/src/repo-validate.ts
+++ b/src/repo-validate.ts
@@ -271,8 +271,11 @@ export function loadViewDocs(root: string): Array<{ path: string; text: string }
 /** Collect every document source (and its `.trs` near-miss) across the model
  *  zones. Deliberately not scoped to `canon/views/documents/**`: a `.ttrs` file
  *  in the wrong folder is precisely what the placement half of the check exists
- *  to catch, and a walk scoped to the right folder would never see one. */
-function loadDocumentSources(root: string): Array<{ path: string; text: string }> {
+ *  to catch, and a walk scoped to the right folder would never see one.
+ *  Exported for `impact.ts` (transitrix-hq#89), which needs the same walk to
+ *  find `.ttrs` sources to check for staged-change coverage — it filters out
+ *  the `.trs` near-miss itself, since that is never a parseable document. */
+export function loadDocumentSources(root: string): Array<{ path: string; text: string }> {
   const docs: Array<{ path: string; text: string }> = [];
   const seen = new Set<string>();
   for (const zone of DOCUMENT_SOURCE_SEARCH_ROOTS) {

--- a/tests/impact.test.ts
+++ b/tests/impact.test.ts
@@ -179,3 +179,123 @@ describe('computeStagedImpact (transitrix-hq#89)', () => {
     ]);
   });
 });
+
+/** A minimal, valid `.ttrs` document source — required header fields only. */
+function ttrsDoc(templateId: string, body: string): string {
+  return [
+    '---',
+    'document: "Test document"',
+    'kind: mrd',
+    `template_id: ${templateId}`,
+    'template_version: "1.0"',
+    '---',
+    '',
+    body,
+    '',
+  ].join('\n');
+}
+
+// These fixtures stage REQ-1, not GOAL-1: seedBaseline's dgca view resolves
+// every GOAL element (`filter: all`), so a staged GOAL-1 change would also
+// land in `affected` via that view and muddy what these tests are checking.
+// REQ-1 is read by nothing in the baseline view (confirmed by the "produces
+// no notice at all" test above), so it isolates the .ttrs-only behaviour.
+describe('computeStagedImpact — .ttrs document coverage (transitrix-hq#89)', () => {
+  it('names a .ttrs document whose inline reference reads a staged, changed element', () => {
+    root = initRepo();
+    seedBaseline(root);
+    write(
+      root,
+      'canon/views/documents/product.mrd.ttrs',
+      ttrsDoc('product.mrd', 'This document cites {{ REQ-1 }} directly.'),
+    );
+    commitAll(root, 'add a document source');
+    write(root, 'canon/elements/requirements/REQ-1.yaml', requirementYaml('REQ-1', 'Reworded wording'));
+    git(['add', 'canon/elements/requirements/REQ-1.yaml'], root);
+
+    const result = computeStagedImpact(root);
+    expect(result.affected).toEqual([
+      { file: 'canon/views/documents/product.mrd.ttrs', notation: 'documents' },
+    ]);
+    expect(result.notDetermined).toEqual([]);
+  });
+
+  it('names a .ttrs document whose instruction-slot inputs name a staged, changed element', () => {
+    root = initRepo();
+    seedBaseline(root);
+    write(
+      root,
+      'canon/views/documents/product.mrd.ttrs',
+      ttrsDoc(
+        'product.mrd',
+        [
+          '{{# instruct market-size }}',
+          'question: How large is the addressable market?',
+          'inputs: REQ-1, GOAL-1',
+          'sufficient: A number with a source.',
+          '{{/ instruct }}',
+        ].join('\n'),
+      ),
+    );
+    commitAll(root, 'add a document source');
+    write(root, 'canon/elements/requirements/REQ-1.yaml', requirementYaml('REQ-1', 'Reworded wording'));
+    git(['add', 'canon/elements/requirements/REQ-1.yaml'], root);
+
+    const result = computeStagedImpact(root);
+    expect(result.affected).toEqual([
+      { file: 'canon/views/documents/product.mrd.ttrs', notation: 'documents' },
+    ]);
+  });
+
+  it('produces no notice for a .ttrs document that cites none of the staged ids', () => {
+    root = initRepo();
+    seedBaseline(root);
+    write(
+      root,
+      'canon/views/documents/product.mrd.ttrs',
+      ttrsDoc('product.mrd', 'This document cites {{ GOAL-1 }} only.'),
+    );
+    commitAll(root, 'add a document source');
+    write(root, 'canon/elements/requirements/REQ-1.yaml', requirementYaml('REQ-1', 'Reworded wording'));
+    git(['add', 'canon/elements/requirements/REQ-1.yaml'], root);
+
+    const result = computeStagedImpact(root);
+    expect(result.affected).toEqual([]);
+    expect(result.notDetermined).toEqual([]);
+  });
+
+  it('reports a .ttrs document holding an unimplemented construct as coverage-not-determined, never as unaffected', () => {
+    root = initRepo();
+    seedBaseline(root);
+    write(
+      root,
+      'canon/views/documents/product.mrd.ttrs',
+      ttrsDoc(
+        'product.mrd',
+        '{{# each REQUIREMENT }}\n{{ .id }}\n{{/ each }}\n\nThis document cites {{ REQ-1 }} too.',
+      ),
+    );
+    commitAll(root, 'add a document source');
+    write(root, 'canon/elements/requirements/REQ-1.yaml', requirementYaml('REQ-1', 'Reworded wording'));
+    git(['add', 'canon/elements/requirements/REQ-1.yaml'], root);
+
+    const result = computeStagedImpact(root);
+    expect(result.affected).toEqual([]);
+    expect(result.notDetermined).toEqual([
+      { file: 'canon/views/documents/product.mrd.ttrs', notation: 'documents' },
+    ]);
+  });
+
+  it('does not check the .trs near-miss (never a parseable document)', () => {
+    root = initRepo();
+    seedBaseline(root);
+    write(root, 'canon/views/documents/product.mrd.trs', ttrsDoc('product.mrd', '{{ REQ-1 }}'));
+    commitAll(root, 'add a near-miss file');
+    write(root, 'canon/elements/requirements/REQ-1.yaml', requirementYaml('REQ-1', 'Reworded wording'));
+    git(['add', 'canon/elements/requirements/REQ-1.yaml'], root);
+
+    const result = computeStagedImpact(root);
+    expect(result.affected).toEqual([]);
+    expect(result.notDetermined).toEqual([]);
+  });
+});

--- a/vendor/methodology/document-renderer/parse-template.d.mts
+++ b/vendor/methodology/document-renderer/parse-template.d.mts
@@ -1,0 +1,67 @@
+// Type contract for the vendored parse-template.mjs — Studio's own, not part
+// of what vendor-methodology-document-renderer.mjs fetches from methodology
+// (that script only writes the five .mjs files; this file is untouched by
+// it). Kept intentionally narrow: only the shape src/impact.ts actually
+// reads. The source of truth for the full contract is parse-template.mjs's
+// own JSDoc and methodology/notations/views/documents/DIRECTIVE_LANGUAGE.md.
+
+export interface TemplateReferenceNode {
+  type: 'reference';
+  id: string;
+  fields: string[];
+}
+
+/** `each` / `trace` / the `.field` row reference — constructs the language
+ *  defines that this pass declines to resolve. `construct` names which one. */
+export interface TemplateUnimplementedNode {
+  type: 'unimplemented';
+  construct: string;
+}
+
+/** `{{# instruct <slot-id> }} … {{/ instruct }}` — `inputs` is the slot's own
+ *  `inputs:` field, already comma-split and trimmed by the parser; each entry
+ *  names a model-object id the slot reads. */
+export interface TemplateInstructNode {
+  type: 'instruct';
+  slotId: string | undefined;
+  question: string | undefined;
+  inputs: string[];
+  sufficient: string | undefined;
+  raw: string;
+}
+
+/** Every other node shape this pass produces (`text`, `view`, `figure`,
+ *  `figref`, `error`) — untyped here because src/impact.ts reads none of
+ *  their fields, only whether a node is a reference, an instruct slot, or
+ *  unimplemented. */
+export interface TemplateOtherNode {
+  type: string;
+  [key: string]: unknown;
+}
+
+export type TemplateNode =
+  | TemplateReferenceNode
+  | TemplateUnimplementedNode
+  | TemplateInstructNode
+  | TemplateOtherNode;
+
+export interface TemplateHeader {
+  document: string;
+  kind: string;
+  template_id: string;
+  template_version: string;
+  canon: string | null;
+}
+
+export interface TemplateParseError {
+  code: string;
+  message: string;
+}
+
+export interface ParseTemplateResult {
+  header: TemplateHeader | null;
+  ast: TemplateNode[];
+  errors: TemplateParseError[];
+}
+
+export function parseTemplate(text: string): ParseTemplateResult;


### PR DESCRIPTION
## Summary

Second slice of THQ-89 ("a change to the model names what it just made untrue"): `transitrix impact` now also checks staged `canon/elements/**` changes against `.ttrs` document sources, not just `canon/views/**` diagram/view notations. This was blocked in the first slice (studio#507) because the Pass 1 resolver wasn't yet vendored on `main` — it landed since (studio#505's vendoring of `@transitrix/document-renderer`).

## What it does

- Reads a `.ttrs` document's referenced ids directly off `parseTemplate()`'s AST — inline `{{ ID }}` / `{{ ID.field }}` references and an instruction slot's own `inputs:` list — rather than running Pass 1's full resolution (which needs a `renderDate` and a resolvable repository index to classify a reference's state; this check only needs to know *which ids a document cites*).
- A document holding an `each`/`trace`/row-`.field` construct (parsed as `unimplemented`) is reported **coverage not determined**, never as unaffected — same honesty rule already applied to a view this repo can't yet resolve.
- The `.trs` near-miss extension is skipped (never a parseable document; `validate` already flags it separately).
- `loadDocumentSources` (repo-validate.ts) is now exported for reuse, same precedent as the earlier `loadViewDocs` export.
- Added `vendor/methodology/document-renderer/parse-template.d.mts` — a narrow, Studio-authored type declaration for the vendored `parseTemplate()`, same pattern as the existing `pass1.d.mts` (untouched by the vendor-refresh script).

## Test plan

- [x] `npm run compile` (typecheck) passes
- [x] `npx vitest run tests/impact.test.ts` — 13/13 passing, including 5 new cases for document coverage (affected via inline ref, affected via instruction-slot inputs, silent when nothing cited, not-determined on `each`, `.trs` near-miss ignored)
- [x] Full `npm test` run — 4 pre-existing failures confirmed unrelated (identical failures reproduced on a clean `main` via `git stash`): 3 in `cli-migrate.test.ts` (needs a local methodology checkout) and 1 syntax error in `ci-hygiene-hashrefs.test.ts`