### PR TITLE
fix: scope export-compliance scans to admitted canon-zone artefacts

### DIFF
--- a/src/export-compliance.ts
+++ b/src/export-compliance.ts
@@ -50,6 +50,23 @@ function isScannableYaml(rel: string): boolean {
 }
 
 /**
+ * True for a parsed doc that is admitted canon-zone material (CONTRACT.md §5/§6):
+ * `zone: canon` with no `admission_state` or `admission_state: active`, or
+ * `zone: codex` (codex's own admission gate is `source_authority`, not
+ * `admission_state`). Everything else — `zone: field`, a `proposed`/`rejected`
+ * draft, or a file with no admission record at all — is not admitted canon and
+ * must not count toward a compliance report, which would otherwise bucket
+ * unadmitted drafts and vendored/example fixtures as if they were canon.
+ */
+function isAdmittedCanonOrCodex(doc: unknown): boolean {
+  if (doc === null || typeof doc !== 'object' || Array.isArray(doc)) return false;
+  const d = doc as Record<string, unknown>;
+  if (d.zone === 'codex') return true;
+  if (d.zone !== 'canon') return false;
+  return d.admission_state === undefined || d.admission_state === 'active';
+}
+
+/**
  * Read + parse a YAML file, skipping (with a stderr note) anything larger than
  * `maxBytes`. Returns `undefined` on a skip or any read/parse failure, so
  * callers can simply ignore it.
@@ -119,6 +136,7 @@ function scanCanonFs(root: string): ComplianceCanon {
     if (typeof rel !== 'string' || !isScannableYaml(rel)) continue;
     const parsed = readYamlBounded(path.join(root, rel));
     if (parsed === undefined) continue;
+    if (!isAdmittedCanonOrCodex(parsed)) continue;
     ingestComplianceDoc(canon, parsed);
   }
   return canon;

--- a/tests/export-compliance-scope-gap.test.ts
+++ b/tests/export-compliance-scope-gap.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { handleExportComplianceCommand } from '../src/export-compliance.js';
+
+// transitrix-hq#125 — `--scope gap`'s recursive scan counted any YAML file with
+// a matching `notation:` value, including draft/unadmitted requirements and
+// vendored example fixtures with no admission record. Only `zone: canon`
+// (admission_state absent or `active`) or `zone: codex` material may count.
+
+describe('export-compliance --scope gap: admitted-canon scoping', () => {
+  let dir: string;
+  let canonDir: string;
+  let outFile: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'export-compliance-gap-scope-test-'));
+    canonDir = join(dir, 'canon');
+    mkdirSync(canonDir, { recursive: true });
+    outFile = join(dir, 'out.md');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const admittedRequirement = [
+    'notation: requirement',
+    'id: REQUIREMENT-ADMITTED-1',
+    'name: "Admitted requirement"',
+    'severity: high',
+    'zone: canon',
+    'admitted_at: "2026-05-28"',
+    'admitted_by: "v.korobeinikov"',
+  ].join('\n');
+
+  it('excludes a draft requirement with no admission record from the gap count', async () => {
+    writeFileSync(join(canonDir, 'admitted.requirement.transitrix.yaml'), admittedRequirement);
+    writeFileSync(
+      join(canonDir, 'draft.requirement.transitrix.yaml'),
+      ['notation: requirement', 'id: REQUIREMENT-DRAFT-1', 'name: "Draft requirement"', 'severity: high'].join('\n'),
+    );
+
+    await handleExportComplianceCommand(['--scope', 'gap', '--root', canonDir, '--format', 'md', '--output', outFile]);
+
+    const written = readFileSync(outFile, 'utf-8');
+    expect(written).toContain('REQUIREMENT-ADMITTED-1');
+    expect(written).not.toContain('REQUIREMENT-DRAFT-1');
+    expect(written).toContain('_2 gap(s) across 6 checks_');
+  });
+
+  it('excludes a proposed (not-yet-admitted) requirement from the gap count', async () => {
+    writeFileSync(join(canonDir, 'admitted.requirement.transitrix.yaml'), admittedRequirement);
+    writeFileSync(
+      join(canonDir, 'proposed.requirement.transitrix.yaml'),
+      [
+        'notation: requirement',
+        'id: REQUIREMENT-PROPOSED-1',
+        'name: "Proposed requirement"',
+        'severity: high',
+        'zone: canon',
+        'admission_state: proposed',
+        'proposed_at: "2026-08-01"',
+        'proposed_by: "reg-intel-collector"',
+      ].join('\n'),
+    );
+
+    await handleExportComplianceCommand(['--scope', 'gap', '--root', canonDir, '--format', 'md', '--output', outFile]);
+
+    const written = readFileSync(outFile, 'utf-8');
+    expect(written).toContain('REQUIREMENT-ADMITTED-1');
+    expect(written).not.toContain('REQUIREMENT-PROPOSED-1');
+    expect(written).toContain('_2 gap(s) across 6 checks_');
+  });
+
+  it('still counts an admitted requirement with no explicit admission_state (back-compat: absent = active)', async () => {
+    writeFileSync(join(canonDir, 'admitted.requirement.transitrix.yaml'), admittedRequirement);
+
+    await handleExportComplianceCommand(['--scope', 'gap', '--root', canonDir, '--format', 'md', '--output', outFile]);
+
+    const written = readFileSync(outFile, 'utf-8');
+    expect(written).toContain('REQUIREMENT-ADMITTED-1');
+    expect(written).toContain('_2 gap(s) across 6 checks_');
+  });
+});


### PR DESCRIPTION
## Summary
- `export-compliance`'s recursive canon scan (`scanCanonFs`) counted any YAML file with a matching `notation:` value regardless of `zone` or `admission_state`, so unadmitted draft artefacts and vendored example fixtures inflated gap/matrix report counts.
- Now requires `zone: canon` (with `admission_state` absent or `active`) or `zone: codex`, per CONTRACT.md §5/§6 — the same admission model already used elsewhere in this repo.

## Test plan
- [x] `npx vitest run tests/export-compliance-scope-gap.test.ts tests/export-compliance-provenance.test.ts tests/export-compliance.test.ts` — new + existing scope/provenance tests pass
- [x] `npx tsc --noEmit` — clean
- [x] Full `npx vitest run` — only pre-existing, unrelated failures (methodology-repo-dependent migrate tests, environment-dependent)

THQ-125

🤖 Generated with [Claude Code](https://claude.com/claude-code)