### PR TITLE
fix(diagrams): BPMN export text classes declare no font-family

### DIFF
--- a/packages/diagrams/src/webview/__tests__/render-process.test.ts
+++ b/packages/diagrams/src/webview/__tests__/render-process.test.ts
@@ -139,6 +139,14 @@ describe('renderProcessLayoutSvg — CSS', () => {
     expect(svg.toLowerCase()).not.toContain('font-style');
     expect(svg.toLowerCase()).not.toContain('italic');
   });
+
+  it('declares font-family on every BPMN text-label class, so an exported SVG renders sans-serif with no host stylesheet present', () => {
+    const svg = renderProcessLayoutSvg(makeLayout());
+    for (const cls of ['bpmn-pool-label', 'bpmn-lane-label', 'bpmn-task-name', 'bpmn-event-label', 'bpmn-gateway-label']) {
+      const rule = svg.match(new RegExp(`\\.${cls}\\s*\\{[^}]*\\}`))?.[0] ?? '';
+      expect(rule).toContain('font-family');
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/diagrams/src/webview/render-process.ts
+++ b/packages/diagrams/src/webview/render-process.ts
@@ -116,17 +116,17 @@ export const BPMN_PROCESS_CSS = `
 .bpmn-pool-name { fill: var(--ts-bg-elevated,#f1f5f9); stroke: var(--ts-node-stroke,#004d67); stroke-width: 0.75; }
 .bpmn-lane { fill: var(--ts-bg,#ffffff); stroke: var(--ts-node-stroke,#004d67); stroke-width: 0.75; }
 .bpmn-lane-header { fill: var(--ts-bg-elevated,#f1f5f9); stroke: var(--ts-node-stroke,#004d67); stroke-width: 0.75; }
-.bpmn-pool-label { fill: var(--ts-text-primary,#0d2b35); font-size: 11px; font-weight: 700; }
-.bpmn-lane-label { fill: var(--ts-text-primary,#0d2b35); font-size: 11px; font-weight: 600; }
+.bpmn-pool-label { fill: var(--ts-text-primary,#0d2b35); font-family: var(--vscode-font-family, system-ui, -apple-system, sans-serif); font-size: 11px; font-weight: 700; }
+.bpmn-lane-label { fill: var(--ts-text-primary,#0d2b35); font-family: var(--vscode-font-family, system-ui, -apple-system, sans-serif); font-size: 11px; font-weight: 600; }
 .bpmn-task { fill: var(--ts-bg,#ffffff); stroke: var(--ts-node-stroke,#004d67); stroke-width: 1.5; }
-.bpmn-task-name { fill: var(--ts-text-primary,#0d2b35); font-size: 11px; text-anchor: middle; }
+.bpmn-task-name { fill: var(--ts-text-primary,#0d2b35); font-family: var(--vscode-font-family, system-ui, -apple-system, sans-serif); font-size: 11px; text-anchor: middle; }
 .bpmn-event { fill: var(--ts-bg,#ffffff); stroke: var(--ts-node-stroke,#004d67); }
 .bpmn-event-start { stroke-width: 1.5; }
 .bpmn-event-end { stroke-width: 4; }
-.bpmn-event-label { fill: var(--ts-text-secondary,#516970); font-size: 10px; text-anchor: middle; }
+.bpmn-event-label { fill: var(--ts-text-secondary,#516970); font-family: var(--vscode-font-family, system-ui, -apple-system, sans-serif); font-size: 10px; text-anchor: middle; }
 .bpmn-gateway { fill: var(--ts-bg,#ffffff); stroke: var(--ts-node-stroke,#004d67); stroke-width: 1.5; }
 .bpmn-gateway-marker { stroke: var(--ts-node-stroke,#004d67); stroke-width: 2.5; stroke-linecap: round; fill: none; }
-.bpmn-gateway-label { fill: var(--ts-text-secondary,#516970); font-size: 10px; text-anchor: middle; }
+.bpmn-gateway-label { fill: var(--ts-text-secondary,#516970); font-family: var(--vscode-font-family, system-ui, -apple-system, sans-serif); font-size: 10px; text-anchor: middle; }
 .bpmn-seq-flow { fill: none; stroke: var(--ts-edge-stroke,#004d67); stroke-width: 1.5; }
 .bpmn-default-mark { stroke: var(--ts-edge-stroke,#004d67); stroke-width: 1.5; stroke-linecap: round; }
 .bpmn-assoc { fill: none; stroke: var(--ts-edge-stroke,#004d67); stroke-width: 1; stroke-dasharray: 4 2; }


### PR DESCRIPTION
## Summary
- `bpmn-lane-label`, `bpmn-task-name`, `bpmn-pool-label`, `bpmn-event-label`, `bpmn-gateway-label` declared no `font-family`, so an SVG exported from the BPMN preview rendered with the default serif fallback once the webview's ambient stylesheet was gone.
- Added the same `font-family: var(--vscode-font-family, system-ui, -apple-system, sans-serif)` declaration the other notations' text classes already carry.
- Added a presence-assertion test (an omission bug only a presence check catches).

Flagging per the source issue: the classes above (and the other notation text classes) reference `var(--vscode-font-family, …)`, an editor-only CSS custom property. The fallback list covers it in any browser today, so nothing is broken, but it's worth a second look now that export-outside-the-editor is a real path. Left as-is here since it's not a trivial one-line change and wasn't required for this task's acceptance.

closes THQ-99

## Test plan
- [x] `npx vitest run` in `packages/diagrams` — 102 files / 1661 tests pass
- [x] `npx tsc --noEmit` in `packages/diagrams` — clean