### PR TITLE
docs: wire listing GIF into both READMEs, guard relative image refs

### DIFF
--- a/.github/workflows/public-surface-hygiene.yml
+++ b/.github/workflows/public-surface-hygiene.yml
@@ -61,3 +61,6 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.after }}
         run: node scripts/ci-hygiene-hashrefs.mjs
+
+      - name: Packaged image references
+        run: node scripts/ci-hygiene-image-refs.mjs

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Text-first BPMN authoring: write your process as structured YAML, compile to valid BPMN 2.0 XML with automatic layout, preview live in VS Code or the browser.
 
+![Transitrix Studio in action — YAML on the left, live Blocks preview on the right, an edit redrawing the diagram](https://raw.githubusercontent.com/transitrix/transitrix-studio/main/extension/docs/listing.gif)
+
 ## What this is
 
 Transitrix Studio brings **text-first diagram authoring** to VS Code. Instead of dragging shapes in a GUI editor, you write YAML — structured, diffable, reviewable in pull requests. The compiler produces BPMN 2.0 XML with computed layout coordinates using the ELK (Eclipse Layout Kernel) engine.

--- a/changelog/fragments/wire-listing-gif-into-readmes-61f3d173.md
+++ b/changelog/fragments/wire-listing-gif-into-readmes-61f3d173.md
@@ -1,0 +1,3 @@
+### Changed
+
+- **Listing demonstration wired into both READMEs.** `extension/README.md` and the repository root `README.md` now reference `extension/docs/listing.gif` by the same absolute `raw.githubusercontent.com` URL, replacing the old `preview.png` reference. A new hygiene check (`scripts/ci-hygiene-image-refs.mjs`) fails the build if a consuming README references a packaged image by a relative path — the cause of the 1.4.3 broken-image regression.

--- a/extension/README.md
+++ b/extension/README.md
@@ -2,7 +2,7 @@
 
 **Diagrams as text, in your editor.** Write a diagram in a plain YAML file, and Transitrix Studio renders it live, right beside your code. No drag-and-drop canvas, no proprietary file format — just text you can diff, review in a pull request, and hand to an AI that reads it natively.
 
-![Process landscape preview — YAML on the left, rendered diagram on the right](https://raw.githubusercontent.com/transitrix/transitrix-studio/main/extension/docs/preview.png)
+![Transitrix Studio in action — YAML on the left, live Blocks preview on the right, an edit redrawing the diagram](https://raw.githubusercontent.com/transitrix/transitrix-studio/main/extension/docs/listing.gif)
 
 ## Why text-native diagrams?
 

--- a/scripts/ci-hygiene-image-refs.mjs
+++ b/scripts/ci-hygiene-image-refs.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+// Public-surface hygiene — packaged image references must be absolute.
+//
+// vsce rewrites a relative image path in a packaged README and drops the
+// `extension/` prefix (the 1.4.3 regression, CHANGELOG.md) — every consuming
+// surface (GitHub, Open VSX, the Marketplace) then renders a broken-image
+// pictogram instead of the demonstration. The only path that survives
+// packaging unmodified is an absolute raw.githubusercontent.com URL, so any
+// relative image reference on a consuming surface is a defect, not a style
+// choice.
+
+import { readFileSync } from 'node:fs';
+
+import { findRelativeImageRefs } from './image-ref-patterns.mjs';
+
+const SURFACES = ['extension/README.md', 'README.md'];
+
+const problems = [];
+for (const file of SURFACES) {
+  let text;
+  try {
+    text = readFileSync(file, 'utf8');
+  } catch {
+    continue; // surface doesn't exist yet
+  }
+  for (const hit of findRelativeImageRefs(text)) {
+    problems.push(`${file}:${hit.line} — ${hit.ref}`);
+  }
+}
+
+if (problems.length === 0) {
+  console.log(`[hygiene-image-refs] clean — ${SURFACES.length} consuming surface(s) scanned.`);
+  process.exit(0);
+}
+
+console.error('[hygiene-image-refs] a consuming README references a packaged image by a relative path.');
+console.error('[hygiene-image-refs] vsce rewrites a relative path and drops the extension/ prefix — use the absolute raw.githubusercontent.com URL instead.');
+for (const p of problems) console.error(`  - ${p}`);
+process.exit(1);

--- a/scripts/image-ref-patterns.mjs
+++ b/scripts/image-ref-patterns.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+// Shared pattern for the packaged-image-reference hygiene guard
+// (scripts/ci-hygiene-image-refs.mjs). Extracted to its own module so the
+// self-test (tests/ci-hygiene-image-refs.test.ts) exercises the exact logic
+// the guard runs in CI, not a hand-copied approximation of it.
+
+const IMAGE_REF = /!\[[^\]]*\]\(([^)]+)\)/g;
+
+/** @returns {{line: number, ref: string}[]} relative-path image references in `text` */
+export function findRelativeImageRefs(text) {
+  const hits = [];
+  const lines = String(text ?? '').split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    for (const m of lines[i].matchAll(IMAGE_REF)) {
+      const ref = m[1].trim();
+      if (!/^https?:\/\//i.test(ref)) {
+        hits.push({ line: i + 1, ref });
+      }
+    }
+  }
+  return hits;
+}

--- a/tests/ci-hygiene-image-refs.test.ts
+++ b/tests/ci-hygiene-image-refs.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { findRelativeImageRefs } from '../scripts/image-ref-patterns.mjs';
+
+// Fixed sample strings only — never a real scanned line.
+describe('packaged image reference pattern', () => {
+  it('flags a seeded relative-path image reference', () => {
+    const seeded = '![preview](extension/docs/listing.gif)';
+    expect(findRelativeImageRefs(seeded)).toEqual([{ line: 1, ref: 'extension/docs/listing.gif' }]);
+  });
+
+  it('passes an absolute raw.githubusercontent.com URL', () => {
+    const clean =
+      '![preview](https://raw.githubusercontent.com/transitrix/transitrix-studio/main/extension/docs/listing.gif)';
+    expect(findRelativeImageRefs(clean)).toEqual([]);
+  });
+
+  it('leaves prose with no image reference alone', () => {
+    expect(findRelativeImageRefs('just some prose, no image here')).toEqual([]);
+  });
+
+  it('reports the 1-indexed line of each hit', () => {
+    const seeded = 'line one\n![preview](docs/preview.png)\nline three';
+    expect(findRelativeImageRefs(seeded)).toEqual([{ line: 2, ref: 'docs/preview.png' }]);
+  });
+});


### PR DESCRIPTION
## Summary
- References `extension/docs/listing.gif` from `extension/README.md` and the root `README.md` by the same absolute `raw.githubusercontent.com` URL, replacing the old `preview.png` reference — a grep across both surfaces finds exactly one asset path.
- Adds `scripts/ci-hygiene-image-refs.mjs` to the `public-surface-hygiene` workflow, failing the build when a consuming README references a packaged image by a relative path (the cause of the 1.4.3 broken-image regression).
- Adds a changelog fragment.

## Test plan
- [x] `npx vitest run tests/ci-hygiene-image-refs.test.ts` — new pattern-detection tests pass
- [x] `node scripts/ci-hygiene-image-refs.mjs` — clean on the shipped tree
- [x] Seeded a relative-path reference locally — the check fails with `file:line` output, then reverted
- [x] `node scripts/verify-extension-packaging.mjs` — OK
- [x] `extension/.vscodeignore` confirmed not excluding `extension/docs/` or `README.md`
- [ ] Full `vsce package` / VSIX install check — not run here per this repo's policy (VSIX builds are maintainer-triggered only); the GIF's presence in the packaged VSIX was already measured on THQ-213 (2.91 MB packed, docs/ 83.35 KB → 277.04 KB)