### PR TITLE
fix(impact): inline-form goals/dgca/fgca/action views are never coverage-not-determined

### DIFF
--- a/src/impact.ts
+++ b/src/impact.ts
@@ -60,6 +60,18 @@ function isYamlPath(p: string): boolean {
   return /\.ya?ml$/i.test(p);
 }
 
+/** True when `data` is a plain object carrying `key` at the top level —
+ *  used to recognize a goals/dgca/fgca/action view's *inline* form (element
+ *  data authored directly in the file, mutually exclusive with
+ *  `view_config` per each notation's spec). An inline-form document has no
+ *  `canon/elements/**` dependency by definition — it stays inline until a
+ *  second document shares it, at which point promotion moves it to
+ *  `view_config` — so it is definitively unaffected by any staged element
+ *  change, not merely undetermined. */
+function hasKey(data: unknown, key: string): boolean {
+  return typeof data === 'object' && data !== null && !Array.isArray(data) && key in (data as Record<string, unknown>);
+}
+
 /** The staged (index) content of `relPath`, or `undefined` when it has none
  *  (deleted in the index, or nothing staged). */
 function gitShowStaged(root: string, relPath: string): string | undefined {
@@ -181,19 +193,34 @@ export function computeStagedImpact(root: string): ImpactResult {
     if (!notation) continue;
 
     let resolvedIds: Set<string> | undefined;
-    if (notation === 'goals' && isGoalsViewDoc(data)) {
-      resolvedIds = idsIn(resolveGoals(data, { elements }), 'goals');
-    } else if ((notation === 'dgca' || notation === 'fgca') && isFGCAViewDoc(data)) {
-      resolvedIds = idsIn(
-        resolveFGCA(data, { elements, relations }),
-        'factors',
-        'goals',
-        'changes',
-        'actions',
-      );
-    } else if (notation === 'action' && isActionViewDoc(data)) {
-      resolvedIds = idsIn(resolveAction(data, { elements, relations }), 'actions');
+    let inlineForm = false;
+    if (notation === 'goals') {
+      if (isGoalsViewDoc(data)) {
+        resolvedIds = idsIn(resolveGoals(data, { elements }), 'goals');
+      } else {
+        inlineForm = hasKey(data, 'goals');
+      }
+    } else if (notation === 'dgca' || notation === 'fgca') {
+      if (isFGCAViewDoc(data)) {
+        resolvedIds = idsIn(
+          resolveFGCA(data, { elements, relations }),
+          'factors',
+          'goals',
+          'changes',
+          'actions',
+        );
+      } else {
+        inlineForm = hasKey(data, 'factors') || hasKey(data, 'goals');
+      }
+    } else if (notation === 'action') {
+      if (isActionViewDoc(data)) {
+        resolvedIds = idsIn(resolveAction(data, { elements, relations }), 'actions');
+      } else {
+        inlineForm = hasKey(data, 'actions');
+      }
     }
+
+    if (inlineForm) continue; // self-contained by notation design — never affected, not merely undetermined
 
     if (!resolvedIds) {
       notDetermined.push({ file: doc.path, notation });

--- a/tests/impact.test.ts
+++ b/tests/impact.test.ts
@@ -178,6 +178,42 @@ describe('computeStagedImpact (transitrix-hq#89)', () => {
       { file: 'canon/views/portfolio/apps.applications.transitrix.yaml', notation: 'applications' },
     ]);
   });
+
+  it('never reports a self-contained inline-form goals view as coverage-not-determined (transitrix-hq#89 Strategist finding)', () => {
+    root = initRepo();
+    seedBaseline(root);
+    write(
+      root,
+      'canon/views/strategy/inline-goals.goals.transitrix.yaml',
+      [
+        'notation: goals',
+        'id: GOALS-INLINE-1',
+        'name: "Inline goals"',
+        'goal_types:',
+        '  - name: Strategic Goal',
+        '    level: 0',
+        'goals:',
+        '  - id: GOAL-RELEASE-CYCLE-1',
+        '    name: "Shorten the release cycle"',
+        '    type: Strategic Goal',
+        '    level: 0',
+        '',
+      ].join('\n'),
+    );
+    commitAll(root, 'add an inline-form goals view');
+    write(root, 'canon/elements/goals/GOAL-1.yaml', goalYaml('GOAL-1', 'Grow revenue by 20%'));
+    git(['add', 'canon/elements/goals/GOAL-1.yaml'], root);
+
+    const result = computeStagedImpact(root);
+    expect(result.affected).toEqual([
+      { file: 'canon/views/strategy/dgca.dgca.transitrix.yaml', notation: 'dgca' },
+    ]);
+    // Inline-form goals carry no canon/elements dependency by notation design
+    // (they stay inline until a second document shares them) — a staged
+    // GOAL-1 change cannot affect this document, so it must not appear in
+    // either list, not even notDetermined.
+    expect(result.notDetermined).toEqual([]);
+  });
 });
 
 /** A minimal, valid `.ttrs` document source — required header fields only. */


### PR DESCRIPTION
## Summary

- `computeStagedImpact` (`transitrix impact`, THQ-89) only recognized a goals/dgca/fgca/action view's `view_config` projection form as having a resolvable `canon/elements/**` dependency. Any document using the *inline* form of those same notations (`goals:`/`factors:`/`actions:` authored directly in the file) fell through to `coverage not determined` on every run that staged any `canon/elements` change — forever, regardless of content.
- Per each notation's own spec, inline and projection form are mutually exclusive, and inline elements stay inline until a second document shares them (at which point they're promoted into `canon/elements/**`). So an inline-form document has zero dependency on `canon/elements` by construction — it is definitively *unaffected*, not merely undetermined.
- Fixed by detecting the inline form explicitly (presence of `goals`/`factors`/`actions` at the document root) and excluding it from both `affected` and `notDetermined`, rather than defaulting unresolved-but-recognized notations into `notDetermined`.

## Context

Raised as an open question by the Strategist on THQ-89 (epic), reproduced against a genuine `GOALS-006`-passing inline goals view. Confirmed the same structural gap exists for `dgca`/`fgca` and `action` (`isFGCAViewDoc`/`isActionViewDoc` use the identical mutually-exclusive-key pattern).

## Test plan

- [x] Added a regression test reproducing the Strategist's exact scenario (inline goals view, staged unrelated `GOAL-1` change) — asserts the document appears in neither `affected` nor `notDetermined`.
- [x] `npx vitest run tests/impact.test.ts` — 14/14 pass.
- [x] `npm run compile` — clean.
- [x] `npx vitest run` (full core suite) — pre-existing failures in `cli-migrate.test.ts` / `cli-validate-hdr-002.test.ts` are unrelated (no reference to `impact.ts`, confirmed via grep) and unaffected by this change.