### PR TITLE
feat(ci): build the universal VSIX once, attested, as a reusable job

### DIFF
--- a/.github/workflows/build-vsix.yml
+++ b/.github/workflows/build-vsix.yml
@@ -1,0 +1,91 @@
+name: Build universal VSIX (attested)
+
+# One CI job produces the universal VSIX from pinned inputs, records its
+# SHA-256, attests it with actions/attest-build-provenance (no external
+# service, no key), and exposes it as a build artifact a later job can
+# download. This is the artefact every later consumer — verification, then
+# registry publish — uses instead of rebuilding, so the artefact that gets
+# verified is the one that ships.
+#
+# Packaging here is not publishing: no registry credentials are in scope,
+# and nothing leaves this workflow run. The standing rule that reserves
+# `vsce package` to Valerii's explicit request covers a command run by hand
+# on a workstation, not a credential-less CI job.
+#
+# Reusable via `workflow_call` — a verification workflow or a publish
+# workflow adds a job with `uses: ./.github/workflows/build-vsix.yml`, then
+# a dependent job downloads the `universal-vsix` artifact this produces.
+# Callers must grant at least the permissions this workflow declares below.
+# `workflow_dispatch` is also available for a standalone run.
+
+on:
+  workflow_call:
+    outputs:
+      sha256:
+        description: SHA-256 of the packaged .vsix
+        value: ${{ jobs.build.outputs.sha256 }}
+      artifact-name:
+        description: Name of the uploaded build artifact containing the .vsix and its .sha256 file
+        value: ${{ jobs.build.outputs.artifact-name }}
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Package, hash, attest
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    outputs:
+      sha256: ${{ steps.hash.outputs.sha256 }}
+      artifact-name: ${{ steps.hash.outputs.artifact-name }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install root dependencies
+        run: npm ci
+
+      - name: Package universal VSIX
+        # extension:prep + verify-extension-packaging + `vsce package` (no
+        # --target: the extension ships no native/platform component, so one
+        # VSIX installs everywhere) -> output/*.vsix
+        run: npm run package-extension
+
+      - name: Record SHA-256
+        id: hash
+        shell: bash
+        run: |
+          vsix=$(ls output/*.vsix | head -n 1)
+          sha=$(sha256sum "$vsix" | cut -d' ' -f1)
+          echo "$sha  $(basename "$vsix")" > "$vsix.sha256"
+          echo "Packaged $vsix"
+          echo "SHA-256: $sha"
+          echo "sha256=$sha" >> "$GITHUB_OUTPUT"
+          echo "artifact-name=universal-vsix" >> "$GITHUB_OUTPUT"
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: output/*.vsix
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: universal-vsix
+          path: |
+            output/*.vsix
+            output/*.sha256
+          if-no-files-found: error
+          retention-days: 90

--- a/docs/internal/packaging.md
+++ b/docs/internal/packaging.md
@@ -31,6 +31,25 @@ Only runtime assets may live under `extension/`. Before every
 non-runtime paths appear there (`extension/.vscodeignore` is a second line of
 defence).
 
+## Building in CI (attested, once)
+
+`.github/workflows/build-vsix.yml` packages the same universal VSIX in CI —
+`npm ci` from the committed lockfile, then `npm run package-extension` — and
+additionally records the artefact's SHA-256 and attests it with
+[`actions/attest-build-provenance`](https://github.com/actions/attest-build-provenance)
+(no external service, no key: GitHub's own OIDC/Sigstore integration). It
+exposes the result as a downloadable build artifact named `universal-vsix`
+(the `.vsix` plus a `.sha256` file) — nothing in this workflow publishes
+anywhere; there are no registry credentials in its scope.
+
+It is a reusable workflow (`workflow_call`), meant to be called once by a
+verification pipeline and once by the registry-publish pipeline, so both
+consume the identical built-and-attested file rather than each rebuilding
+its own copy. `workflow_dispatch` is also available for a standalone
+inspection run. Callers must grant at least `contents: read`,
+`id-token: write`, `attestations: write` for the attestation step to
+succeed.
+
 ## Publishing to the VS Code Marketplace
 
 Publishing a GitHub Release triggers `.github/workflows/vscode-marketplace-publish.yml`,


### PR DESCRIPTION
**From: transitrix-studio.**

## Summary

- New reusable workflow `.github/workflows/build-vsix.yml`: one CI job packages the universal VSIX (`npm ci` from the pinned lockfile, then `npm run package-extension`), records its SHA-256, and attests it with `actions/attest-build-provenance` (GitHub's own OIDC/Sigstore integration -- no external service, no key), then exposes the result as a downloadable `universal-vsix` build artifact.
- No registry credentials are in this workflow's scope -- it packages, it does not publish anywhere. `workflow_call` lets a verification pipeline and a registry-publish pipeline each add a job that consumes this same built-and-attested file instead of rebuilding their own copy; `workflow_dispatch` allows a standalone run for inspection.
- Documented in `docs/internal/packaging.md` under a new "Building in CI (attested, once)" section.

## Why

A verification pass only means something if it exercises the exact artefact that ships, not a copy rebuilt later from the same source. Producing that artefact once, in CI, with no person and no registry credentials involved, is what lets a later verification step and a later publish step both point at the same file by its SHA-256.

## Out of scope (left for follow-up work)

- Pointing the existing headless e2e harness at this artifact instead of `extensionDevelopmentPath` -- unpacking/installing the built VSIX for verification.
- Attaching the artefact to a GitHub Release and switching the Marketplace/Open VSX publish workflows to consume it instead of rebuilding.
- Nothing here touches the VS Code Marketplace or Open VSX -- no publish job was added or modified.

## Test plan

- [x] `npm run compile` -- clean, no source changes made.
- [x] Workflow YAML parsed successfully with `js-yaml` (no linter available in this environment to fully validate GitHub Actions semantics).
- [ ] First real run of `build-vsix.yml` (via `workflow_dispatch` or a caller) will be the first live exercise of the packaging + attestation steps end to end.