### PR TITLE
feat(codex): add PRINCIPLE codex TYPE

### DIFF
--- a/packages/diagrams/src/codex/__tests__/validate.test.ts
+++ b/packages/diagrams/src/codex/__tests__/validate.test.ts
@@ -29,6 +29,19 @@ const VALID_INTERNAL = {
   gate_checks: { source_authority: 'VP Engineering' },
 };
 
+const VALID_PRINCIPLE = {
+  zone: 'codex',
+  id: 'PRINCIPLE-data-minimisation-1',
+  name: 'Data Minimisation',
+  type: 'PRINCIPLE',
+  admitted_at: '2026-08-22',
+  admitted_by: 'v.korobeinikov',
+  gate_checks: { source_authority: 'Architecture Review Board' },
+  statement: 'The organisation collects no personal data beyond what a stated purpose requires.',
+  rationale: 'Reduces breach exposure and regulatory surface.',
+  established_by: 'ADR-2026-08-21-a-catalogue-declares-its-boundary',
+};
+
 describe('validateCodex', () => {
   it('accepts a valid external artefact', () => {
     const r = validateCodex(VALID_EXTERNAL, { folderJurisdiction: 'eu' });
@@ -37,6 +50,32 @@ describe('validateCodex', () => {
 
   it('accepts a valid internal artefact', () => {
     expect(validateCodex(VALID_INTERNAL).valid).toBe(true);
+  });
+
+  it('accepts a valid PRINCIPLE artefact with no errors or warnings', () => {
+    const r = validateCodex(VALID_PRINCIPLE);
+    expect(r.valid, JSON.stringify(r.errors)).toBe(true);
+    expect(r.warnings).toHaveLength(0);
+  });
+
+  it('accepts a PRINCIPLE artefact with no issuing_authority or effective_date', () => {
+    const r = validateCodex(VALID_PRINCIPLE);
+    expect(r.valid).toBe(true);
+  });
+
+  it('CODEX-004 requires statement and rationale on a PRINCIPLE artefact', () => {
+    const noStatement = { ...VALID_PRINCIPLE, statement: '' };
+    expect(validateCodex(noStatement).errors.some((e) => e.code === 'CODEX-004' && e.path === 'statement')).toBe(true);
+
+    const noRationale = { ...VALID_PRINCIPLE, rationale: '' };
+    expect(validateCodex(noRationale).errors.some((e) => e.code === 'CODEX-004' && e.path === 'rationale')).toBe(true);
+  });
+
+  it('CODEX-006 warns (not errors) when a PRINCIPLE artefact omits established_by', () => {
+    const { established_by, ...rest } = VALID_PRINCIPLE;
+    const r = validateCodex(rest);
+    expect(r.valid, JSON.stringify(r.errors)).toBe(true);
+    expect(r.warnings.some((w) => w.code === 'CODEX-006' && w.path === 'established_by')).toBe(true);
   });
 
   it('CODEX-001 rejects non-mapping input', () => {

--- a/packages/diagrams/src/codex/index.ts
+++ b/packages/diagrams/src/codex/index.ts
@@ -1,4 +1,4 @@
-export { CODEX_ARTEFACT_TYPES, EXTERNAL_CODEX_TYPES, INTERNAL_CODEX_TYPES } from './types.js';
+export { CODEX_ARTEFACT_TYPES, EXTERNAL_CODEX_TYPES, INTERNAL_CODEX_TYPES, PRINCIPLE_CODEX_TYPES } from './types.js';
 export type { CodexArtefactType } from './types.js';
 export { validateCodex, isCodexDoc, folderJurisdictionFromPath } from './validate.js';
 export type { CodexValidateOptions } from './validate.js';

--- a/packages/diagrams/src/codex/types.ts
+++ b/packages/diagrams/src/codex/types.ts
@@ -1,13 +1,21 @@
-// Codex artefact — external laws/regulations and internal policies/standards.
+// Codex artefact — external laws/regulations and internal policies/standards/principles.
 // Schema: methodology notations/elements/14-codex.md §3–§4.
 
 /** TYPE prefixes admitted in the codex zone (REQ-003 / 14-codex.md). */
-export const CODEX_ARTEFACT_TYPES = ['LAW', 'REGULATION', 'POLICY', 'INTERNAL_STANDARD'] as const;
+export const CODEX_ARTEFACT_TYPES = ['LAW', 'REGULATION', 'POLICY', 'INTERNAL_STANDARD', 'PRINCIPLE'] as const;
 
 export type CodexArtefactType = (typeof CODEX_ARTEFACT_TYPES)[number];
 
 /** External codex artefacts (codex/external/<jurisdiction>/). */
 export const EXTERNAL_CODEX_TYPES: readonly CodexArtefactType[] = ['LAW', 'REGULATION'];
 
-/** Internal codex artefacts (codex/internal/). */
+/** Internal codex artefacts (codex/internal/) that carry a named issuing authority (§4). */
 export const INTERNAL_CODEX_TYPES: readonly CodexArtefactType[] = ['POLICY', 'INTERNAL_STANDARD'];
+
+/**
+ * Internal codex artefacts (codex/internal/) with the `PRINCIPLE` shape (§4.1) —
+ * `statement` + `rationale` required, `issuing_authority`/`effective_date`/`established_by`
+ * optional. Kept distinct from {@link INTERNAL_CODEX_TYPES} because the required-field set
+ * differs; both share the same file location.
+ */
+export const PRINCIPLE_CODEX_TYPES: readonly CodexArtefactType[] = ['PRINCIPLE'];

--- a/packages/diagrams/src/codex/validate.ts
+++ b/packages/diagrams/src/codex/validate.ts
@@ -3,9 +3,20 @@
 // CODEX-001 — shape, zone, id grammar, admission envelope.
 // CODEX-002 — `type` field matches the id TYPE prefix when present.
 // CODEX-003 — external artefact frontmatter (jurisdiction, effective_date).
-// CODEX-004 — internal artefact frontmatter (issuing_authority, effective_date).
+// CODEX-004 — internal artefact frontmatter (issuing_authority, effective_date for
+//             POLICY/INTERNAL_STANDARD; statement, rationale for PRINCIPLE — §4.1).
 // CODEX-005 — jurisdiction must match the parent folder under codex/external/
 //             (when `folderJurisdiction` is supplied by the repo sweep).
+// CODEX-006 — a PRINCIPLE artefact does not declare `established_by` (§4.1). The spec
+//             marks this "info" severity; this module has no info tier, so it is
+//             surfaced as a warning — the nearest existing severity that does not fail
+//             `valid`.
+//
+// Note: this file's CODEX-00x numbering predates the spec's own v0.2 renumbering
+// (14-codex.md §6, §8.2) and does not track it code-for-code — e.g. the spec's current
+// CODEX-001 is a folder/jurisdiction check this file assigns to CODEX-005. Realigning the
+// full scheme is out of scope here; this change only adds the purely-additive PRINCIPLE
+// TYPE (§4.1) under the existing local numbering.
 
 import type { ValidationError, ValidationWarning, ValidationResult } from '../validation-types.js';
 import { isCanonicalId, typeOfId } from '../typed-id.js';
@@ -13,6 +24,7 @@ import {
   CODEX_ARTEFACT_TYPES,
   EXTERNAL_CODEX_TYPES,
   INTERNAL_CODEX_TYPES,
+  PRINCIPLE_CODEX_TYPES,
   type CodexArtefactType,
 } from './types.js';
 
@@ -48,7 +60,7 @@ export function validateCodex(input: unknown, options: CodexValidateOptions = {}
   if (!isCanonicalId(c.id) || !isCodexType(idType)) {
     errors.push({
       code: 'CODEX-001',
-      message: `id "${String(c.id)}" must be a typed codex id (LAW, REGULATION, POLICY, or INTERNAL_STANDARD).`,
+      message: `id "${String(c.id)}" must be a typed codex id (LAW, REGULATION, POLICY, INTERNAL_STANDARD, or PRINCIPLE).`,
       path: 'id',
     });
   }
@@ -103,6 +115,22 @@ export function validateCodex(input: unknown, options: CodexValidateOptions = {}
     }
     if (typeof c.effective_date !== 'string' || c.effective_date.trim() === '') {
       errors.push({ code: 'CODEX-004', message: 'effective_date is required for internal codex artefacts.', path: 'effective_date' });
+    }
+  }
+
+  if (artefactType && (PRINCIPLE_CODEX_TYPES as readonly string[]).includes(artefactType)) {
+    if (typeof c.statement !== 'string' || c.statement.trim() === '') {
+      errors.push({ code: 'CODEX-004', message: 'statement is required for a PRINCIPLE artefact.', path: 'statement' });
+    }
+    if (typeof c.rationale !== 'string' || c.rationale.trim() === '') {
+      errors.push({ code: 'CODEX-004', message: 'rationale is required for a PRINCIPLE artefact.', path: 'rationale' });
+    }
+    if (typeof c.established_by !== 'string' || c.established_by.trim() === '') {
+      warnings.push({
+        code: 'CODEX-006',
+        message: 'established_by is not declared on this PRINCIPLE artefact — admissible, but a review finding for whoever admits it.',
+        path: 'established_by',
+      });
     }
   }
 

--- a/packages/diagrams/src/requirement/__tests__/validate.test.ts
+++ b/packages/diagrams/src/requirement/__tests__/validate.test.ts
@@ -84,12 +84,12 @@ describe('validateRequirement — REQ-002 (derived_from resolution)', () => {
 });
 
 describe('validateRequirement — REQ-003 (derived_from TYPE)', () => {
-  it('flags a derived_from TYPE outside LAW/REGULATION/POLICY/INTERNAL_STANDARD', () => {
+  it('flags a derived_from TYPE outside LAW/REGULATION/POLICY/INTERNAL_STANDARD/PRINCIPLE', () => {
     expect(codes({ ...valid(), derived_from: ['PRODUCT-MOBILE-1'] })).toContain('REQ-003');
   });
 
   it('accepts each permitted derived_from TYPE', () => {
-    for (const id of ['LAW-X-1', 'REGULATION-X-1', 'POLICY-X-1', 'INTERNAL_STANDARD-X-1']) {
+    for (const id of ['LAW-X-1', 'REGULATION-X-1', 'POLICY-X-1', 'INTERNAL_STANDARD-X-1', 'PRINCIPLE-X-1']) {
       expect(codes({ ...valid(), derived_from: [id] })).not.toContain('REQ-003');
     }
   });

--- a/packages/diagrams/src/requirement/types.ts
+++ b/packages/diagrams/src/requirement/types.ts
@@ -13,7 +13,7 @@ export interface GateChecks {
 }
 
 /** TYPEs a requirement may be derived from (15-requirement.md §2, REQ-003). */
-export const REQUIREMENT_DERIVED_FROM_TYPES = ['LAW', 'REGULATION', 'POLICY', 'INTERNAL_STANDARD'] as const;
+export const REQUIREMENT_DERIVED_FROM_TYPES = ['LAW', 'REGULATION', 'POLICY', 'INTERNAL_STANDARD', 'PRINCIPLE'] as const;
 
 /** ISO/IEC/IEEE 29148 specification-tier ladder (15-requirement.md §2.5, REQ-005). */
 export type RequirementLevel = 'stakeholder' | 'system' | 'software';


### PR DESCRIPTION
**From: transitrix-studio.**

methodology's `notations/elements/14-codex.md` v0.3 (merged 2026-08-22) adds `PRINCIPLE` as a new internal codex TYPE — a rule the organisation holds itself to with no stated issuing authority (§2.1, §4.1). Flagged via THQ-269.

## Changes

- `codex/types.ts` — add `PRINCIPLE` to `CODEX_ARTEFACT_TYPES`; new `PRINCIPLE_CODEX_TYPES` group (distinct required-field set from `POLICY`/`INTERNAL_STANDARD`, same `codex/internal/` file location).
- `codex/validate.ts` — new branch requiring `statement` + `rationale` for `PRINCIPLE` (CODEX-004, same bucket as other internal-artefact required-field checks); `established_by` absence surfaces as a warning under a new `CODEX-006` code (spec marks this "info" severity — this module has no info tier, so it maps to the nearest existing severity that doesn't fail `valid`).
- `requirement/types.ts` — widen `REQUIREMENT_DERIVED_FROM_TYPES` (REQ-003) to include `PRINCIPLE`, per the spec's companion change to `15-requirement.md` §2.
- Test pairs added in both `codex/__tests__/validate.test.ts` and `requirement/__tests__/validate.test.ts`.

Noted in a code comment: this file's `CODEX-00x` numbering predates the spec's own v0.2 renumbering and doesn't track it code-for-code (e.g. spec's current `CODEX-001` is a folder/jurisdiction check this file assigns to `CODEX-005`). Realigning the full scheme is a separate, larger concern — out of scope here, which only adds the purely-additive `PRINCIPLE` TYPE under the existing local numbering.

## Test plan

- [x] `npx vitest run` in `packages/diagrams` — 103 files, 1684 tests pass
- [x] `npx tsc --noEmit` in `packages/diagrams` — clean