### PR TITLE
feat(validate): add PRINCIPLE codex TYPE support

### DIFF
--- a/packages/diagrams/src/codex/__tests__/validate.test.ts
+++ b/packages/diagrams/src/codex/__tests__/validate.test.ts
@@ -29,6 +29,19 @@ const VALID_INTERNAL = {
   gate_checks: { source_authority: 'VP Engineering' },
 };
 
+const VALID_PRINCIPLE = {
+  zone: 'codex',
+  id: 'PRINCIPLE-data-minimisation-1',
+  name: 'Data Minimisation',
+  type: 'PRINCIPLE',
+  admitted_at: '2026-08-22',
+  admitted_by: 'v.korobeinikov',
+  gate_checks: { source_authority: 'Architecture Review Board' },
+  statement: 'The organisation collects no personal data beyond what a stated purpose requires.',
+  rationale: 'Reduces breach exposure and regulatory surface.',
+  established_by: 'ADR-2026-08-21-a-catalogue-declares-its-boundary',
+};
+
 describe('validateCodex', () => {
   it('accepts a valid external artefact', () => {
     const r = validateCodex(VALID_EXTERNAL, { folderJurisdiction: 'eu' });
@@ -66,6 +79,31 @@ describe('validateCodex', () => {
   it('CODEX-004 requires issuing_authority on internal artefacts', () => {
     const r = validateCodex({ ...VALID_INTERNAL, issuing_authority: '' });
     expect(r.errors.some((e) => e.code === 'CODEX-004')).toBe(true);
+  });
+
+  it('accepts a valid PRINCIPLE artefact', () => {
+    const r = validateCodex(VALID_PRINCIPLE);
+    expect(r.valid, JSON.stringify(r.errors)).toBe(true);
+    expect(r.warnings).toHaveLength(0);
+  });
+
+  it('CODEX-004 requires statement and rationale on PRINCIPLE artefacts', () => {
+    const r = validateCodex({ ...VALID_PRINCIPLE, statement: '', rationale: '' });
+    expect(r.errors.some((e) => e.code === 'CODEX-004' && e.path === 'statement')).toBe(true);
+    expect(r.errors.some((e) => e.code === 'CODEX-004' && e.path === 'rationale')).toBe(true);
+  });
+
+  it('PRINCIPLE does not require issuing_authority or effective_date', () => {
+    const { established_by, ...rest } = VALID_PRINCIPLE;
+    const r = validateCodex(rest);
+    expect(r.valid, JSON.stringify(r.errors)).toBe(true);
+  });
+
+  it('CODEX-006 warns (not errors) when a PRINCIPLE omits established_by', () => {
+    const { established_by, ...rest } = VALID_PRINCIPLE;
+    const r = validateCodex(rest);
+    expect(r.valid).toBe(true);
+    expect(r.warnings.some((w) => w.code === 'CODEX-006' && w.path === 'established_by')).toBe(true);
   });
 });
 

--- a/packages/diagrams/src/codex/types.ts
+++ b/packages/diagrams/src/codex/types.ts
@@ -2,12 +2,13 @@
 // Schema: methodology notations/elements/14-codex.md §3–§4.
 
 /** TYPE prefixes admitted in the codex zone (REQ-003 / 14-codex.md). */
-export const CODEX_ARTEFACT_TYPES = ['LAW', 'REGULATION', 'POLICY', 'INTERNAL_STANDARD'] as const;
+export const CODEX_ARTEFACT_TYPES = ['LAW', 'REGULATION', 'POLICY', 'INTERNAL_STANDARD', 'PRINCIPLE'] as const;
 
 export type CodexArtefactType = (typeof CODEX_ARTEFACT_TYPES)[number];
 
 /** External codex artefacts (codex/external/<jurisdiction>/). */
 export const EXTERNAL_CODEX_TYPES: readonly CodexArtefactType[] = ['LAW', 'REGULATION'];
 
-/** Internal codex artefacts (codex/internal/). */
-export const INTERNAL_CODEX_TYPES: readonly CodexArtefactType[] = ['POLICY', 'INTERNAL_STANDARD'];
+/** Internal codex artefacts (codex/internal/). PRINCIPLE is internal but has
+ *  its own required-field shape — see `validateCodex`'s PRINCIPLE branch. */
+export const INTERNAL_CODEX_TYPES: readonly CodexArtefactType[] = ['POLICY', 'INTERNAL_STANDARD', 'PRINCIPLE'];

--- a/packages/diagrams/src/codex/validate.ts
+++ b/packages/diagrams/src/codex/validate.ts
@@ -3,9 +3,14 @@
 // CODEX-001 — shape, zone, id grammar, admission envelope.
 // CODEX-002 — `type` field matches the id TYPE prefix when present.
 // CODEX-003 — external artefact frontmatter (jurisdiction, effective_date).
-// CODEX-004 — internal artefact frontmatter (issuing_authority, effective_date).
+// CODEX-004 — internal artefact frontmatter: issuing_authority + effective_date
+//             for POLICY/INTERNAL_STANDARD; statement + rationale for PRINCIPLE
+//             (14-codex.md §4.1 — issuing_authority/effective_date are optional
+//             on PRINCIPLE, not required).
 // CODEX-005 — jurisdiction must match the parent folder under codex/external/
 //             (when `folderJurisdiction` is supplied by the repo sweep).
+// CODEX-006 — info: a PRINCIPLE artefact does not declare `established_by`
+//             (14-codex.md §4.1 — absence is admissible, not an error).
 
 import type { ValidationError, ValidationWarning, ValidationResult } from '../validation-types.js';
 import { isCanonicalId, typeOfId } from '../typed-id.js';
@@ -48,7 +53,7 @@ export function validateCodex(input: unknown, options: CodexValidateOptions = {}
   if (!isCanonicalId(c.id) || !isCodexType(idType)) {
     errors.push({
       code: 'CODEX-001',
-      message: `id "${String(c.id)}" must be a typed codex id (LAW, REGULATION, POLICY, or INTERNAL_STANDARD).`,
+      message: `id "${String(c.id)}" must be a typed codex id (LAW, REGULATION, POLICY, INTERNAL_STANDARD, or PRINCIPLE).`,
       path: 'id',
     });
   }
@@ -93,7 +98,21 @@ export function validateCodex(input: unknown, options: CodexValidateOptions = {}
     }
   }
 
-  if (artefactType && (INTERNAL_CODEX_TYPES as readonly string[]).includes(artefactType)) {
+  if (artefactType === 'PRINCIPLE') {
+    if (typeof c.statement !== 'string' || c.statement.trim() === '') {
+      errors.push({ code: 'CODEX-004', message: 'statement is required for PRINCIPLE artefacts.', path: 'statement' });
+    }
+    if (typeof c.rationale !== 'string' || c.rationale.trim() === '') {
+      errors.push({ code: 'CODEX-004', message: 'rationale is required for PRINCIPLE artefacts.', path: 'rationale' });
+    }
+    if (typeof c.established_by !== 'string' || c.established_by.trim() === '') {
+      warnings.push({
+        code: 'CODEX-006',
+        message: 'established_by is not set for this PRINCIPLE artefact — absence is admissible, but flag it for review at admission.',
+        path: 'established_by',
+      });
+    }
+  } else if (artefactType && (INTERNAL_CODEX_TYPES as readonly string[]).includes(artefactType)) {
     if (typeof c.issuing_authority !== 'string' || c.issuing_authority.trim() === '') {
       errors.push({
         code: 'CODEX-004',


### PR DESCRIPTION
**From: transitrix-studio.**

Adds the `PRINCIPLE` codex TYPE (methodology `14-codex.md` v0.3, §2/§2.1/§4.1) to `packages/diagrams/src/codex/validate.ts`: a third internal sub-TYPE alongside `POLICY`/`INTERNAL_STANDARD`, with its own required-field pair (`statement`, `rationale`) and `issuing_authority`/`effective_date` made optional. Adds an info-level warning when `established_by` is absent — admissible per spec, not a blocking error.

Positive/negative test pair added in `validate.test.ts`.

Answers THQ-269.

## Test plan
- [x] `npx vitest run` in `packages/diagrams` — 103 files / 1684 tests pass
- [x] `npx tsc -p . --noEmit` in `packages/diagrams` — clean