### PR TITLE
feat(cli): provenance stamp on the compliance-impact Markdown artefact (THQ-89)

### DIFF
--- a/scripts/render-compliance-impact.mjs
+++ b/scripts/render-compliance-impact.mjs
@@ -38,12 +38,17 @@
 
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { execFileSync } from 'node:child_process';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import yaml from 'js-yaml';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const STUDIO_ROOT = path.resolve(HERE, '..');
-const DIST_INDEX = path.join(STUDIO_ROOT, 'packages', 'diagrams', 'dist', 'index.js');
+// The `compliance` subpath, not the package root — the root barrel
+// (`dist/index.js`) also re-exports webview React components that import
+// `reactflow/dist/style.css`, which plain `node` cannot load (no bundler
+// here to strip a bare CSS import). This script never needs those exports.
+const DIST_INDEX = path.join(STUDIO_ROOT, 'packages', 'diagrams', 'dist', 'compliance', 'index.js');
 
 function parseArgs(argv) {
   const out = { view: null, registry: null, report: null, canon: null, output: null };
@@ -167,6 +172,65 @@ function logActiveDefaults(config, defaults) {
   }
 }
 
+/**
+ * `git rev-parse HEAD` at `root`, or `null` when `root` is not inside a git
+ * repository (or git itself is unavailable) — either is a normal outcome for
+ * a canon root, not an error worth failing the render over.
+ */
+function gitCommit(root) {
+  try {
+    return execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: root,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/** True when `root` has uncommitted changes — the recorded commit alone would
+ *  understate what the render actually read. `null` (not a git repo) reads as
+ *  not-dirty; `gitCommit` already carries that case. */
+function gitDirty(root) {
+  try {
+    const out = execFileSync('git', ['status', '--porcelain'], {
+      cwd: root,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return out.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Provenance stamp — source path(s), source commit, generator, generation
+ * time — embedded in the artefact itself per the cross-project derived-artefact
+ * decision (2026-08-08, amended 2026-08-09): "an artefact with no stamp is
+ * stale by definition." An HTML comment so it travels with the Markdown file
+ * without altering its rendered appearance.
+ */
+function buildProvenanceStamp({ canonRoot, viewSource, generatedAt }) {
+  const commit = gitCommit(canonRoot);
+  const sourceCommit = commit
+    ? `${commit}${gitDirty(canonRoot) ? ' (dirty — uncommitted changes present at generation time)' : ''}`
+    : 'unknown (canon root is not a git repository)';
+  return [
+    '<!--',
+    'generated-by: render-compliance-impact.mjs',
+    `canon-root: ${canonRoot}`,
+    `view-config: ${viewSource}`,
+    `source-commit: ${sourceCommit}`,
+    `generated-at: ${generatedAt}`,
+    'no stamp above means stale by definition — do not strip on regeneration.',
+    '-->',
+    '',
+    '',
+  ].join('\n');
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
 
@@ -277,7 +341,14 @@ async function main() {
   }
 
   const matrix = buildImpactMatrix(canon, view, objectDetails);
-  const md = renderImpactMarkdown(matrix);
+  const stamp = buildProvenanceStamp({
+    canonRoot: path.resolve(args.canon),
+    viewSource: args.view
+      ? path.resolve(args.view)
+      : `registry:${path.resolve(args.registry)}#${args.report}`,
+    generatedAt: new Date().toISOString(),
+  });
+  const md = stamp + renderImpactMarkdown(matrix);
 
   if (args.output) {
     await fs.writeFile(args.output, md, 'utf8');

--- a/tests/render-compliance-impact.test.ts
+++ b/tests/render-compliance-impact.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { tmpdir } from 'node:os';
+
+// `scripts/render-compliance-impact.mjs`'s persisted Markdown output must
+// carry the provenance stamp (transitrix-hq#89's regeneration half, unblocked
+// by transitrix-hq#98 / the 2026-08-09 amendment to the cross-project
+// derived-artefact decision): source path(s), source commit, generator,
+// generation time, in the artefact itself — never a sidecar.
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const SCRIPT = join(REPO_ROOT, 'scripts', 'render-compliance-impact.mjs');
+
+function runScript(args: string[]) {
+  return spawnSync(process.execPath, [SCRIPT, ...args], { encoding: 'utf-8' });
+}
+
+describe('render-compliance-impact.mjs provenance stamp', () => {
+  let dir: string;
+  let canonDir: string;
+  let viewFile: string;
+  let outFile: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'render-compliance-impact-test-'));
+    canonDir = join(dir, 'canon');
+    mkdirSync(canonDir, { recursive: true });
+    viewFile = join(dir, 'demo.compliance-impact.view.yaml');
+    writeFileSync(
+      viewFile,
+      'view:\n  id: DEMO-1\n  name: Demo\n  subjects:\n    products: []\n',
+    );
+    outFile = join(dir, 'out.md');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('embeds a stamp naming the generator, both sources, and a generation time', () => {
+    const result = runScript(['--view', viewFile, '--canon', canonDir, '--out', outFile]);
+    expect(result.status).toBe(0);
+
+    const written = readFileSync(outFile, 'utf-8');
+    expect(written).toMatch(/^<!--\n/);
+    expect(written).toContain('generated-by: render-compliance-impact.mjs');
+    expect(written).toContain(`canon-root: ${canonDir}`);
+    expect(written).toContain(`view-config: ${viewFile}`);
+    // canonDir is a bare tmp directory — no git repository above it in scope.
+    expect(written).toContain('source-commit: unknown (canon root is not a git repository)');
+    expect(written).toMatch(/generated-at: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/);
+    // The stamp precedes the report body, which is unaffected by it.
+    expect(written).toContain('# Demo');
+  });
+
+  it('records the HEAD commit of a clean canon-root git repository, with no dirty suffix', () => {
+    spawnSync('git', ['init', '-q'], { cwd: canonDir });
+    spawnSync('git', ['config', 'user.email', 'test@example.com'], { cwd: canonDir });
+    spawnSync('git', ['config', 'user.name', 'Test'], { cwd: canonDir });
+    writeFileSync(join(canonDir, 'placeholder.txt'), 'placeholder\n');
+    spawnSync('git', ['add', '-A'], { cwd: canonDir });
+    spawnSync('git', ['commit', '-q', '-m', 'initial'], { cwd: canonDir });
+    const commit = spawnSync('git', ['rev-parse', 'HEAD'], { cwd: canonDir, encoding: 'utf-8' }).stdout.trim();
+
+    const result = runScript(['--view', viewFile, '--canon', canonDir, '--out', outFile]);
+    expect(result.status).toBe(0);
+
+    const written = readFileSync(outFile, 'utf-8');
+    expect(written).toContain(`source-commit: ${commit}\n`);
+  });
+
+  it('flags a dirty canon-root working tree rather than reading it as clean', () => {
+    spawnSync('git', ['init', '-q'], { cwd: canonDir });
+    spawnSync('git', ['config', 'user.email', 'test@example.com'], { cwd: canonDir });
+    spawnSync('git', ['config', 'user.name', 'Test'], { cwd: canonDir });
+    writeFileSync(join(canonDir, 'placeholder.txt'), 'placeholder\n');
+    spawnSync('git', ['add', '-A'], { cwd: canonDir });
+    spawnSync('git', ['commit', '-q', '-m', 'initial'], { cwd: canonDir });
+    // Uncommitted change after the commit the stamp would otherwise cite.
+    writeFileSync(join(canonDir, 'placeholder.txt'), 'changed\n');
+
+    const result = runScript(['--view', viewFile, '--canon', canonDir, '--out', outFile]);
+    expect(result.status).toBe(0);
+
+    const written = readFileSync(outFile, 'utf-8');
+    expect(written).toContain('(dirty — uncommitted changes present at generation time)');
+  });
+});


### PR DESCRIPTION
## Summary
- THQ-89's regeneration-wiring half was unblocked by THQ-98's amendment to the 2026-08-08 cross-project derived-artefact decision (a tooling-generated report is in scope wherever we are the reader).
- `scripts/render-compliance-impact.mjs`'s persisted Markdown output now embeds a provenance stamp in the artefact itself — canon-root path, view-config path, source commit (flagged when the canon root's working tree is dirty), generator, and generation time — per the decision's stamp shape (no sidecar).
- Fixed a separate, pre-existing break found while testing this: the script imported the diagrams package's root barrel (`dist/index.js`), which also re-exports webview React components pulling in `reactflow/dist/style.css` — something plain `node` cannot load. The script never needed those exports; repointed it to the `compliance` subpath. This is presumably why the script had no test coverage before now — it could not run at all under plain `node`.

**Not in this slice:** wiring this stamp into a staleness *check* (comparing the stamped commit against canon's current HEAD) — the epic's requirement 4 ("which surfaces raise the notice") is still an open decomposition question per the epic's own text. This slice lands the stamp itself, which is what #98 unblocked.

## Test plan
- [x] `npx vitest run tests/render-compliance-impact.test.ts` — 3 new tests (clean stamp, real git-repo commit capture, dirty-tree flag) pass
- [x] `npm run test:core` — full suite green except two pre-existing `cli-migrate.test.ts` cases gated on a sibling `methodology` checkout, unrelated to this change
- [x] `npm run compile` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)