### PR TITLE
feat(packaging): one universal VSIX, drop per-target packaging

### DIFF
--- a/.github/workflows/openvsx-publish.yml
+++ b/.github/workflows/openvsx-publish.yml
@@ -1,6 +1,6 @@
-name: Open VSX — multi-platform publish
+name: Open VSX — publish
 
-# Triggered on every GitHub Release to publish platform-specific VSIXs to the
+# Triggered on every GitHub Release to publish the universal VSIX to the
 # Open VSX Registry (the registry Cursor, VSCodium, and Windsurf read).
 #
 # A workflow_dispatch trigger is available for manual re-runs or to publish a
@@ -9,17 +9,6 @@ name: Open VSX — multi-platform publish
 # Prerequisites (one-time maintainer setup — see docs/internal/openvsx-publish-runbook.md):
 #   - OVSX_PAT repo Actions secret set to an Open VSX personal access token
 #     issued for the `transitrix` namespace.
-#   - The `ubuntu-24.04-arm` runner requires a GitHub-hosted ARM64 runner seat
-#     (available on Team / Enterprise plans, or via GitHub's larger runners).
-#
-# win32-arm64 is not in the matrix: no GA GitHub-hosted Windows ARM runner
-# exists at time of writing. Add it when one becomes available.
-#
-# darwin-x64 (Intel macOS) is intentionally NOT in the matrix: the macos-13
-# (Intel) hosted runner is chronically unschedulable on this account (jobs sat
-# queued for ~18h), and Apple Silicon (darwin-arm64) covers current Macs. Intel
-# Mac is a shrinking segment; if it ever needs coverage, re-add a `macos-13`
-# entry or publish that target manually. Tracked on strategy #184.
 
 on:
   release:
@@ -31,20 +20,8 @@ permissions:
 
 jobs:
   publish:
-    name: Publish (${{ matrix.target }})
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - runner: ubuntu-latest
-            target: linux-x64
-          - runner: ubuntu-24.04-arm
-            target: linux-arm64
-          - runner: macos-latest
-            target: darwin-arm64
-          - runner: windows-latest
-            target: win32-x64
+    name: Publish to Open VSX
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -67,9 +44,9 @@ jobs:
       - name: Verify extension packaging
         run: npm run verify-extension-packaging
 
-      - name: Package VSIX (${{ matrix.target }})
+      - name: Package VSIX
         working-directory: extension
-        run: npx vsce package --target ${{ matrix.target }} --out ../output/
+        run: npx vsce package --out ../output/
 
       - name: Publish to Open VSX
         shell: bash

--- a/.github/workflows/vscode-marketplace-publish.yml
+++ b/.github/workflows/vscode-marketplace-publish.yml
@@ -1,6 +1,6 @@
-name: VS Code Marketplace — multi-platform publish
+name: VS Code Marketplace — publish
 
-# Triggered on every GitHub Release to publish platform-specific VSIXs to the
+# Triggered on every GitHub Release to publish the universal VSIX to the
 # VS Code Marketplace via `vsce publish`.
 #
 # A workflow_dispatch trigger is available for manual re-runs or to re-publish
@@ -10,16 +10,8 @@ name: VS Code Marketplace — multi-platform publish
 #   - VSCE_PAT repo Actions secret set to an Azure DevOps personal access token
 #     for the `transitrix` publisher on the Visual Studio Marketplace.
 #   - Azure DevOps PATs expire (max 1 year). Rotate before expiry — see the
-#     runbook § PAT rotation. An expired token causes all matrix jobs to fail
-#     at the explicit PAT-check step rather than silently skipping.
-#
-# darwin-x64 (Intel macOS) is intentionally NOT in the matrix: the macos-13
-# (Intel) hosted runner is chronically unschedulable on this account, and
-# Apple Silicon (darwin-arm64) covers current Macs. Intel Mac is a shrinking
-# segment; re-add if it ever needs coverage.
-#
-# win32-arm64 is not in the matrix: no GA GitHub-hosted Windows ARM runner
-# exists at time of writing. Add it when one becomes available.
+#     runbook § PAT rotation. An expired token causes the PAT-check step to
+#     fail loudly rather than silently skipping.
 
 on:
   release:
@@ -31,20 +23,8 @@ permissions:
 
 jobs:
   publish:
-    name: Publish to Marketplace (${{ matrix.target }})
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - runner: ubuntu-latest
-            target: linux-x64
-          - runner: ubuntu-24.04-arm
-            target: linux-arm64
-          - runner: macos-latest
-            target: darwin-arm64
-          - runner: windows-latest
-            target: win32-x64
+    name: Publish to Marketplace
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -79,9 +59,9 @@ jobs:
       - name: Verify extension packaging
         run: npm run verify-extension-packaging
 
-      - name: Package VSIX (${{ matrix.target }})
+      - name: Package VSIX
         working-directory: extension
-        run: npx vsce package --target ${{ matrix.target }} --out ../output/
+        run: npx vsce package --out ../output/
 
       - name: Publish to VS Code Marketplace
         shell: bash

--- a/docs/internal/openvsx-publish-runbook.md
+++ b/docs/internal/openvsx-publish-runbook.md
@@ -6,35 +6,24 @@ the Open VSX consumer set — VSCodium, Windsurf, Gitpod, etc.) can install
 it directly from within their editor.
 
 Open VSX is the Eclipse Foundation registry that Cursor reads — there is
-no separate "Cursor marketplace". Publishing the existing per-platform
-`.vsix` artefacts to Open VSX covers all these editors in one action.
+no separate "Cursor marketplace". Publishing the same universal `.vsix`
+to Open VSX covers all these editors in one action.
 
 The npm publish flow for `@transitrix/diagrams` / `@transitrix/cli` is a
 separate procedure — see [`release-runbook.md`](release-runbook.md).
-The VS Code Marketplace publish flow is the same `vsce publish` per
-target documented in [`packaging.md`](packaging.md); the steps below
-mirror it for the `ovsx` CLI.
+The VS Code Marketplace publish flow builds the same universal VSIX
+documented in [`packaging.md`](packaging.md); the steps below mirror it
+for the `ovsx` CLI.
 
 ## What gets published
 
-The **same per-platform VSIXs** the VS Code Marketplace ships. There is
-no separate "Cursor build" — the artefact is the one produced by
-`npm run package-extension` on each matching runner. The native
-`@resvg/resvg-js-*` binary makes the VSIX platform-specific, so a CI
-matrix or several local runs are required to cover the desktop set:
-
-| Target | Built on |
-|---|---|
-| `win32-x64` | Windows x64 |
-| `win32-arm64` | Windows arm64 |
-| `darwin-x64` | macOS x64 |
-| `darwin-arm64` | macOS arm64 |
-| `linux-x64` | Linux x64 |
-| `linux-arm64` | Linux arm64 |
-
-A VSIX built with **no** `--target` claims universal compatibility while
-carrying only the build machine's resvg binary — do not publish one of
-those to Open VSX for the same reason it is avoided on the Marketplace.
+The **same universal VSIX** the VS Code Marketplace ships — there is no
+separate "Cursor build". The extension declares no runtime `dependencies`
+and has no OS/arch-specific content (`@resvg/resvg-js`, its one-time
+native dependency, was removed — hold 3, transitrix-hq#141), so a single
+`vsce package` (no `--target`) run, from any machine, produces the
+artefact for every platform. Per-target packaging was retired in hold 4
+(transitrix-hq#142).
 
 ## Prerequisites (one-time, maintainer action)
 
@@ -66,8 +55,8 @@ Marketplace pre-flight has passed:
 - [ ] The VS Code Marketplace publish for this version is **done** and
       visible at <https://marketplace.visualstudio.com/items?itemName=transitrix.transitrix-studio>.
       Open VSX is the second hop, not the source of truth.
-- [ ] The per-platform VSIX files from the Marketplace step are still
-      on disk (or rebuild them per [`packaging.md`](packaging.md)).
+- [ ] The universal VSIX file from the Marketplace step is still on
+      disk (or rebuild it per [`packaging.md`](packaging.md)).
 - [ ] The `version` field in `extension/package.json` matches the
       Marketplace listing exactly.
 - [ ] `extension/README.md` and the icon (`extension/icon.png`) match
@@ -82,34 +71,20 @@ Marketplace pre-flight has passed:
 
 ## Publishing
 
-Publish each per-platform VSIX from its matching runner (the resvg
-binary is per-OS — a `linux-x64` VSIX cannot be produced on Windows).
 `ovsx publish` accepts a `.vsix` path directly; the namespace and
-version are read from the file:
+version are read from the file. One publish covers every platform:
 
 ```bash
-# on a Windows x64 runner, after `npm run package-extension`
-ovsx publish extension/transitrix-studio-<version>-win32-x64.vsix
-
-# on a macOS arm64 runner
-ovsx publish extension/transitrix-studio-<version>-darwin-arm64.vsix
-
-# on a Linux x64 runner
-ovsx publish extension/transitrix-studio-<version>-linux-x64.vsix
+npm run package-extension
+ovsx publish output/transitrix-studio-<version>.vsix
 ```
 
-Repeat for every target in the table above. `ovsx` returns a JSON blob
-containing the published download URL on success.
-
-> If only a single platform's VSIX is published, Open VSX will refuse to
-> install the extension on any other platform — there is no universal
-> fallback. Either publish the full set or accept a single-platform
-> listing knowingly.
+`ovsx` returns a JSON blob containing the published download URL on
+success.
 
 ## Verify
 
-For every published target, confirm the listing returns the expected
-version:
+Confirm the listing returns the expected version:
 
 ```bash
 ovsx get transitrix.transitrix-studio
@@ -136,32 +111,17 @@ Marketplace release.
 ### CI path (recommended)
 
 The `.github/workflows/openvsx-publish.yml` workflow runs automatically
-on every GitHub Release (`release: types: [published]`) and publishes
-five platform VSIXs in parallel:
-
-| Runner | Target |
-|--------|--------|
-| `ubuntu-latest` | `linux-x64` |
-| `ubuntu-24.04-arm` | `linux-arm64` |
-| `macos-13` | `darwin-x64` |
-| `macos-latest` | `darwin-arm64` |
-| `windows-latest` | `win32-x64` |
-
-The workflow reads `OVSX_PAT` from the repo Actions secret. Each runner
-installs the platform-specific `@resvg/resvg-js-*` native binary during
-`npm run extension:prep`, so every VSIX carries the correct binary for
-its target.
-
-`win32-arm64` is not yet in the matrix — no GA GitHub-hosted Windows
-ARM runner is available at time of writing. Add it to the matrix when
-one becomes available.
+on every GitHub Release (`release: types: [published]`) from a single
+`ubuntu-latest` job: builds the universal VSIX (`npm run extension:prep`
++ `vsce package`, no `--target`) and publishes it with `ovsx publish`.
+The workflow reads `OVSX_PAT` from the repo Actions secret.
 
 ### Manual fallback
 
-To publish a single target by hand (e.g. to fill a CI gap or re-publish
-a failed job), follow the steps in the **Publishing** section above with
-a matching local build environment. You can also trigger the full matrix
-manually via the **workflow_dispatch** button in the Actions tab.
+To publish by hand (e.g. to re-publish a failed run), follow the steps
+in the **Publishing** section above from any machine. You can also
+trigger the workflow manually via the **workflow_dispatch** button in
+the Actions tab.
 
 After every publish (CI or manual):
 

--- a/docs/internal/packaging.md
+++ b/docs/internal/packaging.md
@@ -1,18 +1,20 @@
 # Packaging the VS Code extension
 
-The extension is pure TypeScript/JS and packages into a single,
-platform-neutral `.vsix` — no native module. **PNG export used to be the
-exception:** it depended on `@resvg/resvg-js`, a native module whose
-rasterizer binary shipped as a per-OS optional dependency. That dependency is
-gone (hold 3, transitrix-hq#141): PNG export now rasterizes in the preview
-webview's own canvas, so the packaged extension has no OS/arch-specific
-content and declares no runtime `dependencies` at all.
+The extension is pure TypeScript/JS and packages into a single, universal
+`.vsix` — no native module, no OS/arch-specific content, no runtime
+`dependencies` declared at all. **PNG export used to be the exception:** it
+depended on `@resvg/resvg-js`, a native module whose rasterizer binary
+shipped as a per-OS optional dependency. That dependency is gone (hold 3,
+transitrix-hq#141): PNG export now rasterizes in the preview webview's own
+canvas.
 
-The per-target packaging below is CI's current mechanism, not a correctness
-requirement anymore — dropping it is hold 4 of the same epic
-(transitrix-hq#142).
+With no platform-specific component, `vsce package` (no `--target`) is the
+only packaging path — the per-target CI matrix that used to exist has been
+retired (hold 4, transitrix-hq#142). One VSIX installs on every OS/arch VS
+Code supports, including targets no CI runner ever built for (e.g. Intel
+macOS, Windows ARM).
 
-## Build a VSIX for the current platform
+## Build a VSIX
 
 ```bash
 npm run package-extension
@@ -29,38 +31,10 @@ Only runtime assets may live under `extension/`. Before every
 non-runtime paths appear there (`extension/.vscodeignore` is a second line of
 defence).
 
-## Build per-platform VSIXs for the Marketplace
-
-Until hold 4 (transitrix-hq#142) lands a single universal VSIX, CI still tags
-each VSIX with `vsce package --target <target>` and builds each on a matching
-OS/arch runner (a CI matrix):
-
-```bash
-# on a Windows x64 runner
-npm run extension:prep
-cd extension && npx vsce package --target win32-x64
-
-# on a macOS arm64 runner
-npm run extension:prep
-cd extension && npx vsce package --target darwin-arm64
-
-# on a Linux x64 runner
-npm run extension:prep
-cd extension && npx vsce package --target linux-x64
-```
-
-Targets to cover the common desktop set: `win32-x64`, `win32-arm64`,
-`darwin-x64`, `darwin-arm64`, `linux-x64`, `linux-arm64`. `vsce publish`
-accepts the same `--target` flag.
-
-> A `vsce package` with **no** `--target` produces a genuinely universal VSIX
-> now (no native dependency) — still avoided for Marketplace publishing only
-> because the per-target CI matrix hasn't been retired yet (hold 4).
-
 ## Publishing to the VS Code Marketplace
 
 Publishing a GitHub Release triggers `.github/workflows/vscode-marketplace-publish.yml`,
-which runs `vsce publish` across the platform matrix automatically. The one-time
+which builds and publishes the universal VSIX with `vsce publish`. The one-time
 prerequisite (an Azure DevOps PAT saved as the `VSCE_PAT` Actions secret) and the
 post-publish verification steps are documented in
 [`vscode-marketplace-publish-runbook.md`](vscode-marketplace-publish-runbook.md).
@@ -68,7 +42,7 @@ post-publish verification steps are documented in
 ## Publishing to Open VSX (Cursor, VSCodium, Windsurf)
 
 Cursor and other VS Code derivatives read the [Open VSX Registry](https://open-vsx.org),
-not the VS Code Marketplace. The same per-platform VSIXs above publish to
+not the VS Code Marketplace. The same universal VSIX above publishes to
 Open VSX with `ovsx publish <vsix>` — see [`openvsx-publish-runbook.md`](openvsx-publish-runbook.md)
 for the registry-specific prerequisites (namespace claim, `OVSX_PAT`) and
 the per-release procedure.

--- a/docs/internal/vscode-marketplace-publish-runbook.md
+++ b/docs/internal/vscode-marketplace-publish-runbook.md
@@ -5,27 +5,19 @@ How to publish Transitrix Studio's VS Code extension to the
 so VS Code users can install it from within their editor.
 
 Publishing a GitHub Release triggers `.github/workflows/vscode-marketplace-publish.yml`,
-which runs `vsce publish` across the platform matrix in parallel. The Open VSX
-publish (for Cursor, VSCodium, Windsurf) is a separate workflow;
+which builds and publishes a single universal VSIX with `vsce publish`. The
+Open VSX publish (for Cursor, VSCodium, Windsurf) is a separate workflow;
 see [`openvsx-publish-runbook.md`](openvsx-publish-runbook.md).
 
 ## What gets published
 
-Per-platform VSIXs built on matching OS/arch runners so each carries the
-correct `@resvg/resvg-js-*` native binary. A universal (no `--target`) VSIX
-claims all-platform compatibility while carrying only one binary — do not
-publish one to the Marketplace.
-
-| Target | Runner |
-|--------|--------|
-| `win32-x64` | `windows-latest` |
-| `darwin-arm64` | `macos-latest` |
-| `linux-x64` | `ubuntu-latest` |
-| `linux-arm64` | `ubuntu-24.04-arm` |
-
-`win32-arm64` is not in the matrix (no GA GitHub-hosted Windows ARM runner).
-`darwin-x64` (Intel macOS) is not in the matrix (macos-13 Intel runner is
-chronically unschedulable on this account; Apple Silicon covers current Macs).
+One universal VSIX (`vsce package`, no `--target`) built on a single Linux
+runner. The extension declares no runtime `dependencies` and has no
+OS/arch-specific content (`@resvg/resvg-js`, its one-time native dependency,
+was removed — hold 3, transitrix-hq#141), so the same artefact installs on
+every VS Code platform, including ones no runner ever built for (Intel
+macOS, Windows ARM). Per-target packaging was retired in hold 4
+(transitrix-hq#142); see [`packaging.md`](packaging.md).
 
 ## Prerequisites (one-time, maintainer action)
 
@@ -53,8 +45,8 @@ first automated publish:
    - Value: the token copied above.
 
 The workflow's **Verify VSCE_PAT is set** step checks for the secret at
-runtime and fails all matrix jobs loudly if it is absent or empty, so a
-missing or expired token is never a silent skip.
+runtime and fails loudly if it is absent or empty, so a missing or expired
+token is never a silent skip.
 
 ## PAT rotation
 
@@ -70,39 +62,38 @@ Rotation procedure:
 ## CI path (automated)
 
 `.github/workflows/vscode-marketplace-publish.yml` runs automatically on
-every GitHub Release (`release: types: [published]`) and publishes four
-platform VSIXs in parallel. The workflow also exposes a `workflow_dispatch`
-trigger for manual re-runs without creating a new release.
+every GitHub Release (`release: types: [published]`) and publishes the
+universal VSIX from a single job. The workflow also exposes a
+`workflow_dispatch` trigger for manual re-runs without creating a new release.
 
-Each runner:
+The job:
 1. Checks out the release tag.
 2. Verifies `VSCE_PAT` is set (exits with a clear error if not).
-3. Runs `npm run extension:prep` to lay down the platform-correct
-   `@resvg/resvg-js-*` binary into `extension/node_modules`.
-4. Packages the VSIX with `vsce package --target <target>`.
+3. Runs `npm run extension:prep` to build the extension and compiler bundles
+   (no runtime dependency install — `extension/package.json` declares none).
+4. Packages the VSIX with `vsce package`.
 5. Publishes with `vsce publish --pat "$VSCE_PAT" --packagePath <vsix>`.
 
 ## Manual fallback
 
-To publish a single target by hand — for example to fill a CI gap or
-re-publish a failed job — build the VSIX on a matching machine and publish:
+To publish by hand — for example to re-publish a failed run — build and
+publish from any machine:
 
 ```bash
-# from the repo root on the matching OS/arch
 npm run extension:prep
-cd extension && npx vsce package --target win32-x64 --out ../output/
-cd .. && npx vsce publish --pat "$VSCE_PAT" --packagePath output/transitrix-studio-<version>-win32-x64.vsix
+cd extension && npx vsce package --out ../output/
+cd .. && npx vsce publish --pat "$VSCE_PAT" --packagePath output/transitrix-studio-<version>.vsix
 ```
 
-Replace `win32-x64` and the filename with the target and version being published.
+Replace the filename with the version being published.
 
-You can also trigger the full matrix manually via the **workflow_dispatch**
+You can also trigger the workflow manually via the **workflow_dispatch**
 button in the repository's Actions tab.
 
 ## Post-publish verification
 
-After each publish (CI or manual), verify via the gallery API that every
-matrix target is listed for the new version — not only `win32-x64`:
+After each publish (CI or manual), verify via the gallery API that the new
+version is listed:
 
 ```bash
 curl -s \
@@ -113,9 +104,8 @@ curl -s \
   | jq '[.results[0].extensions[0].versions[] | {version:.version, targetPlatform:.targetPlatform}]'
 ```
 
-The output should list the new version once per target platform (`win32-x64`,
-`darwin-arm64`, `linux-x64`, `linux-arm64`). If only `win32-x64` appears,
-the other runners did not publish — check the workflow run logs.
+`targetPlatform` should be empty/`universal` for the new version — a
+non-empty value would mean a `--target` build slipped back in.
 
 End-to-end install check in VS Code:
 1. Open VS Code → *Extensions* panel.

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - **PNG export rasterizes in the preview webview's own canvas** instead of a bundled native rasterizer — `@resvg/resvg-js` is no longer an extension dependency, and the packaged extension ships no `node_modules` at all. No user-visible change to Save .png / Copy PNG.
+- **Packaging drops per-target `.vsix` builds for one universal `.vsix`.** With no native/platform-specific component left in the package (the item above), `vsce package` with no `--target` is now the only packaging path — `scripts/package-extension.mjs` no longer accepts `--target`, and the Marketplace/Open VSX publish workflows each build and publish from a single job instead of a four-runner matrix. The one artefact installs on every VS Code platform, including ones the old matrix never built for (Intel macOS, Windows ARM).
 
 ### Added
 

--- a/scripts/package-extension.mjs
+++ b/scripts/package-extension.mjs
@@ -1,19 +1,15 @@
 /**
  * Cross-platform replacement for build-extension.bat / build-extension.sh.
  * Runs extension:prep, optionally bumps the version, verifies packaging, and
- * invokes `vsce package` to produce a .vsix in output/.
+ * invokes `vsce package` to produce a universal .vsix in output/.
  *
  * Usage:
- *   node scripts/package-extension.mjs              Universal VSIX (local install only)
+ *   node scripts/package-extension.mjs              Build the VSIX
  *   node scripts/package-extension.mjs --bump       Patch bump, then build
- *   node scripts/package-extension.mjs --target win32-x64  Targeted VSIX
- *   node scripts/package-extension.mjs --bump --target darwin-arm64
  *
- * NOTE — universal build (no --target):
- *   `vsce package` without --target produces a genuinely universal VSIX (no
- *   native dependency). Still avoided for Marketplace publishing only
- *   because the per-target CI matrix hasn't been retired yet — hold 4,
- *   transitrix-hq#142. See docs/internal/packaging.md.
+ * The extension declares no runtime dependencies and no native/platform
+ * component, so `vsce package` (no `--target`) produces a single VSIX that
+ * installs on any OS/arch — see docs/internal/packaging.md.
  */
 import { spawn } from 'node:child_process';
 import fs from 'node:fs/promises';
@@ -24,25 +20,13 @@ const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const extensionDir = path.join(root, 'extension');
 const outputDir = path.join(root, 'output');
 
-const SUPPORTED_TARGETS = [
-  'win32-x64', 'win32-arm64',
-  'darwin-x64', 'darwin-arm64',
-  'linux-x64', 'linux-arm64',
-];
-
-const USAGE = `package-extension — build the VS Code extension .vsix.
+const USAGE = `package-extension — build the VS Code extension's universal .vsix.
 
 Usage:
-  node scripts/package-extension.mjs [--bump] [--target <target>]
+  node scripts/package-extension.mjs [--bump]
 
 Options:
-  --bump            Patch-bump the extension version before packaging.
-  --target <value>  Build a platform-specific VSIX (required for Marketplace).
-                    Supported: ${SUPPORTED_TARGETS.join(', ')}.
-
-NOTE: building without --target produces a genuinely universal VSIX now (no
-native dependency) — not yet published to the Marketplace only because the
-per-target CI matrix hasn't been retired (hold 4). See docs/internal/packaging.md.`;
+  --bump    Patch-bump the extension version before packaging.`;
 
 const argv = process.argv.slice(2);
 if (argv.includes('-h') || argv.includes('--help')) {
@@ -51,26 +35,13 @@ if (argv.includes('-h') || argv.includes('--help')) {
 }
 
 let bump = false;
-let target = '';
 
 for (let i = 0; i < argv.length; i++) {
   if (argv[i] === '--bump') {
     bump = true;
-  } else if (argv[i] === '--target') {
-    if (!argv[i + 1] || argv[i + 1].startsWith('-')) {
-      console.error('package-extension: --target requires a value (e.g. win32-x64).');
-      process.exit(2);
-    }
-    target = argv[++i];
-  } else if (argv[i].startsWith('--target=')) {
-    target = argv[i].slice('--target='.length);
-    if (!target) {
-      console.error('package-extension: --target requires a value (e.g. win32-x64).');
-      process.exit(2);
-    }
   } else {
     console.error(`package-extension: unknown argument "${argv[i]}".`);
-    console.error('Usage: node scripts/package-extension.mjs [--bump] [--target <target>]');
+    console.error('Usage: node scripts/package-extension.mjs [--bump]');
     process.exit(2);
   }
 }
@@ -117,16 +88,9 @@ await run(
   { cwd: root },
 );
 
-if (target) {
-  console.log(`\n=== [3/3] vsce package --target ${target} -> output/`);
-} else {
-  console.log('\n=== [3/3] vsce package -> output/');
-  console.log('package-extension: WARNING - no --target given; VSIX is local-install only.');
-  console.log('package-extension: see docs/internal/packaging.md before publishing to the Marketplace.');
-}
+console.log('\n=== [3/3] vsce package -> output/');
 
 const vsceArgs = ['--no-install', 'vsce', 'package'];
-if (target) vsceArgs.push('--target', target);
 // Relative output path from extensionDir avoids shell-quoting concerns on
 // paths that contain spaces (e.g. a Windows home dir with a space in the name).
 vsceArgs.push('-o', '../output');


### PR DESCRIPTION
## Summary

- With `@resvg/resvg-js` removed (THQ-141), the extension declares no runtime `dependencies` and has no OS/arch-specific content — `vsce package` with no `--target` now produces a genuinely universal `.vsix`, so the per-target packaging path is retired.
- `scripts/package-extension.mjs` drops `--target` support entirely; always builds the universal VSIX.
- `.github/workflows/vscode-marketplace-publish.yml` and `.github/workflows/openvsx-publish.yml` each collapse from a 4-runner matrix to a single job; the stale comments justifying the incomplete target list (darwin-x64/win32-arm64 unserved) go with the matrix.
- `docs/internal/packaging.md`, `vscode-marketplace-publish-runbook.md`, `openvsx-publish-runbook.md` updated to match — no more per-platform build/publish/verify steps.

## Evidence (acceptance criteria — "recorded, not merely asserted")

Ran `node scripts/package-extension.mjs` locally end-to-end on the updated script:

- Produces a single `output/transitrix-studio-3.2.0.vsix` (35 files, 2.69 MB) with no `--target` flag anywhere in the invocation.
- `extension.vsixmanifest` inside the package carries no `TargetPlatform` attribute at all (`grep -o 'TargetPlatform="[^"]*"'` → no match) — the standard marker `vsce`/the Marketplace/Open VSX use to gate a package to one platform. Its absence is what makes a VSIX install on every VS Code platform, including ones no CI runner ever built for (Intel macOS, Windows ARM) — not something a local run can install-test directly, but the mechanism is the documented contract these registries use.
- No `node_modules`, no `.node` native binary anywhere in the unpacked contents.
- `npm run verify-extension-packaging` passes clean.

## Constraints honored

- Nothing submitted to the VS Code Marketplace — no `vsce publish` or release/workflow_dispatch trigger run.
- PlantUML and Graphviz assets untouched.

## Test plan

- [x] `npm run extension:prep` — builds clean
- [x] `npm run verify-extension-packaging` — OK
- [x] `node scripts/package-extension.mjs` — packages a single universal `.vsix`, no `--target`
- [x] Inspected the packaged VSIX manifest — no `TargetPlatform`, no native binaries, no `node_modules`
- [x] YAML-validated both edited workflow files

🤖 Generated with [Claude Code](https://claude.com/claude-code)