### PR TITLE
chore(ci): scan public-surface hygiene on push to main

### DIFF
--- a/.github/workflows/public-surface-hygiene.yml
+++ b/.github/workflows/public-surface-hygiene.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
     branches: [main]
+  push:
+    branches: [main]
 
 permissions:
   contents: read
@@ -18,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Block internal agent-ops filenames
         run: |
@@ -43,8 +45,8 @@ jobs:
           HYGIENE_BLOCKLIST_3: ${{ secrets.HYGIENE_BLOCKLIST_3 }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.after }}
         run: node scripts/ci-hygiene-check.mjs
 
       - name: Run full-tree hygiene check
@@ -56,6 +58,6 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.after }}
         run: node scripts/ci-hygiene-hashrefs.mjs


### PR DESCRIPTION
**From: transitrix-studio.**

Item 3 of THQ-160 (public-surface hygiene tracker): the hygiene-check workflow ran on pull requests only, so a direct push to `main` bypassed the blocklist/commit-message/work-item-reference scans entirely. Adds a `push: branches: [main]` trigger and threads `github.event.before`/`github.event.after` through as a fallback wherever the steps previously assumed a `pull_request` event.

Items 1 and 2 of that tracker were already resolved for this repo (commit-message scanning already existed in `ci-hygiene-check.mjs`/`ci-hygiene-hashrefs.mjs`). Item 4 (secret name `HYGIENE_BLOCKLIST_3` vs `HYGIENE_HUB_SLUG`) is left untouched — renaming it here without migrating the actual secret value would leave the new name unset and silently skip the check, same reasoning methodology gave on the same tracker.

## Test plan
- [ ] CI green on this PR (exercises the `pull_request` path unchanged)
- [ ] Reviewer confirms the push-trigger fallback expressions are correct (no environment to trigger a real push-to-main event pre-merge)