### PR TITLE
feat(validate): reject extraction_confidence on an admitted canon element

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -325,6 +325,45 @@ whether `CMAP-003` should stop *requiring* `current_maturity` inline (a
 validator-tightening question, not a render-pipeline one) — not guessed at
 here.
 
+### Candidate-only fields on admitted canon (`ELEM-CANDIDATE-FIELD-001`)
+
+`ELEMENT_PRIMITIVES.md` §7.29 (methodology v3.6.0) closes `extraction_confidence`
+out of canon for every TYPE, not only for `RELEASE` where the paragraph sits: it
+is a review flag on an ingest **candidate**, surfaced in the review queue and
+used for reviewer-authority routing (CONTRACT.md §6.2), and it is *never
+persisted into canon*. Implemented in
+`packages/diagrams/src/repo-validate/check-candidate-fields.ts`.
+
+| Rule | Severity | Checks |
+|---|---|---|
+| `ELEM-CANDIDATE-FIELD-001` | error | An admitted (`zone: canon`) element carries a candidate-only field (`extraction_confidence`), of any TYPE. |
+
+**Candidate selection is the admission marker, not a notation list** — `zone:
+canon` (`ELEMENT_PRIMITIVES.md` §3, a required envelope field) is what makes the
+field wrong, so the check reads it directly rather than enumerating TYPEs it
+would have to keep in step with §4. It says nothing about `zone: field` or `zone:
+codex` artefacts, where harvest metadata legitimately lives (`source_quality` is
+that zone's own provenance field, CONTRACT.md §5/§11.2), nor about a candidate
+before admission. Sidecars carry neither `zone` nor `id` and fall out for free.
+
+**The message names the replacement, not just the defect** — an element admitted
+from extracted evidence cites it through `derived_from` (§3) pointing at an
+`OBSERVATION` or another Field/Codex artefact, which is the pattern §7.29's own
+fix (`transitrix-hq#197`) put in place.
+
+**The rule code is Studio-authored.** It follows the shape methodology already
+uses for a named element-envelope rule outside the numbered run (`ELEM-ALIAS-001`,
+`ELEM-FORMER-ID-001`) and deliberately avoids taking `ELEM-006` — the numbered
+`ELEM-*` run is methodology's to extend. If methodology registers a code of its
+own for §7.29, this becomes its alias.
+
+**Scope: repo only, for now.** `--scope=file` has no cross-TYPE envelope pass —
+it dispatches to a per-notation validator, and several element TYPEs (`release`
+among them, the one §7.29 is written against) have no file-scope validator wired
+yet, so a check added there would cover the rule unevenly. Whole-canon scope
+covers every TYPE uniformly today; a file-scope half is a follow-up, not a gap
+this rule leaves in `--scope=repo`.
+
 ### Compliance suite (`--scope=repo`, #518)
 
 Repo-scope validation also sweeps the compliance notation surface with the same

--- a/packages/diagrams/src/repo-validate/__tests__/check-candidate-fields.test.ts
+++ b/packages/diagrams/src/repo-validate/__tests__/check-candidate-fields.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import { validateRepoModel } from '../validate-repo.js';
+import type { RepoDoc, RepoModelInput } from '../types.js';
+
+function el(path: string, data: Record<string, unknown> | null): RepoDoc {
+  return { path, data };
+}
+
+const RELEASE_PATH = 'canon/elements/05_implementation/releases/RELEASE-PAYMENTS-GATEWAY-2.yaml';
+
+function release(overrides: Record<string, unknown> = {}): RepoDoc {
+  return el(RELEASE_PATH, {
+    notation: 'release',
+    id: 'RELEASE-PAYMENTS-GATEWAY-2',
+    name: 'Payments Gateway 2.4.0',
+    zone: 'canon',
+    of: 'APPLICATION-PAYMENTS-GATEWAY-1',
+    version: '2.4.0',
+    valid_from: '2026-07-15',
+    valid_to: null,
+    ...overrides,
+  });
+}
+
+function model(elements: RepoDoc[]): RepoModelInput {
+  return { elements, relations: [] };
+}
+
+function candidateFindings(input: RepoModelInput) {
+  return validateRepoModel(input).filter((f) => f.ruleId === 'ELEM-CANDIDATE-FIELD-001');
+}
+
+describe('checkCandidateFields — ELEM-CANDIDATE-FIELD-001', () => {
+  it('flags extraction_confidence on an admitted RELEASE element', () => {
+    const findings = candidateFindings(model([release({ extraction_confidence: 'high' })]));
+    expect(findings.length).toBe(1);
+    expect(findings[0].id).toBe('RELEASE-PAYMENTS-GATEWAY-2');
+    expect(findings[0].message).toContain('extraction_confidence');
+  });
+
+  it('names derived_from and OBSERVATION as the provenance pattern that belongs there', () => {
+    const [finding] = candidateFindings(model([release({ extraction_confidence: 'low' })]));
+    expect(finding.message).toContain('derived_from');
+    expect(finding.message).toContain('OBSERVATION');
+  });
+
+  it('is blocking — no severity set, so it defaults to error', () => {
+    const [finding] = candidateFindings(model([release({ extraction_confidence: 'medium' })]));
+    expect(finding.severity).toBeUndefined();
+  });
+
+  // The spec generalises §7.29 past RELEASE ("neither does any other canon
+  // element, of any TYPE"), so candidate selection is the admission marker,
+  // never a notation list.
+  it.each([
+    ['requirement', 'canon/elements/01_motivation/requirements/REQUIREMENT-AUDIT-1.yaml', 'REQUIREMENT-AUDIT-1'],
+    ['capability', 'canon/elements/02_business/capabilities/CAPABILITY-V1.yaml', 'CAPABILITY-V1'],
+    ['application', 'canon/elements/03_application/applications/APPLICATION-OMS-1.yaml', 'APPLICATION-OMS-1'],
+    ['term', 'canon/elements/02_business/terms/TERM-CHARGEBACK-1.yaml', 'TERM-CHARGEBACK-1'],
+  ])('flags it on a %s element too', (notation, path, id) => {
+    const findings = candidateFindings(
+      model([el(path, { notation, id, name: 'x', zone: 'canon', extraction_confidence: 'high' })]),
+    );
+    expect(findings.length).toBe(1);
+    expect(findings[0].id).toBe(id);
+  });
+
+  it('flags a falsy-but-present value — presence is the defect, not the value', () => {
+    expect(candidateFindings(model([release({ extraction_confidence: null })])).length).toBe(1);
+    expect(candidateFindings(model([release({ extraction_confidence: '' })])).length).toBe(1);
+  });
+
+  it('produces no finding for an admitted element without the field', () => {
+    expect(candidateFindings(model([release()]))).toEqual([]);
+  });
+
+  it('leaves the correct provenance pattern alone — derived_from citing an OBSERVATION', () => {
+    const findings = candidateFindings(
+      model([release({ derived_from: ['OBSERVATION-REPO-TAG-SURVEY-1'] })]),
+    );
+    expect(findings).toEqual([]);
+  });
+
+  // The field is legitimate on an ingest candidate and merely not meaningful in
+  // the field/codex zones — only the admitted form is a defect.
+  it.each(['field', 'codex', 'candidate'])('says nothing about a zone: %s artefact', (zone) => {
+    const findings = candidateFindings(
+      model([
+        el('canon/field/observations/OBSERVATION-REPO-TAG-SURVEY-1.yaml', {
+          id: 'OBSERVATION-REPO-TAG-SURVEY-1',
+          zone,
+          extraction_confidence: 'high',
+        }),
+      ]),
+    );
+    expect(findings).toEqual([]);
+  });
+
+  it('ignores a sidecar, which carries neither zone nor id', () => {
+    const findings = candidateFindings(
+      model([
+        release(),
+        el('canon/elements/05_implementation/releases/RELEASE-PAYMENTS-GATEWAY-2.history.yaml', {
+          target: 'RELEASE-PAYMENTS-GATEWAY-2',
+          attribute_versions: {},
+          extraction_confidence: 'high',
+        }),
+      ]),
+    );
+    expect(findings).toEqual([]);
+  });
+
+  it('falls back to the file path when the offending element has no id', () => {
+    const [finding] = candidateFindings(
+      model([el(RELEASE_PATH, { notation: 'release', zone: 'canon', extraction_confidence: 'high' })]),
+    );
+    expect(finding.id).toBe('');
+    expect(finding.message).toContain(RELEASE_PATH);
+  });
+});

--- a/packages/diagrams/src/repo-validate/check-candidate-fields.ts
+++ b/packages/diagrams/src/repo-validate/check-candidate-fields.ts
@@ -1,0 +1,93 @@
+// Candidate-only fields on admitted canon — `ELEM-CANDIDATE-FIELD-001`.
+//
+// `ELEMENT_PRIMITIVES.md` §7.29 (methodology v3.6.0) states it normatively for
+// `RELEASE` and then generalises it to every TYPE:
+//
+//   > `RELEASE` has no `extraction_confidence` field — and neither does any
+//   > other canon element, of any TYPE. `extraction_confidence` is a review
+//   > flag on an ingest candidate (`candidate.extraction_confidence`,
+//   > vocabulary.yaml); it is surfaced in the review queue, drives
+//   > reviewer-authority routing (CONTRACT.md §6.2), and is never persisted
+//   > into canon. An admitted element carrying it is a defect in whatever
+//   > wrote it, not a precedent to follow.
+//
+// Nothing enforced that mechanically. The ingest pipeline that produces the
+// field lives in `methodology`'s `packages/ingest-cli` and only ever writes
+// *candidates*; admission into `canon/elements/**` happens in an adopter's own
+// tooling, which is `@transitrix/cli validate`'s side of the fence — so this is
+// where the rule has to bite.
+//
+// **Why the check keys on `zone`, not on the folder.** `extraction_confidence`
+// is legitimate on a candidate and meaningless — but not a defect — elsewhere;
+// only the *admitted* form is wrong. `zone: canon` is the admission marker
+// every standalone element carries (`ELEMENT_PRIMITIVES.md` §3, required
+// envelope field, `ELEM-001`), and it is the discriminator against the two
+// zones that may legitimately carry harvest metadata: `zone: field`, whose
+// provenance contract owns `source_quality` (CONTRACT.md §5/§11.2), and
+// `zone: codex`. Sidecars (`*.history.yaml`, `*.runstate.yaml`) carry no
+// `zone` and no `id`, so they fall out for free — the same "no id -> not an
+// element" split `docId` already makes for every sibling check in this folder.
+//
+// **Rule code.** `ELEM-CANDIDATE-FIELD-001` is Studio-authored, in the shape
+// methodology already uses for a named element-envelope rule outside the
+// numbered run (`ELEM-ALIAS-001`, `ELEM-FORMER-ID-001`). It deliberately does
+// not take `ELEM-006`: the numbered `ELEM-*` run is methodology's to extend,
+// and squatting the next free number would collide with whatever it registers
+// there next. If methodology later registers a code of its own for §7.29, this
+// one becomes its alias and the rename is a one-line change here.
+
+import { docId } from './validate-repo.js';
+import type { RepoDoc, RepoFinding, RepoModelInput } from './types.js';
+
+const PScope: RepoFinding['scope'] = 'repo';
+
+/**
+ * Fields that belong to an ingest candidate and are never persisted into
+ * canon. Each entry names the field and the provenance pattern that replaces
+ * it, so the finding points at the correct shape rather than only failing
+ * closed. One entry today; the list is the extension point if methodology
+ * closes another candidate-side field out of canon the same way.
+ */
+const CANDIDATE_ONLY_FIELDS: readonly { field: string; instead: string }[] = [
+  {
+    field: 'extraction_confidence',
+    instead:
+      "cite the evidence through 'derived_from' (ELEMENT_PRIMITIVES.md §3) — " +
+      'an OBSERVATION or another Field/Codex artefact; the review flag stays on the ' +
+      'ingest candidate and is not carried across admission',
+  },
+];
+
+/** True when the doc is an admitted canon element — `zone: canon` per
+ *  `ELEMENT_PRIMITIVES.md` §3. Deliberately narrow: a doc with no `zone`
+ *  (a sidecar) or a non-canon zone (`field`, `codex`) is not admitted canon
+ *  and this rule says nothing about it. */
+function isAdmittedCanonElement(doc: RepoDoc): boolean {
+  return doc.data?.['zone'] === 'canon';
+}
+
+/**
+ * `ELEM-CANDIDATE-FIELD-001` — a candidate-only field present on an admitted
+ * (`zone: canon`) element, of any TYPE. Appends findings; pure, deterministic
+ * order.
+ */
+export function checkCandidateFields(input: RepoModelInput, findings: RepoFinding[]): void {
+  for (const doc of input.elements) {
+    if (!doc.data) continue;
+    if (!isAdmittedCanonElement(doc)) continue;
+
+    const id = docId(doc) ?? '';
+    for (const { field, instead } of CANDIDATE_ONLY_FIELDS) {
+      if (doc.data[field] === undefined) continue;
+      findings.push({
+        scope: PScope,
+        id,
+        ruleId: 'ELEM-CANDIDATE-FIELD-001',
+        message:
+          `ELEM-CANDIDATE-FIELD-001: admitted element '${id || doc.path}' carries '${field}', ` +
+          `which is an ingest-candidate review flag and is never persisted into canon ` +
+          `(ELEMENT_PRIMITIVES.md §7.29). Remove it and ${instead}.`,
+      });
+    }
+  }
+}

--- a/packages/diagrams/src/repo-validate/validate-repo.ts
+++ b/packages/diagrams/src/repo-validate/validate-repo.ts
@@ -30,6 +30,7 @@
 import { checkStrategyChainSemantics } from './check-strategy-chain.js';
 import { checkElementHygiene } from './check-element-hygiene.js';
 import { checkVersionedAttributes } from './check-versioned-attributes.js';
+import { checkCandidateFields } from './check-candidate-fields.js';
 import type { RepoDoc, RepoFinding, RepoModelInput } from './types.js';
 
 const PScope: RepoFinding['scope'] = 'repo';
@@ -431,5 +432,8 @@ export function validateRepoModel(input: RepoModelInput): RepoFinding[] {
   checkElementHygiene(input, findings);
   // Phase 9 — versioned-attribute sidecar rules (CONTRACT.md §9, VERSIONED-001..005).
   checkVersionedAttributes(input, findings);
+  // Phase 10 — candidate-only fields on admitted canon (ELEMENT_PRIMITIVES.md
+  // §7.29, ELEM-CANDIDATE-FIELD-001).
+  checkCandidateFields(input, findings);
   return findings;
 }


### PR DESCRIPTION
## Summary

`ELEMENT_PRIMITIVES.md` §7.29 (methodology v3.6.0) closes `extraction_confidence` out of canon for **every** element TYPE, not only for `RELEASE` where the paragraph sits: it is a review flag on an ingest *candidate*, surfaced in the review queue and used for reviewer-authority routing, and it is never persisted into canon. Nothing enforced that mechanically — the ingest pipeline that produces the field only ever writes candidates, and admission into `canon/elements/**` happens in an adopter's own tooling, which is `@transitrix/cli validate`'s side of the fence.

- New repo-scope check `ELEM-CANDIDATE-FIELD-001` (`packages/diagrams/src/repo-validate/check-candidate-fields.ts`, wired into `validateRepoModel` as phase 10): an admitted (`zone: canon`) element carrying a candidate-only field, of any TYPE.
- Candidate selection reads the admission marker (`zone: canon`) rather than a TYPE list, so it needs no upkeep as the TYPE registry grows — and it stays silent on `zone: field` / `zone: codex` artefacts, where harvest metadata legitimately lives (`source_quality` is that zone's own provenance field). Sidecars carry neither `zone` nor `id` and fall out for free.
- The failure message names the replacement, not just the defect: cite the evidence through `derived_from` pointing at an `OBSERVATION` or another Field/Codex artefact.
- `docs/validation.md` gains a section covering the rule, why the code is Studio-authored rather than taking the next free `ELEM-00x` number, and why the file-scope axis is a follow-up (several element TYPEs — `release` among them — have no per-notation file validator wired yet, so a check added there would cover the rule unevenly).

## Test plan

- [x] `npm --workspace packages/diagrams test` — 1678 tests pass, including 15 new ones for this rule (per-TYPE coverage, the `derived_from`/`OBSERVATION` message contract, falsy-but-present values, non-canon zones, sidecars, missing id).
- [x] `npm run test:core` — 770 pass, 21 skipped.
- [x] `npm run compile` — clean.
- [x] Bundled example audited: `npm run transitrix -- validate --scope=repo --root organizations/acme_corp` reports **no** `ELEM-CANDIDATE-FIELD-001` finding on the fixtures as they stand.
- [x] Positive end-to-end check: appending `extraction_confidence: high` to `GOAL-CUST-1.yaml` makes the same command emit the rule as an error; fixture restored afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
