### PR TITLE
fix(release): make draft attachment explicit

### DIFF
--- a/.github/workflows/attach-release-vsix.yml
+++ b/.github/workflows/attach-release-vsix.yml
@@ -1,25 +1,28 @@
 name: Attach universal VSIX to release draft
 
 # Builds the universal VSIX once (build-vsix.yml) and attaches it, with its
-# recorded SHA-256, to the release as a downloadable asset — at draft
-# creation, before Valerii publishes it. Every registry-publish job
-# downstream of a published release downloads this exact asset instead of
+# recorded SHA-256, to an existing release draft before it is published.
+# Every registry-publish job downstream downloads this exact file instead of
 # repackaging, so the artefact verified before release is the one that ships.
 #
-# Runs on release *creation*, filtered to drafts: the release-runbook draft
-# step happens first, so the asset is already attached by the time
-# publishing the draft fires the registry-publish workflows.
+# Draft release activity does not emit a dependable Actions event. Run this
+# workflow explicitly against the release commit after creating the draft.
+# The attach job refuses a non-draft release or a draft aimed at any other
+# commit.
 
 on:
-  release:
-    types: [created]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing draft release tag (for example v3.3.1)
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 jobs:
   build:
-    if: github.event.release.draft == true
     permissions:
       contents: read
       id-token: write
@@ -28,7 +31,6 @@ jobs:
 
   attach:
     needs: build
-    if: github.event.release.draft == true
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -50,6 +52,35 @@ jobs:
             exit 1
           fi
 
+      - name: Resolve and verify the target release draft
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        shell: bash
+        run: |
+          if ! [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::release tag must be a stable semver tag such as v3.3.1"
+            exit 1
+          fi
+
+          release=$(gh api "/repos/${{ github.repository }}/releases/tags/$RELEASE_TAG")
+          draft=$(jq -r '.draft' <<<"$release")
+          target=$(jq -r '.target_commitish' <<<"$release")
+          release_id=$(jq -r '.id' <<<"$release")
+
+          if [ "$draft" != "true" ]; then
+            echo "::error::$RELEASE_TAG is not an unpublished draft"
+            exit 1
+          fi
+          if [ "$target" != "${{ github.sha }}" ]; then
+            echo "::error::draft target $target does not match workflow commit ${{ github.sha }}"
+            exit 1
+          fi
+
+          echo "release-id=$release_id" >> "$GITHUB_OUTPUT"
+          echo "Verified draft $RELEASE_TAG targets $target"
+
       - name: Attach VSIX and SHA-256 to the release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -61,7 +92,7 @@ jobs:
               --method POST \
               -H "Accept: application/vnd.github+json" \
               -H "Content-Type: application/octet-stream" \
-              "/repos/${{ github.repository }}/releases/${{ github.event.release.id }}/assets?name=$name" \
+              "/repos/${{ github.repository }}/releases/${{ steps.release.outputs.release-id }}/assets?name=$name" \
               --input "$f" > /dev/null
             echo "Attached $name"
           done

--- a/docs/internal/release-runbook.md
+++ b/docs/internal/release-runbook.md
@@ -1,7 +1,7 @@
 # Release runbook
 
-How a Transitrix Studio release ships: **creating the release draft builds
-and attaches the universal VSIX; publishing the draft triggers the
+How a Transitrix Studio release ships: **an explicit draft-attachment run builds
+and attaches the universal VSIX; publishing the verified draft triggers the
 registry-publish jobs**, which consume that same attached file rather than
 rebuilding — npm packages, Open VSX, and the JetBrains plugin all publish
 from CI.
@@ -10,7 +10,7 @@ from CI.
 
 | Artifact | Pipeline | Trigger |
 |---|---|---|
-| Universal VSIX, attached to the release + SHA-256 recorded | `.github/workflows/attach-release-vsix.yml` | GitHub Release **created** as a draft |
+| Universal VSIX, attached to the release + SHA-256 recorded | `.github/workflows/attach-release-vsix.yml` | Explicit `workflow_dispatch` for an existing draft tag, run against its exact target commit |
 | `@transitrix/diagrams` + `@transitrix/cli` → npm | `.github/workflows/npm-publish.yml` | GitHub Release **published** (or `workflow_dispatch`) |
 | VS Code extension → VS Code Marketplace | `.github/workflows/vscode-marketplace-publish.yml` | `workflow_dispatch` only — see that workflow's header before changing this |
 | VS Code extension → Open VSX (Cursor / VSCodium / Windsurf) | `.github/workflows/openvsx-publish.yml` | GitHub Release **published** (or `workflow_dispatch`); downloads the asset `attach-release-vsix.yml` attached rather than rebuilding |
@@ -75,16 +75,19 @@ notes PRs:
 
 ### 3. Draft release (agent-preparable)
 
-- Create a **draft** GitHub Release: tag `vX.Y.Z`, target `main`, title
-  `Transitrix Studio X.Y.Z`, body = the CHANGELOG section under a
-  `## What's changed` heading. (A draft creates no tag; the tag is created
-  on the then-current target when the draft is published — so always merge
-  the release PR **before** drafting.)
-- Creating the draft fires `attach-release-vsix.yml`: it builds the
-  universal VSIX once, records its SHA-256, and attaches both to the draft
-  as release assets. Confirm the assets are present before the next step —
-  a draft published without them leaves the registry-publish jobs with
-  nothing to download.
+- Create a **draft** GitHub Release: tag `vX.Y.Z`, target the exact release
+  commit SHA, title `Transitrix Studio X.Y.Z`, body = the CHANGELOG section
+  under a `## What's changed` heading. A draft creates no tag; the tag is
+  created when the draft is published. Always merge the release PR before
+  drafting, and pin the draft to that merge commit rather than to a moving
+  branch.
+- Dispatch `attach-release-vsix.yml` against that same commit and pass the
+  draft's `vX.Y.Z` tag as its `tag` input. The workflow refuses a published
+  release, a non-semver tag, or a draft targeting a different commit. It
+  builds the universal VSIX once, records its SHA-256, and attaches both to
+  the draft as release assets. Confirm the run is green and both assets are
+  present before the next step — a draft published without them leaves the
+  registry-publish jobs with nothing to download.
 - Valerii reviews the draft, verifies the branch/commit it targets and the
   attached asset, and publishes it — see step 4.
 


### PR DESCRIPTION
## Summary
- replace the unreliable draft-release event with an explicit workflow dispatch
- require an existing semver draft pinned to the workflow commit
- keep build, hash, attestation, and attachment in one run
- update the release runbook to the verified sequence

## Verification
- workflow input and fail-closed draft/commit checks reviewed
- public-surface hygiene check invoked (secret-backed local portion skipped when unavailable)
- git diff --check

Publishing workflows are unchanged. This workflow cannot publish a release or invoke any registry.

**From: Coordinator.**