### PR TITLE
fix: re-check panel before post-await webview write in preview classes

### DIFF
--- a/extension/src/action-preview.ts
+++ b/extension/src/action-preview.ts
@@ -852,6 +852,7 @@ export class ActionPreview {
     } catch {
       // Parse errors are handled (and reported) again inside buildHtml.
     }
+    if (!this.panel) return; // panel may have been disposed while awaiting above
     this.panel.webview.html = this.buildHtml(yamlText, path.basename(doc.fileName), sources);
   }
 

--- a/extension/src/actions-tree-preview.ts
+++ b/extension/src/actions-tree-preview.ts
@@ -223,6 +223,7 @@ export class ActionsTreePreview extends StaticPreview {
   protected override async pushDocument(doc: vscode.TextDocument): Promise<void> {
     if (!this.panel) return;
     const data = await this.loadCanonData(doc.uri);
+    if (!this.panel) return; // panel may have been disposed while awaiting above
     this.panel.webview.html = this.buildHtml(doc.getText(), path.basename(doc.fileName), data);
   }
 

--- a/extension/src/activity-card-preview.ts
+++ b/extension/src/activity-card-preview.ts
@@ -96,6 +96,7 @@ export class ActivityCardPreview extends StaticSvgPreview {
   protected override async pushDocument(doc: vscode.TextDocument): Promise<void> {
     if (!this.panel) return;
     const sources = await loadCanon(doc.uri);
+    if (!this.panel) return; // panel may have been disposed while awaiting above
     this.panel.webview.html = this.buildHtml(doc.getText(), path.basename(doc.fileName), sources);
   }
 

--- a/extension/src/applications-preview.ts
+++ b/extension/src/applications-preview.ts
@@ -164,6 +164,7 @@ export class ApplicationsPreview extends StaticPreview {
   protected override async pushDocument(doc: vscode.TextDocument): Promise<void> {
     if (!this.panel) return;
     const resolved = await this.resolveMaturity(doc.uri);
+    if (!this.panel) return; // panel may have been disposed while awaiting above
     this.panel.webview.html = this.buildHtml(doc.getText(), path.basename(doc.fileName), resolved);
   }
 

--- a/extension/src/capability-map-preview.ts
+++ b/extension/src/capability-map-preview.ts
@@ -208,6 +208,7 @@ export class CapabilityMapPreview {
   private async pushDocument(doc: vscode.TextDocument): Promise<void> {
     if (!this.panel) return;
     const resolved = await this.resolveMaturity(doc.uri);
+    if (!this.panel) return; // panel may have been disposed while awaiting above
     this.panel.webview.html = this.buildHtml(doc.getText(), path.basename(doc.fileName), resolved);
   }
 

--- a/extension/src/coverage-metric-preview.ts
+++ b/extension/src/coverage-metric-preview.ts
@@ -171,7 +171,9 @@ export class CoverageMetricPreview {
   private async pushDocument(doc: vscode.TextDocument): Promise<void> {
     if (!this.panel) return;
     const filename = doc.uri.path.split('/').pop() ?? '';
-    this.panel.webview.html = await this.buildHtml(doc.getText(), filename);
+    const html = await this.buildHtml(doc.getText(), filename);
+    if (!this.panel) return; // panel may have been disposed while awaiting above
+    this.panel.webview.html = html;
   }
 
   private async buildHtml(yamlText: string, filename = ''): Promise<string> {

--- a/extension/src/dgca-preview.ts
+++ b/extension/src/dgca-preview.ts
@@ -399,6 +399,7 @@ export class DGCAPreview {
     if (!this.panel) return;
     const sources = await loadCanon(doc.uri);
     const markers = await this.loadSnapshotMarkers();
+    if (!this.panel) return; // panel may have been disposed while awaiting above
     this.panel.webview.html = this.buildHtml(doc.getText(), path.basename(doc.fileName), sources, markers);
   }
 
@@ -612,6 +613,7 @@ export class DGAPreview {
   private async pushDocument(doc: vscode.TextDocument): Promise<void> {
     if (!this.panel) return;
     const markers = await this.loadSnapshotMarkers();
+    if (!this.panel) return; // panel may have been disposed while awaiting above
     this.panel.webview.html = this.buildHtml(doc.getText(), path.basename(doc.fileName), markers);
   }
 

--- a/extension/src/gap-dashboard-preview.ts
+++ b/extension/src/gap-dashboard-preview.ts
@@ -60,6 +60,7 @@ export class GapDashboardPreview {
     // every requirement + assertion in the repo (CONTRACT §11.6).
     this.lastConfidence = scoreComplianceView(scan.requirements, scan.assertions, today);
     const themeId = vscode.workspace.getConfiguration('transitrix').get<ThemeId>('theme', 'transitrix');
+    if (!this.panel) return; // panel may have been disposed while awaiting above
     this.panel.webview.html = this.buildHtml(this.lastReport, themeId);
   }
 

--- a/extension/src/goals-preview.ts
+++ b/extension/src/goals-preview.ts
@@ -133,6 +133,7 @@ export class GoalsPreview {
     } catch {
       // Parse errors are handled (and reported) again inside buildHtml.
     }
+    if (!this.panel) return; // panel may have been disposed while awaiting above
     this.panel.webview.html = this.buildHtml(yamlText, path.basename(doc.fileName), sources);
   }
 

--- a/extension/src/plantuml-preview.ts
+++ b/extension/src/plantuml-preview.ts
@@ -113,6 +113,7 @@ export class PlantUMLPreview {
     if (!this.panel || !this.trackedUri) return;
     const doc = await vscode.workspace.openTextDocument(vscode.Uri.parse(this.trackedUri));
     const mediaDir = vscode.Uri.joinPath(this.extensionUri, 'media', 'plantuml');
+    if (!this.panel) return; // panel may have been disposed while awaiting above
     this.webviewReady = false;
     this.pendingSource = undefined;
     this.panel.webview.html = this.buildFrameHtml(this.panel.webview, mediaDir, path.basename(doc.fileName));
@@ -132,6 +133,7 @@ export class PlantUMLPreview {
     // A newer sendDocument() call ran while prepareSource() was awaiting —
     // this one is already stale, don't send it.
     if (seq !== this.renderSeq) return;
+    if (!this.panel) return; // panel may have been disposed while awaiting above
     if (this.webviewReady) {
       void this.panel.webview.postMessage({ type: 'render', source, seq });
     } else {

--- a/extension/src/preview.ts
+++ b/extension/src/preview.ts
@@ -160,8 +160,10 @@ export class BpmnJsPreview {
     if (!this.panel) return;
     try {
       const { xml, metrics, validation } = await this.compile(doc.getText());
+      if (!this.panel) return; // panel may have been disposed while awaiting above
       void this.panel.webview.postMessage({ type: 'update', xml, metrics, validation });
     } catch (e) {
+      if (!this.panel) return; // panel may have been disposed while awaiting above
       const err = e as Error & { errors?: string[] };
       const lines = err.errors?.length ? err.errors.join('\n') : '';
       void this.panel.webview.postMessage({

--- a/extension/src/process-blueprint-preview.ts
+++ b/extension/src/process-blueprint-preview.ts
@@ -509,7 +509,9 @@ export class ProcessBlueprintPreview {
     if (!this.panel) return;
     this.lastYamlText = doc.getText();
     this.lastFilename = path.basename(doc.fileName);
-    this.panel.webview.html = await this.buildHtml(this.lastYamlText, this.lastFilename);
+    const html = await this.buildHtml(this.lastYamlText, this.lastFilename);
+    if (!this.panel) return; // panel may have been disposed while awaiting above
+    this.panel.webview.html = html;
   }
 
   private async buildHtml(yamlText: string, filename: string): Promise<string> {

--- a/extension/src/process-preview.ts
+++ b/extension/src/process-preview.ts
@@ -196,6 +196,7 @@ export class ProcessPreview {
       // that all other diagram types expose in their title header.
       const processTitle = layout.process.name || undefined;
 
+      if (!this.panel) return; // panel may have been disposed while awaiting above
       this.panel.webview.html = buildDiagramFrame({
         filename,
         notation: 'BPMN Process',

--- a/extension/src/requirement-trace-preview.ts
+++ b/extension/src/requirement-trace-preview.ts
@@ -116,6 +116,7 @@ export class RequirementTracePreview {
       todayIso(),
     );
 
+    if (!this.panel) return; // panel may have been disposed while awaiting above
     const kind = elementKind ?? trace.requirement.element_kind ?? 'requirement';
     const subtitleBits = [
       elementId,

--- a/extension/src/single-law-preview.ts
+++ b/extension/src/single-law-preview.ts
@@ -98,6 +98,7 @@ export class SingleLawPreview {
     const treeAssertions = tree.requirements.flatMap(n => n.assertions);
     const confidence = scoreComplianceView(treeRequirements, treeAssertions, todayIso());
 
+    if (!this.panel) return; // panel may have been disposed while awaiting above
     this.panel.webview.html = complianceShell({
       notation: 'Law',
       title: lawName,

--- a/extension/src/single-product-preview.ts
+++ b/extension/src/single-product-preview.ts
@@ -95,6 +95,7 @@ export class SingleProductPreview {
     const viewAssertions = view.requirements.map(r => r.assertion);
     const confidence = scoreComplianceView(viewRequirements, viewAssertions, todayIso());
 
+    if (!this.panel) return; // panel may have been disposed while awaiting above
     this.panel.webview.html = complianceShell({
       notation: 'Product compliance',
       title: productName,

--- a/extension/src/ttrs-preview.ts
+++ b/extension/src/ttrs-preview.ts
@@ -127,6 +127,7 @@ export class TtrsPreview extends StaticPreview {
     }
 
     const themeId = vscode.workspace.getConfiguration('transitrix').get<ThemeId>('theme', 'transitrix');
+    if (!this.panel) return; // panel may have been disposed while awaiting above
     this.panel.webview.html = buildDiagramFrame({
       filename,
       notation: 'Document (.ttrs)',


### PR DESCRIPTION
## Summary

- ~15 preview classes guard `if (!this.panel) return;` once at entry to their `pushDocument()`/`push()`/`refresh()` method, then await canon-scanning or parsing work, then write to `this.panel.webview.html` / `.postMessage()` without re-checking the panel is still open.
- If the panel is disposed while that await is in flight (e.g. a user closing the preview tab mid-render), the write throws instead of silently no-oping.
- Fixed by re-checking `this.panel` immediately before every such post-await write.

Found while building the THQ-143 verification harness, which reproduced it via its own test teardown (closing all editors) racing a slow-rendering preview. Independent of that harness's own completeness — this is a real defect a user can hit today.

## Test plan

- [x] `npm run extension:bundle` builds clean on this branch.
- [x] Verified by code reading across all touched files: each site now re-checks `this.panel` immediately before the write it guards.
- [ ] Full e2e exercise blocked in this session by unrelated headless-host flakiness (tracked on THQ-143, not specific to this change).