### PR TITLE
feat(extension): document and surface the preview's save-triggered refresh (THQ-103)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ process:
     - { from: receiveOrder, to: end }
 ```
 
-Open it in VS Code — the preview panel opens automatically and refreshes on every save.
+Open it in VS Code — the preview panel opens automatically and refreshes on save (not on every keystroke — see the extension README's "Get started" section for the recommended `files.autoSave` setting if you want it to feel live).
 
 ## CLI
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -38,7 +38,18 @@ Transitrix flips that:
 
 Every preview ships with a toolbar: title toggle, discrete zoom (50–200%), save as SVG, save as PNG (2× for crisp output), and copy PNG to clipboard (Windows today; macOS / Linux planned).
 
-The preview opens automatically when a recognised file becomes the active editor, and refreshes on every save. Turn this off with `transitrix.preview.autoOpenOnFileOpen` if you'd rather open previews on demand — the toolbar preview icon (same `$(graph)` icon across every notation) always works regardless of the setting.
+The preview opens automatically when a recognised file becomes the active editor, and refreshes **on save — not on every keystroke.** That's deliberate: re-rendering mid-edit would burn CPU and flash parse errors on every intermediate state of a structural change. It also means an edit with no save behind it looks, at a glance, like a broken preview — the toolbar's small "as of last save" label is the tell that nothing's wrong, the file just hasn't been saved yet.
+
+For an edit-and-watch-it-update feel without an explicit save keystroke, turn on autosave with a short delay:
+
+```json
+{
+  "files.autoSave": "afterDelay",
+  "files.autoSaveDelay": 500
+}
+```
+
+Turn auto-open off with `transitrix.preview.autoOpenOnFileOpen` if you'd rather open previews on demand — the toolbar preview icon (same `$(graph)` icon across every notation) always works regardless of the setting.
 
 ## Pairs well with Mermaid
 

--- a/extension/src/diagram-frame.ts
+++ b/extension/src/diagram-frame.ts
@@ -334,6 +334,13 @@ const TITLE_TOGGLE_CSS = `
   text-decoration: none;
 }
 .toolbar-btn:hover { color: var(--ts-text, #0f172a); background: var(--ts-bg-elevated, #f1f5f9); }
+.toolbar-savenote {
+  flex: 0 0 auto;
+  font-size: 10px;
+  color: var(--ts-text-muted, #64748b);
+  white-space: nowrap;
+  cursor: help;
+}
 .title-toggle::before { content: "\\2611\\00a0"; font-size: 12px; }
 .title-toggle:hover { color: var(--ts-text, #0f172a); background: var(--ts-bg-elevated, #f1f5f9); }
 .title-toggle-cb:focus-visible ~ #toolbar .title-toggle { outline: 1px dashed var(--ts-text-muted, #64748b); outline-offset: 2px; }
@@ -608,6 +615,15 @@ export function buildDiagramFrame(opts: DiagramFrameOpts): string {
   const toolbarLabel = filename
     ? `${escXml(notation)}: ${escXml(filename)}`
     : escXml(notation);
+  // As-of-last-save note (epic transitrix-hq#103): the preview renders
+  // doc.getText() on open and on save only, never on every keystroke — so an
+  // unsaved edit shows no change. Only meaningful for a doc-bound preview
+  // (filename set); repo-wide dashboards already carry an explicit Refresh
+  // button instead. Shown on every notation preview because it lives in this
+  // one shared frame builder, not per-preview.
+  const saveNote = filename
+    ? `<span class="toolbar-savenote" title="This preview reflects ${escXml(filename)} as of its last save. Edit and save (or enable files.autoSave) to update it.">as of last save</span>`
+    : '';
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -633,7 +649,7 @@ ${extraStyles}
   ${zoomInputs}
   ${errToggleInput}
   ${warnToggleInput}
-  <div id="toolbar"><span class="toolbar-label">${toolbarLabel}</span>${toolbarRight}</div>
+  <div id="toolbar"><span class="toolbar-label">${toolbarLabel}</span>${saveNote}${toolbarRight}</div>
   ${controlsPanel}
   ${timelineStrip}
   ${snapInfoBox}

--- a/tests/diagram-frame.test.ts
+++ b/tests/diagram-frame.test.ts
@@ -118,6 +118,29 @@ describe('buildDiagramFrame warnings strip', () => {
   });
 });
 
+// transitrix-hq#103 — the preview renders on open/save only, never on every
+// keystroke, so an unsaved edit shows no change. The toolbar note is the
+// product-surface tell that nothing is broken.
+describe('buildDiagramFrame as-of-last-save note', () => {
+  it('shows the note for a document-bound preview (filename set)', () => {
+    const html = buildDiagramFrame({ ...base, svgContent: '<svg/>' });
+    expect(html).toContain('class="toolbar-savenote"');
+    expect(html).toContain('as of last save');
+    expect(html).toContain('demo.goals.transitrix.yaml as of its last save');
+  });
+
+  it('omits the note for a repo-wide preview with no tracked filename', () => {
+    const html = buildDiagramFrame({ ...base, filename: '', svgContent: '<svg/>' });
+    expect(html).not.toContain('class="toolbar-savenote"');
+  });
+
+  it('escapes the filename in the note tooltip', () => {
+    const html = buildDiagramFrame({ ...base, filename: '<evil>.yaml', svgContent: '<svg/>' });
+    expect(html).toContain('&lt;evil&gt;.yaml as of its last save');
+    expect(html).not.toContain('<evil>.yaml as of');
+  });
+});
+
 // The PlantUML preview needs to load its wasm rendering engine as external
 // <script> files inside the frame's strict nonce CSP, rather than
 // re-implementing a bespoke toolbar/CSP.


### PR DESCRIPTION
## Summary
- Preview refresh is save-triggered by design (not per-keystroke); that was undocumented and produces the "why isn't this updating" failure the epic describes.
- Documents the trigger and the recommended `files.autoSave: afterDelay` config in both READMEs (root quick-start and extension README).
- Adds an "as of last save" note to the shared toolbar (`buildDiagramFrame`) so every document-bound notation preview carries it — one shared frame builder, so no per-notation wiring needed.

Addresses deliverables 1–3 of THQ-103. Repo-wide dashboards (Compliance Matrix, Gap Dashboard, etc.) are left out of the toolbar note since they already carry an explicit "Refresh" affordance and have no single tracked file.

## Test plan
- [x] `npx vitest run tests/diagram-frame.test.ts` — 18 passed, including 3 new tests for the save-note (shown/omitted/escaped)
- [x] `npm run build` (tsc, full workspace) — clean
- [x] Full `vitest run` — 748 passed; the 3 pre-existing failures (`cli-migrate.test.ts`) reproduce identically on `main`, unrelated to this change