### PR TITLE
feat(compliance): deterministic requirement-verification matrix builder

### DIFF
--- a/packages/diagrams/src/compliance-verification-matrix/__tests__/build.test.ts
+++ b/packages/diagrams/src/compliance-verification-matrix/__tests__/build.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import yaml from 'js-yaml';
+import { buildComplianceIndex } from '../../compliance/reverse-index.js';
+import { emptyCanon, ingestComplianceDoc } from '../../compliance/classify.js';
+import { buildRequirementVerificationMatrix } from '../build.js';
+import type { ComplianceIndexInput } from '../../compliance/types.js';
+
+// ── Inline unit tests — row cardinality, parent resolution, no roll-up,
+//    labels, outcomes, explicit gaps ─────────────────────────────────────────
+
+describe('buildRequirementVerificationMatrix', () => {
+  const input: ComplianceIndexInput = {
+    requirements: [
+      { id: 'REQUIREMENT-A-1', name: 'A', severity: 'high' }, // one closed verification
+      { id: 'REQUIREMENT-B-1', name: 'B', severity: 'low' }, // no verification -> -001
+      { id: 'REQUIREMENT-C-1', name: 'C', severity: 'medium' }, // only unresolved -> -002
+      { id: 'REQUIREMENT-D-1', name: 'D', severity: 'high', parent: 'REQUIREMENT-A-1' }, // resolvable parent, own verification
+      { id: 'REQUIREMENT-E-1', name: 'E', severity: 'high', parent: 'REQUIREMENT-DOES-NOT-EXIST-1' }, // dangling parent
+    ],
+    assertions: [],
+    verifications: [
+      { id: 'VERIFICATION-A-1', verifies: 'REQUIREMENT-A-1', method: 'test', outcome: 'pass', protocol: 'Protocol A' },
+      { id: 'VERIFICATION-C-1', verifies: 'REQUIREMENT-C-1', method: 'test', outcome: 'not_yet_run', protocol: 'Protocol C1' },
+      { id: 'VERIFICATION-C-2', verifies: 'REQUIREMENT-C-1', method: 'analysis', outcome: 'inconclusive', protocol: 'Protocol C2' },
+      { id: 'VERIFICATION-D-1', verifies: 'REQUIREMENT-D-1', method: 'test', outcome: 'fail' }, // no protocol -> label falls back to id
+      // Dangling verifies — must never attach to any row.
+      { id: 'VERIFICATION-DANGLING-1', verifies: 'REQUIREMENT-DOES-NOT-EXIST-2', method: 'test', outcome: 'pass' },
+    ],
+  };
+  const index = buildComplianceIndex(input);
+  const matrix = buildRequirementVerificationMatrix(index);
+
+  it('produces one row per verification for a requirement with a closed verification', () => {
+    const rows = matrix.rows.filter(r => r.requirementId === 'REQUIREMENT-A-1');
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      requirementLabel: 'A',
+      verificationId: 'VERIFICATION-A-1',
+      verificationLabel: 'Protocol A',
+      verificationOutcome: 'pass',
+    });
+    expect(rows[0].coverageGap).toBeUndefined();
+  });
+
+  it('produces exactly one gap row for a requirement with no verification (REQ-VERIF-COVERAGE-001)', () => {
+    const rows = matrix.rows.filter(r => r.requirementId === 'REQUIREMENT-B-1');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].verificationId).toBeUndefined();
+    expect(rows[0].coverageGap).toBe('REQ-VERIF-COVERAGE-001');
+  });
+
+  it('produces one row per verification, all carrying the gap, when none is closed (REQ-VERIF-COVERAGE-002)', () => {
+    const rows = matrix.rows.filter(r => r.requirementId === 'REQUIREMENT-C-1');
+    expect(rows.map(r => r.verificationId).sort()).toEqual(['VERIFICATION-C-1', 'VERIFICATION-C-2']);
+    expect(rows.every(r => r.coverageGap === 'REQ-VERIF-COVERAGE-002')).toBe(true);
+    expect(rows.every(r => r.verificationOutcome !== undefined)).toBe(true);
+  });
+
+  it('resolves a direct parent id and label when the parent is admitted', () => {
+    const rows = matrix.rows.filter(r => r.requirementId === 'REQUIREMENT-D-1');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].parentId).toBe('REQUIREMENT-A-1');
+    expect(rows[0].parentLabel).toBe('A');
+  });
+
+  it('never rolls a child verification up onto its parent', () => {
+    const parentRows = matrix.rows.filter(r => r.requirementId === 'REQUIREMENT-A-1');
+    expect(parentRows.map(r => r.verificationId)).toEqual(['VERIFICATION-A-1']);
+    expect(parentRows.some(r => r.verificationId === 'VERIFICATION-D-1')).toBe(false);
+  });
+
+  it('falls back to the verification id as its label when protocol is absent', () => {
+    const row = matrix.rows.find(r => r.verificationId === 'VERIFICATION-D-1');
+    expect(row?.verificationLabel).toBe('VERIFICATION-D-1');
+  });
+
+  it('keeps a dangling `parent` visible as a raw id with no resolved label', () => {
+    const rows = matrix.rows.filter(r => r.requirementId === 'REQUIREMENT-E-1');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].parentId).toBe('REQUIREMENT-DOES-NOT-EXIST-1');
+    expect(rows[0].parentLabel).toBeUndefined();
+  });
+
+  it('never attaches a dangling `verifies` to any row, and does not count it', () => {
+    expect(matrix.rows.some(r => r.verificationId === 'VERIFICATION-DANGLING-1')).toBe(false);
+    // Only the 4 real verification rows (A-1, C-1, C-2, D-1) count.
+    expect(matrix.summary.verifications).toBe(4);
+  });
+
+  it('summary counts requirements, real-verification rows, and gapped requirements', () => {
+    expect(matrix.summary.requirements).toBe(5);
+    expect(matrix.summary.gaps).toBe(3); // B-1 (-001), C-1 (-002), E-1 (-001, and also has a dangling parent)
+  });
+
+  it('omits parentId/parentLabel entirely for a requirement with no parent', () => {
+    const row = matrix.rows.find(r => r.requirementId === 'REQUIREMENT-B-1');
+    expect(row).not.toHaveProperty('parentId');
+    expect(row).not.toHaveProperty('parentLabel');
+  });
+
+  it('orders rows by requirement id, then by verification id within a requirement', () => {
+    const seen: string[] = [];
+    for (const row of matrix.rows) {
+      seen.push(`${row.requirementId}:${row.verificationId ?? ''}`);
+    }
+    const sorted = [...seen].sort((a, b) => {
+      const [reqA, verA] = a.split(':');
+      const [reqB, verB] = b.split(':');
+      if (reqA !== reqB) return reqA < reqB ? -1 : 1;
+      return verA < verB ? -1 : verA > verB ? 1 : 0;
+    });
+    expect(seen).toEqual(sorted);
+  });
+
+  it('is independent of input array order (deterministic ordering)', () => {
+    const shuffled: ComplianceIndexInput = {
+      requirements: [...input.requirements].reverse(),
+      assertions: [],
+      verifications: [...(input.verifications ?? [])].reverse(),
+    };
+    const shuffledMatrix = buildRequirementVerificationMatrix(buildComplianceIndex(shuffled));
+    expect(shuffledMatrix).toEqual(matrix);
+  });
+});
+
+// ── Repository-shaped fixture — loaded through the real classifier ─────────
+
+const fixtures = path.resolve(path.dirname(fileURLToPath(import.meta.url)), 'fixtures');
+function loadAll(dir: string): unknown[] {
+  const full = path.join(fixtures, dir);
+  return readdirSync(full)
+    .filter(f => f.endsWith('.yaml'))
+    .map(f => yaml.load(readFileSync(path.join(full, f), 'utf-8')));
+}
+
+describe('requirement-verification matrix — repository-shaped fixture', () => {
+  const canon = emptyCanon();
+  for (const doc of [...loadAll('requirement'), ...loadAll('verification')]) {
+    ingestComplianceDoc(canon, doc);
+  }
+  const index = buildComplianceIndex({
+    requirements: canon.requirements,
+    assertions: canon.assertions,
+    verifications: canon.verifications,
+  });
+  const matrix = buildRequirementVerificationMatrix(index);
+
+  it('ingests every requirement and verification with no duplicates', () => {
+    expect(canon.duplicateIds).toEqual([]);
+    expect(canon.requirements).toHaveLength(6);
+  });
+
+  it('covers the passing, multi-verification, and child-with-parent requirements', () => {
+    const byReq = (id: string) => matrix.rows.filter(r => r.requirementId === id);
+
+    const pass = byReq('REQUIREMENT-MATRIX-PASS-1');
+    expect(pass).toHaveLength(1);
+    expect(pass[0]).toMatchObject({ verificationId: 'VERIFICATION-MATRIX-PASS-1', verificationOutcome: 'pass' });
+    expect(pass[0].coverageGap).toBeUndefined();
+
+    const multi = byReq('REQUIREMENT-MATRIX-MULTI-1');
+    expect(multi.map(r => r.verificationId).sort()).toEqual(['VERIFICATION-MATRIX-MULTI-1', 'VERIFICATION-MATRIX-MULTI-2']);
+    expect(multi.every(r => r.coverageGap === undefined)).toBe(true);
+
+    const child = byReq('REQUIREMENT-MATRIX-CHILD-1');
+    expect(child).toHaveLength(1);
+    expect(child[0].parentId).toBe('REQUIREMENT-MATRIX-PASS-1');
+    expect(child[0].parentLabel).toBe('Matrix fixture — closed, passing verification');
+  });
+
+  it('flags the no-verification and unresolved-verification gaps exactly as repo validation would', () => {
+    const none = matrix.rows.filter(r => r.requirementId === 'REQUIREMENT-MATRIX-NONE-1');
+    expect(none).toHaveLength(1);
+    expect(none[0].coverageGap).toBe('REQ-VERIF-COVERAGE-001');
+    expect(none[0].verificationId).toBeUndefined();
+
+    const open = matrix.rows.filter(r => r.requirementId === 'REQUIREMENT-MATRIX-OPEN-1');
+    expect(open).toHaveLength(1);
+    expect(open[0]).toMatchObject({ coverageGap: 'REQ-VERIF-COVERAGE-002', verificationOutcome: 'not_yet_run' });
+  });
+
+  it('keeps the broken parent reference visible as a raw id with no label', () => {
+    const rows = matrix.rows.filter(r => r.requirementId === 'REQUIREMENT-MATRIX-BROKENPARENT-1');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].parentId).toBe('REQUIREMENT-MATRIX-DOES-NOT-EXIST-1');
+    expect(rows[0].parentLabel).toBeUndefined();
+    // This requirement has no verification of its own -> -001, same as any other unverified requirement.
+    expect(rows[0].coverageGap).toBe('REQ-VERIF-COVERAGE-001');
+  });
+
+  it('drops the dangling VERIFICATION.verifies reference from every row', () => {
+    expect(matrix.rows.some(r => r.verificationId === 'VERIFICATION-MATRIX-DANGLING-1')).toBe(false);
+    // It does not fabricate a row for the id it dangles toward, either.
+    expect(matrix.rows.some(r => r.requirementId === 'REQUIREMENT-MATRIX-DOES-NOT-EXIST-2')).toBe(false);
+  });
+
+  it('produces the same projection regardless of ingestion order', () => {
+    const canonReversed = emptyCanon();
+    for (const doc of [...loadAll('verification'), ...loadAll('requirement')].reverse()) {
+      ingestComplianceDoc(canonReversed, doc);
+    }
+    const indexReversed = buildComplianceIndex({
+      requirements: canonReversed.requirements,
+      assertions: canonReversed.assertions,
+      verifications: canonReversed.verifications,
+    });
+    expect(buildRequirementVerificationMatrix(indexReversed)).toEqual(matrix);
+  });
+});

--- a/packages/diagrams/src/compliance-verification-matrix/__tests__/fixtures/requirement/REQUIREMENT-MATRIX-BROKENPARENT-1.yaml
+++ b/packages/diagrams/src/compliance-verification-matrix/__tests__/fixtures/requirement/REQUIREMENT-MATRIX-BROKENPARENT-1.yaml
@@ -1,0 +1,22 @@
+# Fixture — parent names a REQUIREMENT that is not admitted in this fixture
+# set (dangling; not currently a validator concern per 15-requirement.md
+# §2.4). Must remain visible on the row as a raw id with no resolved label.
+notation: requirement
+id: REQUIREMENT-MATRIX-BROKENPARENT-1
+name: "Matrix fixture — broken parent reference"
+description: >
+  Worked example: `parent` names an id absent from the fixture's requirement
+  set.
+severity: high
+parent: REQUIREMENT-MATRIX-DOES-NOT-EXIST-1
+
+zone: canon
+admitted_at: "2026-08-01"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2026-08-01"
+valid_to: null

--- a/packages/diagrams/src/compliance-verification-matrix/__tests__/fixtures/requirement/REQUIREMENT-MATRIX-CHILD-1.yaml
+++ b/packages/diagrams/src/compliance-verification-matrix/__tests__/fixtures/requirement/REQUIREMENT-MATRIX-CHILD-1.yaml
@@ -1,0 +1,20 @@
+# Fixture — a child with a resolvable direct parent.
+notation: requirement
+id: REQUIREMENT-MATRIX-CHILD-1
+name: "Matrix fixture — child of REQUIREMENT-MATRIX-PASS-1"
+description: >
+  Worked example: same-TYPE decomposition (15-requirement.md §2.4) — this
+  requirement's parent resolves to an admitted REQUIREMENT in the fixture.
+severity: medium
+parent: REQUIREMENT-MATRIX-PASS-1
+
+zone: canon
+admitted_at: "2026-08-01"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2026-08-01"
+valid_to: null

--- a/packages/diagrams/src/compliance-verification-matrix/__tests__/fixtures/requirement/REQUIREMENT-MATRIX-MULTI-1.yaml
+++ b/packages/diagrams/src/compliance-verification-matrix/__tests__/fixtures/requirement/REQUIREMENT-MATRIX-MULTI-1.yaml
@@ -1,0 +1,19 @@
+# Fixture — two admitted verifications against the same requirement.
+notation: requirement
+id: REQUIREMENT-MATRIX-MULTI-1
+name: "Matrix fixture — multiple verifications"
+description: >
+  Worked example: two VERIFICATION records, one pass and one fail — must
+  produce two separate matrix rows.
+severity: high
+
+zone: canon
+admitted_at: "2026-08-01"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2026-08-01"
+valid_to: null

--- a/packages/diagrams/src/compliance-verification-matrix/__tests__/fixtures/requirement/REQUIREMENT-MATRIX-NONE-1.yaml
+++ b/packages/diagrams/src/compliance-verification-matrix/__tests__/fixtures/requirement/REQUIREMENT-MATRIX-NONE-1.yaml
@@ -1,0 +1,19 @@
+# Fixture — no verification at all (REQ-VERIF-COVERAGE-001).
+notation: requirement
+id: REQUIREMENT-MATRIX-NONE-1
+name: "Matrix fixture — no verification"
+description: >
+  Worked example: zero VERIFICATION records — must still produce exactly one
+  gap row.
+severity: low
+
+zone: canon
+admitted_at: "2026-08-01"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2026-08-01"
+valid_to: null

--- a/packages/diagrams/src/compliance-verification-matrix/__tests__/fixtures/requirement/REQUIREMENT-MATRIX-OPEN-1.yaml
+++ b/packages/diagrams/src/compliance-verification-matrix/__tests__/fixtures/requirement/REQUIREMENT-MATRIX-OPEN-1.yaml
@@ -1,0 +1,19 @@
+# Fixture — a verification exists but is not yet closed (REQ-VERIF-COVERAGE-002).
+notation: requirement
+id: REQUIREMENT-MATRIX-OPEN-1
+name: "Matrix fixture — unresolved verification"
+description: >
+  Worked example: exactly one VERIFICATION, still not_yet_run — the
+  REQ-VERIF-COVERAGE-002 case.
+severity: medium
+
+zone: canon
+admitted_at: "2026-08-01"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2026-08-01"
+valid_to: null

--- a/packages/diagrams/src/compliance-verification-matrix/__tests__/fixtures/requirement/REQUIREMENT-MATRIX-PASS-1.yaml
+++ b/packages/diagrams/src/compliance-verification-matrix/__tests__/fixtures/requirement/REQUIREMENT-MATRIX-PASS-1.yaml
@@ -1,0 +1,19 @@
+# Fixture — one passing verification.
+notation: requirement
+id: REQUIREMENT-MATRIX-PASS-1
+name: "Matrix fixture — closed, passing verification"
+description: >
+  Worked example for the requirement-verification matrix builder: exactly one
+  VERIFICATION, closed with outcome pass.
+severity: high
+
+zone: canon
+admitted_at: "2026-08-01"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2026-08-01"
+valid_to: null

--- a/packages/diagrams/src/compliance-verification-matrix/__tests__/fixtures/verification/VERIFICATION-MATRIX-CHILD-1.yaml
+++ b/packages/diagrams/src/compliance-verification-matrix/__tests__/fixtures/verification/VERIFICATION-MATRIX-CHILD-1.yaml
@@ -1,0 +1,18 @@
+notation: verification
+id: VERIFICATION-MATRIX-CHILD-1
+verifies: REQUIREMENT-MATRIX-CHILD-1
+
+method: test
+protocol: "Protocol run directly against the child requirement — must never be attributed to its parent."
+outcome: pass
+
+zone: canon
+admitted_at: "2026-08-05"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2026-08-05"
+valid_to: null

--- a/packages/diagrams/src/compliance-verification-matrix/__tests__/fixtures/verification/VERIFICATION-MATRIX-DANGLING-1.yaml
+++ b/packages/diagrams/src/compliance-verification-matrix/__tests__/fixtures/verification/VERIFICATION-MATRIX-DANGLING-1.yaml
@@ -1,0 +1,21 @@
+# Fixture — verifies names a REQUIREMENT that is not admitted in this fixture
+# set (VERIF-002 in the notation validator). Must never attach to any matrix
+# row and must not affect any other row's cardinality or gap status.
+notation: verification
+id: VERIFICATION-MATRIX-DANGLING-1
+verifies: REQUIREMENT-MATRIX-DOES-NOT-EXIST-2
+
+method: test
+protocol: "Protocol recorded against a requirement id absent from the fixture set."
+outcome: pass
+
+zone: canon
+admitted_at: "2026-08-05"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2026-08-05"
+valid_to: null

--- a/packages/diagrams/src/compliance-verification-matrix/__tests__/fixtures/verification/VERIFICATION-MATRIX-MULTI-1.yaml
+++ b/packages/diagrams/src/compliance-verification-matrix/__tests__/fixtures/verification/VERIFICATION-MATRIX-MULTI-1.yaml
@@ -1,0 +1,18 @@
+notation: verification
+id: VERIFICATION-MATRIX-MULTI-1
+verifies: REQUIREMENT-MATRIX-MULTI-1
+
+method: test
+protocol: "First of two protocols run against the matrix fixture's multi-verification requirement."
+outcome: pass
+
+zone: canon
+admitted_at: "2026-08-05"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2026-08-05"
+valid_to: null

--- a/packages/diagrams/src/compliance-verification-matrix/__tests__/fixtures/verification/VERIFICATION-MATRIX-MULTI-2.yaml
+++ b/packages/diagrams/src/compliance-verification-matrix/__tests__/fixtures/verification/VERIFICATION-MATRIX-MULTI-2.yaml
@@ -1,0 +1,18 @@
+notation: verification
+id: VERIFICATION-MATRIX-MULTI-2
+verifies: REQUIREMENT-MATRIX-MULTI-1
+
+method: analysis
+protocol: "Second of two protocols run against the matrix fixture's multi-verification requirement."
+outcome: fail
+
+zone: canon
+admitted_at: "2026-08-06"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2026-08-06"
+valid_to: null

--- a/packages/diagrams/src/compliance-verification-matrix/__tests__/fixtures/verification/VERIFICATION-MATRIX-OPEN-1.yaml
+++ b/packages/diagrams/src/compliance-verification-matrix/__tests__/fixtures/verification/VERIFICATION-MATRIX-OPEN-1.yaml
@@ -1,0 +1,18 @@
+notation: verification
+id: VERIFICATION-MATRIX-OPEN-1
+verifies: REQUIREMENT-MATRIX-OPEN-1
+
+method: test
+protocol: "Scheduled test protocol for the matrix fixture's open case; not yet executed."
+outcome: not_yet_run
+
+zone: canon
+admitted_at: "2026-08-05"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2026-08-05"
+valid_to: null

--- a/packages/diagrams/src/compliance-verification-matrix/__tests__/fixtures/verification/VERIFICATION-MATRIX-PASS-1.yaml
+++ b/packages/diagrams/src/compliance-verification-matrix/__tests__/fixtures/verification/VERIFICATION-MATRIX-PASS-1.yaml
@@ -1,0 +1,22 @@
+notation: verification
+id: VERIFICATION-MATRIX-PASS-1
+verifies: REQUIREMENT-MATRIX-PASS-1
+
+method: test
+protocol: "Run the matrix fixture's pass-path protocol and confirm the acceptance criterion holds."
+result: "Confirmed."
+outcome: pass
+
+performed_at: "2026-08-05"
+performed_by: ROLE-VERIFICATION-ENG-1
+
+zone: canon
+admitted_at: "2026-08-05"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2026-08-05"
+valid_to: null

--- a/packages/diagrams/src/compliance-verification-matrix/build.ts
+++ b/packages/diagrams/src/compliance-verification-matrix/build.ts
@@ -1,0 +1,84 @@
+// Requirement -> verification matrix builder.
+
+import type { ComplianceIndex } from '../compliance/types.js';
+import { buildGapReport } from '../compliance/gap-report.js';
+import type {
+  RequirementVerificationMatrix,
+  RequirementVerificationMatrixOptions,
+  RequirementVerificationRow,
+} from './types.js';
+
+function byId<T extends { id: string }>(a: T, b: T): number {
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+}
+
+/**
+ * Builds the repository-wide requirement -> verification matrix.
+ *
+ * Pure projection over an already-built `ComplianceIndex`
+ * (`compliance/reverse-index.ts`) — no I/O, no revalidation. Reuses
+ * `buildGapReport`'s `REQ-VERIF-COVERAGE-001`/`-002` verdicts verbatim rather
+ * than recomputing a competing coverage status.
+ *
+ * Ordering: requirements sorted by id; within a requirement, its verification
+ * rows sorted by verification id. Both are explicit sorts over the index's
+ * values, so the result is independent of the Map's insertion order (which —
+ * for a caller that built the index from a filesystem walk — would otherwise
+ * track directory enumeration order).
+ */
+export function buildRequirementVerificationMatrix(
+  index: ComplianceIndex,
+  options: RequirementVerificationMatrixOptions = {},
+): RequirementVerificationMatrix {
+  const gapReport = buildGapReport(index, options);
+  const noVerification = new Set(gapReport.requirementsWithoutVerification.map(r => r.id));
+  const unresolvedVerification = new Set(gapReport.requirementsWithUnresolvedVerification.map(r => r.id));
+
+  const requirements = [...index.requirementById.values()].sort(byId);
+
+  const rows: RequirementVerificationRow[] = [];
+  let verificationRowCount = 0;
+  let gapRequirementCount = 0;
+
+  for (const requirement of requirements) {
+    const parentId = requirement.parent;
+    const parentLabel = parentId ? index.requirementById.get(parentId)?.name : undefined;
+
+    const base: Pick<RequirementVerificationRow, 'requirementId' | 'requirementLabel' | 'parentId' | 'parentLabel'> = {
+      requirementId: requirement.id,
+      requirementLabel: requirement.name,
+      ...(parentId !== undefined ? { parentId } : {}),
+      ...(parentLabel !== undefined ? { parentLabel } : {}),
+    };
+
+    if (noVerification.has(requirement.id)) {
+      gapRequirementCount++;
+      rows.push({ ...base, coverageGap: 'REQ-VERIF-COVERAGE-001' });
+      continue;
+    }
+
+    const gap = unresolvedVerification.has(requirement.id) ? ('REQ-VERIF-COVERAGE-002' as const) : undefined;
+    if (gap) gapRequirementCount++;
+
+    const verifications = [...(index.verificationsByRequirement.get(requirement.id) ?? [])].sort(byId);
+    for (const verification of verifications) {
+      verificationRowCount++;
+      rows.push({
+        ...base,
+        verificationId: verification.id,
+        verificationLabel: verification.protocol ?? verification.id,
+        verificationOutcome: verification.outcome,
+        ...(gap ? { coverageGap: gap } : {}),
+      });
+    }
+  }
+
+  return {
+    rows,
+    summary: {
+      requirements: requirements.length,
+      verifications: verificationRowCount,
+      gaps: gapRequirementCount,
+    },
+  };
+}

--- a/packages/diagrams/src/compliance-verification-matrix/index.ts
+++ b/packages/diagrams/src/compliance-verification-matrix/index.ts
@@ -1,0 +1,6 @@
+export { buildRequirementVerificationMatrix } from './build.js';
+export type {
+  RequirementVerificationMatrix,
+  RequirementVerificationMatrixOptions,
+  RequirementVerificationRow,
+} from './types.js';

--- a/packages/diagrams/src/compliance-verification-matrix/types.ts
+++ b/packages/diagrams/src/compliance-verification-matrix/types.ts
@@ -1,0 +1,85 @@
+// Requirement -> verification matrix — deterministic, repository-wide
+// projection over the shared compliance reverse-index. Pure data; the
+// consumer (a VS Code table, an export) renders it.
+
+import type { VerificationOutcome } from '../verification/types.js';
+
+/**
+ * One row of the requirement-verification matrix.
+ *
+ * A requirement with N admitted VERIFICATION records produces N rows, one per
+ * verification. A requirement with none still produces exactly one row,
+ * carrying the `REQ-VERIF-COVERAGE-001` gap. A requirement whose
+ * verifications exist but never closed (pass/fail) produces one row per
+ * verification — each carrying the `REQ-VERIF-COVERAGE-002` gap alongside its
+ * (still-open) outcome; the open verification is real data and is never
+ * replaced by a placeholder gap row.
+ *
+ * Coverage comes only from `VERIFICATION.verifies` (27-verification.md §2). A
+ * child requirement's verification never covers its `parent`
+ * (15-requirement.md §2.4 — `parent` records structure only, no roll-up).
+ */
+export interface RequirementVerificationRow {
+  requirementId: string;
+  requirementLabel: string;
+
+  /**
+   * Direct `REQUIREMENT.parent` id, verbatim, present whenever the field is
+   * set — whether or not it resolves. `parent` resolution is not currently a
+   * validator concern (15-requirement.md §2.4); a dangling parent must still
+   * be visible on the row, not silently dropped.
+   */
+  parentId?: string;
+  /**
+   * The resolved parent's `name`, present only when `parentId` names an
+   * admitted requirement in the index. Absent when `parentId` is set but
+   * unresolved (dangling), or when the requirement has no parent.
+   */
+  parentLabel?: string;
+
+  /** The verification filling this row, when one exists. */
+  verificationId?: string;
+  /**
+   * VERIFICATION carries no `name`/label field of its own
+   * (27-verification.md §2); `protocol` — the procedure description — is the
+   * closest human-readable text and is what this row shows as its label.
+   */
+  verificationLabel?: string;
+  verificationOutcome?: VerificationOutcome;
+
+  /**
+   * `REQ-VERIF-COVERAGE-001` / `-002` (`compliance/gap-report.ts`), reused
+   * verbatim — this builder never recomputes a competing coverage verdict.
+   * Absent once the requirement has at least one closed (pass/fail)
+   * verification.
+   */
+  coverageGap?: 'REQ-VERIF-COVERAGE-001' | 'REQ-VERIF-COVERAGE-002';
+}
+
+export interface RequirementVerificationMatrixOptions {
+  /**
+   * Forwarded to `buildGapReport`. Neither coverage gap this matrix surfaces
+   * (`REQ-VERIF-COVERAGE-001`/`-002`) depends on `today` — accepted only for
+   * call-site symmetry with the other compliance-view builders.
+   */
+  today?: string;
+}
+
+export interface RequirementVerificationMatrix {
+  /**
+   * One row per (requirement, verification) pair, plus one gap row per
+   * requirement with zero verifications.
+   *
+   * Ordering (stable, independent of filesystem/Map enumeration order):
+   * requirements sorted by id; within a requirement, its verification rows
+   * sorted by verification id.
+   */
+  rows: RequirementVerificationRow[];
+  summary: {
+    requirements: number;
+    /** Rows carrying a real verification (excludes -001 gap-only rows). */
+    verifications: number;
+    /** Requirements carrying a REQ-VERIF-COVERAGE-001 or -002 gap. */
+    gaps: number;
+  };
+}

--- a/packages/diagrams/src/compliance/classify.ts
+++ b/packages/diagrams/src/compliance/classify.ts
@@ -166,6 +166,7 @@ export function ingestComplianceDoc(canon: ComplianceCanon, doc: unknown): strin
     if (!verifies || !method || !outcome) return null;
     const ok = pushUnique(canon, canon.verifications, {
       id, verifies, method, outcome,
+      protocol: str(d.protocol),
       performed_at: str(d.performed_at),
       evidenceCount: Array.isArray(d.evidence) ? d.evidence.length : 0,
       admitted_at: str(d.admitted_at),

--- a/packages/diagrams/src/compliance/types.ts
+++ b/packages/diagrams/src/compliance/types.ts
@@ -128,6 +128,12 @@ export interface IndexVerification {
   verifies: string;
   method: VerificationMethod;
   outcome: VerificationOutcome;
+  /**
+   * The verification procedure (27-verification.md §2). VERIFICATION carries
+   * no `name` field of its own; `protocol` is the closest human-readable
+   * description and is what a matrix/list view shows as the row's label.
+   */
+  protocol?: string;
   performed_at?: string;
   /** Number of evidence entries — feeds the VERIF-006 gap. */
   evidenceCount?: number;

--- a/packages/diagrams/src/index.ts
+++ b/packages/diagrams/src/index.ts
@@ -38,6 +38,7 @@ export {
 export * from "./change/index";
 export * from "./compliance/index";
 export * from "./compliance-matrix/index";
+export * from "./compliance-verification-matrix/index";
 export * from "./confidence/index";
 export * from "./factor/index";
 export * from "./fgca/index";


### PR DESCRIPTION
## Summary
- Adds `buildRequirementVerificationMatrix` to `@transitrix/diagrams` (`packages/diagrams/src/compliance-verification-matrix/`): a pure projection over the existing compliance reverse-index into one row per (requirement, verification) pair, plus an explicit gap row for a requirement with none.
- Reuses `REQ-VERIF-COVERAGE-001`/`-002` from `buildGapReport` verbatim — no competing coverage status is recomputed.
- Adds `protocol` to `IndexVerification` (populated in `classify.ts`): VERIFICATION has no `name`/label field of its own (27-verification.md §2), so `protocol` is what the matrix shows as a row's verification label.

## Design note for reviewers
The task ("the existing validation findings relevant to a broken parent or `VERIFICATION.verifies` endpoint... do not disappear during projection") doesn't map onto an existing id-keyed finding for either case — `REQ-*` has no parent-resolution rule at all (15-requirement.md §2.4 explicitly: "not currently a validator concern"), and the notation-level `VERIF-002` sweep (`src/repo-validate.ts`) is file-keyed, not id-keyed, so a pure index-based builder has no clean way to reattach it to a row. I followed the codebase's existing convention for this exact situation instead — the same "stub"/"unresolved" pattern already used by `RequirementTrace` and `MatrixProduct.unresolved`: a dangling `parent` stays on the row as a raw id with no resolved label (never silently dropped); a dangling `verifies` never attaches to any row (matching how `buildGapReport` already treats it) and is asserted in tests to not leak into any other row's count. Flagging this in case the intended reading was a literal findings-passthrough field instead.

## Test plan
- [x] `packages/diagrams/src/compliance-verification-matrix/__tests__/build.test.ts` — inline-object unit tests (row cardinality, direct-parent resolution, no roll-up, labels, outcomes, explicit gaps, dangling-reference visibility, permuted-input-order determinism) plus a repository-shaped YAML fixture set ingested through the real classifier, covering every case in the task's acceptance list.
- [x] `npm --workspace packages/diagrams test` — 104 files / 1702 tests pass.
- [x] `npm run test:core` (after `npm run build`) — all compliance/repo-validate suites green (Requirement Trace, Compliance Gap Dashboard unaffected); two unrelated pre-existing failures confirmed environmental (missing `extension/schemas` prep output; one CLI test flaked past a 5s timeout under parallel load, passes standalone).
- [x] `tsc -p packages/diagrams --noEmit` clean.