### PR TITLE
fix(compiler): bundle ajv/ajv-formats statically instead of runtime require

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,19 +1,16 @@
-import { createRequire } from 'node:module';
 import { readFileSync } from 'node:fs';
 import yaml from 'js-yaml';
+import { Ajv } from 'ajv';
+import addFormatsImport from 'ajv-formats';
 
 import type { AssociationIr, Bounds, ElementType, ProcessIr, SequenceFlowIr } from './ir.js';
 import { dslSchemaPath } from './schema-path.js';
 
 const SCHEMA = JSON.parse(readFileSync(dslSchemaPath(import.meta.url), 'utf8')) as object;
 
-/** TODO(esm-no-require): Prefer native ESM imports for Ajv/ajv-formats once the Node + bundler lineup no longer forces CJS bridging; upstream context: ajv-validator/ajv tracker (dual‑package exports & NodeNext). */
-const require = createRequire(import.meta.url);
-type AjvClass = typeof import('ajv').default;
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const Ajv = require('ajv') as AjvClass;
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const addFormats = require('ajv-formats') as (instance: InstanceType<AjvClass>) => void;
+// ajv-formats has no NodeNext-friendly named export; its default-import type resolves to the
+// module namespace rather than the callable plugin under `moduleResolution: NodeNext`.
+const addFormats = addFormatsImport as unknown as (instance: Ajv) => void;
 
 const ajv = new Ajv({ allErrors: true, strict: false });
 addFormats(ajv);

--- a/src/transitrixrc.ts
+++ b/src/transitrixrc.ts
@@ -1,14 +1,14 @@
 import { readFileSync, statSync } from 'node:fs'
 import { join } from 'node:path'
-import { createRequire } from 'node:module'
+import { Ajv } from 'ajv'
+import addFormatsImport from 'ajv-formats'
 
 import type { ValidationRule } from './validator-types.js'
 import type { TransitrixrcConfig, ConfigError } from './validator-types.js'
 
-const require = createRequire(import.meta.url)
-type AjvClass = typeof import('ajv').default
-const Ajv = require('ajv') as AjvClass
-const addFormats = require('ajv-formats') as (instance: InstanceType<AjvClass>) => void
+// ajv-formats has no NodeNext-friendly named export; its default-import type resolves to the
+// module namespace rather than the callable plugin under `moduleResolution: NodeNext`.
+const addFormats = addFormatsImport as unknown as (instance: Ajv) => void
 
 // Load schema at module initialization
 const TRANSITRIXRC_SCHEMA = {


### PR DESCRIPTION
## Summary

- `src/parser.ts` and `src/transitrixrc.ts` loaded `ajv`/`ajv-formats` via `createRequire(import.meta.url)('ajv')` — a runtime CJS resolution esbuild cannot statically bundle. It survived `build-compiler-bundle.mjs`'s esbuild packaging as a genuine `node_modules` lookup, contradicting that script's own comment that all `COMPILER_RUNTIME_EXTERNALS` were verified to have none.
- Since the packaged VSIX now ships no `node_modules` at all (THQ-141), any consumer of `compiler.js` in the packaged extension threw `Cannot find module 'ajv'` — `loadCompiler failed`, silently falling back to the legacy BPMN renderer.
- Found while exercising the packaged universal VSIX for THQ-143 (hold 6 verification): the custom BPMN process renderer test failed against the packaged artifact while every other notation (which doesn't route through `compiler.js`) passed.
- Switched both files to static `import` so esbuild inlines `ajv`/`ajv-formats` into the bundle. `ajv-formats`' default export has no NodeNext-friendly typing (known dual-package hazard), so kept a narrow type-only cast rather than reintroducing a runtime `require`.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `node scripts/build-compiler-bundle.mjs` — rebuilt bundle has zero `require("ajv")` call sites (previously 2)
- [x] `npx vitest run` — 772/775 pass (3 pre-existing failures in `tests/cli-migrate.test.ts` are unrelated, gated on an external methodology-repo fixture)
- [x] `npm run extension:prep && npm run verify-extension-packaging` — clean
- [x] Copied `extension/compiler/` + `extension/schemas/` alone (no `node_modules`) into an isolated temp dir and loaded/ran the bundle directly — module loads, and both the valid-document and schema-invalid-document paths exercise ajv validation correctly (previously threw `Cannot find module 'ajv'` on any load)