### PR TITLE
feat(e2e): verify the packaged VSIX, add old-vs-new PNG engine comparison

### DIFF
--- a/.github/workflows/extension-e2e.yml
+++ b/.github/workflows/extension-e2e.yml
@@ -21,9 +21,22 @@ permissions:
   contents: read
 
 jobs:
+  # Builds the exact universal VSIX (build-vsix.yml) this job then verifies —
+  # per hold 6's own acceptance criterion, the artefact that gets verified
+  # has to be the artefact that ships, not a rebuild from source. No
+  # `vsce package` runs by hand here; this calls the same credential-less CI
+  # job the publish pipeline will consume.
+  build-vsix:
+    uses: ./.github/workflows/build-vsix.yml
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+
   e2e:
+    needs: build-vsix
     runs-on: ubuntu-latest
-    name: Extension Development Host e2e (xvfb)
+    name: Extension Development Host e2e (xvfb) — packaged VSIX
 
     steps:
       - name: Checkout code
@@ -38,15 +51,44 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Ensure xvfb is present
-        run: sudo apt-get update && sudo apt-get install -y xvfb
+      - name: Ensure xvfb and unzip are present
+        run: sudo apt-get update && sudo apt-get install -y xvfb unzip
 
-      # test:e2e-extension runs `extension:prep` (build) only — never
-      # `vsce package` / `package-extension`. Building a .vsix is gated to
-      # an explicit request per this repo's CLAUDE.md and is out of scope
-      # for this job.
-      - name: Run extension e2e suite against a real display
-        run: xvfb-run -a npm run test:e2e-extension
+      - name: Download universal VSIX artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.build-vsix.outputs.artifact-name }}
+          path: output
+
+      - name: Verify downloaded artifact matches the attested hash
+        run: |
+          vsix=$(ls output/*.vsix | head -n 1)
+          expected="${{ needs.build-vsix.outputs.sha256 }}"
+          actual=$(sha256sum "$vsix" | cut -d' ' -f1)
+          echo "expected sha256=$expected"
+          echo "actual   sha256=$actual"
+          if [ "$actual" != "$expected" ]; then
+            echo "::error::downloaded artifact does not match the build job's recorded SHA-256"
+            exit 1
+          fi
+          echo "VSIX_PATH=$vsix" >> "$GITHUB_ENV"
+          echo "VSIX_SHA256=$actual" >> "$GITHUB_ENV"
+
+      - name: Unpack VSIX
+        run: |
+          unpack_dir="$RUNNER_TEMP/vsix-unpacked"
+          mkdir -p "$unpack_dir"
+          unzip -q "$VSIX_PATH" -d "$unpack_dir"
+          echo "TX_E2E_EXTENSION_PATH=$unpack_dir/extension" >> "$GITHUB_ENV"
+
+      # test:e2e-extension:packaged does not run `extension:prep` — it runs
+      # the mocha suite against TX_E2E_EXTENSION_PATH (the unpacked, attested
+      # VSIX set above), not a source rebuild. Verifies the shipped artefact,
+      # by its hash (hold 6).
+      - name: Run extension e2e suite against the packaged VSIX
+        run: |
+          echo "Running against sha256=$VSIX_SHA256"
+          xvfb-run -a npm run test:e2e-extension:packaged
 
       - name: Upload PNG export captures
         if: always()
@@ -56,3 +98,45 @@ jobs:
           path: .test-out/png-capture/
           if-no-files-found: ignore
           retention-days: 7
+
+  # Old (pre-webview-canvas-rasterizer, resvg) vs new (webview canvas) PNG
+  # engine comparison, hold 6's remaining acceptance item. Old side is a
+  # rebuild of extension/src/raster.ts at tag v3.1.3
+  # (scripts/compare-png-engines.mjs) — no published pre-PR-#526 .vsix asset
+  # exists to compare against instead, see that script's header comment and
+  # docs/internal/hold6-verification.md.
+  png-comparison:
+    needs: e2e
+    runs-on: ubuntu-latest
+    name: PNG engine comparison (old vs new)
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download PNG export captures
+        uses: actions/download-artifact@v4
+        with:
+          name: e2e-png-captures
+          path: .test-out/png-capture
+
+      - name: Compare old vs new PNG engine output
+        run: npm run compare-png-engines
+
+      - name: Upload comparison report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: png-engine-comparison
+          path: .test-out/png-engine-comparison/
+          if-no-files-found: ignore
+          retention-days: 30

--- a/docs/internal/hold6-verification.md
+++ b/docs/internal/hold6-verification.md
@@ -1,32 +1,38 @@
 # Hold 6 verification — per-notation surface pass, PNG comparison
 
-Status: **in progress, not a completed verification.** transitrix-hq#143 asks for a
+Status: **in progress, not a completed verification.** This hold asks for a
 written record of exercising every preview/export surface against the packaged
 universal VSIX, plus a PNG old-vs-new engine comparison before the old export path
 is deleted. This document records what has been built and run so far, what it
 found, and what is still open — honestly, not as a green checklist.
 
-**2026-08-14 update — clean per-notation pass now exists, from CI.** The
-"disconnected session" theory below (point 2) was correct as far as it went, but
-CI's first real run on `ubuntu-latest` under `xvfb-run` (a host with a real,
-if virtual, attached display) disproved the *reason* given for the 0-panels
-symptom: even direct-command surfaces that bypass the auto-open race entirely
-reported 0 panels there too. Root cause was a loader mismatch, not a focus/session
-property: the extension bundle is ESM, the harness compiles to CommonJS, and the
-two `require('vscode')` paths handed out distinct `vscode.window` objects, so the
-harness's monkey-patch on its own copy never saw the panels the extension bundle's
-own `createWebviewPanel` calls actually created (RPC-backed surfaces were fine;
-per-call-site function references were not). Fixed by having `activate()` hand
-back its own `vscode` binding under `TX_E2E_TESTING=1` for the harness to patch
-instead. Result: **28/28 surfaces passing**, both suites, in CI
-(`Extension E2E (headless)` on transitrix-studio#535) and locally in ~29s. Items
-2 and 3 below are superseded by this — kept as a record of the ruled-out theory,
-not current status. Items 1, 4, and 5 are still open.
+**2026-08-14 update — clean per-notation pass exists, from CI.** CI's first real
+run on `ubuntu-latest` under `xvfb-run` (a host with a real, if virtual, attached
+display) produced **28/28 surfaces passing**, both suites
+(`preview-surfaces.test.ts`, `png-export.test.ts`), merged via
+transitrix-studio#535. Root cause of the earlier 0-panels failures was a loader
+mismatch, not a display/session property (see "A refuted theory" below, kept as a
+record — not current status).
+
+**2026-08-14 update — packaged-VSIX wiring and PNG comparison tooling added.**
+Hold 5a (transitrix-studio#538, part of the universal-VSIX epic) landed a reusable CI job
+that builds, hashes, and attests the universal VSIX. This gives hold 6 something
+to verify *by hash* instead of a source rebuild — the artefact that gets verified
+now has to be the artefact that ships. `.github/workflows/extension-e2e.yml` was
+restructured to build that artefact, verify the downloaded copy's SHA-256 against
+the build job's recorded hash, unpack it, and run the e2e suite against the
+unpacked `extension/` (not `extensionDevelopmentPath` pointed at source) — see
+"Packaged-VSIX wiring" below. A new `scripts/compare-png-engines.mjs` (added this
+session, CI-wired as the `png-comparison` job) supplies the old-engine side of the
+PNG comparison. Both are new as of this update and their CI results are not yet
+recorded here — see "What's still open".
 
 ## The harness
 
-`extension/test-e2e/` (`npm run test:e2e-extension`) launches a real VS Code
-Extension Development Host via `@vscode/test-electron` and drives it through mocha:
+`extension/test-e2e/` (`npm run test:e2e-extension` locally against source, or
+`npm run test:e2e-extension:packaged` against an unpacked `.vsix` — see below)
+launches a real VS Code Extension Development Host via `@vscode/test-electron`
+and drives it through mocha:
 
 - `suite/preview-surfaces.test.ts` — opens the fixture for every notation/document
   surface the extension previews (goals, DGCA, DGA, action, blocks, applications,
@@ -43,9 +49,25 @@ Extension Development Host via `@vscode/test-electron` and drives it through moc
   asserts a real non-empty PNG is written, and captures the exact SVG payload
   handed to the rasterizer (for the old-vs-new comparison below).
 
-Both suites currently run against `extensionDevelopmentPath` (the built
-`extension/` tree), **not an installed packaged `.vsix`** — see "What's still
-open" below.
+## Packaged-VSIX wiring
+
+`runTest.ts` now reads `TX_E2E_EXTENSION_PATH`: if set, it points
+`extensionDevelopmentPath` at that path instead of the source `extension/` tree.
+`.github/workflows/extension-e2e.yml`'s `e2e` job:
+
+1. Calls `build-vsix.yml` (`workflow_call`) to produce the attested universal VSIX
+   and its recorded SHA-256.
+2. Downloads that build artifact and independently re-hashes the downloaded file,
+   failing the job if it doesn't match the build job's own recorded hash — the
+   artifact consumed is verified to be the one produced, not assumed.
+3. Unpacks the `.vsix` (a zip; the extension's own files live under its
+   `extension/` entry) and sets `TX_E2E_EXTENSION_PATH` to the unpacked
+   `extension/` directory.
+4. Runs `npm run test:e2e-extension:packaged` — same mocha suites, same
+   assertions, but exercising the shipped bundle rather than a source rebuild.
+
+Local source-based runs (`npm run test:e2e-extension`) are unaffected — the env
+var is unset by default, so `extensionDevelopmentPath` falls back to source.
 
 ## A real bug found and fixed
 
@@ -63,91 +85,76 @@ user closing the tab mid-render, or (as the harness's own `afterEach` does)
 closing all editors — the write throws (`Cannot read properties of undefined
 (reading 'webview')`, or `Webview is disposed` for the `this.panel.webview.html =
 await …` single-statement form) instead of silently no-oping. Fixed by
-re-checking `this.panel` immediately before every such write. This is a
-production defect independent of the test harness — a real user closing a
-preview mid-render hits the same throw.
+re-checking `this.panel` immediately before every such write (transitrix-studio#529).
+This is a production defect independent of the test harness — a real user closing
+a preview mid-render hits the same throw.
+
+## A refuted theory (kept as a record, not current status)
+
+An earlier session diagnosed the harness's "0 panels" failures as a property of
+this unattended host: the automation account's Windows session showed as
+`Disc` (disconnected), with no attached input desktop, which looked consistent
+with the Electron test window never gaining real focus/window state. That
+diagnosis was **wrong** — CI's first real run on `ubuntu-latest`/`xvfb-run` hit the
+identical 0-panels symptom, including for direct-command surfaces that bypass the
+auto-open race entirely, which the disconnected-session theory could not explain.
+
+The actual root cause: the extension bundle is ESM while the harness compiles to
+CommonJS, and the two `require('vscode')` loader paths handed out **distinct**
+`vscode.window` objects — the harness's monkey-patch on its own copy never saw the
+panels the extension bundle's own `createWebviewPanel` calls actually created.
+Fixed by having `activate()` hand back its own `vscode` binding under
+`TX_E2E_TESTING=1` for the harness to patch instead (see `helpers.ts`'s own header
+comment for the full mechanism). This is what unblocked the 28/28 pass recorded
+above.
 
 ## What's still open
 
-1. **Runs against source, not the packaged VSIX.** The issue title is
-   "per-notation verification of packaged universal VSIX". Pointing
-   `extensionDevelopmentPath` at the unpacked contents of a built `.vsix` (rather
-   than `extension/` source) instead of, or in addition to, the current setup
-   would close this gap; not yet done.
-2. **The suite does not run reliably in this unattended host — now confirmed as
-   an environment property, not a flaky symptom.** Multiple runs this session
-   (before and after the panel-race fix, and with `--disable-gpu` added and
-   removed) showed the same failure shape: `captureWebviewPanels` reports 0
-   panels for surfaces that should render. Diagnostic instrumentation (since
-   reverted) traced this to VS Code's own active-editor tracking, not the
-   extension: `onDidChangeActiveTextEditor` fires once for the opened fixture,
-   then fires again moments later with `undefined` — i.e. the test-host window
-   loses its active editor on its own, before the extension's auto-open listener
-   has necessarily finished. This reproduced even for the very first fixture
-   opened in an otherwise-empty run, with the extension explicitly activated
-   ahead of time (`ensureExtensionActivated()`, added this session — kept, since
-   it removes one real race even though it wasn't the one at fault here). The
-   pattern is consistent with the Electron test window never holding real
-   window/focus state in this unattended session — plausible without an
-   interactive desktop session — rather than with anything the extension or the
-   harness controls.
+1. **Runs against the packaged VSIX — wired this session, not yet confirmed
+   green from CI.** See "Packaged-VSIX wiring" above. Once
+   `.github/workflows/extension-e2e.yml` runs on this change, record the
+   per-notation result here against the exercised artifact's SHA-256.
+2. **PNG comparison (old engine vs. new engine) — tooling added this session, not
+   yet run.** `scripts/compare-png-engines.mjs` rebuilds `extension/src/raster.ts`
+   as it stood at tag v3.1.3 (`flattenCssVars` + `@resvg/resvg-js`, reproduced
+   verbatim in the script) and rasterizes the exact SVG `png-export.test.ts`
+   captures, then pixel-diffs against the new engine's own captured PNG. This is
+   a **deviation from comparing against a previously-published binary**: no
+   released `.vsix` asset for a pre-PR-#526 version is obtainable — the
+   Marketplace listing is gone and no GitHub release ever attached a `.vsix`
+   file. Wired as a CI job (`png-comparison`, depends on `e2e`) that
+   downloads the e2e job's PNG captures and runs the comparison; results land in
+   the `png-engine-comparison` build artifact. Not yet run from this branch —
+   record the outcome here once CI produces it.
+3. **Old PNG-export path deletion — already done, in #526, not blocked on
+   anything here.** `extension/src/raster.ts` and the `@resvg/resvg-js` runtime
+   dependency were removed when the webview-canvas rasterizer landed
+   (transitrix-studio#526); `BpmnJsPreview.saveAsPng` (the one
+   caller not going through `StaticSvgPreview.pngTarget`) was updated in place
+   rather than kept behind a flag. There is no old code path left to delete —
+   this acceptance item is satisfied by #526, not by anything in this hold.
 
-   **Confirmed 2026-08-14, not just plausible.** `query session` on this host
-   shows the automation account's session (`Transitrix`, ID 1) in state `Disc`
-   (disconnected) while a separate console session (`Valerii`, ID 2) is the one
-   in state `Active`; `[System.Environment]::UserInteractive` from a process in
-   the automation account's session returns `False`. A disconnected Windows
-   session has no attached input desktop, so a Win32/Electron top-level window
-   created there cannot become the foreground/focused window in the way
-   `onDidChangeActiveTextEditor` depends on — this is the documented behaviour
-   of disconnected sessions, not a bug to chase further in this codebase. A
-   single-surface rerun this session (`TX_E2E_GREP=goals`) reproduced the exact
-   "0 panels" failure on the very first and only fixture opened, consistent
-   with every prior run. This closes the open question from the prior session:
-   the theory is confirmed, and the fix is a different execution environment,
-   not different code.
-3. **Per-notation results are therefore not a clean pass/fail matrix yet.** An
-   early exploratory run (pre-fix) showed roughly a dozen of the 25 preview cases
-   render successfully in a single pass before hitting the disposed-panel bug on
-   the rest; later full runs, post-fix, showed anywhere from 0 to all 25 fail
-   with the "0 panels" symptom above, depending on the run. That variance is the
-   evidence for (2) above, not a notation-by-notation result — no surface can yet
-   be marked verified-green from this session's runs.
-4. **PNG comparison (old engine vs. currently-published build) not started.**
-   `png-export.test.ts` captures the new (webview-canvas) engine's output and the
-   exact SVG fed to it, which is half of what's needed; the "current published
-   build" side requires installing a previously-published VSIX (e.g. 3.1.x, which
-   still carried `@resvg/resvg-js`) and running the equivalent export, which
-   hasn't been attempted this session.
-5. **Old PNG-export path deletion:** blocked on (4), unchanged from the issue's
-   own acceptance criteria — not attempted.
+## Harness changes (this and prior sessions)
 
-## Harness changes this session (beyond the panel-race fix)
-
-- `helpers.ts`: added `ensureExtensionActivated()`, called from a `before()` hook
-  in both suites — explicitly activates the extension rather than relying on its
+- `helpers.ts`: `ensureExtensionActivated()`, called from a `before()` hook in
+  both suites — explicitly activates the extension rather than relying on its
   `workspaceContains:*` activation events to have completed before the first
-  test's `openFixture()` runs. Kept as a real hardening even though it did not
-  turn out to be the cause of (2) above.
+  test's `openFixture()` runs.
 - `suite/index.ts`: `TX_E2E_GREP` env var, passed to `mocha.grep()` — narrows a
   run to one surface for diagnosis without editing the fixed `SURFACES` list.
-- `captureWebviewPanels` (`helpers.ts`, from an earlier run this session, kept
-  as-is): waits up to `settleMs` (default 15s) past the triggering call
-  returning for a panel to appear, covering the extension's fire-and-forget
-  auto-open path.
+- `captureWebviewPanels` (`helpers.ts`): waits up to `settleMs` (default 15s) past
+  the triggering call returning for a panel to appear, covering the extension's
+  fire-and-forget auto-open path.
+- `runTest.ts` (this session): `TX_E2E_EXTENSION_PATH` override — see
+  "Packaged-VSIX wiring" above.
+- `scripts/compare-png-engines.mjs` (this session, new) — old-vs-new PNG engine
+  comparison tooling; not part of the extension bundle.
 
 ## Next steps
 
-- **Rerun this suite from a session with an attached input desktop** — an
-  interactive console session, or a CI runner (e.g. `windows-latest` GitHub
-  Actions, which runs with a real desktop session unlike this disconnected
-  automation session) — to produce the actual per-notation pass/fail matrix.
-  No further unattended run against this host will produce a different result;
-  this is now a confirmed environment property (see above), not something to
-  keep re-diagnosing.
-- Point the harness at an unpacked packaged `.vsix` instead of source. Wiring
-  this does not itself require a working display, but verifying it works does
-  — worth doing together with the rerun above rather than separately, so the
-  one working run also closes acceptance-criterion (1).
-- Run the old-build side of the PNG comparison — also needs a working display
-  for the same reason.
+- Let `.github/workflows/extension-e2e.yml` run on this branch's PR and record the
+  per-notation result (pass/fail matrix) against the packaged VSIX's SHA-256, and
+  the PNG comparison's per-case diff ratios, in this document.
+- If the PNG comparison surfaces a real divergence beyond the CSS-var-flattening
+  difference already expected between the two engines' SVG handling, record it as
+  a finding — this hold's job is to surface that, not to force a match.

--- a/docs/internal/hold6-verification.md
+++ b/docs/internal/hold6-verification.md
@@ -24,8 +24,12 @@ the build job's recorded hash, unpack it, and run the e2e suite against the
 unpacked `extension/` (not `extensionDevelopmentPath` pointed at source) — see
 "Packaged-VSIX wiring" below. A new `scripts/compare-png-engines.mjs` (added this
 session, CI-wired as the `png-comparison` job) supplies the old-engine side of the
-PNG comparison. Both are new as of this update and their CI results are not yet
-recorded here — see "What's still open".
+PNG comparison. Both are new as of this update.
+
+**2026-08-14 update — CI ran: 27/28 passing, one known failure, fix pending
+merge.** See "What's still open" item 1 for detail: the failure is
+`transitrix-studio#540` (unmerged, based on `main`), not a new bug. PNG
+comparison stayed unrun as a result — item 2.
 
 ## The harness
 
@@ -110,12 +114,24 @@ above.
 
 ## What's still open
 
-1. **Runs against the packaged VSIX — wired this session, not yet confirmed
-   green from CI.** See "Packaged-VSIX wiring" above. Once
-   `.github/workflows/extension-e2e.yml` runs on this change, record the
-   per-notation result here against the exercised artifact's SHA-256.
-2. **PNG comparison (old engine vs. new engine) — tooling added this session, not
-   yet run.** `scripts/compare-png-engines.mjs` rebuilds `extension/src/raster.ts`
+1. **Runs against the packaged VSIX — CI ran, 27/28 passing, 1 known failure
+   with a fix already open in a separate PR.** Artifact
+   `transitrix-studio-3.2.0.vsix`, `sha256:99a9ab97f908c1ae7521f224736105921062c60f227cadf055784efea1150e87`
+   (run [31832521049](https://github.com/transitrix/transitrix-studio/actions/runs/31832521049)).
+   26 `preview-surfaces.test.ts` cases plus the direct-command surfaces passed;
+   `bpmn (custom process renderer, default)` failed —
+   `Transitrix Studio: loadCompiler failed: Error: Cannot find module 'ajv'`. Not a
+   new regression: `compiler.js` was reached via a runtime `createRequire('ajv')`
+   call that esbuild couldn't statically bundle, invisible while the packaged VSIX
+   still shipped `node_modules` and only surfacing once transitrix-hq#141 (PR
+   transitrix-studio#526) stopped bundling it. Fixed in PR
+   transitrix-studio#540 (static `import` of `ajv`/`ajv-formats` so esbuild
+   inlines them) — that PR is based on `main`, not this branch, per this repo's
+   no-stacked-PRs rule, so this branch's e2e run stays red until #540 merges and
+   this branch picks it up via a merge from `main`. `png-comparison` was skipped
+   as a result (see item 2).
+2. **PNG comparison (old engine vs. new engine) — tooling added, not yet run.**
+   `scripts/compare-png-engines.mjs` rebuilds `extension/src/raster.ts`
    as it stood at tag v3.1.3 (`flattenCssVars` + `@resvg/resvg-js`, reproduced
    verbatim in the script) and rasterizes the exact SVG `png-export.test.ts`
    captures, then pixel-diffs against the new engine's own captured PNG. This is
@@ -124,8 +140,9 @@ above.
    Marketplace listing is gone and no GitHub release ever attached a `.vsix`
    file. Wired as a CI job (`png-comparison`, depends on `e2e`) that
    downloads the e2e job's PNG captures and runs the comparison; results land in
-   the `png-engine-comparison` build artifact. Not yet run from this branch —
-   record the outcome here once CI produces it.
+   the `png-engine-comparison` build artifact. Skipped this run because the `e2e`
+   job it depends on failed (item 1) — record the outcome here once #540 merges,
+   this branch merges `main`, and `e2e` goes green.
 3. **Old PNG-export path deletion — already done, in #526, not blocked on
    anything here.** `extension/src/raster.ts` and the `@resvg/resvg-js` runtime
    dependency were removed when the webview-canvas rasterizer landed

--- a/extension/test-e2e/runTest.ts
+++ b/extension/test-e2e/runTest.ts
@@ -1,11 +1,18 @@
 /**
- * Entry point: launches a real VS Code Extension Development Host with the
- * built `extension/` and runs the mocha suite in ./suite against it
- * (transitrix-hq#143, hold 6 — "a green build is not evidence").
+ * Entry point: launches a real VS Code Extension Development Host and runs
+ * the mocha suite in ./suite against it (hold 6 — "a green build is not
+ * evidence").
  *
- * Requires `npm run extension:prep` to have already produced
- * extension/out, extension/media, extension/compiler (this script does not
- * rebuild them — invoke via `npm run test:e2e-extension`, which does both).
+ * By default targets the built `extension/` source tree — requires
+ * `npm run extension:prep` to have already produced extension/out,
+ * extension/media, extension/compiler (this script does not rebuild them —
+ * invoke via `npm run test:e2e-extension`, which does both).
+ *
+ * Set `TX_E2E_EXTENSION_PATH` to instead target an unpacked packaged
+ * `.vsix` (its `extension/` subfolder) — the artefact that actually ships,
+ * per hold 6's own acceptance criterion. See
+ * `npm run test:e2e-extension:packaged` and .github/workflows/extension-e2e.yml,
+ * which unpacks the attested build-vsix.yml artifact before setting this.
  */
 import * as fs from 'node:fs';
 import * as os from 'node:os';
@@ -13,7 +20,9 @@ import * as path from 'node:path';
 import { runTests } from '@vscode/test-electron';
 
 async function main(): Promise<void> {
-  const extensionDevelopmentPath = path.resolve(__dirname, '..', '..', 'extension');
+  const extensionDevelopmentPath = process.env.TX_E2E_EXTENSION_PATH
+    ? path.resolve(process.env.TX_E2E_EXTENSION_PATH)
+    : path.resolve(__dirname, '..', '..', 'extension');
   const extensionTestsPath = path.resolve(__dirname, 'suite', 'index.js');
   const workspacePath = path.resolve(__dirname, '..', '..', 'tests', 'fixtures', 'notation-corpus');
   const repoRoot = path.resolve(__dirname, '..', '..');
@@ -24,6 +33,8 @@ async function main(): Promise<void> {
 
   const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tx-e2e-userdata-'));
   const extensionsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tx-e2e-extensions-'));
+
+  console.log(`extension-e2e: extensionDevelopmentPath = ${extensionDevelopmentPath}`);
 
   const exitCode = await runTests({
     extensionDevelopmentPath,

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
       },
       "devDependencies": {
         "@plantuml/core": "^1.2026.6",
+        "@resvg/resvg-js": "^2.6.2",
         "@types/js-yaml": "^4.0.9",
         "@types/mocha": "^10.0.10",
         "@types/node": "^22.20.1",
@@ -1222,6 +1223,246 @@
       "peerDependencies": {
         "react": ">=17",
         "react-dom": ">=17"
+      }
+    },
+    "node_modules/@resvg/resvg-js": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
+      "integrity": "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@resvg/resvg-js-android-arm-eabi": "2.6.2",
+        "@resvg/resvg-js-android-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-x64": "2.6.2",
+        "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-musl": "2.6.2",
+        "@resvg/resvg-js-linux-x64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-x64-musl": "2.6.2",
+        "@resvg/resvg-js-win32-arm64-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-ia32-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-x64-msvc": "2.6.2"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm-eabi": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.6.2.tgz",
+      "integrity": "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.6.2.tgz",
+      "integrity": "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.6.2.tgz",
+      "integrity": "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-x64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.6.2.tgz",
+      "integrity": "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm-gnueabihf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.6.2.tgz",
+      "integrity": "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.6.2.tgz",
+      "integrity": "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.6.2.tgz",
+      "integrity": "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.6.2.tgz",
+      "integrity": "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.6.2.tgz",
+      "integrity": "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-arm64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.6.2.tgz",
+      "integrity": "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-ia32-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.6.2.tgz",
+      "integrity": "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-x64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.6.2.tgz",
+      "integrity": "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,9 @@
     "sync-examples": "node scripts/sync-examples-from-methodology.mjs",
     "build:plantuml-assets": "node scripts/build-plantuml-assets.mjs",
     "build:test-e2e-extension": "tsc -p extension/test-e2e/tsconfig.json",
-    "test:e2e-extension": "npm run extension:prep && npm run build:test-e2e-extension && node scripts/prep-test-out-commonjs.mjs && node .test-out/extension-e2e/runTest.js"
+    "test:e2e-extension": "npm run extension:prep && npm run build:test-e2e-extension && node scripts/prep-test-out-commonjs.mjs && node .test-out/extension-e2e/runTest.js",
+    "test:e2e-extension:packaged": "npm run build:test-e2e-extension && node scripts/prep-test-out-commonjs.mjs && node .test-out/extension-e2e/runTest.js",
+    "compare-png-engines": "node scripts/compare-png-engines.mjs"
   },
   "bin": {
     "transitrix": "./dist/cli.js"
@@ -69,6 +71,7 @@
   },
   "devDependencies": {
     "@plantuml/core": "^1.2026.6",
+    "@resvg/resvg-js": "^2.6.2",
     "@types/js-yaml": "^4.0.9",
     "@types/mocha": "^10.0.10",
     "@types/node": "^22.20.1",

--- a/scripts/compare-png-engines.mjs
+++ b/scripts/compare-png-engines.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+/**
+ * Old (@resvg/resvg-js, pre-webview-canvas-rasterizer) vs new (webview
+ * Chromium canvas) PNG-engine comparison — hold 6's remaining acceptance item.
+ *
+ * Consumes the SVG + PNG pairs `extension/test-e2e/suite/png-export.test.ts`
+ * captures (the exact `transitrix:renderPng` payload and the resulting PNG
+ * for goals/blocks/plantuml), rasterizes the same SVG bytes through the old
+ * engine, and pixel-diffs the two outputs.
+ *
+ * "Old engine" here is a rebuild of `extension/src/raster.ts` as it stood at
+ * tag v3.1.3 (deleted in PR #526, which moved PNG export to the webview
+ * canvas) — `flattenCssVars` and the `Resvg` call are reproduced verbatim
+ * below. This is a deviation from comparing against a previously-published
+ * binary: no released `.vsix` asset for a pre-#526 version is obtainable —
+ * the Marketplace listing was removed and no GitHub release ever attached a
+ * `.vsix` file. Recorded as a deviation, not hidden — see
+ * docs/internal/hold6-verification.md.
+ *
+ * Usage:
+ *   node scripts/compare-png-engines.mjs [captureDir]
+ *   (defaults to .test-out/png-capture, the harness's own TX_E2E_CAPTURE_DIR)
+ *
+ * Not part of the extension bundle or the VSIX — comparison tooling only,
+ * run against the e2e harness's captures. @resvg/resvg-js is a devDependency
+ * of the root package for this reason alone; extension/package.json still
+ * declares no runtime dependencies.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Resvg } from '@resvg/resvg-js';
+import { PNG } from 'pngjs';
+import pixelmatch from 'pixelmatch';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const captureDir = path.resolve(process.argv[2] ?? path.join(root, '.test-out', 'png-capture'));
+const reportDir = path.join(root, '.test-out', 'png-engine-comparison');
+
+const CASES = ['goals', 'blocks', 'plantuml'];
+
+// Verbatim from extension/src/raster.ts at tag v3.1.3 — see that file's own
+// comment for why this pass exists (resvg's usvg engine does not resolve
+// CSS custom properties; our exported SVGs define every colour as a
+// `--ts-*` custom property).
+function flattenCssVars(svg) {
+  const defs = new Map();
+  const declRe = /(--[A-Za-z0-9-]+)\s*:\s*([^;}]+)/g;
+  let m;
+  while ((m = declRe.exec(svg)) !== null) {
+    defs.set(m[1], m[2].trim());
+  }
+
+  const varRe = /var\(\s*(--[A-Za-z0-9-]+)\s*(?:,\s*([^)]*))?\)/g;
+  const resolve = (name, fallback) => {
+    if (defs.has(name)) return defs.get(name);
+    return fallback !== undefined ? fallback.trim() : `var(${name})`;
+  };
+
+  let out = svg;
+  let prev = '';
+  let pass = 0;
+  while (out !== prev && pass < 10) {
+    prev = out;
+    pass += 1;
+    out = out.replace(varRe, (_whole, name, fb) => resolve(name, fb));
+  }
+  return out;
+}
+
+// Same defaults raster.ts's rasterizeSvgToPng used (scale 2, white background).
+function rasterizeOld(svg) {
+  const flattened = flattenCssVars(svg);
+  const resvg = new Resvg(flattened, {
+    background: 'white',
+    fitTo: { mode: 'zoom', value: 2 },
+    font: { loadSystemFonts: true },
+  });
+  return Buffer.from(resvg.render().asPng());
+}
+
+function readPng(buf) {
+  return PNG.sync.read(buf);
+}
+
+async function main() {
+  fs.mkdirSync(reportDir, { recursive: true });
+  const results = [];
+
+  for (const name of CASES) {
+    const svgPath = path.join(captureDir, `${name}.svg`);
+    const newPngPath = path.join(captureDir, `${name}.png`);
+
+    if (!fs.existsSync(svgPath) || !fs.existsSync(newPngPath)) {
+      results.push({ name, status: 'missing-capture', detail: `expected ${svgPath} and ${newPngPath} from the e2e harness run` });
+      continue;
+    }
+
+    const svg = fs.readFileSync(svgPath, 'utf-8');
+    const oldPngBuf = rasterizeOld(svg);
+    const oldPngPath = path.join(reportDir, `${name}.old.png`);
+    fs.writeFileSync(oldPngPath, oldPngBuf);
+
+    const oldPng = readPng(oldPngBuf);
+    const newPng = readPng(fs.readFileSync(newPngPath));
+
+    if (oldPng.width !== newPng.width || oldPng.height !== newPng.height) {
+      results.push({
+        name,
+        status: 'dimension-mismatch',
+        detail: `old ${oldPng.width}x${oldPng.height} vs new ${newPng.width}x${newPng.height}`,
+      });
+      continue;
+    }
+
+    const { width, height } = oldPng;
+    const diff = new PNG({ width, height });
+    const diffPixels = pixelmatch(oldPng.data, newPng.data, diff.data, width, height, { threshold: 0.1 });
+    const diffPath = path.join(reportDir, `${name}.diff.png`);
+    fs.writeFileSync(diffPath, PNG.sync.write(diff));
+
+    const totalPixels = width * height;
+    const diffRatio = diffPixels / totalPixels;
+    results.push({
+      name,
+      status: 'compared',
+      width,
+      height,
+      diffPixels,
+      totalPixels,
+      diffRatio,
+    });
+  }
+
+  const summary = results
+    .map((r) => {
+      if (r.status === 'compared') {
+        return `- **${r.name}**: ${r.diffPixels}/${r.totalPixels} px differ (${(r.diffRatio * 100).toFixed(3)}%), ${r.width}x${r.height}`;
+      }
+      return `- **${r.name}**: ${r.status} — ${r.detail}`;
+    })
+    .join('\n');
+
+  const report = `# PNG engine comparison (hold 6)
+
+Old engine: rebuild of \`extension/src/raster.ts\` at tag v3.1.3 (@resvg/resvg-js
+2.6.2 + \`flattenCssVars\`), not a previously-published binary — see this
+script's header comment for why. New engine: the current webview Chromium
+canvas rasterizer (\`webview-png-rasterizer.ts\`), captured by
+\`extension/test-e2e/suite/png-export.test.ts\`.
+
+${summary}
+
+Diff images (old, and a pixelmatch visual diff where dimensions matched) are
+in this same directory alongside this report.
+`;
+
+  fs.writeFileSync(path.join(reportDir, 'report.md'), report);
+  fs.writeFileSync(path.join(reportDir, 'report.json'), JSON.stringify(results, null, 2));
+
+  console.log(report);
+
+  const failed = results.some((r) => r.status !== 'compared');
+  if (failed) {
+    console.error('compare-png-engines: one or more cases did not produce a pixel comparison — see report above.');
+    process.exitCode = 1;
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Points the extension e2e harness (`extension/test-e2e/`) at an unpacked, hash-verified universal VSIX (built by the reusable `build-vsix.yml` job) instead of a source rebuild — `runTest.ts` now honours `TX_E2E_EXTENSION_PATH`, and `.github/workflows/extension-e2e.yml`'s `e2e` job builds the VSIX, independently re-hashes the downloaded artifact against the build job's own recorded SHA-256, unpacks it, and runs the suite against that.
- Adds `scripts/compare-png-engines.mjs`: rebuilds the pre-webview-canvas `raster.ts` rasterizer (`flattenCssVars` + `@resvg/resvg-js`, as it stood at tag `v3.1.3`) and pixel-diffs it against the current webview-canvas engine's captured output for goals/blocks/plantuml. This is the old-engine side of the PNG comparison — no previously-published `.vsix` asset exists to compare against instead, which is documented as a deviation both in the script and in `docs/internal/hold6-verification.md`. Wired as a new `png-comparison` CI job consuming the `e2e` job's PNG captures.
- Corrects `docs/internal/hold6-verification.md` in place: an earlier "disconnected Windows session" diagnosis for the harness's 0-panels failures was refuted by CI (the real cause was a CJS/ESM `vscode` loader mismatch, already fixed and merged) but the doc still recorded it as confirmed. Also records that the old PNG-export code path was already deleted in a prior PR — nothing left to delete for that acceptance item.

## Test plan
- [x] `npx tsc -p extension/test-e2e/tsconfig.json --noEmit` — clean
- [x] `node --check scripts/compare-png-engines.mjs` — clean
- [x] Smoke-tested `compare-png-engines.mjs` against a synthetic SVG/PNG capture pair locally — dimension matching, pixelmatch diffing, and report generation all work as intended (correctly caught an unflattened `var()` producing a large diff, confirming the CSS-var-flattening logic is load-bearing)
- [ ] CI (`extension-e2e.yml`: `build-vsix` → `e2e` → `png-comparison`) — will run on this PR; per-notation pass/fail and PNG diff ratios should be recorded back into `hold6-verification.md` once green

🤖 Generated with [Claude Code](https://claude.com/claude-code)