### PR TITLE
fix(release): resolve unpublished drafts

### DIFF
--- a/.github/workflows/attach-release-vsix.yml
+++ b/.github/workflows/attach-release-vsix.yml
@@ -64,7 +64,19 @@ jobs:
             exit 1
           fi
 
-          release=$(gh api "/repos/${{ github.repository }}/releases/tags/$RELEASE_TAG")
+          # GitHub's tag endpoint returns 404 for drafts because their tags do
+          # not exist until publication. Resolve the unique draft from the
+          # release collection instead.
+          release=$(
+            gh api --paginate "/repos/${{ github.repository }}/releases" |
+              jq -s --arg tag "$RELEASE_TAG" '
+                [.[][] | select(.draft == true and .tag_name == $tag)] |
+                if length == 1 then .[0]
+                elif length == 0 then error("no unpublished draft has that tag")
+                else error("multiple unpublished drafts have that tag")
+                end
+              '
+          )
           draft=$(jq -r '.draft' <<<"$release")
           target=$(jq -r '.target_commitish' <<<"$release")
           release_id=$(jq -r '.id' <<<"$release")


### PR DESCRIPTION
## Summary
- resolve an unpublished draft from the releases collection
- require exactly one draft matching the requested tag
- retain the existing draft-state and exact-commit checks

## Verification
- acceptance run #32728270742 proved build/hash/attestation and exposed the draft tag-endpoint 404
- live API confirms the test draft is present in the releases collection
- git diff --check

No release or registry publication occurs.

**From: Coordinator.**