### PR TITLE
fix(intellij): remove instrumentationTools(), fix Gradle 10 delegate deprecation

### DIFF
--- a/intellij/build.gradle.kts
+++ b/intellij/build.gradle.kts
@@ -19,10 +19,6 @@ dependencies {
     intellijPlatform {
         intellijIdeaCommunity(providers.gradleProperty("platformVersion"))
         testFramework(TestFrameworkType.Platform)
-        // Required by the IntelliJ Platform Gradle Plugin v2 for the
-        // `instrumentCode` task (form/NotNull bytecode instrumentation);
-        // without it the build fails with "No Java Compiler dependency found".
-        instrumentationTools()
         // Required for the `signPlugin` task — downloads the Marketplace ZIP Signer CLI.
         zipSigner()
     }
@@ -84,7 +80,7 @@ val webviewBundleDir = rootProject.layout.projectDirectory
 // output without a declared dependency (Gradle 8.x validation error).
 val webviewResourcesDir = layout.buildDirectory.dir("webview-resources")
 
-val syncWebviewBundle by tasks.registering(Copy::class) {
+val syncWebviewBundle = tasks.register<Copy>("syncWebviewBundle") {
     description = "Copy the @transitrix/diagrams webview bundle into the plugin resources."
     from(webviewBundleDir) {
         include("transitrix-render.js", "transitrix-render.css")


### PR DESCRIPTION
## Summary
- IntelliJ Platform Gradle Plugin 2.12.0 removed `instrumentationTools()` as a deprecated compatibility helper in the same release that raised the minimum supported Gradle version to 9.0.0. Calling it against the pinned 2.18.1 plugin is an unresolved reference and the root cause of the `jetbrains-publish.yml` failure this issue tracks. Instrumentation no longer needs an explicit dependency helper.
- Also switched `syncWebviewBundle` off the `val x by tasks.registering(Type::class)` delegate syntax to `tasks.register<Type>(name)`, since Gradle 9.7.0 flags the delegate form as deprecated and scheduled for removal in Gradle 10 — found while investigating whether that warning was actually build-blocking (it wasn't, but it's a one-line fix).

## Test plan
- [x] `gradlew tasks` — runs clean against Gradle 9.7.0, zero errors
- [x] `gradlew help --warning-mode all` — zero deprecation warnings after the fix (previously flagged the `tasks.registering` delegate)
- [ ] `compileKotlin` not run locally — this machine has no JDK 21 and no toolchain download repository configured; CI provisions JDK 21 separately, out of scope for this fix
- [ ] Re-run `jetbrains-publish.yml` (workflow_dispatch) for v3.2.0 and confirm it publishes — acceptance criteria 2/3 of THQ-128, left for the maintainer per the standing rule against triggering external-registry publishes autonomously

Addresses THQ-128.