### PR TITLE
feat(process-blueprint): admit PROCESS- columns in validators

### DIFF
--- a/changelog/fragments/process-blueprint-process-columns-5a51e58a.md
+++ b/changelog/fragments/process-blueprint-process-columns-5a51e58a.md
@@ -1,0 +1,3 @@
+### Added
+
+- **Process Blueprint validators admit catalogued `PROCESS-` columns.** A column id may be a document-local `STAGE-…` sketch or an admitted `PROCESS-…`; sketch columns still require `name` / `goal` / `result` on the view (`BP-005`), catalogued columns must not restate those fields (`BP-013`) and must resolve to a `PROCESS` element (`BP-012`). Aspect `stages: […]` arrays accept either form. Composition stays the `process_parent` relation (`PROCESS` → `PROCESS`): self-reference is `REL-007`, a cycle is `REL-008` (warning), and a named parent process with a `PROCESS-` column and no in-effect parent link is `BP-014` (warning — a sketch overlay and a shared subprocess remain well-formed). Existing `STAGE-` only blueprints keep validating.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -43,10 +43,12 @@ suite, see below):
 - **Policy** — an element marked `Active`/`Production` (`metadata.status`) with no `metadata.owner`.
 - **ArchiMate layer-semantics** — endpoint-type constraints for the relation
   kinds with a formally-defined methodology semantics (`unit_located_at`,
-  `located_at`, `offers`, `realizes`, `hosts`, `uses`), plus `TSVC-003`
-  (TECHNOLOGY_SERVICE.node → NODE) and `INT-002` (INTEGRATION interface
-  endpoints → APPLICATION). lint.py ships this phase as a no-op stub; Studio
-  is ahead of the Python tool here — these findings are TypeScript-only.
+  `located_at`, `offers`, `realizes`, `hosts`, `uses`, `process_parent`), plus
+  `TSVC-003` (TECHNOLOGY_SERVICE.node → NODE) and `INT-002` (INTEGRATION
+  interface endpoints → APPLICATION). `process_parent` also fires `REL-007`
+  (self-reference, error) and `REL-008` (cycle in the child→parent graph,
+  warning). lint.py ships this phase as a no-op stub; Studio is ahead of the
+  Python tool here — these findings are TypeScript-only.
 - **Strategy-chain semantics** (`GOALS-009`..`011`, `ACT-005`..`009`,
   `FGCA-008`..`014`) — see below.
 - **Standalone-element envelope hygiene** (`GOAL-ELEM-002`/`003`,

--- a/packages/diagrams/src/process-blueprint/__tests__/validate.test.ts
+++ b/packages/diagrams/src/process-blueprint/__tests__/validate.test.ts
@@ -164,7 +164,7 @@ describe('validateProcessBlueprint', () => {
     expect(r.errors.some(e => e.code === 'BP-008')).toBe(false);
   });
 
-  it('BP-006: rejects stage id that does not match STAGE grammar', () => {
+  it('BP-006: rejects stage id that does not match STAGE or PROCESS grammar', () => {
     const r = validateProcessBlueprint({
       ...VALID_BLUEPRINT,
       process_blueprint: {
@@ -173,6 +173,184 @@ describe('validateProcessBlueprint', () => {
       },
     });
     expect(r.errors.some(e => e.code === 'BP-006')).toBe(true);
+  });
+
+  it('BP-006: accepts PROCESS-… column ids', () => {
+    const r = validateProcessBlueprint({
+      ...VALID_BLUEPRINT,
+      process_blueprint: {
+        ...VALID_BLUEPRINT.process_blueprint,
+        stages: [{ id: 'PROCESS-FULFIL-RECEIVE-1' }],
+        systems: [{ name: 'OMS', stages: ['PROCESS-FULFIL-RECEIVE-1'] }],
+        actors: undefined,
+        equipment: undefined,
+        information_entities: undefined,
+      },
+    });
+    expect(r.errors.some(e => e.code === 'BP-006')).toBe(false);
+    expect(r.valid).toBe(true);
+  });
+
+  it('BP-005: does not require name/goal/result on a PROCESS-… column', () => {
+    const r = validateProcessBlueprint({
+      ...VALID_BLUEPRINT,
+      process_blueprint: {
+        ...VALID_BLUEPRINT.process_blueprint,
+        stages: [{ id: 'PROCESS-FULFIL-RECEIVE-1' }],
+        systems: [{ name: 'OMS', stages: ['PROCESS-FULFIL-RECEIVE-1'] }],
+        actors: undefined,
+        equipment: undefined,
+        information_entities: undefined,
+      },
+    });
+    expect(r.errors.some(e => e.code === 'BP-005')).toBe(false);
+  });
+
+  it('BP-013: rejects a PROCESS-… column that restates name/goal/result', () => {
+    const r = validateProcessBlueprint({
+      ...VALID_BLUEPRINT,
+      process_blueprint: {
+        ...VALID_BLUEPRINT.process_blueprint,
+        stages: [{
+          id: 'PROCESS-FULFIL-RECEIVE-1',
+          name: 'Receive',
+          goal: 'Capture order',
+          result: 'Validated order',
+        }],
+        systems: [{ name: 'OMS', stages: ['PROCESS-FULFIL-RECEIVE-1'] }],
+        actors: undefined,
+        equipment: undefined,
+        information_entities: undefined,
+      },
+    });
+    expect(r.errors.filter(e => e.code === 'BP-013')).toHaveLength(3);
+    expect(r.valid).toBe(false);
+  });
+
+  it('BP-012: skipped when no catalogue is supplied', () => {
+    const r = validateProcessBlueprint({
+      ...VALID_BLUEPRINT,
+      process_blueprint: {
+        ...VALID_BLUEPRINT.process_blueprint,
+        stages: [{ id: 'PROCESS-MISSING-1' }],
+        systems: [{ name: 'OMS', stages: ['PROCESS-MISSING-1'] }],
+        actors: undefined,
+        equipment: undefined,
+        information_entities: undefined,
+      },
+    });
+    expect(r.errors.some(e => e.code === 'BP-012')).toBe(false);
+  });
+
+  it('BP-012: rejects a PROCESS-… column that does not resolve to an admitted PROCESS', () => {
+    const r = validateProcessBlueprint(
+      {
+        ...VALID_BLUEPRINT,
+        process_blueprint: {
+          ...VALID_BLUEPRINT.process_blueprint,
+          stages: [{ id: 'PROCESS-MISSING-1' }],
+          systems: [{ name: 'OMS', stages: ['PROCESS-MISSING-1'] }],
+          actors: undefined,
+          equipment: undefined,
+          information_entities: undefined,
+        },
+      },
+      { catalog: { typeOf: () => undefined } },
+    );
+    expect(r.errors.some(e => e.code === 'BP-012')).toBe(true);
+    expect(r.valid).toBe(false);
+  });
+
+  it('BP-012: accepts a PROCESS-… column that resolves to PROCESS', () => {
+    const r = validateProcessBlueprint(
+      {
+        ...VALID_BLUEPRINT,
+        process_blueprint: {
+          ...VALID_BLUEPRINT.process_blueprint,
+          stages: [{ id: 'PROCESS-FULFIL-RECEIVE-1' }],
+          systems: [{ name: 'OMS', stages: ['PROCESS-FULFIL-RECEIVE-1'] }],
+          actors: undefined,
+          equipment: undefined,
+          information_entities: undefined,
+        },
+      },
+      { catalog: { typeOf: (id) => (id === 'PROCESS-FULFIL-RECEIVE-1' ? 'PROCESS' : undefined) } },
+    );
+    expect(r.errors.some(e => e.code === 'BP-012')).toBe(false);
+    expect(r.valid).toBe(true);
+  });
+
+  it('BP-014: warns when process is set, a column is PROCESS-…, and no in-effect process_parent links them', () => {
+    const r = validateProcessBlueprint(
+      {
+        ...VALID_BLUEPRINT,
+        process_blueprint: {
+          ...VALID_BLUEPRINT.process_blueprint,
+          process: 'PROCESS-FULFIL-CHAIN-1',
+          stages: [{ id: 'PROCESS-FULFIL-RECEIVE-1' }],
+          systems: [{ name: 'OMS', stages: ['PROCESS-FULFIL-RECEIVE-1'] }],
+          actors: undefined,
+          equipment: undefined,
+          information_entities: undefined,
+        },
+      },
+      { processParentEdges: [] },
+    );
+    expect(r.warnings.some(w => w.code === 'BP-014')).toBe(true);
+    expect(r.valid).toBe(true);
+  });
+
+  it('BP-014: silent when an in-effect process_parent links the column to the parent', () => {
+    const r = validateProcessBlueprint(
+      {
+        ...VALID_BLUEPRINT,
+        process_blueprint: {
+          ...VALID_BLUEPRINT.process_blueprint,
+          process: 'PROCESS-FULFIL-CHAIN-1',
+          stages: [{ id: 'PROCESS-FULFIL-RECEIVE-1' }],
+          systems: [{ name: 'OMS', stages: ['PROCESS-FULFIL-RECEIVE-1'] }],
+          actors: undefined,
+          equipment: undefined,
+          information_entities: undefined,
+        },
+      },
+      {
+        processParentEdges: [
+          { from: 'PROCESS-FULFIL-RECEIVE-1', to: 'PROCESS-FULFIL-CHAIN-1' },
+        ],
+      },
+    );
+    expect(r.warnings.some(w => w.code === 'BP-014')).toBe(false);
+  });
+
+  it('BP-014: does not fire on a STAGE- only blueprint that names process', () => {
+    const r = validateProcessBlueprint(
+      {
+        ...VALID_BLUEPRINT,
+        process_blueprint: {
+          ...VALID_BLUEPRINT.process_blueprint,
+          process: 'PROCESS-ORD-FULFILL-1',
+        },
+      },
+      { processParentEdges: [] },
+    );
+    expect(r.warnings.some(w => w.code === 'BP-014')).toBe(false);
+  });
+
+  it('BP-014: skipped when processParentEdges is omitted', () => {
+    const r = validateProcessBlueprint({
+      ...VALID_BLUEPRINT,
+      process_blueprint: {
+        ...VALID_BLUEPRINT.process_blueprint,
+        process: 'PROCESS-FULFIL-CHAIN-1',
+        stages: [{ id: 'PROCESS-FULFIL-RECEIVE-1' }],
+        systems: [{ name: 'OMS', stages: ['PROCESS-FULFIL-RECEIVE-1'] }],
+        actors: undefined,
+        equipment: undefined,
+        information_entities: undefined,
+      },
+    });
+    expect(r.warnings.some(w => w.code === 'BP-014')).toBe(false);
   });
 
   it('BP-007: rejects aspect entry missing name', () => {
@@ -284,9 +462,9 @@ describe('validateProcessBlueprint', () => {
     expect(r.valid).toBe(true);
   });
 
-  // BP-012 was removed from the spec on 2026-05-21 (methodology PR #15):
-  // a single-stage aspect entry is normal, valid blueprint content and the
-  // warning fired on the common case. Studio side dropped to match.
+  // The former BP-012 warning (single-stage aspect entry) was removed from
+  // the spec on 2026-05-21. The code BP-012 now names a different rule:
+  // a PROCESS-… column must resolve to an admitted PROCESS.
 
   it('happy path: surfaces no warnings on a well-formed multi-stage blueprint', () => {
     const r = validateProcessBlueprint(VALID_BLUEPRINT);

--- a/packages/diagrams/src/process-blueprint/index.ts
+++ b/packages/diagrams/src/process-blueprint/index.ts
@@ -27,6 +27,8 @@ export type {
   ValidationError as ProcessBlueprintValidationError,
   ValidationWarning as ProcessBlueprintValidationWarning,
   ValidationResult as ProcessBlueprintValidationResult,
+  ProcessBlueprintValidateOptions,
+  ProcessParentEdge,
 } from './validate.js';
 
 export { layoutProcessBlueprint } from './layout.js';

--- a/packages/diagrams/src/process-blueprint/validate.ts
+++ b/packages/diagrams/src/process-blueprint/validate.ts
@@ -1,21 +1,63 @@
 import type { AspectCategory } from './types.js';
 import type { ValidationError, ValidationWarning, ValidationResult } from '../validation-types.js';
+import type { CanonCatalog } from '../typed-id.js';
 
 export type { ValidationError, ValidationWarning, ValidationResult };
 
 const ID_GRAMMAR_RE = /^[A-Z][A-Z_]*(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
 const PROCESS_BLUEPRINT_ID_RE = /^PROCESS_BLUEPRINT(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
 const STAGE_ID_RE = /^STAGE(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
+const PROCESS_ID_RE = /^PROCESS(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
 const APPLICATION_ID_RE = /^APPLICATION(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
 const ROLE_ID_RE = /^ROLE(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
 
 const ASPECT_CATEGORIES: AspectCategory[] = ['systems', 'actors', 'equipment', 'information_entities'];
 
+const RESTATED_COLUMN_FIELDS = ['name', 'goal', 'result'] as const;
+
+export interface ProcessParentEdge {
+  /** Child process id (`from`). */
+  from: string;
+  /** Parent process id (`to`). */
+  to: string;
+}
+
+export interface ProcessBlueprintValidateOptions {
+  /** When provided, BP-012 resolves `PROCESS-…` column ids against admitted canon. */
+  catalog?: CanonCatalog;
+  /**
+   * In-effect `process_parent` edges (child → parent). When provided, BP-014
+   * warns if `process_blueprint.process` is set and a `PROCESS-…` column has
+   * no such edge to that parent. Omit to skip BP-014 (file-scope without the
+   * relation catalogue).
+   */
+  processParentEdges?: readonly ProcessParentEdge[];
+}
+
 function isNonEmptyString(v: unknown): v is string {
   return typeof v === 'string' && v.trim().length > 0;
 }
 
-export function validateProcessBlueprint(input: unknown): ValidationResult {
+function isProcessColumnId(id: string): boolean {
+  return PROCESS_ID_RE.test(id);
+}
+
+function isStageColumnId(id: string): boolean {
+  return STAGE_ID_RE.test(id);
+}
+
+function isColumnId(id: string): boolean {
+  return isStageColumnId(id) || isProcessColumnId(id);
+}
+
+function fieldIsPresent(record: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(record, key);
+}
+
+export function validateProcessBlueprint(
+  input: unknown,
+  options: ProcessBlueprintValidateOptions = {},
+): ValidationResult {
   const errors: ValidationError[] = [];
   const warnings: ValidationWarning[] = [];
 
@@ -63,6 +105,7 @@ export function validateProcessBlueprint(input: unknown): ValidationResult {
   }
 
   const stageIds = new Set<string>();
+  const processColumnIds: string[] = [];
   for (let i = 0; i < stagesRaw.length; i++) {
     const s = stagesRaw[i] as Record<string, unknown> | undefined;
     const path = `stages[${i}]`;
@@ -71,29 +114,72 @@ export function validateProcessBlueprint(input: unknown): ValidationResult {
       continue;
     }
     if (!isNonEmptyString(s['id'])) {
-      errors.push({ code: 'BP-005', message: `${path}.id is required` });
+      errors.push({ code: 'BP-006', message: `${path}.id is required` });
+      continue;
+    }
+
+    const sid = s['id'].trim();
+    if (stageIds.has(sid)) {
+      errors.push({ code: 'BP-006', message: `Duplicate stage id: "${sid}"` });
     } else {
-      const sid = s['id'].trim();
-      if (stageIds.has(sid)) {
-        errors.push({ code: 'BP-006', message: `Duplicate stage id: "${sid}"` });
-      } else {
-        stageIds.add(sid);
+      stageIds.add(sid);
+    }
+    if (!isColumnId(sid)) {
+      errors.push({
+        code: 'BP-006',
+        message: `${path}.id "${sid}" must match STAGE-[<middle>-]<INTEGER> or PROCESS-[<middle>-]<INTEGER>`,
+      });
+      continue;
+    }
+
+    if (isProcessColumnId(sid)) {
+      processColumnIds.push(sid);
+      for (const field of RESTATED_COLUMN_FIELDS) {
+        if (fieldIsPresent(s, field)) {
+          errors.push({
+            code: 'BP-013',
+            message: `${path}.${field} must not be restated on a PROCESS-… column — derive it from the process element`,
+          });
+        }
       }
-      if (!STAGE_ID_RE.test(sid)) {
-        errors.push({
-          code: 'BP-006',
-          message: `${path}.id "${sid}" must match STAGE-[<middle>-]<INTEGER>`,
+      if (options.catalog) {
+        const resolved = options.catalog.typeOf(sid);
+        if (resolved !== 'PROCESS') {
+          errors.push({
+            code: 'BP-012',
+            message: `${path}.id "${sid}" must resolve to an admitted PROCESS element`,
+          });
+        }
+      }
+    } else {
+      if (!isNonEmptyString(s['name'])) {
+        errors.push({ code: 'BP-005', message: `${path}.name is required` });
+      }
+      if (!isNonEmptyString(s['goal'])) {
+        errors.push({ code: 'BP-005', message: `${path}.goal is required` });
+      }
+      if (!isNonEmptyString(s['result'])) {
+        errors.push({ code: 'BP-005', message: `${path}.result is required` });
+      }
+    }
+  }
+
+  const parentProcess = isNonEmptyString(pb['process']) ? pb['process'].trim() : undefined;
+  if (parentProcess && options.processParentEdges && processColumnIds.length > 0) {
+    const linked = new Set(
+      options.processParentEdges
+        .filter((e) => e.to === parentProcess)
+        .map((e) => e.from),
+    );
+    for (const child of processColumnIds) {
+      if (!linked.has(child)) {
+        warnings.push({
+          code: 'BP-014',
+          message:
+            `Column "${child}" is a PROCESS-… id and process_blueprint.process is "${parentProcess}", ` +
+            `but no in-effect process_parent REL links that column to that parent`,
         });
       }
-    }
-    if (!isNonEmptyString(s['name'])) {
-      errors.push({ code: 'BP-005', message: `${path}.name is required` });
-    }
-    if (!isNonEmptyString(s['goal'])) {
-      errors.push({ code: 'BP-005', message: `${path}.goal is required` });
-    }
-    if (!isNonEmptyString(s['result'])) {
-      errors.push({ code: 'BP-005', message: `${path}.result is required` });
     }
   }
 
@@ -123,7 +209,7 @@ export function validateProcessBlueprint(input: unknown): ValidationResult {
       if (!Array.isArray(entryStages) || entryStages.length === 0) {
         errors.push({
           code: 'BP-007',
-          message: `${path}.stages must be a non-empty array of STAGE-… ids`,
+          message: `${path}.stages must be a non-empty array of declared column ids`,
         });
       } else {
         for (let j = 0; j < entryStages.length; j++) {

--- a/packages/diagrams/src/repo-validate/__tests__/check-process-parent.test.ts
+++ b/packages/diagrams/src/repo-validate/__tests__/check-process-parent.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import {
+  collectInEffectProcessParentEdges,
+  relationInEffectAt,
+} from '../check-process-parent.js';
+import type { RepoDoc, RepoModelInput } from '../types.js';
+
+function el(path: string, data: Record<string, unknown>): RepoDoc {
+  return { path, data };
+}
+
+describe('relationInEffectAt', () => {
+  it('treats a null valid_to as still in effect', () => {
+    expect(relationInEffectAt({ valid_from: '2026-01-01', valid_to: null }, '2026-08-25')).toBe(true);
+  });
+
+  it('is inclusive at both ends', () => {
+    expect(relationInEffectAt({ valid_from: '2026-01-01', valid_to: '2026-08-25' }, '2026-08-25')).toBe(true);
+    expect(relationInEffectAt({ valid_from: '2026-08-25', valid_to: null }, '2026-08-25')).toBe(true);
+  });
+
+  it('excludes a window that has not started or has ended', () => {
+    expect(relationInEffectAt({ valid_from: '2026-09-01', valid_to: null }, '2026-08-25')).toBe(false);
+    expect(relationInEffectAt({ valid_from: '2026-01-01', valid_to: '2026-06-30' }, '2026-08-25')).toBe(false);
+  });
+});
+
+describe('collectInEffectProcessParentEdges', () => {
+  it('keeps an in-effect process_parent and drops an expired one', () => {
+    const input: RepoModelInput = {
+      elements: [],
+      relations: [
+        el('canon/relations/REL-LIVE.yaml', {
+          type: 'process_parent',
+          from: 'PROCESS-A-1',
+          to: 'PROCESS-P-1',
+          valid_from: '2026-01-01',
+          valid_to: null,
+        }),
+        el('canon/relations/REL-DEAD.yaml', {
+          type: 'process_parent',
+          from: 'PROCESS-B-1',
+          to: 'PROCESS-P-1',
+          valid_from: '2025-01-01',
+          valid_to: '2026-06-30',
+        }),
+      ],
+    };
+    expect(collectInEffectProcessParentEdges(input, '2026-08-25')).toEqual([
+      { from: 'PROCESS-A-1', to: 'PROCESS-P-1' },
+    ]);
+  });
+});

--- a/packages/diagrams/src/repo-validate/__tests__/validate-repo.test.ts
+++ b/packages/diagrams/src/repo-validate/__tests__/validate-repo.test.ts
@@ -704,3 +704,110 @@ describe('validateRepoModel — layer-semantics (hosts / uses / TSVC-003)', () =
     expect(findings).toHaveLength(0);
   });
 });
+
+describe('validateRepoModel — process_parent (REL-007 / REL-008 / endpoints)', () => {
+  function processModel(): RepoModelInput {
+    const model = cleanModel();
+    model.elements.push(
+      el('canon/elements/02_business/processes/PROCESS-CHAIN-1.yaml', {
+        notation: 'process',
+        id: 'PROCESS-CHAIN-1',
+      }),
+      el('canon/elements/02_business/processes/PROCESS-RECEIVE-1.yaml', {
+        notation: 'process',
+        id: 'PROCESS-RECEIVE-1',
+      }),
+      el('canon/elements/02_business/processes/PROCESS-PICK-1.yaml', {
+        notation: 'process',
+        id: 'PROCESS-PICK-1',
+      }),
+    );
+    return model;
+  }
+
+  it('accepts a well-formed process_parent PROCESS → PROCESS', () => {
+    const model = processModel();
+    model.relations.push(
+      el('canon/relations/REL-PP-1.yaml', {
+        notation: 'relation',
+        id: 'REL-PP-1',
+        type: 'process_parent',
+        from: 'PROCESS-RECEIVE-1',
+        to: 'PROCESS-CHAIN-1',
+      }),
+    );
+    expect(validateRepoModel(model).filter((f) => f.ruleId?.startsWith('REL-00'))).toEqual([]);
+  });
+
+  it('REL-007: flags a process_parent whose from equals to', () => {
+    const model = processModel();
+    model.relations.push(
+      el('canon/relations/REL-SELF.yaml', {
+        notation: 'relation',
+        id: 'REL-SELF',
+        type: 'process_parent',
+        from: 'PROCESS-CHAIN-1',
+        to: 'PROCESS-CHAIN-1',
+      }),
+    );
+    const findings = validateRepoModel(model).filter((f) => f.ruleId === 'REL-007');
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ scope: 'repo', id: 'REL-SELF', ruleId: 'REL-007' });
+  });
+
+  it('REL-008: warns on a cycle in the process_parent graph', () => {
+    const model = processModel();
+    model.relations.push(
+      el('canon/relations/REL-A.yaml', {
+        notation: 'relation',
+        id: 'REL-A',
+        type: 'process_parent',
+        from: 'PROCESS-RECEIVE-1',
+        to: 'PROCESS-PICK-1',
+      }),
+      el('canon/relations/REL-B.yaml', {
+        notation: 'relation',
+        id: 'REL-B',
+        type: 'process_parent',
+        from: 'PROCESS-PICK-1',
+        to: 'PROCESS-RECEIVE-1',
+      }),
+    );
+    const findings = validateRepoModel(model).filter((f) => f.ruleId === 'REL-008');
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('warning');
+  });
+
+  it('REL-002: flags process_parent whose from is not a PROCESS', () => {
+    const model = processModel();
+    model.relations.push(
+      el('canon/relations/REL-BAD-FROM.yaml', {
+        notation: 'relation',
+        id: 'REL-BAD-FROM',
+        type: 'process_parent',
+        from: 'GOAL-OPS-1',
+        to: 'PROCESS-CHAIN-1',
+      }),
+    );
+    const findings = validateRepoModel(model).filter((f) => f.ruleId === 'REL-002');
+    expect(findings).toHaveLength(1);
+    expect(findings[0].message).toContain('process_parent');
+    expect(findings[0].message).toContain('from');
+  });
+
+  it('does not emit endpoint findings for unknown process_parent endpoints', () => {
+    const model = processModel();
+    model.relations.push(
+      el('canon/relations/REL-MISS.yaml', {
+        notation: 'relation',
+        id: 'REL-MISS',
+        type: 'process_parent',
+        from: 'PROCESS-UNKNOWN-99',
+        to: 'PROCESS-ALSO-UNKNOWN-99',
+      }),
+    );
+    const findings = validateRepoModel(model);
+    expect(findings.every((f) => f.ruleId !== 'REL-002')).toBe(true);
+    expect(findings.some((f) => f.message.includes('PROCESS-UNKNOWN-99'))).toBe(true);
+  });
+});

--- a/packages/diagrams/src/repo-validate/check-process-parent.ts
+++ b/packages/diagrams/src/repo-validate/check-process-parent.ts
@@ -1,0 +1,184 @@
+// process_parent relation checks — 17-relations.md §3 / §5 (REL-007, REL-008)
+// and endpoint TYPE (PROCESS → PROCESS), plus the in-effect edge collector
+// that process-blueprint BP-014 consumes.
+//
+// REL-007 is single-file (from === to). REL-008 is cross-cutting over the
+// admitted process_parent graph and is a warning, parallel to REL-006.
+
+import { docId, endpointId } from './validate-repo.js';
+import type { ProcessParentEdge } from '../process-blueprint/validate.js';
+import type { RepoFinding, RepoModelInput } from './types.js';
+
+const PScope: RepoFinding['scope'] = 'repo';
+
+function isProcessNotation(n: unknown): boolean {
+  return n === 'process';
+}
+
+function isoDate(value: unknown): string | undefined {
+  return typeof value === 'string' && /^\d{4}-\d{2}-\d{2}/.test(value) ? value.slice(0, 10) : undefined;
+}
+
+/** Inclusive window: in effect at `asOf` iff valid_from ≤ asOf and (valid_to is null or asOf ≤ valid_to). */
+export function relationInEffectAt(data: Record<string, unknown>, asOf: string): boolean {
+  const from = isoDate(data['valid_from']);
+  if (from && from > asOf) return false;
+  const to = data['valid_to'];
+  if (to === null || to === undefined) return true;
+  const toDate = isoDate(to);
+  if (!toDate) return true;
+  return asOf <= toDate;
+}
+
+export function todayIsoDate(now: Date = new Date()): string {
+  return now.toISOString().slice(0, 10);
+}
+
+/** In-effect `process_parent` edges (child → parent) among loaded REL files. */
+export function collectInEffectProcessParentEdges(
+  input: RepoModelInput,
+  asOf: string = todayIsoDate(),
+): ProcessParentEdge[] {
+  const edges: ProcessParentEdge[] = [];
+  for (const doc of input.relations) {
+    if (!doc.data) continue;
+    if (doc.data['type'] !== 'process_parent') continue;
+    if (!relationInEffectAt(doc.data, asOf)) continue;
+    const fromId = endpointId(doc.data['from']) ?? endpointId(doc.data['source']);
+    const toId = endpointId(doc.data['to']) ?? endpointId(doc.data['target']);
+    if (!fromId || !toId) continue;
+    edges.push({ from: fromId, to: toId });
+  }
+  return edges;
+}
+
+interface ParentRel {
+  relId: string;
+  fromId: string;
+  toId: string;
+}
+
+function processParentRels(input: RepoModelInput): ParentRel[] {
+  const out: ParentRel[] = [];
+  for (const doc of input.relations) {
+    if (!doc.data) continue;
+    if (doc.data['type'] !== 'process_parent') continue;
+    const fromId = endpointId(doc.data['from']) ?? endpointId(doc.data['source']);
+    const toId = endpointId(doc.data['to']) ?? endpointId(doc.data['target']);
+    if (!fromId || !toId) continue;
+    out.push({ relId: docId(doc) ?? '', fromId, toId });
+  }
+  return out;
+}
+
+/** REL-007 — process_parent self-reference. */
+function checkSelfReference(rels: ParentRel[], findings: RepoFinding[]): void {
+  for (const rel of rels) {
+    if (rel.fromId === rel.toId) {
+      findings.push({
+        scope: PScope,
+        id: rel.relId,
+        ruleId: 'REL-007',
+        message: `REL-007: process_parent relation '${rel.relId}' has from equal to to ('${rel.fromId}').`,
+      });
+    }
+  }
+}
+
+/** REL-008 — cycle in the process_parent graph (warning). */
+function checkCycle(rels: ParentRel[], findings: RepoFinding[]): void {
+  const childrenOf = new Map<string, string[]>();
+  const relByChildParent = new Map<string, string>();
+  const nodes = new Set<string>();
+  for (const rel of rels) {
+    if (rel.fromId === rel.toId) continue;
+    nodes.add(rel.fromId);
+    nodes.add(rel.toId);
+    const list = childrenOf.get(rel.fromId);
+    if (list) list.push(rel.toId);
+    else childrenOf.set(rel.fromId, [rel.toId]);
+    relByChildParent.set(`${rel.fromId}\0${rel.toId}`, rel.relId);
+  }
+
+  const UNVISITED = 0;
+  const VISITING = 1;
+  const DONE = 2;
+  const state = new Map<string, number>();
+  let hit: string | undefined;
+
+  function walk(id: string): boolean {
+    const s = state.get(id) ?? UNVISITED;
+    if (s === DONE) return false;
+    if (s === VISITING) {
+      hit = id;
+      return true;
+    }
+    state.set(id, VISITING);
+    for (const parent of childrenOf.get(id) ?? []) {
+      if (nodes.has(parent) && walk(parent)) return true;
+    }
+    state.set(id, DONE);
+    return false;
+  }
+
+  for (const id of nodes) {
+    if (walk(id)) break;
+  }
+  if (!hit) return;
+
+  const relId =
+    [...relByChildParent.entries()].find(([key]) => key.startsWith(`${hit}\0`))?.[1] ?? hit;
+  findings.push({
+    scope: PScope,
+    id: relId,
+    ruleId: 'REL-008',
+    severity: 'warning',
+    message: `REL-008: process_parent graph contains a cycle involving '${hit}'.`,
+  });
+}
+
+/**
+ * Endpoint TYPE for process_parent: both ends must be PROCESS when they
+ * resolve. Unknown endpoints stay with referential integrity; this pass only
+ * fires when the element exists and is the wrong notation.
+ */
+function checkEndpointTypes(input: RepoModelInput, rels: ParentRel[], findings: RepoFinding[]): void {
+  const elementById = new Map<string, Record<string, unknown>>();
+  for (const doc of input.elements) {
+    const id = docId(doc);
+    if (id && doc.data) elementById.set(id, doc.data);
+  }
+
+  for (const rel of rels) {
+    const from = elementById.get(rel.fromId);
+    if (from && !isProcessNotation(from['notation'])) {
+      findings.push({
+        scope: PScope,
+        id: rel.relId,
+        ruleId: 'REL-002',
+        message:
+          `Layer-semantics: '${rel.relId}' type 'process_parent' requires from to be ` +
+          `PROCESS; got notation='${from['notation']}'.`,
+      });
+    }
+    const to = elementById.get(rel.toId);
+    if (to && !isProcessNotation(to['notation'])) {
+      findings.push({
+        scope: PScope,
+        id: rel.relId,
+        ruleId: 'REL-002',
+        message:
+          `Layer-semantics: '${rel.relId}' type 'process_parent' requires to to be ` +
+          `PROCESS; got notation='${to['notation']}'.`,
+      });
+    }
+  }
+}
+
+export function checkProcessParentSemantics(input: RepoModelInput, findings: RepoFinding[]): void {
+  const rels = processParentRels(input);
+  if (rels.length === 0) return;
+  checkSelfReference(rels, findings);
+  checkCycle(rels, findings);
+  checkEndpointTypes(input, rels, findings);
+}

--- a/packages/diagrams/src/repo-validate/index.ts
+++ b/packages/diagrams/src/repo-validate/index.ts
@@ -1,3 +1,8 @@
 export { validateRepoModel } from './validate-repo.js';
 export { resolveRepoModel } from './resolve-model.js';
+export {
+  checkProcessParentSemantics,
+  collectInEffectProcessParentEdges,
+  todayIsoDate,
+} from './check-process-parent.js';
 export type { RepoDoc, RepoFinding, RepoModelInput, ResolvedElementRecord, ResolvedRelationRecord, ResolvedRepoModel } from './types.js';

--- a/packages/diagrams/src/repo-validate/validate-repo.ts
+++ b/packages/diagrams/src/repo-validate/validate-repo.ts
@@ -31,6 +31,7 @@ import { checkStrategyChainSemantics } from './check-strategy-chain.js';
 import { checkElementHygiene } from './check-element-hygiene.js';
 import { checkVersionedAttributes } from './check-versioned-attributes.js';
 import { checkCandidateFields } from './check-candidate-fields.js';
+import { checkProcessParentSemantics } from './check-process-parent.js';
 import type { RepoDoc, RepoFinding, RepoModelInput } from './types.js';
 
 const PScope: RepoFinding['scope'] = 'repo';
@@ -161,6 +162,7 @@ function checkReferentialIntegrity(input: RepoModelInput, findings: RepoFinding[
  *   realizes        — BUSINESS_SERVICE → CAPABILITY           (25-business-services.md)
  *   hosts           — NODE → TECHNOLOGY_SERVICE               (25-nodes.md / 26-technology-services.md)
  *   uses            — APPLICATION → TECHNOLOGY_SERVICE        (26-technology-services.md)
+ *   process_parent  — PROCESS → PROCESS (17-relations.md §3; REL-007/008)
  *
  * Implemented element checks:
  *   TSVC-003        — TECHNOLOGY_SERVICE.node must resolve to NODE notation
@@ -423,6 +425,7 @@ export function validateRepoModel(input: RepoModelInput): RepoFinding[] {
   checkAtomicity(input, findings);
   checkReferentialIntegrity(input, findings);
   checkLayerSemantics(input, findings);
+  checkProcessParentSemantics(input, findings);
   checkPolicy(input, findings);
   // Phase 7 — strategy-chain semantic rules ported from DSM's Go Validate*
   // functions (GOALS-010, ACT-006..009, FGCA-008..011).

--- a/src/notation-types.ts
+++ b/src/notation-types.ts
@@ -24,6 +24,12 @@ export interface ValidateNotationOptions {
   filePath?: string;
   /** Admitted canon catalogue — enables catalogue-aware checks (e.g. REQ-002, ASSERT-002..005). */
   catalog?: CanonCatalog;
+  /**
+   * In-effect `process_parent` edges (child → parent). Enables BP-014 on a
+   * process-blueprint document when `validate --scope=repo` has the relation
+   * catalogue loaded.
+   */
+  processParentEdges?: ReadonlyArray<{ from: string; to: string }>;
   /** Grid-template name (matrix subset, §6a) — e.g. "raci" — opts a `blocks`
    *  document into that template's extra GridRule checks. */
   template?: string;

--- a/src/repo-validate.ts
+++ b/src/repo-validate.ts
@@ -28,6 +28,7 @@ import {
   type RepoModelInput,
   type ResolvedRepoModel,
 } from '@transitrix/diagrams/repo-validate';
+import { collectInEffectProcessParentEdges } from '@transitrix/diagrams/repo-validate/check-process-parent.js';
 import {
   buildComplianceScan,
   buildComplianceIndex,
@@ -346,10 +347,15 @@ export function runViewValidate(
   // cross-reference checks) instead of walking it a second time; otherwise
   // loads lazily, at most once per run, only when a projection-form document
   // is actually encountered.
+  let loadedModel: RepoModelInput | undefined;
+  function ensureRepoModel(): RepoModelInput {
+    if (!loadedModel) loadedModel = preloadedModel ?? loadRepoModel(root);
+    return loadedModel;
+  }
   let canonModel: { elements: unknown[]; relations: unknown[] } | undefined;
   function ensureCanonModel(): { elements: unknown[]; relations: unknown[] } {
     if (!canonModel) {
-      const model = preloadedModel ?? loadRepoModel(root);
+      const model = ensureRepoModel();
       canonModel = {
         elements: model.elements.map((d) => d.data).filter((d): d is Record<string, unknown> => d != null),
         relations: model.relations.map((d) => d.data).filter((d): d is Record<string, unknown> => d != null),
@@ -432,7 +438,13 @@ export function runViewValidate(
       data = resolveGoals(data, { elements: ensureCanonModel().elements });
     }
 
-    const validateOpts = { catalog: ctx?.catalog };
+    const validateOpts = {
+      catalog: ctx?.catalog,
+      processParentEdges:
+        notation === 'process-blueprint'
+          ? collectInEffectProcessParentEdges(ensureRepoModel())
+          : undefined,
+    };
 
     if (notation === 'compliance-impact' && ctx) {
       for (const f of validateNotationDoc(notation, data, validateOpts).findings) {

--- a/src/validators/process-blueprint.ts
+++ b/src/validators/process-blueprint.ts
@@ -1,8 +1,22 @@
 import { validateProcessBlueprint } from '@transitrix/diagrams/process-blueprint/validate.js';
-import { wrapValidator, type ValidatorRegistration } from '../notation-types.js';
+import {
+  mapPackageResult,
+  type NotationValidationResult,
+  type ValidateNotationOptions,
+  type ValidatorRegistration,
+} from '../notation-types.js';
+
+function validate(input: unknown, options: ValidateNotationOptions = {}): NotationValidationResult {
+  return mapPackageResult(
+    validateProcessBlueprint(input, {
+      catalog: options.catalog,
+      processParentEdges: options.processParentEdges,
+    }),
+  );
+}
 
 export const registration: ValidatorRegistration = {
   notation: 'process-blueprint',
-  validator: wrapValidator(validateProcessBlueprint),
+  validator: validate,
   canonicalViewExtension: true,
 };

--- a/tests/repo-validate-views.test.ts
+++ b/tests/repo-validate-views.test.ts
@@ -360,3 +360,104 @@ describe('repo-scope views sweep — unquoted canon element dates (valid_at filt
     expect(result.views.some((f) => f.message.includes('ACTION-EXPIRED-1'))).toBe(false);
   });
 });
+
+describe('repo-scope process-blueprint PROCESS- columns', () => {
+  let root: string;
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), 'tx-bp-process-'));
+    write(
+      root,
+      'canon/elements/02_business/processes/PROCESS-FULFIL-CHAIN-1.yaml',
+      [
+        'notation: process',
+        'id: PROCESS-FULFIL-CHAIN-1',
+        'name: Fulfilment chain',
+        'zone: canon',
+        'admitted_at: "2026-08-25"',
+        'admitted_by: example',
+        'valid_from: "2026-01-01"',
+        'valid_to: null',
+      ].join('\n'),
+    );
+    write(
+      root,
+      'canon/elements/02_business/processes/PROCESS-FULFIL-RECEIVE-1.yaml',
+      [
+        'notation: process',
+        'id: PROCESS-FULFIL-RECEIVE-1',
+        'name: Receive order',
+        'zone: canon',
+        'admitted_at: "2026-08-25"',
+        'admitted_by: example',
+        'valid_from: "2026-01-01"',
+        'valid_to: null',
+      ].join('\n'),
+    );
+    write(
+      root,
+      'canon/relations/REL-FULFIL-RECEIVE-PROCESS-PARENT-1.yaml',
+      [
+        'notation: relation',
+        'id: REL-FULFIL-RECEIVE-PROCESS-PARENT-1',
+        'type: process_parent',
+        'from: PROCESS-FULFIL-RECEIVE-1',
+        'to: PROCESS-FULFIL-CHAIN-1',
+        'zone: canon',
+        'admitted_at: "2026-08-25"',
+        'admitted_by: example',
+        'valid_from: "2026-01-01"',
+        'valid_to: null',
+      ].join('\n'),
+    );
+    write(
+      root,
+      'canon/views/process-blueprint/chain.process-blueprint.transitrix.yaml',
+      [
+        'notation: process-blueprint',
+        'process_blueprint:',
+        '  id: PROCESS_BLUEPRINT-FULFIL-CHAIN-1',
+        '  name: Fulfilment chain',
+        '  process: PROCESS-FULFIL-CHAIN-1',
+        '  stages:',
+        '    - id: PROCESS-FULFIL-RECEIVE-1',
+        '  systems:',
+        '    - name: OMS',
+        '      stages: [PROCESS-FULFIL-RECEIVE-1]',
+      ].join('\n'),
+    );
+    write(
+      root,
+      'canon/views/process-blueprint/unresolved.process-blueprint.transitrix.yaml',
+      [
+        'notation: process-blueprint',
+        'process_blueprint:',
+        '  id: PROCESS_BLUEPRINT-UNRESOLVED-1',
+        '  name: Unresolved column',
+        '  stages:',
+        '    - id: PROCESS-DOES-NOT-EXIST-1',
+        '  systems:',
+        '    - name: OMS',
+        '      stages: [PROCESS-DOES-NOT-EXIST-1]',
+      ].join('\n'),
+    );
+  });
+
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('accepts a catalogued-column blueprint whose PROCESS- ids resolve and are parented', () => {
+    const result = runRepoValidate(root);
+    const chain = result.views.filter((f) => f.file.endsWith('chain.process-blueprint.transitrix.yaml'));
+    expect(chain.filter((f) => f.severity === 'error')).toEqual([]);
+    expect(chain.some((f) => f.ruleId === 'BP-014')).toBe(false);
+    expect(result.canon.filter((f) => f.ruleId === 'REL-007' || f.ruleId === 'REL-008')).toEqual([]);
+  });
+
+  it('BP-012: flags a PROCESS-… column that does not resolve', () => {
+    const result = runRepoValidate(root);
+    const unresolved = result.views.filter((f) => f.file.endsWith('unresolved.process-blueprint.transitrix.yaml'));
+    expect(unresolved.some((f) => f.ruleId === 'BP-012' && f.severity === 'error')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Process Blueprint column ids may be a sketch `STAGE-…` or an admitted `PROCESS-…`. Sketch columns still require `name` / `goal` / `result` on the view; catalogued columns must not restate those fields and must resolve to a `PROCESS` element.
- Aspect `stages: […]` arrays accept either form. Composition is the `process_parent` relation (`PROCESS` → `PROCESS`): self-reference is an error, a cycle is a warning, and a named parent with no in-effect parent link is a warning so a sketch overlay and a shared subprocess stay well-formed.
- Existing `STAGE-` only blueprints keep validating.

## Test plan
- [x] Unit tests for `BP-005` (STAGE only), `BP-006`, `BP-012`, `BP-013`, `BP-014`, `REL-007`, `REL-008`
- [x] Notation-corpus `order-fulfilment` fixture still validates
- [x] Repo-scope integration: resolved catalogued columns pass; unresolved `PROCESS-` column fails `BP-012`
