### PR TITLE
fix(validate): rename ELEM-CANDIDATE-FIELD-001 to ADMIT-009

### DIFF
--- a/changelog/fragments/rename-elem-candidate-field-001-to-admit-009-88e1be19.md
+++ b/changelog/fragments/rename-elem-candidate-field-001-to-admit-009-88e1be19.md
@@ -1,0 +1,3 @@
+### Changed
+
+- **`ELEM-CANDIDATE-FIELD-001` renamed to `ADMIT-009`.** The candidate-only-field-on-admitted-canon check was Studio-authored under a placeholder code (`ELEMENT_PRIMITIVES.md` §7.29) since methodology had not yet registered one of its own. `transitrix/methodology#505` (merged 2026-08-19) registered `ADMIT-009` for the same rule; Studio's check, tests and docs now use that code. No functional change.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -325,7 +325,7 @@ whether `CMAP-003` should stop *requiring* `current_maturity` inline (a
 validator-tightening question, not a render-pipeline one) — not guessed at
 here.
 
-### Candidate-only fields on admitted canon (`ELEM-CANDIDATE-FIELD-001`)
+### Candidate-only fields on admitted canon (`ADMIT-009`)
 
 `ELEMENT_PRIMITIVES.md` §7.29 (methodology v3.6.0) closes `extraction_confidence`
 out of canon for every TYPE, not only for `RELEASE` where the paragraph sits: it
@@ -336,7 +336,7 @@ persisted into canon*. Implemented in
 
 | Rule | Severity | Checks |
 |---|---|---|
-| `ELEM-CANDIDATE-FIELD-001` | error | An admitted (`zone: canon`) element carries a candidate-only field (`extraction_confidence`), of any TYPE. |
+| `ADMIT-009` | error | An admitted (`zone: canon`) element carries a candidate-only field (`extraction_confidence`), of any TYPE. |
 
 **Candidate selection is the admission marker, not a notation list** — `zone:
 canon` (`ELEMENT_PRIMITIVES.md` §3, a required envelope field) is what makes the
@@ -351,11 +351,12 @@ from extracted evidence cites it through `derived_from` (§3) pointing at an
 `OBSERVATION` or another Field/Codex artefact, which is the pattern §7.29's own
 fix (`transitrix-hq#197`) put in place.
 
-**The rule code is Studio-authored.** It follows the shape methodology already
-uses for a named element-envelope rule outside the numbered run (`ELEM-ALIAS-001`,
-`ELEM-FORMER-ID-001`) and deliberately avoids taking `ELEM-006` — the numbered
-`ELEM-*` run is methodology's to extend. If methodology registers a code of its
-own for §7.29, this becomes its alias.
+**The rule code was Studio-authored, `ELEM-CANDIDATE-FIELD-001`,** following the
+shape methodology already uses for a named element-envelope rule outside the
+numbered run (`ELEM-ALIAS-001`, `ELEM-FORMER-ID-001`) and deliberately avoiding
+`ELEM-006` — the numbered `ELEM-*` run is methodology's to extend. Renamed to
+`ADMIT-009` (transitrix/methodology#505, merged 2026-08-19) now that methodology
+has registered a code of its own for §7.29 — no functional change.
 
 **Scope: repo only, for now.** `--scope=file` has no cross-TYPE envelope pass —
 it dispatches to a per-notation validator, and several element TYPEs (`release`

--- a/packages/diagrams/src/repo-validate/__tests__/check-candidate-fields.test.ts
+++ b/packages/diagrams/src/repo-validate/__tests__/check-candidate-fields.test.ts
@@ -27,10 +27,10 @@ function model(elements: RepoDoc[]): RepoModelInput {
 }
 
 function candidateFindings(input: RepoModelInput) {
-  return validateRepoModel(input).filter((f) => f.ruleId === 'ELEM-CANDIDATE-FIELD-001');
+  return validateRepoModel(input).filter((f) => f.ruleId === 'ADMIT-009');
 }
 
-describe('checkCandidateFields — ELEM-CANDIDATE-FIELD-001', () => {
+describe('checkCandidateFields — ADMIT-009', () => {
   it('flags extraction_confidence on an admitted RELEASE element', () => {
     const findings = candidateFindings(model([release({ extraction_confidence: 'high' })]));
     expect(findings.length).toBe(1);

--- a/packages/diagrams/src/repo-validate/check-candidate-fields.ts
+++ b/packages/diagrams/src/repo-validate/check-candidate-fields.ts
@@ -1,4 +1,4 @@
-// Candidate-only fields on admitted canon — `ELEM-CANDIDATE-FIELD-001`.
+// Candidate-only fields on admitted canon — `ADMIT-009`.
 //
 // `ELEMENT_PRIMITIVES.md` §7.29 (methodology v3.6.0) states it normatively for
 // `RELEASE` and then generalises it to every TYPE:
@@ -28,13 +28,14 @@
 // `zone` and no `id`, so they fall out for free — the same "no id -> not an
 // element" split `docId` already makes for every sibling check in this folder.
 //
-// **Rule code.** `ELEM-CANDIDATE-FIELD-001` is Studio-authored, in the shape
+// **Rule code.** Studio-authored as `ELEM-CANDIDATE-FIELD-001` (in the shape
 // methodology already uses for a named element-envelope rule outside the
-// numbered run (`ELEM-ALIAS-001`, `ELEM-FORMER-ID-001`). It deliberately does
-// not take `ELEM-006`: the numbered `ELEM-*` run is methodology's to extend,
-// and squatting the next free number would collide with whatever it registers
-// there next. If methodology later registers a code of its own for §7.29, this
-// one becomes its alias and the rename is a one-line change here.
+// numbered run — `ELEM-ALIAS-001`, `ELEM-FORMER-ID-001` — deliberately not
+// `ELEM-006`, since the numbered `ELEM-*` run is methodology's to extend and
+// squatting the next free number would collide with whatever it registers
+// there next). Renamed to `ADMIT-009` (transitrix/methodology#505, merged
+// 2026-08-19) now that methodology has registered a code of its own for
+// §7.29 — no functional change, this is that alias.
 
 import { docId } from './validate-repo.js';
 import type { RepoDoc, RepoFinding, RepoModelInput } from './types.js';
@@ -67,9 +68,8 @@ function isAdmittedCanonElement(doc: RepoDoc): boolean {
 }
 
 /**
- * `ELEM-CANDIDATE-FIELD-001` — a candidate-only field present on an admitted
- * (`zone: canon`) element, of any TYPE. Appends findings; pure, deterministic
- * order.
+ * `ADMIT-009` — a candidate-only field present on an admitted (`zone: canon`)
+ * element, of any TYPE. Appends findings; pure, deterministic order.
  */
 export function checkCandidateFields(input: RepoModelInput, findings: RepoFinding[]): void {
   for (const doc of input.elements) {
@@ -82,9 +82,9 @@ export function checkCandidateFields(input: RepoModelInput, findings: RepoFindin
       findings.push({
         scope: PScope,
         id,
-        ruleId: 'ELEM-CANDIDATE-FIELD-001',
+        ruleId: 'ADMIT-009',
         message:
-          `ELEM-CANDIDATE-FIELD-001: admitted element '${id || doc.path}' carries '${field}', ` +
+          `ADMIT-009: admitted element '${id || doc.path}' carries '${field}', ` +
           `which is an ingest-candidate review flag and is never persisted into canon ` +
           `(ELEMENT_PRIMITIVES.md §7.29). Remove it and ${instead}.`,
       });

--- a/packages/diagrams/src/repo-validate/validate-repo.ts
+++ b/packages/diagrams/src/repo-validate/validate-repo.ts
@@ -433,7 +433,7 @@ export function validateRepoModel(input: RepoModelInput): RepoFinding[] {
   // Phase 9 — versioned-attribute sidecar rules (CONTRACT.md §9, VERSIONED-001..005).
   checkVersionedAttributes(input, findings);
   // Phase 10 — candidate-only fields on admitted canon (ELEMENT_PRIMITIVES.md
-  // §7.29, ELEM-CANDIDATE-FIELD-001).
+  // §7.29, ADMIT-009).
   checkCandidateFields(input, findings);
   return findings;
 }


### PR DESCRIPTION
## Summary
- Renames the candidate-only-field-on-admitted-canon validation rule from Studio's placeholder code `ELEM-CANDIDATE-FIELD-001` to `ADMIT-009`, the code the spec side registered for the same rule.
- Updates the rule implementation, its tests, and `docs/validation.md` to the new code; no functional change.

## Test plan
- [x] `packages/diagrams` test suite passes (`npm --workspace packages/diagrams test`)
- [x] `npm run compile` passes