### PR TITLE
feat(cli): offer documents regeneration in interactive transitrix impact

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { writeFileSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
+import { createInterface } from 'node:readline/promises';
 import * as path from 'node:path';
 
 import jsyaml from 'js-yaml';
@@ -45,7 +46,7 @@ import {
 } from './validate-fix.js';
 import { handleExportComplianceCommand } from './export-compliance.js';
 import { handleRenderCommand } from './render-document.js';
-import { computeStagedImpact, reportImpact } from './impact.js';
+import { computeStagedImpact, reportImpact, offerDocumentRegeneration } from './impact.js';
 import { transitrixPackageVersion } from './package-version.js';
 import { bundledDiagramsVersion } from './diagrams-version.js';
 import { isActionViewDoc } from '@transitrix/diagrams/activities';
@@ -780,6 +781,23 @@ async function handleImpactCommand(argv: string[]): Promise<void> {
 
   const result = computeStagedImpact(root);
   reportImpact(result, useJson);
+
+  // Regeneration offer: interactive (TTY) `transitrix impact` only —
+  // transitrix-hq#182. `--json` stays script-safe (no prompt, no behavior
+  // change) and a non-TTY run (CI, a pipe) is left exactly as `reportImpact`
+  // already printed it, since there is no one to answer a prompt.
+  const hasDocumentOffer = result.affected.some((f) => f.notation === 'documents');
+  if (!useJson && hasDocumentOffer && process.stdin.isTTY) {
+    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    try {
+      await offerDocumentRegeneration(result, root, async (file) => {
+        const answer = await rl.question(`Regenerate ${file}? [y/N] `);
+        return /^y(es)?$/i.test(answer.trim());
+      });
+    } finally {
+      rl.close();
+    }
+  }
 }
 
 async function handleMetricsCommand(argv: string[]): Promise<void> {

--- a/src/impact.ts
+++ b/src/impact.ts
@@ -22,6 +22,7 @@
 // coverage-not-determined, same honesty rule as an unresolvable view.
 
 import { execFileSync } from 'node:child_process';
+import * as path from 'node:path';
 import yaml from 'js-yaml';
 import { coerceDatesToIsoStrings } from '@transitrix/diagrams/yaml-normalize.js';
 import { resolveGoals, isGoalsViewDoc } from '@transitrix/diagrams/goals/resolver.js';
@@ -30,6 +31,7 @@ import { resolveAction, isActionViewDoc } from '@transitrix/diagrams/activities'
 import { loadRepoModel, loadViewDocs, loadDocumentSources } from './repo-validate.js';
 import { loadNotationYaml, notationOf } from './validate-notation.js';
 import { DOCUMENT_SOURCE_EXTENSION } from './validate-document-source.js';
+import { renderDocumentToDisk } from './render-document.js';
 // Vendored from methodology — see scripts/vendor-methodology-document-renderer.mjs
 // and tests/document-renderer-vendor.test.ts for the integrity check that
 // keeps this import target trustworthy. Only the syntax half (parseTemplate)
@@ -312,5 +314,39 @@ export function reportImpact(result: ImpactResult, useJson: boolean): void {
       console.log(`  • ${n.file} [${n.notation}]`);
     }
     console.log();
+  }
+}
+
+/** For each `documents` (`.ttrs`) artefact in `result.affected`, asks
+ *  `confirm` whether to regenerate it and, on acceptance, runs the same
+ *  render path `transitrix render` uses (transitrix-hq#186) — output is
+ *  identical to invoking that command directly on the same document
+ *  (transitrix-hq#182 acceptance criterion 3). `goals`/`dgca`/`fgca`/`action`
+ *  view findings are skipped: no headless-rendering path exists for them
+ *  (transitrix-hq#182's narrowed scope), so they get the notice `reportImpact`
+ *  already prints and nothing more. Declining writes nothing — `confirm`
+ *  returning `false` is a no-op, so the identical offer reappears on the next
+ *  run against the same staged change (acceptance criterion 4). Never called
+ *  for `--json` mode or for a `notDetermined` finding — both are the caller's
+ *  responsibility to keep out of `result.affected` before this runs. */
+export async function offerDocumentRegeneration(
+  result: ImpactResult,
+  root: string,
+  confirm: (file: string) => Promise<boolean>,
+): Promise<void> {
+  for (const finding of result.affected) {
+    if (finding.notation !== 'documents') continue;
+    const accept = await confirm(finding.file);
+    if (!accept) continue;
+
+    const renderResult = await renderDocumentToDisk({ path: path.join(root, finding.file), root });
+    if (renderResult.ok) {
+      console.log(`  ✓ regenerated ${finding.file} → ${renderResult.markdownPath}, ${renderResult.pdfPath}, ${renderResult.runRecordPath}`);
+    } else {
+      console.error(`  ✗ ${finding.file}`);
+      for (const e of renderResult.errors) {
+        console.error(`    ${e.code}: ${e.message}`);
+      }
+    }
   }
 }

--- a/tests/impact.test.ts
+++ b/tests/impact.test.ts
@@ -1,11 +1,11 @@
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 
 import { afterEach, describe, it, expect, vi } from 'vitest';
 
-import { computeStagedImpact, stagedCanonElementIds, reportImpact } from '../src/impact.js';
+import { computeStagedImpact, stagedCanonElementIds, reportImpact, offerDocumentRegeneration } from '../src/impact.js';
 
 // A staged canon/elements/** change is only meaningful against a real git
 // index (git diff --cached), so — same pattern as
@@ -333,5 +333,149 @@ describe('computeStagedImpact — .ttrs document coverage (transitrix-hq#89)', (
     const result = computeStagedImpact(root);
     expect(result.affected).toEqual([]);
     expect(result.notDetermined).toEqual([]);
+  });
+});
+
+describe('offerDocumentRegeneration (transitrix-hq#182)', () => {
+  it('offers each documents artefact by name and skips a view finding entirely', async () => {
+    root = initRepo();
+    seedBaseline(root); // dgca view resolves every GOAL element (filter: all)
+    write(
+      root,
+      'canon/views/documents/product.mrd.ttrs',
+      ttrsDoc('product.mrd', 'Cites {{ GOAL-1 }} directly.'),
+    );
+    commitAll(root, 'add a document source');
+    write(root, 'canon/elements/goals/GOAL-1.yaml', goalYaml('GOAL-1', 'Grow revenue by 20%'));
+    git(['add', 'canon/elements/goals/GOAL-1.yaml'], root);
+
+    const result = computeStagedImpact(root);
+    expect(result.affected).toEqual([
+      { file: 'canon/views/strategy/dgca.dgca.transitrix.yaml', notation: 'dgca' },
+      { file: 'canon/views/documents/product.mrd.ttrs', notation: 'documents' },
+    ]);
+
+    const confirm = vi.fn(async () => false);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await offerDocumentRegeneration(result, root, confirm);
+    log.mockRestore();
+
+    // Asked once, for the documents artefact only — never for the dgca view.
+    expect(confirm).toHaveBeenCalledTimes(1);
+    expect(confirm).toHaveBeenCalledWith('canon/views/documents/product.mrd.ttrs');
+  });
+
+  it('never offers a coverage-not-determined document, only the determined one', async () => {
+    root = initRepo();
+    seedBaseline(root);
+    write(
+      root,
+      'canon/views/documents/determined.mrd.ttrs',
+      ttrsDoc('determined.mrd', 'Cites {{ REQ-1 }} directly.'),
+    );
+    write(
+      root,
+      'canon/views/documents/undetermined.mrd.ttrs',
+      ttrsDoc('undetermined.mrd', '{{# each REQUIREMENT }}\n{{ .id }}\n{{/ each }}\n\nAlso cites {{ REQ-1 }}.'),
+    );
+    commitAll(root, 'add two document sources');
+    write(root, 'canon/elements/requirements/REQ-1.yaml', requirementYaml('REQ-1', 'Reworded wording'));
+    git(['add', 'canon/elements/requirements/REQ-1.yaml'], root);
+
+    const result = computeStagedImpact(root);
+    expect(result.affected).toEqual([
+      { file: 'canon/views/documents/determined.mrd.ttrs', notation: 'documents' },
+    ]);
+    expect(result.notDetermined).toEqual([
+      { file: 'canon/views/documents/undetermined.mrd.ttrs', notation: 'documents' },
+    ]);
+
+    const confirm = vi.fn(async () => false);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await offerDocumentRegeneration(result, root, confirm);
+    log.mockRestore();
+
+    expect(confirm).toHaveBeenCalledTimes(1);
+    expect(confirm).toHaveBeenCalledWith('canon/views/documents/determined.mrd.ttrs');
+  });
+
+  it('accepting the offer regenerates the document — identical to running the render path directly', async () => {
+    root = initRepo();
+    seedBaseline(root);
+    // `canon: ../..` (from canon/views/documents/ back to canon/) gives Pass 1
+    // a real repository to resolve {{ REQ-1 }} against, same as any other
+    // document that declares its own repository root.
+    write(
+      root,
+      'canon/views/documents/product.mrd.ttrs',
+      [
+        '---',
+        'document: "Test document"',
+        'kind: mrd',
+        'template_id: product.mrd',
+        'template_version: "1.0"',
+        'canon: ../..',
+        '---',
+        '',
+        'Cites {{ REQ-1 }} directly.',
+        '',
+      ].join('\n'),
+    );
+    commitAll(root, 'add a document source');
+    write(root, 'canon/elements/requirements/REQ-1.yaml', requirementYaml('REQ-1', 'Reworded wording'));
+    git(['add', 'canon/elements/requirements/REQ-1.yaml'], root);
+
+    const result = computeStagedImpact(root);
+    const markdownPath = join(root, 'canon/views/documents/product.mrd.md');
+    const pdfPath = join(root, 'canon/views/documents/product.mrd.pdf');
+    const runRecordPath = join(root, 'canon/views/documents/product.mrd.run-record.json');
+    expect(existsSync(markdownPath)).toBe(false);
+
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await offerDocumentRegeneration(result, root, async () => true);
+    log.mockRestore();
+
+    expect(existsSync(markdownPath)).toBe(true);
+    expect(existsSync(pdfPath)).toBe(true);
+    expect(existsSync(runRecordPath)).toBe(true);
+
+    const offerMarkdown = readFileSync(markdownPath, 'utf8');
+    expect(offerMarkdown).toContain('REQ-1');
+
+    const { renderDocumentToDisk } = await import('../src/render-document.js');
+    const direct = await renderDocumentToDisk({
+      path: join(root, 'canon/views/documents/product.mrd.ttrs'),
+      root,
+      outDir: join(root, 'direct-out'),
+    });
+    expect(direct.ok).toBe(true);
+    expect(readFileSync(direct.markdownPath, 'utf8')).toBe(offerMarkdown);
+  });
+
+  it('declining performs no regeneration and writes no state — the identical offer reappears', async () => {
+    root = initRepo();
+    seedBaseline(root);
+    write(
+      root,
+      'canon/views/documents/product.mrd.ttrs',
+      ttrsDoc('product.mrd', 'Cites {{ REQ-1 }} directly.'),
+    );
+    commitAll(root, 'add a document source');
+    write(root, 'canon/elements/requirements/REQ-1.yaml', requirementYaml('REQ-1', 'Reworded wording'));
+    git(['add', 'canon/elements/requirements/REQ-1.yaml'], root);
+
+    const firstResult = computeStagedImpact(root);
+    const markdownPath = join(root, 'canon/views/documents/product.mrd.md');
+
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await offerDocumentRegeneration(firstResult, root, async () => false);
+    log.mockRestore();
+
+    expect(existsSync(markdownPath)).toBe(false);
+
+    // Nothing was staged or written as a side effect of declining — the same
+    // staged change produces the identical offer on a second run.
+    const secondResult = computeStagedImpact(root);
+    expect(secondResult).toEqual(firstResult);
   });
 });


### PR DESCRIPTION
## Summary

- `transitrix impact` (interactive/TTY, non-`--json`) now offers to regenerate each `documents` (`.ttrs`) artefact it names as affected, per artefact, using THQ-186's `renderDocumentToDisk` render path.
- Declining an offer performs no regeneration and writes no state — the identical offer reappears on the next run against the same staged change.
- `goals`/`dgca`/`fgca`/`action` view findings keep their existing notice, unchanged — no regeneration offer, since no headless-rendering path exists for views (deliberate narrowing per the 2026-08-15 decomposition on THQ-182).
- `--json` mode is completely unaffected — no prompt, no behavior change.
- A `notDetermined` artefact is never offered regeneration (structurally guaranteed — it never lands in `result.affected`).
- Non-TTY interactive runs (CI, a pipe) skip the offer silently rather than hanging on a prompt no one can answer.

## Implementation

- `src/impact.ts`: new exported `offerDocumentRegeneration(result, root, confirm)` — pure or artefact-notation filter, calls the injected `confirm` callback per `documents` finding, and on acceptance calls `renderDocumentToDisk` (same path `transitrix render` uses).
- `src/cli.ts`: `handleImpactCommand` wires a `node:readline/promises` y/n prompt into `offerDocumentRegeneration` when `!useJson && process.stdin.isTTY`.

## Test plan

- [x] `npx vitest run tests/impact.test.ts` — 18/18 passing, including 4 new tests covering: per-artefact offer by name (skipping view findings), never offering a `notDetermined` document, accept-runs-render-identically-to-direct-call, and decline-writes-no-state-and-reoffers-identically.
- [x] `npm run compile` — clean.
- [x] `npm run test:core` — 768 passing; 2 pre-existing failures unrelated to this change (a flaky timeout that passes in isolation, and a schema-copy check that needs `extension:prep`).

Closes THQ-182.