### PR TITLE
feat(blocks): wire grid: root (§4a matrix subset) into the IntelliJ webview bundle

### DIFF
--- a/packages/diagrams/src/blocks/__tests__/validate.test.ts
+++ b/packages/diagrams/src/blocks/__tests__/validate.test.ts
@@ -486,7 +486,9 @@ describe('blocks examples (regression)', () => {
     it(`validates tests/fixtures/notation-corpus/blocks/${file}`, () => {
       const text = fs.readFileSync(path.join(EXAMPLES_DIR, file), 'utf8');
       const parsed = yaml.load(text);
-      const r = validateNestedBlocks(parsed);
+      // Dispatcher, not validateNestedBlocks directly — this directory holds
+      // examples of both root forms (nested_blocks and grid, §4a).
+      const r = validateBlocks(parsed);
       expect(r.errors).toEqual([]);
       expect(r.valid).toBe(true);
     });

--- a/packages/diagrams/src/webview/__tests__/entry-notations.test.ts
+++ b/packages/diagrams/src/webview/__tests__/entry-notations.test.ts
@@ -61,6 +61,19 @@ describe('webview/entry — Step 4 notation coverage', () => {
     });
   }
 
+  it('renders blocks (grid form, §4a matrix subset) from its example fixture', () => {
+    const source = readFileSync(path.join(EXAMPLES, 'blocks/raci.blocks.transitrix.yaml'), 'utf8');
+    const r = render('blocks', source);
+    expect(r.notation).toBe('blocks');
+    expect(r.errors).toEqual([]);
+    expect(r.status).toBe('ok');
+    expect(r.svg.length).toBeGreaterThan(0);
+    expect(r.svg).toContain('<svg ');
+    // Grid-specific: column/row headers should be present as rendered text.
+    expect(r.svg).toContain('Product Manager');
+    expect(r.svg).toContain('Security sign-off');
+  });
+
   it('degrades malformed input to the error panel for a diagram notation', () => {
     const r = render('process-blueprint', 'process_blueprint:\n  stages: "not a list"\n');
     expect(r.status).toBe('error');

--- a/packages/diagrams/src/webview/entry.ts
+++ b/packages/diagrams/src/webview/entry.ts
@@ -32,8 +32,8 @@ import { validateActivityCard } from '../activity-card/index.js';
 import type { ActivityCardDoc } from '../activity-card/index.js';
 import { validateApplicationsCatalogue } from '../applications/index.js';
 import type { ApplicationsCatalogueFile } from '../applications/index.js';
-import { validateNestedBlocks } from '../blocks/index.js';
-import type { BlocksFile } from '../blocks/index.js';
+import { validateBlocks } from '../blocks/index.js';
+import type { BlocksFile, GridFile } from '../blocks/index.js';
 import { validateCapabilityMap } from '../capability-map/validate.js';
 import type { CapabilityMapFile } from '../capability-map/types.js';
 import { parseCanonicalFGCA, parseCanonicalFGA } from '../fgca/parse-canonical.js';
@@ -51,7 +51,7 @@ import { coerceDatesToIsoStrings } from '../yaml-normalize.js';
 import { renderActivitiesSvg } from './render-activities.js';
 import { renderActivityCardSvg } from './render-activity-card.js';
 import { renderApplicationsHtml } from './render-applications.js';
-import { renderBlocksSvg } from './render-blocks.js';
+import { renderBlocksSvg, renderGridSvg } from './render-blocks.js';
 import { renderCapabilityMapHtml } from './render-capability-map.js';
 import { renderFgcaSvg } from './render-fgca.js';
 import { renderGoalsSvg } from './render-goals.js';
@@ -218,10 +218,17 @@ function dispatchValidate(kind: NotationKind, doc: unknown): RenderResult {
       return renderFromValidation('process-blueprint', validateProcessBlueprint(doc), () =>
         renderProcessBlueprintSvg(doc as ProcessBlueprintFile),
       );
-    case 'blocks':
-      return renderFromValidation('blocks', validateNestedBlocks(doc), () =>
-        renderBlocksSvg(doc as BlocksFile),
+    case 'blocks': {
+      // Two alternative root forms (08-blocks.md §4): a `nested_blocks:`
+      // containment tree, or a `grid:` matrix subset (§4a). `validateBlocks`
+      // is the shared root-form dispatcher (BL-020 on both/neither present);
+      // mirrors the VS Code path's `hasGrid` branch in `blocks-preview.ts`.
+      const raw = (doc && typeof doc === 'object' ? doc : {}) as Record<string, unknown>;
+      const hasGrid = raw['grid'] !== undefined && raw['grid'] !== null;
+      return renderFromValidation('blocks', validateBlocks(doc), () =>
+        hasGrid ? renderGridSvg(doc as GridFile) : renderBlocksSvg(doc as BlocksFile),
       );
+    }
     // Catalogue notations render an HTML fragment from the header nested under
     // their top-level wrapper key (`<thing>_catalogue` / `scenario` / …).
     case 'applications':

--- a/tests/fixtures/notation-corpus/blocks/README.md
+++ b/tests/fixtures/notation-corpus/blocks/README.md
@@ -37,8 +37,13 @@ Recommended maximum: **5 levels** (root = level 1). Deeper nesting is permitted 
 
 The renderer assigns colour fill by nesting depth: the outermost block is the lightest, each deeper level progressively darker — drawn from the Transitrix Studio brand colour ramp. Authors do not need to set colours by hand.
 
+## Matrix subset (§4a)
+
+A document MAY instead carry a `grid:` root — a single-layer, rectangular matrix of `columns[]` × `rows[]`, with each row's `assign:` mapping column id → cell value (RACI-style matrices, coverage grids). See the methodology reference §4a for the full field/rule set (`BL-020`–`BL-025`). A document declares exactly one of `nested_blocks` or `grid`, never both.
+
 ## Examples in this folder
 
 | File | Description |
 |---|---|
-| `architecture.blocks.transitrix.yaml` | 2-tier software architecture (Application Layer + Data Layer) |
+| `architecture.blocks.transitrix.yaml` | 2-tier software architecture (Application Layer + Data Layer) — `nested_blocks:` form |
+| `raci.blocks.transitrix.yaml` | Release approval RACI matrix — `grid:` form (§4a) |

--- a/tests/fixtures/notation-corpus/blocks/raci.blocks.transitrix.yaml
+++ b/tests/fixtures/notation-corpus/blocks/raci.blocks.transitrix.yaml
@@ -1,0 +1,33 @@
+notation: blocks
+spec_version: "0.1"
+name: "Release approval RACI"
+generated_at: "2026-08-14"
+
+grid:
+  columns:
+    - { id: PM, name: "Product Manager" }
+    - { id: ENG, name: "Engineering Lead" }
+    - { id: QA, name: "QA Lead" }
+    - { id: SEC, name: "Security" }
+
+  rows:
+    - id: SCOPE
+      name: "Define release scope"
+      assign:
+        PM: "A"
+        ENG: "C"
+        QA: "I"
+
+    - id: BUILD
+      name: "Build and unit-test"
+      assign:
+        PM: "I"
+        ENG: "A"
+        QA: "C"
+
+    - id: SIGNOFF
+      name: "Security sign-off"
+      assign:
+        ENG: "C"
+        QA: "C"
+        SEC: "A"


### PR DESCRIPTION
**From: transitrix-studio.**

## Summary

- The `grid:` root form (single-layer rectangular matrix, §4a of the `blocks` notation spec) already renders correctly in the VS Code preview path (`blocks-preview.ts` dispatches on `hasGrid` since `c553e04`). The IntelliJ/JCEF-neutral bundle (`packages/diagrams/src/webview/entry.ts`) still hard-wired the `blocks` case to `validateNestedBlocks`/`renderBlocksSvg` only — a `grid:` document opened through that host would fail `BL-001` ("missing nested_blocks") instead of rendering as a matrix.
- Switched `entry.ts`'s `case 'blocks':` to the `validateBlocks` root-form dispatcher and branch to `renderGridSvg` when `grid:` is present, mirroring `blocks-preview.ts`'s own `hasGrid` check — no new rendering logic, both `renderGridSvg`/`renderGridLayoutSvg` already existed and are covered by their own tests.
- Added a grid-form (RACI) example fixture — none existed in this repo's notation corpus (the spec points only to an external `transitrix/templates` file) — and widened the `blocks` example regression suite from `validateNestedBlocks` to the dispatcher so it covers both root forms present in that fixture directory.

## Test plan

- [x] `npx vitest run` in `packages/diagrams` — 102 files, 1663 tests pass.
- [x] `npm run compile` (builds `@transitrix/diagrams` + root `tsc --noEmit`) — clean.
- [x] `npm run compile:extension` — clean.
- [x] `npm run test` (root, core + diagrams) — 3 pre-existing failures in `tests/cli-migrate.test.ts`/`tests/ci-hygiene-hashrefs.test.ts`, confirmed present on `main` before this change (unrelated to blocks).
- [x] New test: `entry-notations.test.ts` renders the new grid fixture through `render('blocks', …)` and asserts column/row header text appears in the output SVG.

Closes THQ-26.