### PR TITLE
docs: route root README VS Code install through Open VSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,20 +14,12 @@ Studio previews the full Transitrix notation kit — **13 diagram notations** pl
 
 ## Install
 
-**From the VS Code Marketplace (VS Code):**
-
-Search for **Transitrix Studio** in the Extensions panel, or install via CLI:
-
-```bash
-code --install-extension transitrix.transitrix-studio
-```
-
-**From the Open VSX Registry (Cursor, VSCodium, Windsurf):**
+**From the Open VSX Registry (VS Code, Cursor, VSCodium, Windsurf):**
 
 Search for **Transitrix Studio** in the Extensions panel of your editor. The
-same artefact is published to [Open VSX](https://open-vsx.org/extension/transitrix/transitrix-studio),
-which Cursor and other VS Code derivatives read by default. No
-per-editor build — the VSIX is identical to the Marketplace listing.
+[Open VSX Registry](https://open-vsx.org/extension/transitrix/transitrix-studio) is the
+primary install route for VS Code as well as its derivatives — no per-editor build, the
+VSIX is identical everywhere.
 
 **From GitHub Releases:**
 


### PR DESCRIPTION
## Summary

- Root `README.md` still named the removed VS Code Marketplace listing as the primary install route. `#519` already fixed `extension/README.md` (the VSIX-bundled README) and the IntelliJ plugin descriptor but missed this GitHub-facing surface.
- Install section now names Open VSX as the primary route for VS Code and its derivatives, matching the wording already landed in `extension/README.md`.

## Verification (THQ-146)

Swept the tree for `marketplace.visualstudio.com` / `VS Code Marketplace` reader-facing hits:
- Root `README.md` — fixed here.
- `extension/README.md`, `intellij/plugin.xml` — already fixed in `#519`.
- `docs/internal/*` (runbooks, packaging, audit) — internal, intended remainder.
- `CHANGELOG.md`, `extension/CHANGELOG.md`, `docs/internal/archive/*` — historical records, left as written.
- `.github/workflows/vscode-marketplace-publish.yml` — internal CI, not reader-facing.
- `organizations/acme_corp/canon/views/*/README.md` — unrelated `bierner.markdown-mermaid` hits, not this extension.

No packaging/publishing workflow changes. No JetBrains plugin release performed.

Closes THQ-146.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>