### PR TITLE
feat(cli): vendor pass2/render-pdf/run-record, add `transitrix render`

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -77,6 +77,7 @@ transitrix validate --scope=repo [--root <dir>] [--json] [--include-model]
 transitrix new <goal|driver|constraint|requirement> --id <ID> --name "<label>" [options]
 transitrix export-compliance [--format md|pdf] [--scope law:<ID>|product:<ID>|gap] [--output <path>] [--root <dir>]
 transitrix impact [--root <dir>] [--json]
+transitrix render <input.ttrs> [--out <dir>] [--root <dir>] [--json]
 ```
 
 | Command | Purpose |
@@ -88,6 +89,7 @@ transitrix impact [--root <dir>] [--json]
 | `new <type>` | Scaffolds a standalone motivation-layer element (`goal`, `driver`, `constraint`, `requirement`) with the admission record and lifecycle envelope computed rather than hand-typed — see [Envelope defaults](#envelope-defaults). `--dry-run` previews without writing. Run `transitrix new <type> --help` for the per-type fields. |
 | `export-compliance` | Markdown or PDF report of the compliance views (matrix by default; `law:` / `product:` / `gap` scopes). Scans `--root` (default cwd). PDF needs WeasyPrint on PATH (`pipx install weasyprint`). |
 | `impact` | Names which `canon/views/**` documents a *staged* (`git add`, not yet committed) `canon/elements/**` change makes stale. Silent when nothing is staged, or when nothing this can resolve is affected. Resolves the three canon-projection view notations with a static resolver (`goals`, `dgca`/`fgca`, `action`); every other view (inline-form views, `blocks`, `applications`, `capability-map`, `compliance-impact`, `coverage-metric`, `bpmn`) is reported as coverage not determined, never as unaffected. Document (`.ttrs`) coverage is not yet included. `--root` sets the repo to check (default cwd). |
+| `render` | Renders a `.ttrs` document end to end — Pass 1 + Pass 2 + Markdown + PDF + a run-record — and writes `<basename>.md`, `<basename>.pdf` and `<basename>.run-record.json` next to the source (or into `--out`). No instruction-slot filler is supplied, so every slot renders open, same as the source's own unfilled state — this is a building block for a future regeneration offer, not a document-authoring tool of its own. `--root` sets the repo whose `git rev-parse HEAD` is recorded in the run-record (default: the source file's directory). Exits 1 on any unresolved model-object reference (`strict` profile, `runPass1`'s own default). |
 
 Flags: `--no-metrics` suppresses the metrics report on compile; `--no-validate`
 suppresses validation **warnings** (errors always run). Input files must use a
@@ -102,6 +104,7 @@ transitrix validate order.bpmn.transitrix.yaml --json
 transitrix validate --scope=repo --root organizations/acme_corp
 transitrix metrics order.bpmn.transitrix.yaml --json
 transitrix export-compliance --format md --scope gap --output gaps.md
+transitrix render canon/views/documents/product.mrd.ttrs
 transitrix serve --port 9000
 ```
 

--- a/scripts/vendor-methodology-document-renderer.mjs
+++ b/scripts/vendor-methodology-document-renderer.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Re-vendor @transitrix/document-renderer's pass-1 resolver into vendor/methodology/.
+ * Re-vendor @transitrix/document-renderer's render pipeline into vendor/methodology/.
  *
  * Same contract as vendor-methodology-vocabulary.mjs: vendor a tagged release,
  * never a local sibling checkout and never a branch, so what lands here is what
@@ -8,14 +8,19 @@
  * path — "Pass 1 ships as a unit callable on its own, so pass 2 and Studio's
  * preview can both depend on it as a library."
  *
- * Five files make up the callable unit: pass1.mjs is the entry point;
- * parse-template.mjs, repository.mjs, ids.mjs and syntax.mjs are what it
- * imports. Vendored verbatim, with their relative imports intact, so
- * pass1.mjs resolves the same way here as it does in methodology's own tree.
+ * Eight files make up the vendored surface: pass1.mjs (the deterministic
+ * resolver) and its four imports (parse-template.mjs, repository.mjs,
+ * ids.mjs, syntax.mjs) — vendored first for the .ttrs preview — plus
+ * pass2.mjs (fills instruction slots via a caller-supplied agent hook),
+ * render-pdf.mjs (Markdown → PDF, dependency-free) and run-record.mjs (the
+ * provenance stamp), vendored for `transitrix render`'s persisted end-to-end
+ * render (transitrix-hq#186). Vendored verbatim, with their relative imports
+ * intact, so each file resolves the same way here as it does in methodology's
+ * own tree.
  *
  * Usage:
- *   node scripts/vendor-methodology-document-renderer.mjs --ref v3.4.0
- *   node scripts/vendor-methodology-document-renderer.mjs --ref v3.4.0 --check
+ *   node scripts/vendor-methodology-document-renderer.mjs --ref v3.5.0
+ *   node scripts/vendor-methodology-document-renderer.mjs --ref v3.5.0 --check
  *
  * --check fetches and reports what would change without writing anything.
  *
@@ -33,7 +38,10 @@ const VENDOR_DIR = path.resolve(HERE, '..', 'vendor', 'methodology', 'document-r
 
 const SOURCE_REPO = 'transitrix/methodology';
 const SOURCE_DIR = 'packages/document-renderer/src';
-const FILES = ['pass1.mjs', 'parse-template.mjs', 'repository.mjs', 'ids.mjs', 'syntax.mjs'];
+const FILES = [
+  'pass1.mjs', 'parse-template.mjs', 'repository.mjs', 'ids.mjs', 'syntax.mjs',
+  'pass2.mjs', 'render-pdf.mjs', 'run-record.mjs',
+];
 
 function parseArgs(argv) {
   const out = { ref: null, check: false };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,6 +44,7 @@ import {
   type FixFieldResult,
 } from './validate-fix.js';
 import { handleExportComplianceCommand } from './export-compliance.js';
+import { handleRenderCommand } from './render-document.js';
 import { computeStagedImpact, reportImpact } from './impact.js';
 import { transitrixPackageVersion } from './package-version.js';
 import { bundledDiagramsVersion } from './diagrams-version.js';
@@ -91,6 +92,7 @@ function printUsage(): void {
        transitrix validate --scope=repo [--root <dir>] [--json] [--include-model]
        transitrix export-compliance [--format md|pdf] [--scope law:<ID>|product:<ID>|gap] [--output <path>] [--root <dir>]
        transitrix impact [--root <dir>] [--json]
+       transitrix render <input.ttrs> [--out <dir>] [--root <dir>] [--json]
        transitrix migrate [--from X.Y] [--to X.Y] [--dry-run] [--recipes <dir>] [target-dir]
        transitrix new <goal|driver|constraint|requirement> --id <ID> --name "<label>" [--author <name>] [--valid-from <YYYY-MM-DD>] [--root <dir>] [--dry-run]
 
@@ -123,6 +125,15 @@ function printUsage(): void {
               each/trace/row-field construct is reported as coverage not
               determined, never as unaffected. --root sets the repo to check
               (default cwd).
+  render    — renders a .ttrs document end to end (Pass 1 + Pass 2 + Markdown
+              + PDF + a run-record) and writes <basename>.md, <basename>.pdf
+              and <basename>.run-record.json alongside the source (or into
+              --out). No instruction-slot filler is supplied — every slot
+              renders open, same as the source's own unfilled state. --root
+              sets the repo git commit recorded in the run-record (default:
+              the source file's directory). Exits 1 on any unresolved
+              reference (strict profile — the same default runPass1 itself
+              uses).
   migrate   — migrate an adopter repo to a newer methodology version by running
               the ordered recipes from the methodology repo. Reads the current
               version from transitrix.yaml (or --from X.Y); --dry-run previews
@@ -866,6 +877,8 @@ try {
     await handleExportComplianceCommand(process.argv.slice(3));
   } else if (subcommand === 'impact') {
     await handleImpactCommand(process.argv.slice(3));
+  } else if (subcommand === 'render') {
+    await handleRenderCommand(process.argv.slice(3));
   } else if (subcommand === 'migrate') {
     await handleMigrateCommand(process.argv.slice(3));
   } else if (subcommand === 'new') {

--- a/src/render-document.ts
+++ b/src/render-document.ts
@@ -1,0 +1,165 @@
+// `transitrix render` — renders a `.ttrs` document end-to-end (Pass 1 + Pass
+// 2 + Markdown + PDF + a run-record) and writes the result to disk
+// (transitrix-hq#186). A building block for transitrix-hq#182's per-artefact
+// regeneration offer — non-interactive, scriptable, no TTY prompt of its own.
+//
+// No `fill` hook is supplied to Pass 2: this CLI is not itself an agent, and
+// the vendored pass2.mjs's own contract is that an omitted `fill` resolves
+// every instruction slot `not-attempted` and behaves like Pass 1 alone —
+// unfilled and visible, never silently dropped. That keeps this command
+// deterministic the same way Pass 1 already is: same source, same Markdown
+// and PDF bytes, every run (the run-record's own `run_timestamp` is the one
+// field that legitimately varies — recording when a run happened is its
+// purpose, not something byte-identity claims apply to).
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import * as path from 'node:path';
+
+// Vendored from methodology — see scripts/vendor-methodology-document-renderer.mjs
+// and tests/document-renderer-vendor.test.ts for the integrity check that
+// keeps these import targets trustworthy. Typed by the co-located *.d.mts
+// files (vendor/methodology/document-renderer/) — Studio's own type
+// contracts for the vendored JS, not part of what's fetched.
+import { runPass1 } from '../vendor/methodology/document-renderer/pass1.mjs';
+import { runPass2 } from '../vendor/methodology/document-renderer/pass2.mjs';
+import { renderMarkdownToPdf } from '../vendor/methodology/document-renderer/render-pdf.mjs';
+import { buildRunRecord, serializeRunRecord } from '../vendor/methodology/document-renderer/run-record.mjs';
+
+export interface RenderDocumentOptions {
+  /** The `.ttrs` source to render. */
+  path: string;
+  /** Directory the three output files are written into. Default: alongside the source. */
+  outDir?: string;
+  /** Repository root `git rev-parse HEAD` is read from for the run-record's
+   *  `repository_commit`. Default: the source file's directory. */
+  root?: string;
+  /** Overrides the run-record's `run_timestamp` — for deterministic tests
+   *  only; a real render leaves this to `run-record.mjs`'s own `Date.now()` default. */
+  runTimestamp?: string;
+}
+
+export interface RenderDocumentResult {
+  ok: boolean;
+  templateId: string | null;
+  markdownPath: string;
+  pdfPath: string;
+  runRecordPath: string;
+  errors: { code: string; message: string }[];
+}
+
+/** `git rev-parse HEAD` at `root`, or `null` when it isn't a git repository —
+ *  matches export-compliance.ts's own `gitCommit`, duplicated rather than
+ *  imported since that module is excluded from the root emit build. */
+function gitCommitOf(root: string): string | null {
+  try {
+    return execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: root,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Renders `options.path` end to end and writes three files next to each
+ * other: `<basename>.md`, `<basename>.pdf`, `<basename>.run-record.json`.
+ *
+ * Pass 1 runs `profile: 'strict'` (its own default) — a render persisted to
+ * disk fails closed on an unresolved reference rather than rendering it as a
+ * visible-but-wrong marker for a reader who may never open the source
+ * template to see the warning. That is a deliberate difference from the live
+ * `.ttrs` preview (extension/src/ttrs-preview.ts), which runs `review` so an
+ * in-progress document stays viewable while it's being written.
+ */
+export async function renderDocumentToDisk(options: RenderDocumentOptions): Promise<RenderDocumentResult> {
+  const srcPath = path.resolve(options.path);
+  const text = readFileSync(srcPath, 'utf8');
+  const outDir = options.outDir ? path.resolve(options.outDir) : path.dirname(srcPath);
+  const repoRoot = options.root ? path.resolve(options.root) : path.dirname(srcPath);
+
+  const pass1Result = await runPass1({ text, templatePath: srcPath, profile: 'strict' });
+
+  const pass2Result = pass1Result.header
+    ? await runPass2({ markdown: pass1Result.markdown, instructionSlots: pass1Result.instructionSlots })
+    : { markdown: pass1Result.markdown, slotResults: [] };
+
+  const baseName = path.basename(srcPath).replace(/\.ttrs$/i, '');
+  const markdownPath = path.join(outDir, `${baseName}.md`);
+  const pdfPath = path.join(outDir, `${baseName}.pdf`);
+  const runRecordPath = path.join(outDir, `${baseName}.run-record.json`);
+
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(markdownPath, pass2Result.markdown, 'utf8');
+  writeFileSync(pdfPath, renderMarkdownToPdf(pass2Result.markdown));
+
+  // A run that never got past a missing `---` front matter has no header to
+  // build a run-record from (run-record.mjs throws on `header: null`) — the
+  // Markdown/PDF above still carry pass 1's own error text, so the failure is
+  // visible in the persisted artefacts, not just in `errors` below.
+  if (pass1Result.header) {
+    const record = buildRunRecord({
+      header: pass1Result.header,
+      repositoryCommit: gitCommitOf(repoRoot),
+      modelId: null,
+      runTimestamp: options.runTimestamp,
+      renderDate: pass1Result.renderDate,
+      profile: pass1Result.profile,
+      slotResults: pass2Result.slotResults,
+    });
+    writeFileSync(runRecordPath, serializeRunRecord(record), 'utf8');
+  }
+
+  return {
+    ok: pass1Result.ok,
+    templateId: pass1Result.header?.template_id ?? null,
+    markdownPath,
+    pdfPath,
+    runRecordPath,
+    errors: pass1Result.errors,
+  };
+}
+
+export async function handleRenderCommand(argv: string[]): Promise<void> {
+  if (argv.includes('--help') || argv.includes('-h')) {
+    console.error('usage: transitrix render <input.ttrs> [--out <dir>] [--root <dir>] [--json]');
+    process.exit(0);
+  }
+  const useJson = argv.includes('--json');
+
+  function flagValue(name: string): string | undefined {
+    const i = argv.indexOf(name);
+    return i >= 0 && i + 1 < argv.length ? argv[i + 1] : undefined;
+  }
+
+  const positional = argv.filter((a, i) => !a.startsWith('--') && argv[i - 1] !== '--out' && argv[i - 1] !== '--root');
+  const [src] = positional;
+  if (!src) {
+    console.error('transitrix render: missing input file');
+    console.error('usage: transitrix render <input.ttrs> [--out <dir>] [--root <dir>] [--json]');
+    process.exit(1);
+  }
+
+  const result = await renderDocumentToDisk({
+    path: src,
+    outDir: flagValue('--out'),
+    root: flagValue('--root'),
+  });
+
+  if (useJson) {
+    console.log(JSON.stringify(result, null, 2));
+  } else if (result.ok) {
+    console.log(`✓ ${src} → ${result.markdownPath}, ${result.pdfPath}, ${result.runRecordPath}`);
+  } else {
+    console.error(`✗ ${src}`);
+    for (const e of result.errors) {
+      console.error(`  ${e.code}: ${e.message}`);
+    }
+  }
+
+  if (!result.ok) {
+    process.exit(1);
+  }
+}

--- a/tests/document-renderer-vendor.test.ts
+++ b/tests/document-renderer-vendor.test.ts
@@ -1,7 +1,9 @@
-// Integrity check for vendor/methodology/document-renderer/ — the five source
-// files of @transitrix/document-renderer's pass-1 resolver, vendored so the
-// .ttrs preview (extension/src/ttrs-preview.ts) can call `runPass1` as a real
-// library import rather than reimplementing its resolution logic.
+// Integrity check for vendor/methodology/document-renderer/ — the eight
+// source files of @transitrix/document-renderer's render pipeline, vendored
+// so the .ttrs preview (extension/src/ttrs-preview.ts) can call `runPass1`,
+// and `transitrix render` (src/render-document.ts) can call `runPass1` +
+// `runPass2` + `renderMarkdownToPdf` + `buildRunRecord`, as real library
+// imports rather than reimplementations of methodology's own logic.
 //
 // Unlike vocabulary-drift.test.ts, this is not a divergence check against a
 // local reimplementation — there is no local copy of the resolution logic to
@@ -43,7 +45,10 @@ function loadPin(): VendoredPin {
   return pin;
 }
 
-const EXPECTED_FILES = ['pass1.mjs', 'parse-template.mjs', 'repository.mjs', 'ids.mjs', 'syntax.mjs'];
+const EXPECTED_FILES = [
+  'pass1.mjs', 'parse-template.mjs', 'repository.mjs', 'ids.mjs', 'syntax.mjs',
+  'pass2.mjs', 'render-pdf.mjs', 'run-record.mjs',
+];
 
 describe('vendor/methodology/document-renderer — integrity', () => {
   it('VENDORED.json pins exactly the five files the resolver needs', () => {
@@ -107,5 +112,57 @@ describe('vendor/methodology/document-renderer — the resolver actually runs', 
     const result = await mod.runPass1({ text, profile: 'review' });
     expect(result.errors.some((e) => e.code === 'TTRS-004')).toBe(true);
     expect(result.errors.some((e) => e.code === 'TTRS-002')).toBe(false);
+  });
+});
+
+describe('vendor/methodology/document-renderer — pass 2, PDF render, run record actually run', () => {
+  it('runPass2 with no `fill` leaves every slot `not-attempted`, unchanged from pass 1', async () => {
+    const mod = await import(pathToFileURL(path.join(VENDOR_DIR, 'pass2.mjs')).href) as {
+      runPass2: (opts: { markdown: string; instructionSlots: unknown[] }) => Promise<{
+        markdown: string;
+        slotResults: { verdict: string }[];
+      }>;
+    };
+    const markdown = '{{# instruct market-size }}open{{/ instruct }}';
+    const instructionSlots = [{ slotId: 'market-size', question: 'q', inputs: [], sufficient: 's' }];
+    const result = await mod.runPass2({ markdown, instructionSlots });
+    expect(result.slotResults).toHaveLength(1);
+    expect(result.slotResults[0].verdict).toBe('not-attempted');
+    expect(result.markdown).toContain('Open — not answered.');
+  });
+
+  it('renderMarkdownToPdf produces a well-formed PDF buffer', async () => {
+    const mod = await import(pathToFileURL(path.join(VENDOR_DIR, 'render-pdf.mjs')).href) as {
+      renderMarkdownToPdf: (markdown: string) => Buffer;
+    };
+    const pdf = mod.renderMarkdownToPdf('# Title\n\nBody text.');
+    expect(Buffer.isBuffer(pdf)).toBe(true);
+    expect(pdf.subarray(0, 5).toString('latin1')).toBe('%PDF-');
+    expect(pdf.toString('latin1')).toContain('%%EOF');
+  });
+
+  it('buildRunRecord + serializeRunRecord assemble a record carrying every slot, including one that produced nothing', async () => {
+    const mod = await import(pathToFileURL(path.join(VENDOR_DIR, 'run-record.mjs')).href) as {
+      buildRunRecord: (opts: Record<string, unknown>) => Record<string, unknown>;
+      serializeRunRecord: (record: Record<string, unknown>) => string;
+    };
+    const record = mod.buildRunRecord({
+      header: { template_id: 'smoke.mrd', template_version: '1.0' },
+      repositoryCommit: null,
+      modelId: null,
+      runTimestamp: '2026-08-17T00:00:00.000Z',
+      renderDate: '2026-08-17',
+      profile: 'strict',
+      slotResults: [
+        { slotId: 'market-size', question: 'q', inputs: [], sufficient: 's', verdict: 'not-attempted', reason: 'no declared inputs', text: null },
+      ],
+    });
+    expect(record.template_id).toBe('smoke.mrd');
+    expect(record.run_timestamp).toBe('2026-08-17T00:00:00.000Z');
+    expect(record.slots).toHaveLength(1);
+    expect((record.slots as Array<Record<string, unknown>>)[0].verdict).toBe('not-attempted');
+    const serialized = mod.serializeRunRecord(record);
+    expect(serialized.endsWith('\n')).toBe(true);
+    expect(JSON.parse(serialized)).toEqual(record);
   });
 });

--- a/tests/render-document.test.ts
+++ b/tests/render-document.test.ts
@@ -1,0 +1,164 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+
+import { afterEach, describe, it, expect } from 'vitest';
+
+import { renderDocumentToDisk } from '../src/render-document.js';
+
+let root: string | undefined;
+
+afterEach(() => {
+  if (root) rmSync(root, { recursive: true, force: true });
+  root = undefined;
+});
+
+function write(base: string, rel: string, body: string): void {
+  const p = join(base, rel);
+  mkdirSync(dirname(p), { recursive: true });
+  writeFileSync(p, body, 'utf8');
+}
+
+function git(args: string[], cwd: string): void {
+  execFileSync('git', args, { cwd, stdio: 'ignore' });
+}
+
+function initRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'tx-render-'));
+  git(['init', '-q'], dir);
+  git(['config', 'user.email', 'test@example.com'], dir);
+  git(['config', 'user.name', 'Test'], dir);
+  return dir;
+}
+
+const NO_REFERENCE_DOC = [
+  '---',
+  'document: Smoke Test',
+  'kind: mrd',
+  'template_id: smoke.mrd',
+  'template_version: "1.0"',
+  '---',
+  '# Fixed text only, no model references',
+  '',
+  'A plain paragraph with no reference at all.',
+].join('\n');
+
+describe('renderDocumentToDisk (transitrix-hq#186)', () => {
+  it('writes markdown, PDF and a run-record next to the source by default', async () => {
+    root = mkdtempSync(join(tmpdir(), 'tx-render-'));
+    write(root, 'product.mrd.ttrs', NO_REFERENCE_DOC);
+
+    const result = await renderDocumentToDisk({ path: join(root, 'product.mrd.ttrs') });
+
+    expect(result.ok).toBe(true);
+    expect(result.templateId).toBe('smoke.mrd');
+    expect(result.markdownPath).toBe(join(root, 'product.mrd.md'));
+    expect(result.pdfPath).toBe(join(root, 'product.mrd.pdf'));
+    expect(result.runRecordPath).toBe(join(root, 'product.mrd.run-record.json'));
+
+    const markdown = readFileSync(result.markdownPath, 'utf8');
+    expect(markdown).toContain('Fixed text only, no model references');
+
+    const pdf = readFileSync(result.pdfPath);
+    expect(pdf.subarray(0, 5).toString('latin1')).toBe('%PDF-');
+
+    const record = JSON.parse(readFileSync(result.runRecordPath, 'utf8'));
+    expect(record.template_id).toBe('smoke.mrd');
+    expect(record.slots).toEqual([]);
+  });
+
+  it('writes to --out when given, leaving the source directory untouched', async () => {
+    root = mkdtempSync(join(tmpdir(), 'tx-render-'));
+    write(root, 'src/product.mrd.ttrs', NO_REFERENCE_DOC);
+    const outDir = join(root, 'out');
+
+    const result = await renderDocumentToDisk({
+      path: join(root, 'src/product.mrd.ttrs'),
+      outDir,
+    });
+
+    expect(result.markdownPath).toBe(join(outDir, 'product.mrd.md'));
+    expect(() => readFileSync(join(root, 'src/product.mrd.md'))).toThrow();
+    expect(readFileSync(result.markdownPath, 'utf8')).toContain('Fixed text only');
+  });
+
+  it('every instruction slot renders open — no `fill` hook is ever supplied', async () => {
+    root = mkdtempSync(join(tmpdir(), 'tx-render-'));
+    const doc = [
+      '---',
+      'document: Smoke Test',
+      'kind: mrd',
+      'template_id: smoke.mrd',
+      'template_version: "1.0"',
+      '---',
+      '{{# instruct market-size }}',
+      'question: How large is the market?',
+      'inputs:',
+      'sufficient: a number',
+      '{{/ instruct }}',
+    ].join('\n');
+    write(root, 'product.mrd.ttrs', doc);
+
+    const result = await renderDocumentToDisk({ path: join(root, 'product.mrd.ttrs') });
+
+    expect(result.ok).toBe(true);
+    const markdown = readFileSync(result.markdownPath, 'utf8');
+    expect(markdown).toContain('Open — not answered.');
+    const record = JSON.parse(readFileSync(result.runRecordPath, 'utf8'));
+    expect(record.slots).toHaveLength(1);
+    expect(record.slots[0].verdict).toBe('not-attempted');
+    expect(record.model_id).toBeNull();
+  });
+
+  it('fails closed on an unresolved reference (strict profile) — still writes markdown/PDF, never a run-record', async () => {
+    root = mkdtempSync(join(tmpdir(), 'tx-render-'));
+    const doc = [
+      '---',
+      'document: Smoke Test',
+      'kind: mrd',
+      'template_id: smoke.mrd',
+      'template_version: "1.0"',
+      '---',
+      'Cites {{ REQ-1 }}, which has no repository configured to resolve against.',
+    ].join('\n');
+    write(root, 'product.mrd.ttrs', doc);
+
+    const result = await renderDocumentToDisk({ path: join(root, 'product.mrd.ttrs') });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+    // Markdown/PDF are still written — the failure is visible in the persisted
+    // artefact, not just swallowed into a non-zero exit code.
+    expect(readFileSync(result.markdownPath, 'utf8')).toContain('«');
+  });
+
+  it('records `git rev-parse HEAD` of --root as the run-record\'s repository_commit', async () => {
+    root = initRepo();
+    write(root, 'product.mrd.ttrs', NO_REFERENCE_DOC);
+    git(['add', '-A'], root);
+    git(['commit', '-q', '-m', 'init'], root);
+    const commit = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf-8' }).trim();
+
+    const result = await renderDocumentToDisk({ path: join(root, 'product.mrd.ttrs'), root });
+
+    const record = JSON.parse(readFileSync(result.runRecordPath, 'utf8'));
+    expect(record.repository_commit).toBe(commit);
+  });
+
+  it('is deterministic — rendering an unchanged document twice produces byte-identical markdown and PDF', async () => {
+    root = mkdtempSync(join(tmpdir(), 'tx-render-'));
+    write(root, 'product.mrd.ttrs', NO_REFERENCE_DOC);
+
+    const first = await renderDocumentToDisk({ path: join(root, 'product.mrd.ttrs') });
+    const firstMarkdown = readFileSync(first.markdownPath);
+    const firstPdf = readFileSync(first.pdfPath);
+
+    const second = await renderDocumentToDisk({ path: join(root, 'product.mrd.ttrs') });
+    const secondMarkdown = readFileSync(second.markdownPath);
+    const secondPdf = readFileSync(second.pdfPath);
+
+    expect(secondMarkdown.equals(firstMarkdown)).toBe(true);
+    expect(secondPdf.equals(firstPdf)).toBe(true);
+  });
+});

--- a/vendor/methodology/README.md
+++ b/vendor/methodology/README.md
@@ -39,14 +39,20 @@ in the same change.
 
 ## `document-renderer/`
 
-The five source files of `@transitrix/document-renderer`'s pass-1 resolver
-(`pass1.mjs` and the four modules it imports: `parse-template.mjs`,
-`repository.mjs`, `ids.mjs`, `syntax.mjs`). The package's own README states this
-is the intended integration path: "Pass 1 ships as a unit callable on its own,
-so pass 2 and Studio's preview can both depend on it as a library rather than
-on the whole renderer." Studio's `.ttrs` preview (`extension/src/ttrs-preview.ts`)
-imports `runPass1` from the vendored copy — a real library call against the
-methodology-authored resolver, not a reimplementation of its resolution logic.
+Eight source files of `@transitrix/document-renderer`'s render pipeline:
+`pass1.mjs` (the deterministic resolver) and the four modules it imports
+(`parse-template.mjs`, `repository.mjs`, `ids.mjs`, `syntax.mjs`) — vendored
+first for the `.ttrs` preview — plus `pass2.mjs` (fills instruction slots via
+a caller-supplied agent hook), `render-pdf.mjs` (Markdown → PDF, dependency-
+free) and `run-record.mjs` (the provenance stamp), vendored for
+`transitrix render`'s persisted end-to-end render (transitrix-hq#186). The
+package's own README states this is the intended integration path: "Pass 1
+ships as a unit callable on its own, so pass 2 and Studio's preview can both
+depend on it as a library rather than on the whole renderer." Studio's
+`.ttrs` preview (`extension/src/ttrs-preview.ts`) imports `runPass1` from the
+vendored copy, and `src/render-document.ts` imports all three render-pipeline
+modules — real library calls against the methodology-authored renderer, not a
+reimplementation of its logic.
 
 `VENDORED.json` records the source tag and a per-file SHA-256 (LF-normalised).
 `tests/document-renderer-vendor.test.ts` fails closed: a missing file, an
@@ -55,7 +61,7 @@ unpinned file, or a hash mismatch is a build failure, never a pass.
 ### Refreshing
 
 ```
-node scripts/vendor-methodology-document-renderer.mjs --ref v3.4.0
+node scripts/vendor-methodology-document-renderer.mjs --ref v3.5.0
 ```
 
 Same fetch-from-tag contract as `vocabulary.yaml` above — never a sibling

--- a/vendor/methodology/document-renderer/VENDORED.json
+++ b/vendor/methodology/document-renderer/VENDORED.json
@@ -1,13 +1,16 @@
 {
   "source_repo": "transitrix/methodology",
-  "source_ref": "v3.3.0",
+  "source_ref": "v3.5.0",
   "source_path": "packages/document-renderer/src",
   "files": {
     "pass1.mjs": "10de90ea275d74680bbb8586136bbdb59485090cc263edc0d3dfa903a444abc7",
     "parse-template.mjs": "0109b7ac5edc733e01bb3ec1cd1b8fff10127b06a3d3dc5e33d85a4674065ca0",
     "repository.mjs": "4b90bfe47507205495ea297d7a666c718058ece3d5569a1403059b7f59260493",
     "ids.mjs": "f007b6b1d266b661dcb2a47c91e61c61466af06add68e09f3d8576d05059b084",
-    "syntax.mjs": "b6d1f5bf74d705c262454202289e64475cbaad3e4924e2c89a64660c6de2fd97"
+    "syntax.mjs": "b6d1f5bf74d705c262454202289e64475cbaad3e4924e2c89a64660c6de2fd97",
+    "pass2.mjs": "0f27365e60a4982265c7efd3b93fc09465700cbd6191370b8f7e741bc2a6825b",
+    "render-pdf.mjs": "c2b9679c9b5420fc211dfeba4e196350da1b92e468b46be7b95cc7b3520f1455",
+    "run-record.mjs": "d972147a246c21c438cf12cf67564e7db473fd4aa60bd763ac75fa0942869b60"
   },
-  "vendored_on": "2026-08-08"
+  "vendored_on": "2026-08-16"
 }

--- a/vendor/methodology/document-renderer/pass2.d.mts
+++ b/vendor/methodology/document-renderer/pass2.d.mts
@@ -1,0 +1,43 @@
+// Type contract for the vendored pass2.mjs — Studio's own, not part of what
+// vendor-methodology-document-renderer.mjs fetches from methodology (that
+// script only writes the .mjs files; this file is untouched by it).
+// Kept intentionally narrow: only the shape src/render-document.ts actually
+// reads. The source of truth for the full contract is pass2.mjs's own JSDoc
+// and the 2026-08-12 instruction-slot ADR it implements.
+
+export interface Pass2SlotInput {
+  slotId: string;
+  question: string;
+  inputs: string[];
+  sufficient: string;
+}
+
+export interface Pass2FillOutcome {
+  status: 'sufficient' | 'insufficient';
+  text?: string;
+  attributions?: string[];
+}
+
+export interface Pass2SlotResult {
+  slotId: string;
+  question: string;
+  inputs: string[];
+  sufficient: string;
+  verdict: 'sufficient' | 'insufficient' | 'not-attempted';
+  reason: string | null;
+  text: string | null;
+  attributions?: string[];
+}
+
+export interface RunPass2Options {
+  markdown: string;
+  instructionSlots: Pass2SlotInput[];
+  fill?: (slot: Pass2SlotInput) => Promise<Pass2FillOutcome>;
+}
+
+export interface Pass2Result {
+  markdown: string;
+  slotResults: Pass2SlotResult[];
+}
+
+export function runPass2(options: RunPass2Options): Promise<Pass2Result>;

--- a/vendor/methodology/document-renderer/pass2.mjs
+++ b/vendor/methodology/document-renderer/pass2.mjs
@@ -1,0 +1,156 @@
+// Pass 2 — fills the instruction slots pass 1 left untouched.
+//
+// Pass 1 is deterministic and calls no model (pass1.mjs). Pass 2 is the other
+// half of the two-pass split: "an agent, executing the instruction the slot
+// carries". This module stays agent-agnostic on purpose —
+// it takes the agent as a caller-supplied `fill` hook, the same shape pass 1
+// already uses for figure rasterisation (`rasterise`). Nothing in this file
+// calls a model; it orchestrates a caller-supplied one.
+//
+// The rules below are normative — the 2026-08-12 decision "an instruction
+// slot specifies the outcome, not the procedure" (accepted 2026-08-15):
+//
+//   * `inputs:` is a closed list. A slot declaring none is not fillable by a
+//     conforming implementation — it renders open, verdict `not-attempted`,
+//     and `fill` is never called for it.
+//   * Every statement in a filled slot is attributable to a declared input —
+//     that is the filler's obligation, not this module's; pass 2 only carries
+//     the filler's own account of what it used, and rejects the one part of
+//     that account it CAN check mechanically: an attribution outside the
+//     slot's own declared `inputs:` is a closed-list violation, not a content
+//     question, so it throws rather than passing it through.
+//   * An insufficient answer is declared, not padded — a slot the filler could
+//     not fill to `sufficient:` stays visibly open, never dressed up as text
+//     that reads like an answer.
+//   * The run record — built from this module's `slotResults`, see
+//     run-record.mjs — carries a verdict per slot: `sufficient`,
+//     `insufficient`, or `not-attempted`.
+//
+// Scope: filling slots and rewriting the markdown they sit in. Nothing here
+// writes to the model, and nothing here decides what a "sufficient" answer
+// looks like beyond what the filler itself reports.
+
+// Matches a `{{# instruct <slot-id> }} … {{/ instruct }}` span, verbatim, the
+// same shape pass 1 copies through untouched
+// (DIRECTIVE_LANGUAGE.md §4.2 — the body is opaque). Pass 2 deliberately does
+// not re-parse the slot body; it locates the span in pass 1's own markdown
+// output and treats it as a unit to replace, matching pass1's instructionSlots
+// (by document order) for the instruction text.
+const INSTRUCT_SPAN = /\{\{#\s*instruct\s+([a-z0-9][a-z0-9-]*)\s*\}\}[\s\S]*?\{\{\/\s*instruct\s*\}\}/g;
+
+const OPEN_MARKER = '*Open — not answered.*';
+const DISCLOSURE =
+  '\n\n*This section was produced by an automated pass; it has not been admitted through a review gate.*';
+
+function notAttempted(slot, reason) {
+  return { ...slot, verdict: 'not-attempted', reason, text: null };
+}
+
+async function resolveSlot(slot, fill) {
+  if (slot.inputs.length === 0) {
+    return notAttempted(slot, 'no declared inputs');
+  }
+  if (typeof fill !== 'function') {
+    return notAttempted(slot, 'no filler configured');
+  }
+
+  const outcome = await fill({
+    slotId: slot.slotId,
+    question: slot.question,
+    inputs: slot.inputs,
+    sufficient: slot.sufficient,
+  });
+
+  if (!outcome || (outcome.status !== 'sufficient' && outcome.status !== 'insufficient')) {
+    throw new TypeError(
+      `pass2: fill(${JSON.stringify(slot.slotId)}) must resolve to `
+      + '{ status: "sufficient", text } or { status: "insufficient" }, '
+      + `got ${JSON.stringify(outcome)}`,
+    );
+  }
+
+  if (outcome.status === 'insufficient') {
+    return { ...slot, verdict: 'insufficient', reason: null, text: null };
+  }
+
+  if (typeof outcome.text !== 'string' || outcome.text.trim() === '') {
+    throw new TypeError(
+      `pass2: fill(${JSON.stringify(slot.slotId)}) reported "sufficient" with no text`,
+    );
+  }
+
+  const attributions = Array.isArray(outcome.attributions) ? outcome.attributions : [];
+  // The closed-input discipline (2026-08-12 ADR §3, §6) is mechanically checkable
+  // at this one point: a filler cannot attribute a statement to something it was
+  // never given. Content-level attribution — that each *sentence* is actually
+  // supported by what it cites — stays the filler's own obligation; this module
+  // only enforces that it cited from the set it was allowed to read.
+  const undeclared = attributions.filter((a) => !slot.inputs.includes(a));
+  if (undeclared.length > 0) {
+    throw new TypeError(
+      `pass2: fill(${JSON.stringify(slot.slotId)}) attributed to ${JSON.stringify(undeclared)}, `
+      + `not in this slot's declared inputs ${JSON.stringify(slot.inputs)} — inputs is a closed list`,
+    );
+  }
+
+  return {
+    ...slot,
+    verdict: 'sufficient',
+    reason: null,
+    text: outcome.text,
+    attributions,
+  };
+}
+
+/**
+ * Run pass 2 over pass 1's output.
+ *
+ * @param {object} options
+ * @param {string} options.markdown          pass 1's `markdown` — instruction
+ *                                            slots still present verbatim
+ * @param {Array}  options.instructionSlots   pass 1's `instructionSlots`, in
+ *                                            document order
+ * @param {Function} [options.fill]           `(slot) => Promise<{status, text?}>`
+ *                                            — the agent. Omitted entirely, every
+ *                                            slot resolves `not-attempted` and pass 2
+ *                                            behaves like pass 1 alone: unfilled and
+ *                                            visible.
+ * @returns {Promise<{markdown, slotResults}>}
+ */
+export async function runPass2({ markdown, instructionSlots, fill } = {}) {
+  const spans = [...markdown.matchAll(INSTRUCT_SPAN)];
+  if (spans.length !== instructionSlots.length) {
+    throw new Error(
+      `pass2: markdown carries ${spans.length} instruction slot(s) but `
+      + `instructionSlots lists ${instructionSlots.length} — pass 2 must run `
+      + 'against the markdown pass 1 produced for the same template',
+    );
+  }
+  for (let i = 0; i < spans.length; i++) {
+    if (spans[i][1] !== instructionSlots[i].slotId) {
+      throw new Error(
+        `pass2: slot order mismatch at position ${i} — markdown has `
+        + `"${spans[i][1]}", instructionSlots has "${instructionSlots[i].slotId}"`,
+      );
+    }
+  }
+
+  const slotResults = [];
+  for (const slot of instructionSlots) {
+    slotResults.push(await resolveSlot(slot, fill));
+  }
+
+  let cursor = 0;
+  let out = '';
+  let i = 0;
+  for (const match of markdown.matchAll(INSTRUCT_SPAN)) {
+    out += markdown.slice(cursor, match.index);
+    const result = slotResults[i];
+    out += result.verdict === 'sufficient' ? `${result.text}${DISCLOSURE}` : OPEN_MARKER;
+    cursor = match.index + match[0].length;
+    i++;
+  }
+  out += markdown.slice(cursor);
+
+  return { markdown: out, slotResults };
+}

--- a/vendor/methodology/document-renderer/render-pdf.d.mts
+++ b/vendor/methodology/document-renderer/render-pdf.d.mts
@@ -1,0 +1,6 @@
+// Type contract for the vendored render-pdf.mjs — Studio's own, not part of
+// what vendor-methodology-document-renderer.mjs fetches from methodology.
+// Source of truth for the full contract is render-pdf.mjs's own module header
+// (A4, Helvetica, figures reduced to a text placeholder — no rasterisation).
+
+export function renderMarkdownToPdf(markdown: string): Buffer;

--- a/vendor/methodology/document-renderer/render-pdf.mjs
+++ b/vendor/methodology/document-renderer/render-pdf.mjs
@@ -1,0 +1,231 @@
+// Markdown → PDF, hand-rolled and dependency-free.
+//
+// Every package in this repository ships with zero runtime dependencies
+// (`package.json`'s `dependencies` is `{}` throughout, and `ids.mjs`/
+// `syntax.mjs` hand-roll ID grammar and a YAML-front-matter reader for the
+// same reason). A full-fidelity Markdown renderer or an HTML-to-PDF pipeline
+// would break that posture for one output format. What this module produces
+// instead is a plain, paginated PDF: headings, paragraphs (word-wrapped,
+// bold/italic markers stripped rather than styled), and figures reduced to a
+// text placeholder — never rasterised, since embedding an image is a second,
+// larger feature this module deliberately does not take on.
+//
+// This is named, not silent, scope: a reader comparing the PDF to the
+// Markdown will see plainer typography and a placeholder where a figure was.
+// What is NOT negotiable is an explicit constraint on this output — the page
+// size. **A4, declared explicitly**, because a renderer that omits the
+// declaration defaults to US Letter and silently spills the last 18mm onto a
+// second page. A4 at 72 dpi is 595 x 842 pt; every page this module emits
+// carries that exact `/MediaBox`.
+//
+// The base-14 font `Helvetica` needs no embedding — every conformant PDF
+// reader carries it — so this module ships no font file either.
+
+const PAGE_WIDTH = 595; // A4, 72dpi — an explicit constraint on this output
+const PAGE_HEIGHT = 842;
+const MARGIN = 56; // ~20mm
+const USABLE_WIDTH = PAGE_WIDTH - 2 * MARGIN;
+
+const BODY_SIZE = 11;
+const HEADING_SIZE = { 1: 18, 2: 15, 3: 13 };
+const LINE_HEIGHT = 1.4; // multiple of font size
+const PARAGRAPH_GAP = BODY_SIZE * 0.9;
+const HEADING_GAP_BEFORE = { 1: BODY_SIZE * 1.6, 2: BODY_SIZE * 1.3, 3: BODY_SIZE };
+
+// Helvetica has no fixed width, but every layout decision here only needs to
+// avoid overflowing the page, not to justify text — an average glyph width
+// of half the font size is close enough for that, and keeps this file free
+// of a 256-entry width table.
+const AVG_CHAR_WIDTH_FACTOR = 0.52;
+
+// Characters this module's own output can contain (the `«unresolved: …»` /
+// `⚑U` markers pass 1 and pass 2 emit) plus common prose punctuation, mapped
+// to their nearest WinAnsi/ASCII equivalent. Anything left outside printable
+// ASCII after this pass becomes `?` rather than corrupting the byte stream —
+// the base-14 fonts are not expected to carry full Unicode.
+const CHAR_MAP = {
+  '–': '-', // en dash
+  '—': '--', // em dash
+  '‘': "'",
+  '’': "'",
+  '“': '"',
+  '”': '"',
+  '…': '...',
+  '«': '<<', // «
+  '»': '>>', // »
+  '⚑': '!', // ⚑
+  '☐': '[ ]',
+};
+
+function sanitize(text) {
+  let out = '';
+  for (const ch of text) {
+    if (CHAR_MAP[ch] !== undefined) { out += CHAR_MAP[ch]; continue; }
+    const code = ch.codePointAt(0);
+    out += (code >= 0x20 && code <= 0x7E) ? ch : '?';
+  }
+  return out;
+}
+
+function stripEmphasis(text) {
+  return text.replace(/\*\*(.+?)\*\*/g, '$1').replace(/__(.+?)__/g, '$1').replace(/`(.+?)`/g, '$1');
+}
+
+// Greedy word wrap at a given font size, using the average-width estimate.
+function wrap(text, size) {
+  const maxChars = Math.max(1, Math.floor(USABLE_WIDTH / (size * AVG_CHAR_WIDTH_FACTOR)));
+  const words = text.split(/\s+/).filter(Boolean);
+  const lines = [];
+  let current = '';
+  for (const word of words) {
+    const candidate = current === '' ? word : `${current} ${word}`;
+    if (candidate.length > maxChars && current !== '') {
+      lines.push(current);
+      current = word;
+    } else {
+      current = candidate;
+    }
+  }
+  if (current !== '') lines.push(current);
+  return lines.length > 0 ? lines : [''];
+}
+
+const HEADING_RE = /^(#{1,3})\s+(.*)$/;
+const IMAGE_RE = /^!\[(.*?)\]\((.*?)\)$/;
+
+// Blocks: 'heading' | 'paragraph' | 'figure'. Blank lines separate
+// paragraphs; a heading or a figure line is always its own block.
+function toBlocks(markdown) {
+  const blocks = [];
+  let paragraph = [];
+  const flush = () => {
+    if (paragraph.length > 0) { blocks.push({ type: 'paragraph', text: paragraph.join(' ') }); paragraph = []; }
+  };
+  for (const raw of markdown.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (line === '') { flush(); continue; }
+    const heading = HEADING_RE.exec(line);
+    if (heading) { flush(); blocks.push({ type: 'heading', level: heading[1].length, text: heading[2] }); continue; }
+    const image = IMAGE_RE.exec(line);
+    if (image) { flush(); blocks.push({ type: 'figure', caption: image[1] }); continue; }
+    paragraph.push(line);
+  }
+  flush();
+  return blocks;
+}
+
+// Blocks → laid-out lines, each carrying its own font size and the vertical
+// gap to leave before it. Pagination (render-pdf.mjs's other half) only
+// needs to walk this list and break pages on overflow — it does not need to
+// know it came from Markdown at all.
+function layout(markdown) {
+  const lines = [];
+  for (const block of toBlocks(markdown)) {
+    if (block.type === 'heading') {
+      const size = HEADING_SIZE[block.level] ?? HEADING_SIZE[3];
+      const wrapped = wrap(sanitize(stripEmphasis(block.text)), size);
+      wrapped.forEach((text, i) => {
+        lines.push({ text, size, gapBefore: i === 0 ? HEADING_GAP_BEFORE[block.level] ?? HEADING_GAP_BEFORE[3] : 0 });
+      });
+    } else if (block.type === 'figure') {
+      // Rasterising a figure into the PDF is out of scope (module header) —
+      // named here as a placeholder rather than silently dropped.
+      const text = sanitize(`[Figure: ${block.caption || 'untitled'}]`);
+      lines.push({ text, size: BODY_SIZE, gapBefore: PARAGRAPH_GAP });
+    } else {
+      const wrapped = wrap(sanitize(stripEmphasis(block.text)), BODY_SIZE);
+      wrapped.forEach((text, i) => {
+        lines.push({ text, size: BODY_SIZE, gapBefore: i === 0 ? PARAGRAPH_GAP : 0 });
+      });
+    }
+  }
+  return lines;
+}
+
+// Lines → pages, each page a list of { text, size, x, y } ready to place in
+// a content stream. A line whose own gap plus height would cross the bottom
+// margin starts a new page instead.
+function paginate(lines) {
+  const pages = [];
+  let page = [];
+  let cursorY = PAGE_HEIGHT - MARGIN;
+  const newPage = () => { pages.push(page); page = []; cursorY = PAGE_HEIGHT - MARGIN; };
+  for (const line of lines) {
+    const advance = line.gapBefore + line.size * LINE_HEIGHT;
+    if (cursorY - advance < MARGIN && page.length > 0) newPage();
+    cursorY -= line.gapBefore + line.size;
+    page.push({ text: line.text, size: line.size, x: MARGIN, y: cursorY });
+    cursorY -= line.size * (LINE_HEIGHT - 1);
+  }
+  pages.push(page); // always at least one page, even for an empty document
+  return pages;
+}
+
+function escapePdfString(text) {
+  return text.replace(/\\/g, '\\\\').replace(/\(/g, '\\(').replace(/\)/g, '\\)');
+}
+
+function contentStreamFor(page) {
+  const ops = ['BT'];
+  for (const line of page) {
+    ops.push(`/F1 ${line.size} Tf`);
+    ops.push(`1 0 0 1 ${line.x} ${line.y} Tm`);
+    ops.push(`(${escapePdfString(line.text)}) Tj`);
+  }
+  ops.push('ET');
+  return ops.join('\n');
+}
+
+// Assembles a minimal, valid PDF: a Catalog, a Pages tree, one Type1
+// Helvetica font shared by every page, and one Page + one Contents object
+// per page. Byte offsets for the xref table are tracked as each object is
+// appended, in the same pass — there is no second pass over the buffer.
+function assemblePdf(pages) {
+  const objects = [];
+  objects.push('<< /Type /Catalog /Pages 2 0 R >>'); // 1
+  const pageObjNums = pages.map((_, i) => 4 + 2 * i);
+  const contentObjNums = pages.map((_, i) => 5 + 2 * i);
+  objects.push(`<< /Type /Pages /Kids [${pageObjNums.map((n) => `${n} 0 R`).join(' ')}] /Count ${pages.length} >>`); // 2
+  objects.push('<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>'); // 3
+  pages.forEach((page, i) => {
+    const contentNum = contentObjNums[i];
+    objects.push(
+      `<< /Type /Page /Parent 2 0 R /MediaBox [0 0 ${PAGE_WIDTH} ${PAGE_HEIGHT}] `
+      + `/Resources << /Font << /F1 3 0 R >> >> /Contents ${contentNum} 0 R >>`,
+    ); // page object
+    const stream = contentStreamFor(page);
+    objects.push({ stream }); // content object, marked so we know to wrap it as a stream
+  });
+
+  let out = '%PDF-1.4\n';
+  const offsets = [];
+  objects.forEach((obj, i) => {
+    offsets.push(out.length);
+    const num = i + 1;
+    if (typeof obj === 'object' && obj.stream !== undefined) {
+      const length = Buffer.byteLength(obj.stream, 'latin1');
+      out += `${num} 0 obj\n<< /Length ${length} >>\nstream\n${obj.stream}\nendstream\nendobj\n`;
+    } else {
+      out += `${num} 0 obj\n${obj}\nendobj\n`;
+    }
+  });
+
+  const xrefOffset = out.length;
+  let xref = `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`;
+  for (const offset of offsets) xref += `${String(offset).padStart(10, '0')} 00000 n \n`;
+  out += xref;
+  out += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF\n`;
+
+  return Buffer.from(out, 'latin1');
+}
+
+/**
+ * Render Markdown to a PDF, A4, one Helvetica text stream per page.
+ *
+ * @param {string} markdown
+ * @returns {Buffer} PDF bytes
+ */
+export function renderMarkdownToPdf(markdown) {
+  const pages = paginate(layout(String(markdown ?? '')));
+  return assemblePdf(pages);
+}

--- a/vendor/methodology/document-renderer/run-record.d.mts
+++ b/vendor/methodology/document-renderer/run-record.d.mts
@@ -1,0 +1,59 @@
+// Type contract for the vendored run-record.mjs — Studio's own, not part of
+// what vendor-methodology-document-renderer.mjs fetches from methodology.
+// Kept intentionally narrow: only the shape src/render-document.ts actually
+// reads. Source of truth for the full contract is run-record.mjs's own JSDoc
+// and the 2026-08-12 instruction-slot ADR.
+
+export interface RunRecordHeader {
+  template_id: string;
+  template_version: string;
+}
+
+/** Structurally what pass2.mjs's `slotResults` entries carry — kept local
+ *  rather than imported from pass2.d.mts so this file has no cross-vendor-file
+ *  coupling. */
+export interface RunRecordSlotInput {
+  slotId: string;
+  question: string;
+  inputs: string[];
+  sufficient: string;
+  verdict: 'sufficient' | 'insufficient' | 'not-attempted';
+  reason?: string | null;
+  text?: string | null;
+  attributions?: string[];
+}
+
+export interface BuildRunRecordOptions {
+  header: RunRecordHeader;
+  repositoryCommit?: string | null;
+  modelId?: string | null;
+  runTimestamp?: string;
+  renderDate: string;
+  profile: 'strict' | 'review';
+  slotResults?: RunRecordSlotInput[];
+}
+
+export interface RunRecordSlot {
+  slot_id: string;
+  question: string;
+  inputs: string[];
+  sufficient: string;
+  verdict: 'sufficient' | 'insufficient' | 'not-attempted';
+  reason: string | null;
+  produced_text: string | null;
+  attributions: string[];
+}
+
+export interface RunRecord {
+  template_id: string;
+  template_version: string;
+  repository_commit: string | null;
+  model_id: string | null;
+  run_timestamp: string;
+  render_date: string;
+  profile: 'strict' | 'review';
+  slots: RunRecordSlot[];
+}
+
+export function buildRunRecord(options: BuildRunRecordOptions): RunRecord;
+export function serializeRunRecord(record: RunRecord): string;

--- a/vendor/methodology/document-renderer/run-record.mjs
+++ b/vendor/methodology/document-renderer/run-record.mjs
@@ -1,0 +1,75 @@
+// The run record — the third artefact a full render produces, beside the
+// Markdown and the PDF.
+//
+// What it must carry:
+//
+//   template id and version, repository commit, model id, run timestamp
+//   (ISO 8601), and per instruction slot the instruction text and the text
+//   it produced — every slot, including those that produced nothing.
+//
+// The 2026-08-12 ADR adds one more field per slot: a verdict —
+// `sufficient` / `insufficient` / `not-attempted` — because that is the
+// evidence a reader needs to tell "this section is missing" from "this
+// section was tried and the model could not support an answer". This module
+// only assembles the record; it computes nothing pass 1 and pass 2 have not
+// already decided.
+//
+// This is a pure function over its inputs. It does not read the filesystem
+// or git — `repositoryCommit` and `modelId` are the caller's to supply,
+// because "which commit" and "which model" are facts about the run's
+// environment, not something a record-builder can discover on its own
+// without inventing a dependency this package does not otherwise carry.
+
+/**
+ * @param {object} options
+ * @param {object} options.header          pass 1's `header` — carries
+ *                                          `template_id` and `template_version`
+ * @param {string} [options.repositoryCommit] the commit the repository was
+ *                                          read at; `null` when no repository
+ *                                          was configured for this run
+ * @param {string} [options.modelId]       identifies which model ran pass 2;
+ *                                          `null` when pass 2 filled nothing
+ *                                          (no `fill` supplied)
+ * @param {string} [options.runTimestamp]  ISO 8601 timestamp; defaults to now
+ * @param {string} options.renderDate      pass 1's `renderDate` — the date
+ *                                          validity was resolved at
+ * @param {string} options.profile         pass 1's `profile` — `strict` | `review`
+ * @param {Array}  options.slotResults     pass 2's `slotResults`, in document order
+ * @returns {object} a plain, JSON-serialisable run record
+ */
+export function buildRunRecord({
+  header, repositoryCommit = null, modelId = null, runTimestamp, renderDate, profile, slotResults = [],
+} = {}) {
+  if (!header) {
+    throw new TypeError('buildRunRecord: header is required — pass 1 must have parsed the template');
+  }
+  return {
+    template_id: header.template_id,
+    template_version: header.template_version,
+    repository_commit: repositoryCommit,
+    model_id: modelId,
+    run_timestamp: runTimestamp ?? new Date().toISOString(),
+    render_date: renderDate,
+    profile,
+    // Every slot pass 1 found, in document order — including one that
+    // produced nothing. A slot absent from this list would be indistinguishable
+    // from a slot that was never in the template at all.
+    slots: slotResults.map((s) => ({
+      slot_id: s.slotId,
+      question: s.question,
+      inputs: s.inputs,
+      sufficient: s.sufficient,
+      verdict: s.verdict,
+      reason: s.reason ?? null,
+      produced_text: s.text ?? null,
+      attributions: s.attributions ?? [],
+    })),
+  };
+}
+
+// Newline-terminated, stable key order (object literals above already fix
+// it) — the record is written as one file, not diffed field-by-field, so
+// pretty JSON is the readable choice over a packed one.
+export function serializeRunRecord(record) {
+  return `${JSON.stringify(record, null, 2)}\n`;
+}


### PR DESCRIPTION
## Summary
- Vendors the remaining three files of methodology's `document-renderer` package (`pass2.mjs`, `render-pdf.mjs`, `run-record.mjs`), pinned to `v3.5.0` — same pinning/drift discipline as the five files already vendored for the `.ttrs` preview.
- Adds `transitrix render <input.ttrs> [--out <dir>] [--root <dir>] [--json]`: Pass 1 + Pass 2 (no filler configured, so every instruction slot renders open) + Markdown + PDF + a run-record, written to disk non-interactively. A building block for THQ-182's per-artefact regeneration offer, not a user-facing feature of its own.
- Pass 1 runs `strict` profile (its own default) — the persisted render fails closed on an unresolved reference rather than silently shipping a wrong-but-plausible value.

## Test plan
- [x] `npx vitest run tests/document-renderer-vendor.test.ts` — integrity check + smoke tests for all 8 vendored files, including the 3 new ones (pass2 leaves every slot `not-attempted` with no filler, `render-pdf` produces a well-formed PDF, `run-record` assembles/serializes correctly).
- [x] `npx vitest run tests/render-document.test.ts` — new command: default output paths, `--out`, instruction slots render open, fails closed on an unresolved reference (still writes markdown/PDF), `--root`'s git commit lands in the run-record, determinism across two runs of an unchanged document.
- [x] `npx tsc --noEmit` — clean.
- [x] Full `npx vitest run` — 784 passing; the only 3 failures (`tests/cli-migrate.test.ts`) are pre-existing on `main`, confirmed via `git stash` before this change, and depend on an external methodology repo checkout unrelated to this PR.
- [x] Manual smoke test of the actual CLI entrypoint (`npx tsx src/cli.ts render ... --json`) against a real `.ttrs` fixture — markdown/PDF/run-record all written and sane.

THQ-186