### PR TITLE
feat(cli): provenance stamp on export-compliance Markdown output (THQ-108)

### DIFF
--- a/src/export-compliance.ts
+++ b/src/export-compliance.ts
@@ -11,7 +11,7 @@
 import { writeFileSync, readFileSync, readdirSync, statSync, mkdtempSync, rmSync } from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { spawnSync } from 'node:child_process';
+import { spawnSync, execFileSync } from 'node:child_process';
 import yaml from 'js-yaml';
 import {
   emptyCanon,
@@ -185,6 +185,58 @@ export function runWeasyPrint(
   };
 }
 
+function gitCommit(root: string): string | null {
+  try {
+    return execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: root,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/** `null` (not a git repo) reads as not-dirty; `gitCommit` already carries that case. */
+function gitDirty(root: string): boolean {
+  try {
+    const out = execFileSync('git', ['status', '--porcelain'], {
+      cwd: root,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return out.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Provenance stamp — source path(s), source commit, generator, generation
+ * time — embedded in the artefact itself per the cross-project derived-artefact
+ * decision (2026-08-08, amended 2026-08-09): "an artefact with no stamp is
+ * stale by definition." An HTML comment so it travels with the Markdown file
+ * without altering its rendered appearance. Mirrors `render-compliance-impact.mjs`'s
+ * stamp shape.
+ */
+function buildProvenanceStamp(canonRoot: string, sourceLines: Array<[string, string]>, generatedAt: string): string {
+  const commit = gitCommit(canonRoot);
+  const sourceCommit = commit
+    ? `${commit}${gitDirty(canonRoot) ? ' (dirty — uncommitted changes present at generation time)' : ''}`
+    : 'unknown (canon root is not a git repository)';
+  return [
+    '<!--',
+    'generated-by: transitrix export-compliance',
+    ...sourceLines.map(([k, v]) => `${k}: ${v}`),
+    `source-commit: ${sourceCommit}`,
+    `generated-at: ${generatedAt}`,
+    'no stamp above means stale by definition — do not strip on regeneration.',
+    '-->',
+    '',
+    '',
+  ].join('\n');
+}
+
 function defaultPdfFilename(scope: ReportScope): string {
   switch (scope.mode) {
     case 'matrix': return 'compliance-matrix.pdf';
@@ -234,8 +286,17 @@ export async function handleExportComplianceCommand(argv: string[]): Promise<voi
 
     if (format === 'md') {
       const markdown = renderImpactMarkdown(matrix);
-      if (output) { writeFileSync(output, markdown, 'utf-8'); console.error(`Wrote ${output}`); }
-      else { process.stdout.write(markdown); }
+      const stamp = buildProvenanceStamp(
+        path.resolve(root),
+        [
+          ['canon-root', path.resolve(root)],
+          ['view-config', registry ? `registry:${path.resolve(registry)}#${reportId}` : `root:${path.resolve(root)}#${reportId}`],
+        ],
+        new Date().toISOString(),
+      );
+      const stamped = stamp + markdown;
+      if (output) { writeFileSync(output, stamped, 'utf-8'); console.error(`Wrote ${output}`); }
+      else { process.stdout.write(stamped); }
       return;
     }
     // format === 'pdf'
@@ -265,11 +326,21 @@ export async function handleExportComplianceCommand(argv: string[]): Promise<voi
 
   if (format === 'md') {
     const markdown = renderComplianceMarkdown(canon, scope, { today });
+    const scopeDescriptor = scope.mode === 'matrix' || scope.mode === 'gap' ? scope.mode : `${scope.mode}:${scope.id}`;
+    const stamp = buildProvenanceStamp(
+      path.resolve(root),
+      [
+        ['canon-root', path.resolve(root)],
+        ['scope', scopeDescriptor],
+      ],
+      new Date().toISOString(),
+    );
+    const stamped = stamp + markdown;
     if (output) {
-      writeFileSync(output, markdown, 'utf-8');
+      writeFileSync(output, stamped, 'utf-8');
       console.error(`Wrote ${output}`);
     } else {
-      process.stdout.write(markdown);
+      process.stdout.write(stamped);
     }
     return;
   }

--- a/tests/export-compliance-provenance.test.ts
+++ b/tests/export-compliance-provenance.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { handleExportComplianceCommand } from '../src/export-compliance.js';
+
+// `transitrix export-compliance --format md`'s persisted Markdown output must
+// carry the same provenance stamp as `render-compliance-impact.mjs`
+// (transitrix-hq#108): source path(s), source commit, generator, generation
+// time, in the artefact itself — never a sidecar. This is a separate test
+// file (rather than tests/export-compliance.test.ts) because that file
+// mocks `node:child_process` wholesale, which would swallow the real
+// `execFileSync` git calls the stamp depends on.
+
+describe('export-compliance provenance stamp', () => {
+  let dir: string;
+  let canonDir: string;
+  let outFile: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'export-compliance-provenance-test-'));
+    canonDir = join(dir, 'canon');
+    mkdirSync(canonDir, { recursive: true });
+    outFile = join(dir, 'out.md');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('legacy --scope path: embeds a stamp naming the generator, canon root, scope, and a generation time', async () => {
+    await handleExportComplianceCommand(['--scope', 'matrix', '--root', canonDir, '--format', 'md', '--output', outFile]);
+
+    const written = readFileSync(outFile, 'utf-8');
+    expect(written).toMatch(/^<!--\n/);
+    expect(written).toContain('generated-by: transitrix export-compliance');
+    expect(written).toContain(`canon-root: ${canonDir}`);
+    expect(written).toContain('scope: matrix');
+    // canonDir is a bare tmp directory — no git repository above it in scope.
+    expect(written).toContain('source-commit: unknown (canon root is not a git repository)');
+    expect(written).toMatch(/generated-at: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/);
+    expect(written).toContain('# Compliance Matrix');
+  });
+
+  it('CV-6 --report path: embeds a stamp naming the generator, canon root, view-config, and a generation time', async () => {
+    writeFileSync(
+      join(canonDir, 'demo.compliance-impact.view.yaml'),
+      'view:\n  id: demo\n  name: Demo\n  subjects:\n    products: []\n',
+    );
+
+    await handleExportComplianceCommand(['--report', 'demo', '--root', canonDir, '--format', 'md', '--output', outFile]);
+
+    const written = readFileSync(outFile, 'utf-8');
+    expect(written).toContain('generated-by: transitrix export-compliance');
+    expect(written).toContain(`canon-root: ${canonDir}`);
+    expect(written).toContain(`view-config: root:${canonDir}#demo`);
+    expect(written).toContain('source-commit: unknown (canon root is not a git repository)');
+    expect(written).toMatch(/generated-at: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/);
+  });
+
+  it('flags a dirty canon-root working tree rather than reading it as clean', async () => {
+    spawnSync('git', ['init', '-q'], { cwd: canonDir });
+    spawnSync('git', ['config', 'user.email', 'test@example.com'], { cwd: canonDir });
+    spawnSync('git', ['config', 'user.name', 'Test'], { cwd: canonDir });
+    writeFileSync(join(canonDir, 'placeholder.txt'), 'placeholder\n');
+    spawnSync('git', ['add', '-A'], { cwd: canonDir });
+    spawnSync('git', ['commit', '-q', '-m', 'initial'], { cwd: canonDir });
+    const commit = spawnSync('git', ['rev-parse', 'HEAD'], { cwd: canonDir, encoding: 'utf-8' }).stdout.trim();
+    // Uncommitted change after the commit the stamp would otherwise cite.
+    writeFileSync(join(canonDir, 'placeholder.txt'), 'changed\n');
+
+    await handleExportComplianceCommand(['--scope', 'matrix', '--root', canonDir, '--format', 'md', '--output', outFile]);
+
+    const written = readFileSync(outFile, 'utf-8');
+    expect(written).toContain(`source-commit: ${commit} (dirty`);
+  });
+});


### PR DESCRIPTION
## Summary
- THQ-108 (routed from THQ-101, item 2): artefacts written by this repo's own generators must carry source path, source commit, generator, and generation time in the artefact itself, per the amended cross-project derived-artefact decision.
- `scripts/render-compliance-impact.mjs` already got this stamp (THQ-89 / #511, merged). `transitrix export-compliance --format md` — both the CV-6 `--report` path and the legacy `--scope` path — wrote its Markdown report with no stamp at all.
- Adds the same shape: `generated-by`, `canon-root`, `view-config` (or `scope` on the legacy path), `source-commit` (flagged when the canon root's working tree is dirty), `generated-at`. Same HTML-comment banner convention so it travels with the file without altering the rendered Markdown.

**Not in this slice:** `--format pdf`. The reference implementation (`render-compliance-impact.mjs`) only ever produced Markdown, and an HTML-comment banner doesn't survive into a WeasyPrint-rendered PDF — stamping the PDF needs a visible-footer design (the existing `cmp-stamp` header already carries a bare "Generated <date>"), which is a separate, larger change to the shared `packages/diagrams/src/compliance/html.ts` renderers. Flagging rather than silently doing a partial job on it.

## Test plan
- [x] `npx vitest run tests/export-compliance-provenance.test.ts tests/export-compliance.test.ts` — 3 new tests (CV-6 path stamp, legacy-scope path stamp, dirty-tree flag) + existing 6 pass
- [x] `npm run test:core` — full suite green except the pre-existing `cli-migrate.test.ts` failures gated on a sibling `methodology` checkout (same exclusion #511 documented)
- [x] `npm run compile` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)