### PR TITLE
fix(export-compliance): scope canon scan out of vendored examples, reject duplicate ids

### DIFF
--- a/packages/diagrams/src/compliance/__tests__/classify.test.ts
+++ b/packages/diagrams/src/compliance/__tests__/classify.test.ts
@@ -61,4 +61,23 @@ describe('ingestComplianceDoc', () => {
     expect(canon.products).toEqual([]);
     expect(canon.subjects).toEqual([]);
   });
+
+  // transitrix-hq#218 — two documents claiming the same product id rendered as
+  // two identical matrix columns because canon.products.push had no dedup.
+  it('drops a second document that reuses an already-ingested id in the same bucket', () => {
+    const canon = emptyCanon();
+    expect(ingestComplianceDoc(canon, { notation: 'product', id: 'PRODUCT-1', name: 'First' })).toBe('PRODUCT-1');
+    expect(ingestComplianceDoc(canon, { notation: 'product', id: 'PRODUCT-1', name: 'Duplicate' })).toBeNull();
+    expect(canon.products).toEqual([{ id: 'PRODUCT-1', name: 'First' }]);
+    expect(canon.duplicateIds).toEqual(['PRODUCT-1']);
+  });
+
+  it('does not flag a repeated id across different buckets as a duplicate', () => {
+    const canon = emptyCanon();
+    ingestComplianceDoc(canon, { notation: 'product', id: 'SAME-1', name: 'P' });
+    ingestComplianceDoc(canon, { notation: 'capability', id: 'SAME-1', name: 'C' });
+    expect(canon.products).toEqual([{ id: 'SAME-1', name: 'P' }]);
+    expect(canon.subjects).toEqual([{ id: 'SAME-1', name: 'C' }]);
+    expect(canon.duplicateIds).toEqual([]);
+  });
 });

--- a/packages/diagrams/src/compliance/classify.ts
+++ b/packages/diagrams/src/compliance/classify.ts
@@ -40,6 +40,14 @@ export interface ComplianceCanon {
   /** VALIDATION artefacts (28-validation.md) — the validation-domain peer of
    *  `verifications`, anchored on NEED instead of REQUIREMENT. */
   validations: IndexValidation[];
+  /**
+   * Ids rejected by `ingestComplianceDoc` because that id was already present
+   * in the same bucket (two documents claiming one id — transitrix-hq#218).
+   * The second and any later document is dropped rather than silently
+   * duplicating a matrix column; callers that scan a filesystem can surface
+   * this list as a diagnostic.
+   */
+  duplicateIds: string[];
 }
 
 export function emptyCanon(): ComplianceCanon {
@@ -52,6 +60,7 @@ export function emptyCanon(): ComplianceCanon {
     subjects: [],
     needs: [],
     validations: [],
+    duplicateIds: [],
   };
 }
 
@@ -60,11 +69,28 @@ const strArray = (v: unknown): string[] | undefined =>
   Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string') : undefined;
 
 /**
+ * Pushes `item` onto `list` unless `list` already holds an entry with the same
+ * id, in which case the id is recorded in `canon.duplicateIds` and the item is
+ * dropped — two documents claiming one id is a defect (transitrix-hq#218), not
+ * a second matrix column.
+ */
+function pushUnique<T extends { id: string }>(canon: ComplianceCanon, list: T[], item: T): boolean {
+  if (list.some(existing => existing.id === item.id)) {
+    canon.duplicateIds.push(item.id);
+    return false;
+  }
+  list.push(item);
+  return true;
+}
+
+/**
  * Classifies one parsed YAML document and, if it is a compliance artefact,
  * pushes its projection into `canon`. Products / requirements / assertions are
  * identified by their `notation` tag; codex source documents by `zone: codex`.
  * Returns the artefact id when ingested (so the caller can record its path), or
- * null when the document is not a (well-formed) compliance artefact.
+ * null when the document is not a (well-formed) compliance artefact, or when
+ * its id duplicates one already ingested into the same bucket (see
+ * `canon.duplicateIds`).
  */
 export function ingestComplianceDoc(canon: ComplianceCanon, doc: unknown): string | null {
   if (doc === null || typeof doc !== 'object' || Array.isArray(doc)) return null;
@@ -73,8 +99,7 @@ export function ingestComplianceDoc(canon: ComplianceCanon, doc: unknown): strin
   if (!id) return null;
 
   if (d.notation === 'product') {
-    canon.products.push({ id, name: str(d.name) ?? id });
-    return id;
+    return pushUnique(canon, canon.products, { id, name: str(d.name) ?? id }) ? id : null;
   }
   if (
     d.notation === 'capability' ||
@@ -82,12 +107,11 @@ export function ingestComplianceDoc(canon: ComplianceCanon, doc: unknown): strin
     d.notation === 'application' ||
     d.notation === 'system'
   ) {
-    canon.subjects.push({ id, name: str(d.name) ?? id });
-    return id;
+    return pushUnique(canon, canon.subjects, { id, name: str(d.name) ?? id }) ? id : null;
   }
   if (d.notation === 'requirement' || d.notation === 'constraint') {
     const origin = str(d.origin);
-    canon.requirements.push({
+    const ok = pushUnique(canon, canon.requirements, {
       id,
       name: str(d.name) ?? id,
       severity: str(d.severity),
@@ -101,31 +125,30 @@ export function ingestComplianceDoc(canon: ComplianceCanon, doc: unknown): strin
       next_review_at: str(d.next_review_at),
       serves: str(d.serves),
     });
-    return id;
+    return ok ? id : null;
   }
   if (d.notation === 'need') {
-    canon.needs.push({ id, name: str(d.name) ?? id });
-    return id;
+    return pushUnique(canon, canon.needs, { id, name: str(d.name) ?? id }) ? id : null;
   }
   if (d.notation === 'validation') {
     const validates = str(d.validates);
     const method = str(d.method) as ValidationMethod | undefined;
     const outcome = str(d.outcome) as ValidationOutcome | undefined;
     if (!validates || !method || !outcome) return null;
-    canon.validations.push({
+    const ok = pushUnique(canon, canon.validations, {
       id, validates, method, outcome,
       performed_at: str(d.performed_at),
       evidenceCount: Array.isArray(d.evidence) ? d.evidence.length : 0,
       admitted_at: str(d.admitted_at),
     });
-    return id;
+    return ok ? id : null;
   }
   if (d.notation === 'assertion') {
     const about = str(d.about);
     const subject = str(d.subject);
     const status = str(d.status) as AssertionStatus | undefined;
     if (!about || !subject || !status) return null;
-    canon.assertions.push({
+    const ok = pushUnique(canon, canon.assertions, {
       id, about, subject, status,
       assessed_at: str(d.assessed_at),
       next_review_at: str(d.next_review_at),
@@ -134,24 +157,23 @@ export function ingestComplianceDoc(canon: ComplianceCanon, doc: unknown): strin
       realised_via: strArray(d.realised_via),
       owner_to_confirm: str(d.owner_to_confirm),
     });
-    return id;
+    return ok ? id : null;
   }
   if (d.notation === 'verification') {
     const verifies = str(d.verifies);
     const method = str(d.method) as VerificationMethod | undefined;
     const outcome = str(d.outcome) as VerificationOutcome | undefined;
     if (!verifies || !method || !outcome) return null;
-    canon.verifications.push({
+    const ok = pushUnique(canon, canon.verifications, {
       id, verifies, method, outcome,
       performed_at: str(d.performed_at),
       evidenceCount: Array.isArray(d.evidence) ? d.evidence.length : 0,
       admitted_at: str(d.admitted_at),
     });
-    return id;
+    return ok ? id : null;
   }
   if (d.zone === 'codex') {
-    canon.codex.push({ id, name: str(d.name) ?? id, type: str(d.type), jurisdiction: str(d.jurisdiction) });
-    return id;
+    return pushUnique(canon, canon.codex, { id, name: str(d.name) ?? id, type: str(d.type), jurisdiction: str(d.jurisdiction) }) ? id : null;
   }
   return null;
 }

--- a/src/export-compliance.ts
+++ b/src/export-compliance.ts
@@ -43,10 +43,28 @@ export const MAX_YAML_BYTES = 2 * 1024 * 1024; // 2 MiB
 /** Directories never worth descending into during the canon scan. */
 const IGNORED_SCAN_DIRS = new Set(['node_modules', '.git']);
 
-/** True for `*.yaml`/`*.yml` paths that don't live under an ignored directory. */
+/**
+ * True for a path with a `notations/examples/` segment pair — the methodology
+ * repo's bundled worked examples. Those are complete, admission-stamped
+ * documents (transitrix-hq#218): indistinguishable from adopter canon to the
+ * `zone: canon` admission check, so a vendored/sibling copy of the methodology
+ * anywhere under `--root` would otherwise have its example subjects silently
+ * absorbed into the scan.
+ */
+function isVendoredMethodologyExample(rel: string): boolean {
+  const segs = rel.split(/[\\/]/);
+  for (let i = 0; i < segs.length - 1; i++) {
+    if (segs[i] === 'notations' && segs[i + 1] === 'examples') return true;
+  }
+  return false;
+}
+
+/** True for `*.yaml`/`*.yml` paths that don't live under an ignored directory
+ *  or a vendored methodology examples tree. */
 function isScannableYaml(rel: string): boolean {
   if (!/\.ya?ml$/i.test(rel)) return false;
-  return !rel.split(/[\\/]/).some(seg => IGNORED_SCAN_DIRS.has(seg));
+  if (rel.split(/[\\/]/).some(seg => IGNORED_SCAN_DIRS.has(seg))) return false;
+  return !isVendoredMethodologyExample(rel);
 }
 
 /**
@@ -138,6 +156,12 @@ function scanCanonFs(root: string): ComplianceCanon {
     if (parsed === undefined) continue;
     if (!isAdmittedCanonOrCodex(parsed)) continue;
     ingestComplianceDoc(canon, parsed);
+  }
+  if (canon.duplicateIds.length > 0) {
+    console.error(
+      `[export-compliance] duplicate element id(s) found under ${root}, second and later occurrences dropped: ` +
+      canon.duplicateIds.join(', '),
+    );
   }
   return canon;
 }

--- a/tests/export-compliance-vendored-examples.test.ts
+++ b/tests/export-compliance-vendored-examples.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { handleExportComplianceCommand } from '../src/export-compliance.js';
+
+// transitrix-hq#218 — a vendored/sibling copy of the methodology's bundled
+// worked examples under `notations/examples/**` is a complete, admission-
+// stamped document, indistinguishable from adopter canon by the `zone: canon`
+// admission check alone. A zero-config scan must not absorb those example
+// subjects, and two documents that do claim the same id must not silently
+// render as two columns.
+
+describe('export-compliance: vendored methodology examples and duplicate ids', () => {
+  let dir: string;
+  let canonDir: string;
+  let outFile: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'export-compliance-vendored-test-'));
+    canonDir = join(dir, 'canon');
+    mkdirSync(canonDir, { recursive: true });
+    outFile = join(dir, 'out.md');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const admittedProduct = (id: string, name: string) => [
+    'notation: product',
+    `id: ${id}`,
+    `name: "${name}"`,
+    'zone: canon',
+    'admitted_at: "2026-05-28"',
+    'admitted_by: "v.korobeinikov"',
+  ].join('\n');
+
+  const admittedRequirement = [
+    'notation: requirement',
+    'id: REQUIREMENT-1',
+    'name: "A requirement"',
+    'severity: high',
+    'zone: canon',
+    'admitted_at: "2026-05-28"',
+    'admitted_by: "v.korobeinikov"',
+  ].join('\n');
+
+  it('excludes an admission-stamped product under a vendored notations/examples/ tree', async () => {
+    writeFileSync(join(canonDir, 'real.product.transitrix.yaml'), admittedProduct('PRODUCT-REAL-1', 'Real Product'));
+    writeFileSync(join(canonDir, 'requirement.transitrix.yaml'), admittedRequirement);
+
+    const vendoredDir = join(dir, 'vendor', 'methodology', 'notations', 'examples', 'bpmn', 'canon', 'products');
+    mkdirSync(vendoredDir, { recursive: true });
+    writeFileSync(join(vendoredDir, 'example.product.transitrix.yaml'), admittedProduct('PRODUCT-EXAMPLE-1', 'Example Product'));
+
+    await handleExportComplianceCommand(['--scope', 'matrix', '--root', dir, '--format', 'md', '--output', outFile]);
+
+    const written = readFileSync(outFile, 'utf-8');
+    expect(written).toContain('Real Product');
+    expect(written).not.toContain('Example Product');
+    expect(written).not.toContain('PRODUCT-EXAMPLE-1');
+    expect(written).toContain('_1 products');
+  });
+
+  it('drops a duplicate product id and prints a diagnostic instead of a second column', async () => {
+    writeFileSync(join(canonDir, 'first.product.transitrix.yaml'), admittedProduct('PRODUCT-DUP-1', 'First Copy'));
+    writeFileSync(join(canonDir, 'second.product.transitrix.yaml'), admittedProduct('PRODUCT-DUP-1', 'Second Copy'));
+    writeFileSync(join(canonDir, 'requirement.transitrix.yaml'), admittedRequirement);
+
+    const warn = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await handleExportComplianceCommand(['--scope', 'matrix', '--root', dir, '--format', 'md', '--output', outFile]);
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('PRODUCT-DUP-1'));
+    warn.mockRestore();
+
+    const written = readFileSync(outFile, 'utf-8');
+    expect(written).toContain('_1 products');
+    const productLines = written.split('\n').filter(l => l.includes('Copy'));
+    expect(productLines).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- A zero-config compliance canon scan walked every YAML file under `--root`, so a vendored/sibling copy of the methodology repo's admission-stamped worked examples (`notations/examples/**`) was silently absorbed as if it were adopter canon — inflating product counts and derived totals with no warning.
- `scanCanonFs`'s scan now excludes any path with a `notations/examples/` segment pair.
- `ingestComplianceDoc` (the shared classifier used by both the CLI scan and the Studio extension's workspace scan) now rejects a second document that reuses an id already ingested into the same bucket, recording it in `canon.duplicateIds` instead of pushing a duplicate. The CLI scan prints a diagnostic to stderr when this happens.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm --workspace packages/diagrams test` — 103 files / 1680 tests pass
- [x] `npx vitest run` (root) — all pass except one pre-existing, unrelated failure (`extension/schemas/bpmn-dsl.schema.json` missing from this checkout — not touched by this change)
- [x] New regression coverage: a fixture tree with an admission-stamped product under a vendored `notations/examples/` path is excluded from the matrix; a duplicate product id across two documents renders once and logs a diagnostic

🤖 Generated with [Claude Code](https://claude.com/claude-code)