### PR TITLE
fix(intellij): bump Gradle wrapper to 9.7.0

### DIFF
--- a/intellij/gradle.properties
+++ b/intellij/gradle.properties
@@ -12,7 +12,7 @@ pluginSinceBuild = 242
 # later IDEs; widen this as new IDEA majors are validated.
 pluginUntilBuild = 262.*
 
-gradleVersion = 8.10.2
+gradleVersion = 9.7.0
 
 # Suppress the legacy IntelliJ Plugin v1 warning that surfaces from the toolchain.
 org.gradle.jvmargs = -Xmx2g -XX:+UseG1GC -Dfile.encoding=UTF-8

--- a/intellij/gradle/wrapper/gradle-wrapper.properties
+++ b/intellij/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- IntelliJ Platform Gradle Plugin 2.18.1 requires Gradle >= 9.0.0; the wrapper was still pinned at 8.14.5, which broke `jetbrains-publish.yml` for v3.2.0.
- Bumps `intellij/gradle/wrapper/gradle-wrapper.properties` `distributionUrl` to `gradle-9.7.0-bin.zip` and aligns `intellij/gradle.properties` `gradleVersion` to match (was drifted to 8.10.2).
- `gradle-wrapper.jar` is unchanged — byte-identical between the pinned distribution and a freshly generated 9.7.0 wrapper.

Refs: THQ-128

## Test plan
- [x] `./gradlew --version` resolves and launches Gradle 9.7.0 from the updated wrapper.
- [ ] CI (`jetbrains-publish.yml`) builds and publishes v3.2.0 successfully with this wrapper.