### PR TITLE
fix(release): upload release assets through the correct API host

### DIFF
--- a/.github/workflows/attach-release-vsix.yml
+++ b/.github/workflows/attach-release-vsix.yml
@@ -98,13 +98,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
-          for f in output/*.vsix output/*.sha256; do
-            name=$(basename "$f")
-            gh api \
-              --method POST \
-              -H "Accept: application/vnd.github+json" \
-              -H "Content-Type: application/octet-stream" \
-              "/repos/${{ github.repository }}/releases/${{ steps.release.outputs.release-id }}/assets?name=$name" \
-              --input "$f" > /dev/null
-            echo "Attached $name"
-          done
+          # Release assets upload through uploads.github.com, not the api.github.com
+          # host `gh api` defaults to for a bare path — `gh release upload` targets
+          # the correct host itself.
+          gh release upload "${{ inputs.tag }}" output/*.vsix output/*.sha256 \
+            -R ${{ github.repository }}


### PR DESCRIPTION
## Summary
- `attach-release-vsix.yml`'s attach step called `gh api` with a bare path, which resolves against `api.github.com` — but release asset uploads only exist on `uploads.github.com`, so every attach attempt 404'd.
- Switched to `gh release upload`, which targets the correct host itself.

## Test plan
- [x] Ran `attach-release-vsix.yml` via `workflow_dispatch` on this branch against the standing `v999.0.0` unpublished test draft, repointed to this branch's commit: build, hash-verify, draft-resolve, and attach all succeeded, and the VSIX + `.sha256` landed on the draft (https://github.com/transitrix/transitrix-studio/actions/runs/32752488941).
- [x] Removed the test assets and repointed the draft back to `main`'s tip afterward so the fixture stays clean for the next run.