### PR TITLE
fix: reject an unregistered notation: value as HDR-002

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,6 +28,7 @@ import {
 } from './repo-validate.js';
 import {
   isFileValidatableNotation,
+  isRegisteredNotation,
   loadNotationYaml,
   validateNotationDoc,
   CANONICAL_NOTATION_FILE_EXTENSIONS,
@@ -640,6 +641,26 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
       }
       return;
     }
+    // HDR-002: `notation:` names no notation the methodology registers at
+    // all — not merely one this CLI hasn't wired a validator for yet. Reject
+    // it at this file rather than let it surface later as an unexplained
+    // `notation='<bogus>'` deep in another file's relation resolution.
+    if (!isUnresolvableProjection && !isRegisteredNotation(validatorKey)) {
+      const report: ValidationReport = {
+        isValid: false,
+        findings: [
+          {
+            ruleId: 'HDR-002',
+            severity: 'error',
+            message: `notation "${validatorKey}" is not a registered short name (CONTRACT.md §2) — check for a typo against the notations registry.`,
+          },
+        ],
+        summary: { errorCount: 1, warningCount: 0, infoCount: 0 },
+      };
+      emitFileReport(src, report, useJson, validatorKey);
+      process.exit(1);
+    }
+
     // Recognised notation, but no file-scope CLI validator yet — or a
     // projection-form document this single-file scope has no canon context
     // to resolve.

--- a/src/validate-notation.ts
+++ b/src/validate-notation.ts
@@ -83,6 +83,34 @@ export function isFileValidatableNotation(notation: string): boolean {
   return Object.prototype.hasOwnProperty.call(VALIDATORS, notation);
 }
 
+/** Notation short names the methodology registers (element TYPE short names —
+ *  `ELEMENT_PRIMITIVES.md` §4 — and native view notations — `architecture/
+ *  notations.md` §2, hub canon) that have no file-scope CLI validator wired
+ *  under `src/validators/` yet. Combined with `FILE_VALIDATABLE_NOTATIONS`
+ *  below, this is the full registered short-name list HDR-002 checks a
+ *  `notation:` value against — update it when methodology registers a new
+ *  short name with no CLI validator of its own. */
+const REGISTERED_NOT_YET_VALIDATABLE_NOTATIONS: readonly string[] = [
+  // Element TYPE short names with no standalone-file CLI validator yet.
+  'assessment', 'capability', 'process', 'product', 'role', 'rule',
+  'registry', 'application', 'release', 'business-object', 'equipment',
+  'term', 'step', 'goal', 'scenario',
+  // Native view notations with no file-scope CLI validator of their own —
+  // 'bpmn' is dispatched through the separate BPMN/IR path (cli.ts special-
+  // cases it ahead of this registry) rather than through VALIDATORS.
+  'bpmn', 'actions-tree',
+];
+
+/** True when `notation` is a value the methodology spec registers as a
+ *  notation short name — whether or not the CLI has a file-scope validator
+ *  for it yet. HDR-002 rejects any other value as unregistered. */
+export function isRegisteredNotation(notation: string): boolean {
+  return (
+    isFileValidatableNotation(notation)
+    || REGISTERED_NOT_YET_VALIDATABLE_NOTATIONS.includes(notation)
+  );
+}
+
 /** Read the `notation:` field from parsed YAML data, if present. */
 export function notationOf(data: unknown): string | undefined {
   if (data && typeof data === 'object' && !Array.isArray(data)) {

--- a/tests/cli-validate-hdr-002.test.ts
+++ b/tests/cli-validate-hdr-002.test.ts
@@ -1,0 +1,54 @@
+// transitrix-hq#123 — HDR-002 (CONTRACT.md §2) must reject a `notation:`
+// value that names no notation the methodology registers, instead of the
+// generic "not yet validated by the CLI" notice that the same fallback path
+// gives a *recognised* notation with no CLI validator of its own yet.
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliPath = join(__dirname, '..', 'dist', 'cli.js');
+
+function runCli(args: string[]): { status: number; stdout: string; stderr: string } {
+  const r = spawnSync(process.execPath, [cliPath, ...args], { encoding: 'utf8' });
+  return { status: r.status ?? 1, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+
+describe('transitrix validate — HDR-002 rejects an unregistered notation (transitrix-hq#123)', () => {
+  const temps: string[] = [];
+
+  afterEach(() => {
+    for (const t of temps) rmSync(t, { recursive: true, force: true });
+    temps.length = 0;
+  });
+
+  function writeFixture(name: string, content: string): string {
+    const dir = mkdtempSync(join(tmpdir(), 'tx-hdr-002-'));
+    temps.push(dir);
+    const file = join(dir, name);
+    writeFileSync(file, content, 'utf8');
+    return file;
+  }
+
+  it('fails with HDR-002 on a notation: value no registry carries', () => {
+    const file = writeFixture('bogus.yaml', 'notation: element\nid: X-1\nname: X\n');
+    const { status, stdout } = runCli(['validate', file, '--json']);
+    expect(status).not.toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.valid).toBe(false);
+    expect(parsed.findings.some((f: { ruleId: string }) => f.ruleId === 'HDR-002')).toBe(true);
+  });
+
+  it('still gives the soft "not yet validated" notice for a recognised-but-unimplemented notation', () => {
+    const file = writeFixture('role.yaml', 'notation: role\nid: ROLE-X-1\nname: X\n');
+    const { status, stdout } = runCli(['validate', file, '--json']);
+    expect(status).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.valid).toBeNull();
+    expect(parsed.message).toContain('not yet validated by the CLI');
+  });
+});

--- a/tests/validate-notation.test.ts
+++ b/tests/validate-notation.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect } from 'vitest';
 
 import {
   isFileValidatableNotation,
+  isRegisteredNotation,
   validateNotationDoc,
   loadNotationYaml,
   notationOf,
@@ -138,6 +139,23 @@ describe('validate-notation — dispatch (#258, #518 C1)', () => {
   it('does not claim BPMN or unknown notations', () => {
     for (const n of ['bpmn', 'nonsense']) {
       expect(isFileValidatableNotation(n)).toBe(false);
+    }
+  });
+
+  it('isRegisteredNotation accepts every CLI-validated notation', () => {
+    for (const n of ALL_NOTATIONS) expect(isRegisteredNotation(n)).toBe(true);
+  });
+
+  it('isRegisteredNotation accepts element short names with no CLI validator yet', () => {
+    for (const n of ['capability', 'process', 'application', 'role', 'rule', 'goal']) {
+      expect(isFileValidatableNotation(n)).toBe(false);
+      expect(isRegisteredNotation(n)).toBe(true);
+    }
+  });
+
+  it('isRegisteredNotation rejects a value no methodology short-name list carries (transitrix-hq#123)', () => {
+    for (const n of ['element', 'nonsense', 'bpmn2', '']) {
+      expect(isRegisteredNotation(n)).toBe(false);
     }
   });
 


### PR DESCRIPTION
## Summary
- `HDR-002` only fired when a per-notation CLI validator was already dispatched and its own expected-name check failed against a *known* notation. A `notation:` value that named no notation at all (e.g. a typo) fell through to the generic "not yet validated by the CLI" soft notice instead of a hard error — it could pass silently at the file that carried it and later surface confusingly as an unexplained value deep in a relation-resolution check on a different file.
- `isRegisteredNotation()` (`src/validate-notation.ts`) extends the CLI-validated notation set with the element short names (`ELEMENT_PRIMITIVES.md` §4) and view notations (hub `architecture/notations.md` §2) that methodology registers but this CLI has no file-scope validator for yet. `transitrix validate <file>`'s fallback path now only gives the soft notice for those, and raises `HDR-002` for anything else.

## Test plan
- [x] `npm run compile` (type-check) — clean
- [x] `npx vitest run tests/validate-notation.test.ts tests/notation-registry.test.ts tests/cli-validate-hdr-002.test.ts tests/vocabulary-drift.test.ts` — 129 passed
- [x] `npx vitest run` (full core suite) — no new failures; the 3 pre-existing `cli-migrate.test.ts` failures and the `ci-hygiene-hashrefs.test.ts` syntax error reproduce identically on unmodified `main` (environment-dependent, unrelated to this change)

Closes THQ-123.