### PR TITLE
feat(process-blueprint): render catalogued PROCESS- columns

### DIFF
--- a/changelog/fragments/process-blueprint-catalogued-columns-8c5f94f1.md
+++ b/changelog/fragments/process-blueprint-catalogued-columns-8c5f94f1.md
@@ -1,0 +1,3 @@
+### Added
+
+- **Process Blueprint catalogued columns render from the PROCESS element, and the compliance lane joins on that process (or a STEP of it).** A `PROCESS-…` column header and goal / result come from the child process (`name`, optional `goal` / `result`); restated view fields are ignored. Sketch `STAGE-…` columns keep their authored copy. The compliance overlay pins an assertion when `realised_via` names that process or a step whose home is that process, and no longer treats a sketch `STAGE-…` id as a join key. The STAGE-only fulfilment blueprint still renders as before.

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -553,6 +553,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void |
       void dgcaPreview.refreshIfSiblingSaved(doc);
       void actionPreview.refreshIfSiblingSaved(doc);
       void goalsPreview.refreshIfSiblingSaved(doc);
+      void processBlueprintPreview.refreshIfSiblingSaved(doc);
       // Compliance views are repo-wide: re-scan the open ones whenever a canon
       // artefact (by filename convention) is saved. No-op when no panel is open.
       if (/^(PRODUCT|REQUIREMENT|CONSTRAINT|ASSERTION|VERIFICATION|LAW|REGULATION|POLICY|INTERNAL_STANDARD)-.*\.ya?ml$/.test(path.basename(doc.fileName))) {

--- a/extension/src/process-blueprint-preview.ts
+++ b/extension/src/process-blueprint-preview.ts
@@ -32,7 +32,7 @@ const LEGEND_H = 44;
  * Canon root for a blueprint view: ancestor named `canon/`, or a sibling
  * `canon/` next to the view (the methodology process-parent worked example).
  */
-function findBlueprintCanonRoot(fileUri: vscode.Uri): vscode.Uri | undefined {
+function findBlueprintCanonRoot(fileUri: vscode.Uri): vscode.Uri {
   const ancestor = findCanonRoot(fileUri);
   if (ancestor) return ancestor;
   return vscode.Uri.joinPath(vscode.Uri.file(path.dirname(fileUri.fsPath)), 'canon');
@@ -533,7 +533,6 @@ export class ProcessBlueprintPreview {
     if (!doc.fileName.endsWith('.yaml')) return;
     const viewUri = vscode.Uri.parse(this.trackedUri);
     const canonRoot = findBlueprintCanonRoot(viewUri);
-    if (!canonRoot) return;
     if (!isUnderCanon(canonRoot, doc.uri)) return;
     const viewDoc = await vscode.workspace.openTextDocument(viewUri);
     await this.pushDocument(viewDoc);

--- a/extension/src/process-blueprint-preview.ts
+++ b/extension/src/process-blueprint-preview.ts
@@ -6,6 +6,9 @@ import { TITLE_BLOCK_H, titleBlockSvg, todayIso } from './svg-title-block.js';
 import {
   validateProcessBlueprint,
   layoutProcessBlueprint,
+  collectProcessColumnRecords,
+  collectStepHomeProcess,
+  resolveColumnDisplay,
   type AspectCategory,
   type ComplianceLaneConfig,
   type ComplianceLaneInput,
@@ -21,8 +24,27 @@ import { genNonce } from './preview-controls.js';
 import { readProcessBlueprintSize } from './node-size-config.js';
 import { escXml } from '@transitrix/diagrams/webview/render-util.js';
 import { renderProcessBlueprintBody } from '@transitrix/diagrams/webview/render-process-blueprint.js';
+import { findCanonRoot, isUnderCanon, readYamlDocsUnder } from './canon-loader.js';
 
 const LEGEND_H = 44;
+
+/**
+ * Canon root for a blueprint view: ancestor named `canon/`, or a sibling
+ * `canon/` next to the view (the methodology process-parent worked example).
+ */
+function findBlueprintCanonRoot(fileUri: vscode.Uri): vscode.Uri | undefined {
+  const ancestor = findCanonRoot(fileUri);
+  if (ancestor) return ancestor;
+  return vscode.Uri.joinPath(vscode.Uri.file(path.dirname(fileUri.fsPath)), 'canon');
+}
+
+async function loadBlueprintElementDocs(fileUri: vscode.Uri): Promise<unknown[]> {
+  const root = findBlueprintCanonRoot(fileUri);
+  const elements: unknown[] = [];
+  const warnings: string[] = [];
+  await readYamlDocsUnder(vscode.Uri.joinPath(root, 'elements'), elements, warnings);
+  return elements;
+}
 
 function buildChipLegendSvgElements(x: number, y: number, totalWidth: number): string {
   const midY = y + LEGEND_H / 2;
@@ -505,16 +527,28 @@ export class ProcessBlueprintPreview {
     await this.pushDocument(doc);
   }
 
+  /** Re-render when a PROCESS / STEP under the owning canon/ tree is saved. */
+  async refreshIfSiblingSaved(doc: vscode.TextDocument): Promise<void> {
+    if (!this.panel || !this.trackedUri) return;
+    if (!doc.fileName.endsWith('.yaml')) return;
+    const viewUri = vscode.Uri.parse(this.trackedUri);
+    const canonRoot = findBlueprintCanonRoot(viewUri);
+    if (!canonRoot) return;
+    if (!isUnderCanon(canonRoot, doc.uri)) return;
+    const viewDoc = await vscode.workspace.openTextDocument(viewUri);
+    await this.pushDocument(viewDoc);
+  }
+
   private async pushDocument(doc: vscode.TextDocument): Promise<void> {
     if (!this.panel) return;
     this.lastYamlText = doc.getText();
     this.lastFilename = path.basename(doc.fileName);
-    const html = await this.buildHtml(this.lastYamlText, this.lastFilename);
+    const html = await this.buildHtml(this.lastYamlText, this.lastFilename, doc.uri);
     if (!this.panel) return; // panel may have been disposed while awaiting above
     this.panel.webview.html = html;
   }
 
-  private async buildHtml(yamlText: string, filename: string): Promise<string> {
+  private async buildHtml(yamlText: string, filename: string, fileUri?: vscode.Uri): Promise<string> {
     let svgContent = '';
     this.lastSvgWithLegend = '';
     let errorMsg = '';
@@ -564,7 +598,13 @@ export class ProcessBlueprintPreview {
         if (file.process_blueprint.information_entities?.length) availableRows.push({ id: 'information_entities', label: 'Information' });
         if (laneCfg.enabled) availableRows.push({ id: 'compliance', label: 'Compliance' });
 
-        const availableStages = file.process_blueprint.stages.map(s => ({ id: s.id, name: s.name }));
+        const elementDocs = fileUri ? await loadBlueprintElementDocs(fileUri) : [];
+        const processCatalog = collectProcessColumnRecords(elementDocs);
+        const stepHomeProcess = collectStepHomeProcess(elementDocs);
+        const availableStages = file.process_blueprint.stages.map(s => ({
+          id: s.id,
+          name: resolveColumnDisplay(s, processCatalog).name,
+        }));
 
         // Derive layout filter lists from session state.
         const visibleRowsForLayout: RowId[] | undefined = this.hiddenRows.size === 0
@@ -608,6 +648,8 @@ export class ProcessBlueprintPreview {
           visibleAspects: visibleRowsForLayout ? undefined : visibleAspects,
           visibleRows: visibleRowsForLayout,
           visibleStages: visibleStagesList,
+          processCatalog,
+          stepHomeProcess,
         });
         svgContent = layoutToSvg(layout, filename, docDate, docVersion);
 

--- a/packages/diagrams/src/compliance/__tests__/impact.test.ts
+++ b/packages/diagrams/src/compliance/__tests__/impact.test.ts
@@ -406,13 +406,12 @@ describe('CV-3a — stage grouping (ImpactColumn, extractObjectDetails, buildImp
     expect(matrix.cells[0][1].kind).toBe('bound');
   });
 
-  it('assertion with realised_via fills only the matching stage column', () => {
+  it('assertion with realised_via fills only the matching PROCESS column', () => {
     const canon = emptyCanon();
     canon.requirements.push({ id: 'REQ-1', name: 'R1' });
-    // Assertion only covers STAGE-A.
     canon.assertions.push({
       id: 'ASS-1', about: 'REQ-1', subject: 'PROD-1', status: 'compliant',
-      realised_via: ['STAGE-A'],
+      realised_via: ['PROCESS-RECEIVE-1'],
     });
     const matrix = buildImpactMatrix(
       canon,
@@ -422,10 +421,53 @@ describe('CV-3a — stage grouping (ImpactColumn, extractObjectDetails, buildImp
         obligations: {},
         grouping: { columns: 'product-stage' },
       },
-      [{ objectId: 'PROD-1', details: [{ id: 'STAGE-A', name: 'a' }, { id: 'STAGE-B', name: 'b' }] }],
+      [{ objectId: 'PROD-1', details: [{ id: 'PROCESS-RECEIVE-1', name: 'Receive' }, { id: 'PROCESS-SHIP-1', name: 'Ship' }] }],
     );
-    expect(matrix.cells[0][0].kind).toBe('bound');   // STAGE-A: covered
-    expect(matrix.cells[0][1].kind).toBe('gap');     // STAGE-B: gap
+    expect(matrix.cells[0][0].kind).toBe('bound');
+    expect(matrix.cells[0][1].kind).toBe('gap');
+  });
+
+  it('does not pin a STAGE- sketch column from realised_via', () => {
+    const canon = emptyCanon();
+    canon.requirements.push({ id: 'REQ-1', name: 'R1' });
+    canon.assertions.push({
+      id: 'ASS-1', about: 'REQ-1', subject: 'PROD-1', status: 'compliant',
+      realised_via: ['STAGE-1'],
+    });
+    const matrix = buildImpactMatrix(
+      canon,
+      {
+        id: 'V', name: 'V',
+        subjects: { products: ['PROD-1'] },
+        obligations: {},
+        grouping: { columns: 'product-stage' },
+      },
+      [{ objectId: 'PROD-1', details: [{ id: 'STAGE-1', name: 'Sketch' }, { id: 'PROCESS-RECEIVE-1', name: 'Receive' }] }],
+    );
+    expect(matrix.cells[0][0].kind).toBe('gap');
+    expect(matrix.cells[0][1].kind).toBe('gap');
+  });
+
+  it('pins a PROCESS column when realised_via names a STEP of that process', () => {
+    const canon = emptyCanon();
+    canon.requirements.push({ id: 'REQ-1', name: 'R1' });
+    canon.assertions.push({
+      id: 'ASS-1', about: 'REQ-1', subject: 'PROD-1', status: 'compliant',
+      realised_via: ['STEP-RECV-1'],
+    });
+    const matrix = buildImpactMatrix(
+      canon,
+      {
+        id: 'V', name: 'V',
+        subjects: { products: ['PROD-1'] },
+        obligations: {},
+        grouping: { columns: 'product-stage' },
+      },
+      [{ objectId: 'PROD-1', details: [{ id: 'PROCESS-RECEIVE-1', name: 'Receive' }, { id: 'PROCESS-SHIP-1', name: 'Ship' }] }],
+      { stepHomeProcess: new Map([['STEP-RECV-1', 'PROCESS-RECEIVE-1']]) },
+    );
+    expect(matrix.cells[0][0].kind).toBe('bound');
+    expect(matrix.cells[0][1].kind).toBe('gap');
   });
 
   it('subject with no stage mapping falls back to single product-grain column', () => {

--- a/packages/diagrams/src/compliance/impact.ts
+++ b/packages/diagrams/src/compliance/impact.ts
@@ -12,6 +12,7 @@ import type { ComplianceCanon } from './classify.js';
 import { buildComplianceIndex } from './reverse-index.js';
 import type { CanonCatalog } from '../typed-id.js';
 import type { ComplianceIndex, IndexAssertion, IndexRequirement, ObjectDetailInput, ObjectDetailDef, DeadlineStatus } from './types.js';
+import { isStageColumnId } from '../process-blueprint/resolve-columns.js';
 
 /** Filter selecting REQUIREMENTs by codex source (jurisdiction / regime keys
  *  are accepted for forward compatibility but not yet honoured — the canon
@@ -649,22 +650,48 @@ function buildTaskColumns(
  *
  * At `'product'` grain: `a.subject` must match `col.subjectId`.
  * At `'product-stage'` grain: `a.subject` must match AND either
- * `a.realised_via` is absent (claim covers the whole subject) OR
- * `col.stageId` ∈ `a.realised_via`.
- * At `'product-stage-task'` grain: as above for stage, plus `col.taskId` ∈
- * `a.realised_via` counts as a match (task-level claim covers this task column).
- * A stage-level claim (`col.stageId` ∈ `a.realised_via`) covers all task columns
- * in that stage.
+ * `a.realised_via` is absent (claim covers the whole subject) OR the token
+ * pins this column: a `PROCESS-…` id matching `col.stageId`, or a STEP whose
+ * home process is that column. Sketch `STAGE-…` ids are never a join key.
+ * At `'product-stage-task'` grain: a task-id hit covers that task column; a
+ * process-level claim covers every task column of that process.
  */
-function assertionMatchesColumn(a: IndexAssertion, col: ImpactColumn): boolean {
+function assertionMatchesColumn(
+  a: IndexAssertion,
+  col: ImpactColumn,
+  stepHomeProcess?: ReadonlyMap<string, string>,
+): boolean {
   if (a.subject !== col.subjectId) return false;
   if (!col.stageId) return true;
   if (!a.realised_via || a.realised_via.length === 0) return true;
-  if (col.taskId) {
-    // Task grain: match on taskId OR on stageId (stage claim covers all tasks).
-    return a.realised_via.includes(col.taskId) || a.realised_via.includes(col.stageId);
+
+  const stageId = col.stageId;
+  if (isStageColumnId(stageId)) {
+    // Sketch column: only a task-id hit counts — never the STAGE- key.
+    return col.taskId != null && a.realised_via.includes(col.taskId);
   }
-  return a.realised_via.includes(col.stageId);
+
+  for (const ref of a.realised_via) {
+    if (typeof ref !== 'string') continue;
+    if (isStageColumnId(ref)) continue;
+    if (col.taskId && ref === col.taskId) return true;
+    if (ref === stageId) return true;
+    if (!col.taskId && stepHomeProcess?.get(ref) === stageId) return true;
+  }
+  return false;
+}
+
+function stepHomeFromObjectDetails(objectDetails?: ObjectDetailInput[]): Map<string, string> {
+  const out = new Map<string, string>();
+  if (!objectDetails) return out;
+  for (const od of objectDetails) {
+    for (const d of od.details ?? []) {
+      for (const t of d.tasks ?? []) {
+        if (typeof t?.id === 'string' && t.id.length > 0) out.set(t.id, d.id);
+      }
+    }
+  }
+  return out;
 }
 
 /**
@@ -691,6 +718,7 @@ export function buildImpactMatrix(
   canon: ComplianceCanon,
   config: ImpactViewConfig,
   objectDetails?: ObjectDetailInput[],
+  join?: { stepHomeProcess?: ReadonlyMap<string, string> },
 ): ImpactMatrix {
   const index = buildComplianceIndex({
     requirements: canon.requirements,
@@ -755,6 +783,7 @@ export function buildImpactMatrix(
 
   const rowIndex = new Set(obligations.map(r => r.id));
   const cells: ImpactCell[][] = obligations.map(() => columns.map(() => emptyCell()));
+  const stepHome = join?.stepHomeProcess ?? stepHomeFromObjectDetails(objectDetails);
 
   for (let c = 0; c < columns.length; c++) {
     const col = columns[c];
@@ -762,7 +791,7 @@ export function buildImpactMatrix(
     for (const a of subjectAssertions) {
       if (!rowIndex.has(a.about)) continue;
       if (!allowedStatuses.has(a.status)) continue;
-      if (!assertionMatchesColumn(a, col)) continue;
+      if (!assertionMatchesColumn(a, col, stepHome)) continue;
       const rowIdx = obligations.findIndex(r => r.id === a.about);
       if (rowIdx < 0) continue;
       cells[rowIdx][c].assertions.push(a);

--- a/packages/diagrams/src/process-blueprint/__tests__/compliance-lane.test.ts
+++ b/packages/diagrams/src/process-blueprint/__tests__/compliance-lane.test.ts
@@ -9,7 +9,13 @@ import type {
 
 // ── fixtures ────────────────────────────────────────────────────────────────
 
-const STAGES: ProcessBlueprintFile['process_blueprint']['stages'] = [
+const PROCESS_STAGES: ProcessBlueprintFile['process_blueprint']['stages'] = [
+  { id: 'PROCESS-RECEIVE-1' },
+  { id: 'PROCESS-PACK-1' },
+  { id: 'PROCESS-SHIP-1' },
+];
+
+const STAGE_STAGES: ProcessBlueprintFile['process_blueprint']['stages'] = [
   { id: 'STAGE-1', name: 'Receive', goal: 'g1', result: 'r1' },
   { id: 'STAGE-2', name: 'Process', goal: 'g2', result: 'r2' },
   { id: 'STAGE-3', name: 'Ship', goal: 'g3', result: 'r3' },
@@ -18,7 +24,14 @@ const STAGES: ProcessBlueprintFile['process_blueprint']['stages'] = [
 function buildFile(overrides: Partial<ProcessBlueprintFile['process_blueprint']> = {}): ProcessBlueprintFile {
   return {
     notation: 'process-blueprint',
-    process_blueprint: { id: 'PROCESS_BLUEPRINT-T-1', name: 'Test', stages: STAGES, ...overrides },
+    process_blueprint: { id: 'PROCESS_BLUEPRINT-T-1', name: 'Test', stages: PROCESS_STAGES, ...overrides },
+  };
+}
+
+function buildStageFile(overrides: Partial<ProcessBlueprintFile['process_blueprint']> = {}): ProcessBlueprintFile {
+  return {
+    notation: 'process-blueprint',
+    process_blueprint: { id: 'PROCESS_BLUEPRINT-T-1', name: 'Test', stages: STAGE_STAGES, ...overrides },
   };
 }
 
@@ -43,11 +56,17 @@ function makeAssertion(
 function layout(
   file: ProcessBlueprintFile,
   input: ComplianceLaneInput,
-  overrides: { jurisdictions?: string[]; previousSnapshot?: Record<string, string[]> } = {},
+  overrides: {
+    jurisdictions?: string[];
+    previousSnapshot?: Record<string, string[]>;
+    stepHomeProcess?: ReadonlyMap<string, string>;
+  } = {},
 ) {
+  const { stepHomeProcess, ...lane } = overrides;
   return layoutProcessBlueprint(file, {
-    complianceLane: { enabled: true, ...overrides },
+    complianceLane: { enabled: true, ...lane },
     complianceInput: input,
+    stepHomeProcess,
   });
 }
 
@@ -75,7 +94,7 @@ describe('compliance lane derivation', () => {
 
   it('derives a chip for each law-stage pair', () => {
     const input: ComplianceLaneInput = {
-      assertions: [makeAssertion('REQ-1', 'compliant', ['STAGE-1'])],
+      assertions: [makeAssertion('REQ-1', 'compliant', ['PROCESS-RECEIVE-1'])],
       requirements: [REQ_A],
     };
     const l = layout(buildFile(), input);
@@ -88,7 +107,7 @@ describe('compliance lane derivation', () => {
 
   it('produces one chip per law per stage (same law, two stages → two chips)', () => {
     const input: ComplianceLaneInput = {
-      assertions: [makeAssertion('REQ-1', 'compliant', ['STAGE-1', 'STAGE-2'])],
+      assertions: [makeAssertion('REQ-1', 'compliant', ['PROCESS-RECEIVE-1', 'PROCESS-PACK-1'])],
       requirements: [REQ_A],
     };
     const l = layout(buildFile(), input);
@@ -101,8 +120,8 @@ describe('compliance lane derivation', () => {
   it('merges multiple assertions for the same law-stage into one chip', () => {
     const input: ComplianceLaneInput = {
       assertions: [
-        makeAssertion('REQ-1', 'compliant', ['STAGE-1']),
-        makeAssertion('REQ-1', 'partial', ['STAGE-1']),
+        makeAssertion('REQ-1', 'compliant', ['PROCESS-RECEIVE-1']),
+        makeAssertion('REQ-1', 'partial', ['PROCESS-RECEIVE-1']),
       ],
       requirements: [REQ_A],
     };
@@ -113,19 +132,19 @@ describe('compliance lane derivation', () => {
   describe('decoration: new', () => {
     it('marks chip as new when law is not in previous snapshot', () => {
       const input: ComplianceLaneInput = {
-        assertions: [makeAssertion('REQ-1', 'compliant', ['STAGE-1'])],
+        assertions: [makeAssertion('REQ-1', 'compliant', ['PROCESS-RECEIVE-1'])],
         requirements: [REQ_A],
       };
-      const l = layout(buildFile(), input, { previousSnapshot: { 'STAGE-1': [] } });
+      const l = layout(buildFile(), input, { previousSnapshot: { 'PROCESS-RECEIVE-1': [] } });
       expect(l.complianceRow!.chips[0].decorations).toContain('new');
     });
 
     it('does not mark chip as new when law is in previous snapshot', () => {
       const input: ComplianceLaneInput = {
-        assertions: [makeAssertion('REQ-1', 'compliant', ['STAGE-1'])],
+        assertions: [makeAssertion('REQ-1', 'compliant', ['PROCESS-RECEIVE-1'])],
         requirements: [REQ_A],
       };
-      const l = layout(buildFile(), input, { previousSnapshot: { 'STAGE-1': ['LAW-GDPR-1'] } });
+      const l = layout(buildFile(), input, { previousSnapshot: { 'PROCESS-RECEIVE-1': ['LAW-GDPR-1'] } });
       expect(l.complianceRow!.chips[0].decorations).not.toContain('new');
     });
   });
@@ -133,7 +152,7 @@ describe('compliance lane derivation', () => {
   describe('decoration: gap', () => {
     it('marks chip as gap when assertion status is non_compliant', () => {
       const input: ComplianceLaneInput = {
-        assertions: [makeAssertion('REQ-1', 'non_compliant', ['STAGE-1'])],
+        assertions: [makeAssertion('REQ-1', 'non_compliant', ['PROCESS-RECEIVE-1'])],
         requirements: [REQ_A],
       };
       const l = layout(buildFile(), input);
@@ -142,7 +161,7 @@ describe('compliance lane derivation', () => {
 
     it('marks chip as gap when assertion status is partial', () => {
       const input: ComplianceLaneInput = {
-        assertions: [makeAssertion('REQ-1', 'partial', ['STAGE-2'])],
+        assertions: [makeAssertion('REQ-1', 'partial', ['PROCESS-PACK-1'])],
         requirements: [REQ_A],
       };
       const l = layout(buildFile(), input);
@@ -151,7 +170,7 @@ describe('compliance lane derivation', () => {
 
     it('does not mark chip as gap for compliant assertion', () => {
       const input: ComplianceLaneInput = {
-        assertions: [makeAssertion('REQ-1', 'compliant', ['STAGE-1'])],
+        assertions: [makeAssertion('REQ-1', 'compliant', ['PROCESS-RECEIVE-1'])],
         requirements: [REQ_A],
       };
       const l = layout(buildFile(), input);
@@ -161,8 +180,8 @@ describe('compliance lane derivation', () => {
     it('propagates gap if any assertion for the same law-stage is non-compliant', () => {
       const input: ComplianceLaneInput = {
         assertions: [
-          makeAssertion('REQ-1', 'compliant', ['STAGE-1']),
-          makeAssertion('REQ-1', 'non_compliant', ['STAGE-1']),
+          makeAssertion('REQ-1', 'compliant', ['PROCESS-RECEIVE-1']),
+          makeAssertion('REQ-1', 'non_compliant', ['PROCESS-RECEIVE-1']),
         ],
         requirements: [REQ_A],
       };
@@ -174,7 +193,7 @@ describe('compliance lane derivation', () => {
   describe('decoration: deadline', () => {
     it('marks chip as deadline when gap exists and requirement deadline is past_due', () => {
       const input: ComplianceLaneInput = {
-        assertions: [makeAssertion('REQ-3', 'non_compliant', ['STAGE-1'])],
+        assertions: [makeAssertion('REQ-3', 'non_compliant', ['PROCESS-RECEIVE-1'])],
         requirements: [REQ_DEADLINE],
       };
       const l = layout(buildFile(), input);
@@ -185,7 +204,7 @@ describe('compliance lane derivation', () => {
 
     it('does not mark deadline when gap is absent even if deadline is past_due', () => {
       const input: ComplianceLaneInput = {
-        assertions: [makeAssertion('REQ-3', 'compliant', ['STAGE-1'])],
+        assertions: [makeAssertion('REQ-3', 'compliant', ['PROCESS-RECEIVE-1'])],
         requirements: [REQ_DEADLINE],
       };
       const l = layout(buildFile(), input);
@@ -194,7 +213,7 @@ describe('compliance lane derivation', () => {
 
     it('does not mark deadline when no deadline on requirement', () => {
       const input: ComplianceLaneInput = {
-        assertions: [makeAssertion('REQ-1', 'non_compliant', ['STAGE-1'])],
+        assertions: [makeAssertion('REQ-1', 'non_compliant', ['PROCESS-RECEIVE-1'])],
         requirements: [REQ_A],
       };
       const l = layout(buildFile(), input);
@@ -203,10 +222,10 @@ describe('compliance lane derivation', () => {
 
     it('all three decorations can stack on the same chip', () => {
       const input: ComplianceLaneInput = {
-        assertions: [makeAssertion('REQ-3', 'non_compliant', ['STAGE-1'])],
+        assertions: [makeAssertion('REQ-3', 'non_compliant', ['PROCESS-RECEIVE-1'])],
         requirements: [REQ_DEADLINE],
       };
-      const l = layout(buildFile(), input, { previousSnapshot: { 'STAGE-1': [] } });
+      const l = layout(buildFile(), input, { previousSnapshot: { 'PROCESS-RECEIVE-1': [] } });
       const d = l.complianceRow!.chips[0].decorations;
       expect(d).toContain('new');
       expect(d).toContain('gap');
@@ -217,7 +236,7 @@ describe('compliance lane derivation', () => {
   describe('jurisdiction filter', () => {
     it('passes through all laws when no jurisdictions filter', () => {
       const input: ComplianceLaneInput = {
-        assertions: [makeAssertion('REQ-2', 'compliant', ['STAGE-1'])],
+        assertions: [makeAssertion('REQ-2', 'compliant', ['PROCESS-RECEIVE-1'])],
         requirements: [REQ_B], // derived_from: [LAW-GDPR-1, LAW-SOX-2]
         codexJurisdictions: { 'LAW-GDPR-1': 'EU', 'LAW-SOX-2': 'US' },
       };
@@ -227,7 +246,7 @@ describe('compliance lane derivation', () => {
 
     it('filters to only the selected jurisdictions', () => {
       const input: ComplianceLaneInput = {
-        assertions: [makeAssertion('REQ-2', 'compliant', ['STAGE-1'])],
+        assertions: [makeAssertion('REQ-2', 'compliant', ['PROCESS-RECEIVE-1'])],
         requirements: [REQ_B],
         codexJurisdictions: { 'LAW-GDPR-1': 'EU', 'LAW-SOX-2': 'US' },
       };
@@ -238,7 +257,7 @@ describe('compliance lane derivation', () => {
 
     it('returns no row when jurisdiction filter excludes all laws', () => {
       const input: ComplianceLaneInput = {
-        assertions: [makeAssertion('REQ-2', 'compliant', ['STAGE-1'])],
+        assertions: [makeAssertion('REQ-2', 'compliant', ['PROCESS-RECEIVE-1'])],
         requirements: [REQ_B],
         codexJurisdictions: { 'LAW-GDPR-1': 'EU', 'LAW-SOX-2': 'US' },
       };
@@ -250,7 +269,7 @@ describe('compliance lane derivation', () => {
   describe('null-guards', () => {
     it('tolerates null assertion entries without throwing', () => {
       const input: ComplianceLaneInput = {
-        assertions: [null as unknown as ComplianceLaneAssertion, makeAssertion('REQ-1', 'compliant', ['STAGE-1'])],
+        assertions: [null as unknown as ComplianceLaneAssertion, makeAssertion('REQ-1', 'compliant', ['PROCESS-RECEIVE-1'])],
         requirements: [REQ_A],
       };
       expect(() => layout(buildFile(), input)).not.toThrow();
@@ -267,7 +286,7 @@ describe('compliance lane derivation', () => {
 
     it('skips assertions whose requirement is not in the input', () => {
       const input: ComplianceLaneInput = {
-        assertions: [makeAssertion('REQ-MISSING', 'non_compliant', ['STAGE-1'])],
+        assertions: [makeAssertion('REQ-MISSING', 'non_compliant', ['PROCESS-RECEIVE-1'])],
         requirements: [REQ_A],
       };
       const l = layout(buildFile(), input);
@@ -278,7 +297,7 @@ describe('compliance lane derivation', () => {
   describe('legend', () => {
     it('adds a compliance legend entry when the row is present', () => {
       const input: ComplianceLaneInput = {
-        assertions: [makeAssertion('REQ-1', 'compliant', ['STAGE-1'])],
+        assertions: [makeAssertion('REQ-1', 'compliant', ['PROCESS-RECEIVE-1'])],
         requirements: [REQ_A],
       };
       const l = layout(buildFile(), input);
@@ -297,7 +316,7 @@ describe('compliance lane derivation', () => {
     it('total height grows by the compliance row height', () => {
       const withoutLane = layoutProcessBlueprint(buildFile(), {});
       const input: ComplianceLaneInput = {
-        assertions: [makeAssertion('REQ-1', 'compliant', ['STAGE-1'])],
+        assertions: [makeAssertion('REQ-1', 'compliant', ['PROCESS-RECEIVE-1'])],
         requirements: [REQ_A],
       };
       const withLane = layout(buildFile(), input);
@@ -307,7 +326,7 @@ describe('compliance lane derivation', () => {
 
     it('chip x aligns to the stage column', () => {
       const input: ComplianceLaneInput = {
-        assertions: [makeAssertion('REQ-1', 'compliant', ['STAGE-2'])],
+        assertions: [makeAssertion('REQ-1', 'compliant', ['PROCESS-PACK-1'])],
         requirements: [REQ_A],
       };
       const l = layout(buildFile(), input);
@@ -315,6 +334,41 @@ describe('compliance lane derivation', () => {
       // Chip x must be at the start of stage-2's column (index 1) + cellPadding.
       const expectedX = l.legendColumnWidth + 1 * l.stageColumnWidth + 8; // default cellPadding = 8
       expect(chip.x).toBe(expectedX);
+    });
+  });
+
+  describe('catalogued PROCESS- join vs STAGE- sketch', () => {
+    it('does not pin a STAGE- only blueprint from realised_via STAGE- ids', () => {
+      const input: ComplianceLaneInput = {
+        assertions: [makeAssertion('REQ-1', 'compliant', ['STAGE-1', 'STAGE-2'])],
+        requirements: [REQ_A],
+      };
+      const l = layout(buildStageFile(), input);
+      expect(l.complianceRow).toBeUndefined();
+    });
+
+    it('pins a PROCESS- column when realised_via names a STEP of that process', () => {
+      const input: ComplianceLaneInput = {
+        assertions: [makeAssertion('REQ-1', 'compliant', ['STEP-RECV-1'])],
+        requirements: [REQ_A],
+      };
+      const l = layout(buildFile(), input, {
+        stepHomeProcess: new Map([['STEP-RECV-1', 'PROCESS-RECEIVE-1']]),
+      });
+      expect(l.complianceRow).toBeDefined();
+      expect(l.complianceRow!.chips).toHaveLength(1);
+      expect(l.complianceRow!.chips[0].stageIndex).toBe(0);
+    });
+
+    it('does not pin a PROCESS- column from a STEP that belongs to another process', () => {
+      const input: ComplianceLaneInput = {
+        assertions: [makeAssertion('REQ-1', 'compliant', ['STEP-SHIP-1'])],
+        requirements: [REQ_A],
+      };
+      const l = layout(buildFile(), input, {
+        stepHomeProcess: new Map([['STEP-SHIP-1', 'PROCESS-OTHER-1']]),
+      });
+      expect(l.complianceRow).toBeUndefined();
     });
   });
 });

--- a/packages/diagrams/src/process-blueprint/__tests__/layout.test.ts
+++ b/packages/diagrams/src/process-blueprint/__tests__/layout.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import yaml from 'js-yaml';
 import { layoutProcessBlueprint } from '../layout.js';
+import { collectProcessColumnRecords } from '../resolve-columns.js';
 import type { ProcessBlueprintFile } from '../types.js';
 
 function build(file: Partial<ProcessBlueprintFile['process_blueprint']>): ProcessBlueprintFile {
@@ -235,6 +239,122 @@ describe('layoutProcessBlueprint', () => {
       });
       expect(layout.aspectRows).toHaveLength(1);
       expect(layout.aspectRows[0].category).toBe('systems');
+    });
+  });
+
+  describe('catalogued PROCESS- columns', () => {
+    const catalog = new Map([
+      ['PROCESS-RECEIVE-1', { name: 'Receive order', goal: 'Capture a validated customer order.', result: 'Validated order record.' }],
+      ['PROCESS-PICK-1', { name: 'Pick and pack', goal: 'Assemble the physical order.', result: 'Packed shipment.' }],
+      ['PROCESS-SHIP-1', { name: 'Ship', goal: 'Hand to the carrier.', result: 'In-transit shipment.' }],
+    ]);
+
+    it('headers and goal/result come from the catalogue, not restated view fields', () => {
+      const layout = layoutProcessBlueprint(
+        build({
+          stages: [
+            { id: 'PROCESS-RECEIVE-1', name: 'ignore', goal: 'ignore', result: 'ignore' },
+            { id: 'PROCESS-PICK-1' },
+            { id: 'PROCESS-SHIP-1' },
+          ],
+        }),
+        { processCatalog: catalog },
+      );
+      expect(layout.stageHeaders.map(h => h.name)).toEqual(['Receive order', 'Pick and pack', 'Ship']);
+      expect(layout.goalCells.map(c => c.text)).toEqual([
+        'Capture a validated customer order.',
+        'Assemble the physical order.',
+        'Hand to the carrier.',
+      ]);
+      expect(layout.resultCells.map(c => c.text)).toEqual([
+        'Validated order record.',
+        'Packed shipment.',
+        'In-transit shipment.',
+      ]);
+    });
+
+    it('places aspect pills by PROCESS- id in stages[] array order', () => {
+      const layout = layoutProcessBlueprint(
+        build({
+          stages: [
+            { id: 'PROCESS-RECEIVE-1' },
+            { id: 'PROCESS-PICK-1' },
+            { id: 'PROCESS-SHIP-1' },
+          ],
+          systems: [
+            { name: 'OMS', stages: ['PROCESS-RECEIVE-1', 'PROCESS-PICK-1'] },
+            { name: 'TMS', stages: ['PROCESS-SHIP-1'] },
+          ],
+        }),
+        { processCatalog: catalog },
+      );
+      const pills = layout.aspectRows[0].pills;
+      expect(pills).toHaveLength(2);
+      expect(pills[0].startStageIndex).toBe(0);
+      expect(pills[0].endStageIndex).toBe(1);
+      expect(pills[1].startStageIndex).toBe(2);
+      expect(pills[1].endStageIndex).toBe(2);
+    });
+
+    it('STAGE- only columns still take name/goal/result from the view', () => {
+      const layout = layoutProcessBlueprint(
+        build({
+          stages: [{ id: 'STAGE-1', name: 'Receive', goal: 'g', result: 'r' }],
+        }),
+        { processCatalog: catalog },
+      );
+      expect(layout.stageHeaders[0].name).toBe('Receive');
+      expect(layout.goalCells[0].text).toBe('g');
+      expect(layout.resultCells[0].text).toBe('r');
+    });
+  });
+
+  describe('notation-corpus fixtures', () => {
+    const corpus = path.resolve(process.cwd(), '..', '..', 'tests', 'fixtures', 'notation-corpus');
+
+    function collectYamlUnder(dir: string): unknown[] {
+      const out: unknown[] = [];
+      for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+        const p = path.join(dir, e.name);
+        if (e.isDirectory()) out.push(...collectYamlUnder(p));
+        else if (e.name.endsWith('.yaml')) out.push(yaml.load(fs.readFileSync(p, 'utf8')));
+      }
+      return out;
+    }
+
+    it('STAGE-only order-fulfilment still lays out authored headers', () => {
+      const file = yaml.load(
+        fs.readFileSync(
+          path.join(corpus, 'process-blueprint', 'order-fulfilment.process-blueprint.transitrix.yaml'),
+          'utf8',
+        ),
+      ) as ProcessBlueprintFile;
+      const layout = layoutProcessBlueprint(file);
+      expect(layout.stageHeaders).toHaveLength(5);
+      expect(layout.stageHeaders.map(h => h.name)).toEqual([
+        'Receive order',
+        'Allocate inventory',
+        'Pick & pack',
+        'Ship',
+        'Confirm delivery & close',
+      ]);
+      expect(layout.aspectRows.length).toBeGreaterThan(0);
+    });
+
+    it('catalogued fulfilment-chain headers and goal/result come from PROCESS elements', () => {
+      const parent = path.join(corpus, 'relations', 'process-parent');
+      const file = yaml.load(
+        fs.readFileSync(path.join(parent, 'fulfilment-chain.process-blueprint.transitrix.yaml'), 'utf8'),
+      ) as ProcessBlueprintFile;
+      const catalog = collectProcessColumnRecords(collectYamlUnder(path.join(parent, 'canon', 'elements')));
+      const layout = layoutProcessBlueprint(file, { processCatalog: catalog });
+      expect(layout.stageHeaders.map(h => h.name)).toEqual(['Receive order', 'Pick and pack', 'Ship']);
+      expect(layout.goalCells.map(c => c.text)).toEqual([
+        'Capture a validated customer order.',
+        'Assemble the physical order from reserved inventory.',
+        'Hand the shipment to the carrier and notify the customer.',
+      ]);
+      expect(layout.aspectRows[0].pills.length).toBeGreaterThan(0);
     });
   });
 });

--- a/packages/diagrams/src/process-blueprint/__tests__/resolve-columns.test.ts
+++ b/packages/diagrams/src/process-blueprint/__tests__/resolve-columns.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import {
+  collectProcessColumnRecords,
+  collectStepHomeProcess,
+  columnIndexesForRealisedVia,
+  isProcessColumnId,
+  isStageColumnId,
+  resolveColumnDisplay,
+} from '../resolve-columns.js';
+
+describe('column id predicates', () => {
+  it('accepts PROCESS- and STAGE- grammar', () => {
+    expect(isProcessColumnId('PROCESS-FULFIL-RECEIVE-1')).toBe(true);
+    expect(isProcessColumnId('PROCESS-1')).toBe(true);
+    expect(isStageColumnId('STAGE-1')).toBe(true);
+    expect(isStageColumnId('STAGE-RECV-1')).toBe(true);
+  });
+
+  it('rejects sketch-like STAGE-A and non-column ids', () => {
+    expect(isStageColumnId('STAGE-A')).toBe(false);
+    expect(isProcessColumnId('STAGE-1')).toBe(false);
+    expect(isStageColumnId('PROCESS-1')).toBe(false);
+  });
+});
+
+describe('collectProcessColumnRecords', () => {
+  it('indexes notation: process documents by id', () => {
+    const map = collectProcessColumnRecords([
+      { notation: 'process', id: 'PROCESS-RECEIVE-1', name: 'Receive', goal: 'g', result: 'r' },
+      { notation: 'relation', id: 'REL-1', type: 'process_parent', from: 'A', to: 'B' },
+      { notation: 'process', id: 'PROCESS-1' }, // no name — skipped
+    ]);
+    expect([...map.keys()]).toEqual(['PROCESS-RECEIVE-1']);
+    expect(map.get('PROCESS-RECEIVE-1')).toEqual({ name: 'Receive', goal: 'g', result: 'r' });
+  });
+});
+
+describe('collectStepHomeProcess', () => {
+  it('maps inline flow steps and promoted STEP elements', () => {
+    const map = collectStepHomeProcess([
+      {
+        notation: 'process',
+        id: 'PROCESS-RECEIVE-1',
+        flow: { steps: [{ id: 'STEP-RECV-1', type: 'task' }, { id: 'STEP-RECV-2' }] },
+      },
+      { notation: 'step', id: 'STEP-SHIP-1', process: 'PROCESS-SHIP-1' },
+    ]);
+    expect(map.get('STEP-RECV-1')).toBe('PROCESS-RECEIVE-1');
+    expect(map.get('STEP-RECV-2')).toBe('PROCESS-RECEIVE-1');
+    expect(map.get('STEP-SHIP-1')).toBe('PROCESS-SHIP-1');
+  });
+});
+
+describe('resolveColumnDisplay', () => {
+  it('uses catalogue fields for PROCESS- columns and ignores restated view copy', () => {
+    const catalog = new Map([
+      ['PROCESS-RECEIVE-1', { name: 'Receive order', goal: 'Capture', result: 'Record' }],
+    ]);
+    const d = resolveColumnDisplay(
+      { id: 'PROCESS-RECEIVE-1', name: 'restated', goal: 'no', result: 'no' },
+      catalog,
+    );
+    expect(d).toEqual({ name: 'Receive order', goal: 'Capture', result: 'Record' });
+  });
+
+  it('falls back to the process id when the catalogue has no record', () => {
+    const d = resolveColumnDisplay({ id: 'PROCESS-RECEIVE-1' });
+    expect(d).toEqual({ name: 'PROCESS-RECEIVE-1', goal: '', result: '' });
+  });
+
+  it('keeps authored STAGE- name/goal/result', () => {
+    const d = resolveColumnDisplay({ id: 'STAGE-1', name: 'Receive', goal: 'g', result: 'r' });
+    expect(d).toEqual({ name: 'Receive', goal: 'g', result: 'r' });
+  });
+});
+
+describe('columnIndexesForRealisedVia', () => {
+  const idx = new Map([
+    ['PROCESS-RECEIVE-1', 0],
+    ['PROCESS-SHIP-1', 1],
+    ['STAGE-1', 2],
+  ]);
+
+  it('pins a PROCESS- column by process id', () => {
+    expect(columnIndexesForRealisedVia('PROCESS-RECEIVE-1', idx)).toEqual([0]);
+  });
+
+  it('never pins a STAGE- token', () => {
+    expect(columnIndexesForRealisedVia('STAGE-1', idx)).toEqual([]);
+  });
+
+  it('pins a PROCESS- column from a STEP whose home is that process', () => {
+    const home = new Map([['STEP-RECV-1', 'PROCESS-RECEIVE-1']]);
+    expect(columnIndexesForRealisedVia('STEP-RECV-1', idx, home)).toEqual([0]);
+  });
+});

--- a/packages/diagrams/src/process-blueprint/__tests__/validate.test.ts
+++ b/packages/diagrams/src/process-blueprint/__tests__/validate.test.ts
@@ -486,3 +486,26 @@ describe('process-blueprint examples (regression)', () => {
     });
   }
 });
+
+describe('catalogued-column fixture (relations/process-parent)', () => {
+  const parentDir = path.resolve(
+    process.cwd(),
+    '..',
+    '..',
+    'tests',
+    'fixtures',
+    'notation-corpus',
+    'relations',
+    'process-parent',
+  );
+
+  it('validates fulfilment-chain.process-blueprint.transitrix.yaml at file scope', () => {
+    const text = fs.readFileSync(
+      path.join(parentDir, 'fulfilment-chain.process-blueprint.transitrix.yaml'),
+      'utf8',
+    );
+    const r = validateProcessBlueprint(yaml.load(text));
+    expect(r.errors).toEqual([]);
+    expect(r.valid).toBe(true);
+  });
+});

--- a/packages/diagrams/src/process-blueprint/index.ts
+++ b/packages/diagrams/src/process-blueprint/index.ts
@@ -32,3 +32,12 @@ export type {
 } from './validate.js';
 
 export { layoutProcessBlueprint } from './layout.js';
+export {
+  collectProcessColumnRecords,
+  collectStepHomeProcess,
+  columnIndexesForRealisedVia,
+  isProcessColumnId,
+  isStageColumnId,
+  resolveColumnDisplay,
+} from './resolve-columns.js';
+export type { ProcessColumnRecord } from './resolve-columns.js';

--- a/packages/diagrams/src/process-blueprint/layout.ts
+++ b/packages/diagrams/src/process-blueprint/layout.ts
@@ -19,6 +19,7 @@ import type {
   StageTextCell,
 } from './types.js';
 import { wrapTextLines } from '../webview/entity-text-layout.js';
+import { columnIndexesForRealisedVia, resolveColumnDisplay } from './resolve-columns.js';
 
 const ASPECT_CATEGORIES: AspectCategory[] = ['systems', 'actors', 'equipment', 'information_entities'];
 
@@ -33,7 +34,13 @@ const ASPECT_LABEL: Record<AspectCategory, string> = {
 // (absent = feature disabled) and must stay optional in the resolved type.
 type SizingOptionKeys = Exclude<
   keyof ProcessBlueprintLayoutOptions,
-  'complianceLane' | 'complianceInput' | 'visibleAspects' | 'visibleRows' | 'visibleStages'
+  | 'complianceLane'
+  | 'complianceInput'
+  | 'visibleAspects'
+  | 'visibleRows'
+  | 'visibleStages'
+  | 'processCatalog'
+  | 'stepHomeProcess'
 >;
 
 /**
@@ -41,7 +48,16 @@ type SizingOptionKeys = Exclude<
  * the opt-in feature fields stay optional (undefined = feature disabled).
  */
 type ResolvedLayoutOptions = Required<Pick<ProcessBlueprintLayoutOptions, SizingOptionKeys>> &
-  Pick<ProcessBlueprintLayoutOptions, 'complianceLane' | 'complianceInput' | 'visibleAspects' | 'visibleRows' | 'visibleStages'>;
+  Pick<
+    ProcessBlueprintLayoutOptions,
+    | 'complianceLane'
+    | 'complianceInput'
+    | 'visibleAspects'
+    | 'visibleRows'
+    | 'visibleStages'
+    | 'processCatalog'
+    | 'stepHomeProcess'
+  >;
 
 const DEFAULTS = {
   legendColumnWidth: 140,
@@ -258,27 +274,29 @@ function deriveComplianceRow(
 
     for (const stageRef of realisedVia) {
       if (typeof stageRef !== 'string') continue;
-      const idx = stageIndexById.get(stageRef.trim());
-      if (idx === undefined) continue;
+      const idxs = columnIndexesForRealisedVia(stageRef, stageIndexById, opts.stepHomeProcess);
+      if (idxs.length === 0) continue;
 
-      for (const lawId of lawIds) {
-        // Apply jurisdiction filter.
-        if (filterJurisdictions) {
-          const jur = input.codexJurisdictions?.[lawId];
-          if (!jur || !filterJurisdictions.has(jur)) continue;
-        }
+      for (const idx of idxs) {
+        for (const lawId of lawIds) {
+          // Apply jurisdiction filter.
+          if (filterJurisdictions) {
+            const jur = input.codexJurisdictions?.[lawId];
+            if (!jur || !filterJurisdictions.has(jur)) continue;
+          }
 
-        if (!stageAccum.has(idx)) stageAccum.set(idx, new Map());
-        const lawMap = stageAccum.get(idx)!;
-        const existing = lawMap.get(lawId);
-        const isGap = a.status === 'non_compliant' || a.status === 'partial';
-        if (!existing) {
-          lawMap.set(lawId, { gap: isGap, deadline: req.deadline });
-        } else {
-          existing.gap = existing.gap || isGap;
-          // Keep the earlier deadline (more urgent).
-          if (req.deadline && (!existing.deadline || req.deadline < existing.deadline)) {
-            existing.deadline = req.deadline;
+          if (!stageAccum.has(idx)) stageAccum.set(idx, new Map());
+          const lawMap = stageAccum.get(idx)!;
+          const existing = lawMap.get(lawId);
+          const isGap = a.status === 'non_compliant' || a.status === 'partial';
+          if (!existing) {
+            lawMap.set(lawId, { gap: isGap, deadline: req.deadline });
+          } else {
+            existing.gap = existing.gap || isGap;
+            // Keep the earlier deadline (more urgent).
+            if (req.deadline && (!existing.deadline || req.deadline < existing.deadline)) {
+              existing.deadline = req.deadline;
+            }
           }
         }
       }
@@ -338,6 +356,7 @@ export function layoutProcessBlueprint(
     ? allStages.filter(s => s?.id != null && opts.visibleStages!.includes(s.id))
     : allStages;
   const stageIndexById = buildStageIndex(stages);
+  const display = stages.map(s => resolveColumnDisplay(s, opts.processCatalog));
 
   // Row visibility from visibleRows
   const visRows = opts.visibleRows;
@@ -354,7 +373,7 @@ export function layoutProcessBlueprint(
   const stageHeaders: StageHeaderCell[] = stages.map((s, i) => ({
     stageIndex: i,
     id: s?.id ?? '',
-    name: s?.name ?? '',
+    name: display[i].name,
     x: opts.legendColumnWidth + i * opts.stageColumnWidth,
     y: 0,
     width: opts.stageColumnWidth,
@@ -373,8 +392,8 @@ export function layoutProcessBlueprint(
     return Math.max(minHeight, maxLines * opts.textLineHeight + 2 * opts.cellTextPadY);
   };
 
-  const goalLines = stages.map(s => wrap(s?.goal ?? ''));
-  const resultLines = stages.map(s => wrap(s?.result ?? ''));
+  const goalLines = display.map(d => wrap(d.goal));
+  const resultLines = display.map(d => wrap(d.result));
 
   let cursorY = opts.stageHeaderHeight;
   let goalRowY = 0, goalRowHeight = 0;
@@ -385,8 +404,8 @@ export function layoutProcessBlueprint(
   if (showGoal) {
     goalRowY = cursorY;
     goalRowHeight = rowHeightFor(goalLines.map(l => l.length), opts.goalRowHeight);
-    goalCells.push(...stages.map((s, i) => ({
-      stageIndex: i, text: s?.goal ?? '', lines: goalLines[i],
+    goalCells.push(...display.map((d, i) => ({
+      stageIndex: i, text: d.goal, lines: goalLines[i],
       x: opts.legendColumnWidth + i * opts.stageColumnWidth, y: goalRowY,
       width: opts.stageColumnWidth, height: goalRowHeight,
     })));
@@ -395,8 +414,8 @@ export function layoutProcessBlueprint(
   if (showResult) {
     resultRowY = cursorY;
     resultRowHeight = rowHeightFor(resultLines.map(l => l.length), opts.resultRowHeight);
-    resultCells.push(...stages.map((s, i) => ({
-      stageIndex: i, text: s?.result ?? '', lines: resultLines[i],
+    resultCells.push(...display.map((d, i) => ({
+      stageIndex: i, text: d.result, lines: resultLines[i],
       x: opts.legendColumnWidth + i * opts.stageColumnWidth, y: resultRowY,
       width: opts.stageColumnWidth, height: resultRowHeight,
     })));

--- a/packages/diagrams/src/process-blueprint/resolve-columns.ts
+++ b/packages/diagrams/src/process-blueprint/resolve-columns.ts
@@ -1,0 +1,147 @@
+/**
+ * Render-time resolution of Process Blueprint column headers and the
+ * compliance-lane join key.
+ *
+ * A `PROCESS-…` column is the process: `name` / `goal` / `result` come from
+ * the child PROCESS element (ELEMENT_PRIMITIVES §7.5), never from restated
+ * view fields. A `STAGE-…` column keeps the authored sketch copy.
+ *
+ * Pure: no I/O. The host (VS Code preview, JCEF, CLI) already owns loading
+ * canon/elements/** — this module only knows how to pick PROCESS / STEP
+ * records out of that pool.
+ *
+ * This is a read model, never storage. Callers render an ephemeral display
+ * copy and must never serialise it back onto the view.
+ */
+
+import type { Stage } from './types.js';
+
+const PROCESS_ID_RE = /^PROCESS(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
+const STAGE_ID_RE = /^STAGE(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
+
+export function isProcessColumnId(id: string): boolean {
+  return PROCESS_ID_RE.test(id);
+}
+
+export function isStageColumnId(id: string): boolean {
+  return STAGE_ID_RE.test(id);
+}
+
+/** Display fields taken from a `notation: process` element. */
+export interface ProcessColumnRecord {
+  name: string;
+  goal?: string;
+  result?: string;
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+function optionalString(v: unknown): string | undefined {
+  return typeof v === 'string' && v.trim().length > 0 ? v.trim() : undefined;
+}
+
+/**
+ * Collect admitted PROCESS elements from a raw canon/elements/** doc pool,
+ * keyed by id. Malformed documents are skipped.
+ */
+export function collectProcessColumnRecords(docs: readonly unknown[]): Map<string, ProcessColumnRecord> {
+  const out = new Map<string, ProcessColumnRecord>();
+  for (const doc of docs) {
+    if (!isRecord(doc)) continue;
+    if (doc['notation'] !== 'process') continue;
+    const id = optionalString(doc['id']);
+    if (!id || !isProcessColumnId(id)) continue;
+    const name = optionalString(doc['name']);
+    if (!name) continue;
+    const rec: ProcessColumnRecord = { name };
+    const goal = optionalString(doc['goal']);
+    const result = optionalString(doc['result']);
+    if (goal) rec.goal = goal;
+    if (result) rec.result = result;
+    out.set(id, rec);
+  }
+  return out;
+}
+
+/**
+ * Map each STEP id onto the PROCESS that contains it — either inline in
+ * `PROCESS.flow.steps[]` or a promoted `{ notation: step, process }` element.
+ * First writer wins; a later duplicate is ignored.
+ */
+export function collectStepHomeProcess(docs: readonly unknown[]): Map<string, string> {
+  const out = new Map<string, string>();
+  for (const doc of docs) {
+    if (!isRecord(doc)) continue;
+    if (doc['notation'] === 'process') {
+      const processId = optionalString(doc['id']);
+      if (!processId || !isProcessColumnId(processId)) continue;
+      const flow = isRecord(doc['flow']) ? doc['flow'] : undefined;
+      const steps = flow && Array.isArray(flow['steps']) ? flow['steps'] : [];
+      for (const step of steps) {
+        if (!isRecord(step)) continue;
+        const stepId = optionalString(step['id']);
+        if (!stepId || out.has(stepId)) continue;
+        out.set(stepId, processId);
+      }
+      continue;
+    }
+    if (doc['notation'] === 'step') {
+      const stepId = optionalString(doc['id']);
+      const processId = optionalString(doc['process']);
+      if (!stepId || !processId || !isProcessColumnId(processId)) continue;
+      if (!out.has(stepId)) out.set(stepId, processId);
+    }
+  }
+  return out;
+}
+
+/**
+ * Display copy for one column. PROCESS- columns ignore any restated view
+ * fields; missing catalogue falls back to the id (header) and empty
+ * goal/result. STAGE- columns keep authored name/goal/result.
+ */
+export function resolveColumnDisplay(
+  stage: Stage,
+  catalog?: ReadonlyMap<string, ProcessColumnRecord>,
+): { name: string; goal: string; result: string } {
+  const id = typeof stage.id === 'string' ? stage.id.trim() : '';
+  if (isProcessColumnId(id)) {
+    const rec = catalog?.get(id);
+    return {
+      name: rec?.name ?? id,
+      goal: rec?.goal ?? '',
+      result: rec?.result ?? '',
+    };
+  }
+  return {
+    name: typeof stage.name === 'string' ? stage.name : '',
+    goal: typeof stage.goal === 'string' ? stage.goal : '',
+    result: typeof stage.result === 'string' ? stage.result : '',
+  };
+}
+
+/**
+ * Column indexes a `realised_via` token pins on this blueprint.
+ *
+ * `STAGE-…` is never a join key (ASSERT-004). A `PROCESS-…` token pins that
+ * column. A STEP whose home process is a column pins that column.
+ */
+export function columnIndexesForRealisedVia(
+  ref: string,
+  stageIndexById: ReadonlyMap<string, number>,
+  stepHomeProcess?: ReadonlyMap<string, string>,
+): number[] {
+  const token = ref.trim();
+  if (token.length === 0) return [];
+  if (isStageColumnId(token)) return [];
+  const direct = stageIndexById.get(token);
+  if (direct !== undefined && isProcessColumnId(token)) return [direct];
+  const home = stepHomeProcess?.get(token);
+  if (home && isProcessColumnId(home)) {
+    const idx = stageIndexById.get(home);
+    if (idx !== undefined) return [idx];
+  }
+  return [];
+}

--- a/packages/diagrams/src/process-blueprint/types.ts
+++ b/packages/diagrams/src/process-blueprint/types.ts
@@ -33,8 +33,9 @@ export interface ComplianceLaneAssertion {
   /** Compliance realisation status. */
   status: 'compliant' | 'partial' | 'non_compliant' | 'under_review' | 'pending_owner' | 'n_a';
   /**
-   * Typed IDs of stages / process steps where the requirement is realised.
-   * When empty/absent, the assertion covers the entire subject, not a specific stage.
+   * Typed IDs of processes or steps where the requirement is realised.
+   * Sketch `STAGE-…` ids are not a join key. When empty/absent, the assertion
+   * covers the entire subject, not a specific column.
    */
   realised_via?: string[];
 }
@@ -100,9 +101,12 @@ export interface ComplianceRow {
 
 export interface Stage {
   id: string;
-  name: string;
-  goal: string;
-  result: string;
+  /** Required on `STAGE-…` sketch columns (`BP-005`); omitted on `PROCESS-…`. */
+  name?: string;
+  /** Required on `STAGE-…` sketch columns (`BP-005`); omitted on `PROCESS-…`. */
+  goal?: string;
+  /** Required on `STAGE-…` sketch columns (`BP-005`); omitted on `PROCESS-…`. */
+  result?: string;
   description?: string;
 }
 
@@ -204,6 +208,16 @@ export interface ProcessBlueprintLayoutOptions {
    * When absent, all stages are shown.
    */
   visibleStages?: string[];
+  /**
+   * Catalogue of `PROCESS-…` column records (id → name / optional goal / result).
+   * Required to header catalogued columns; ignored for `STAGE-…` sketches.
+   */
+  processCatalog?: ReadonlyMap<string, { name: string; goal?: string; result?: string }>;
+  /**
+   * STEP id → home PROCESS id (contained in `PROCESS.flow` or promoted).
+   * Used by the compliance-lane join; omit to skip STEP-level pins.
+   */
+  stepHomeProcess?: ReadonlyMap<string, string>;
 }
 
 import type { LayoutBounds } from '../geometry.js';

--- a/scripts/sync-examples-from-methodology.mjs
+++ b/scripts/sync-examples-from-methodology.mjs
@@ -5,8 +5,8 @@
  * example YAMLs used by the spec, by the extension's example folder,
  * and by the conformance tests in packages/diagrams/src/<notation>/__tests__/.
  *
- * Default behaviour is a dry run that prints the diff between
- * <methodology>/notations/examples/ and <studio>/examples/. Pass
+ * Source scope: every *.transitrix.yaml under <methodology>/notations/examples/,
+ * plus companion PROCESS / relation YAML under relations/process-parent/.
  * --apply to copy added/changed files. Pass --apply --delete-stale to
  * also remove files in <studio>/examples/ that have no counterpart in
  * methodology — a strict mirror.
@@ -93,6 +93,17 @@ function relForward(from, full) {
   return path.relative(from, full).replace(/\\/g, '/');
 }
 
+function isSyncableExample(p) {
+  const n = p.replace(/\\/g, '/');
+  if (p.endsWith('.transitrix.yaml')) return true;
+  // Companion PROCESS / relation YAML for the process-parent worked example —
+  // those files are not views, so they miss the *.transitrix.yaml filter.
+  if (n.includes('/relations/process-parent/') && p.endsWith('.yaml')) {
+    return true;
+  }
+  return false;
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const methodologyRoot = path.resolve(
@@ -109,12 +120,11 @@ async function main() {
     process.exit(2);
   }
 
-  // Source scope: every *.transitrix.yaml under <methodology>/notations/examples/
-  const srcFiles = await walk(srcRoot, (p) => p.endsWith('.transitrix.yaml'));
-  // Destination scope: every *.transitrix.yaml under <studio>/examples/.
-  // (The short `.bpmn.yaml` legacy was retired from Studio in the BPMN
-  // extension migration; no legacy form is scanned here.)
-  const dstFiles = await walk(dstRoot, (p) => p.endsWith('.transitrix.yaml'));
+  // Source scope: every *.transitrix.yaml under <methodology>/notations/examples/,
+  // plus the process-parent companion canon (PROCESS / relation YAML).
+  const srcFiles = await walk(srcRoot, isSyncableExample);
+  // Destination scope: the same predicate under the Studio notation corpus.
+  const dstFiles = await walk(dstRoot, isSyncableExample);
 
   const srcRel = new Set(srcFiles.map((p) => relForward(srcRoot, p)));
   const dstRel = new Set(dstFiles.map((p) => relForward(dstRoot, p)));

--- a/tests/fixtures/notation-corpus/README.md
+++ b/tests/fixtures/notation-corpus/README.md
@@ -14,6 +14,7 @@ One subfolder per diagram format. Open any `*.transitrix.yaml` file in VS Code w
 | [`capability-map/`](capability-map/) | `*.capability-map.transitrix.yaml` | Capability map | Capability hierarchies with maturity overlay |
 | [`process-map/`](process-map/) | `*.process-map.transitrix.yaml` | Process map | Top-level process catalogues |
 | [`process-blueprint/`](process-blueprint/) | `*.process-blueprint.transitrix.yaml` | Process Blueprint | Wide value-chain blueprint with stage aspects |
+| [`relations/process-parent/`](relations/process-parent/) | `*.process-blueprint.transitrix.yaml` plus companion PROCESS / relation YAML | Process Blueprint (catalogued columns) | Fulfilment-chain blueprint whose columns are child `PROCESS` elements |
 | [`scenarios/`](scenarios/) | `*.scenarios.transitrix.yaml` | Scenarios | Alternative strategic development paths |
 | [`products/`](products/) | `*.products.transitrix.yaml` | Products catalogue | Portfolio of digital products, services, platforms, and bundles |
 | [`product/`](product/) | `*.product.transitrix.yaml` | Product view | Filtered views over Product elements |

--- a/tests/fixtures/notation-corpus/process-blueprint/README.md
+++ b/tests/fixtures/notation-corpus/process-blueprint/README.md
@@ -6,7 +6,9 @@ File extension: **`.process-blueprint.transitrix.yaml`**
 
 A process blueprint is a wide, single-page diagram that maps each stage of a value chain to its supporting operational context — systems, actors, equipment, and information entities — together with the stage's goal and result. Stages are laid out left to right; each stage is a column, and the aspect categories are fixed rows that align horizontally across columns.
 
-The data shape is **flat**: a single `process_blueprint:` root with parallel arrays for `stages[]` and the four aspect categories. Each aspect entry carries a `stages: [STAGE-…]` cross-reference listing every stage it appears in. The nested-box visual is derived from this flat shape by the renderer — entries spanning consecutive stages render as a single pill; entries on non-consecutive stages render as one pill per stage.
+The data shape is **flat**: a single `process_blueprint:` root with parallel arrays for `stages[]` and the four aspect categories. Each aspect entry carries a `stages: […]` cross-reference listing every column it appears in — a document-local `STAGE-…` sketch or an admitted `PROCESS-…`. The nested-box visual is derived from this flat shape by the renderer — entries spanning consecutive columns render as a single pill; entries on non-consecutive columns render as one pill per column.
+
+A catalogued-column worked example (columns are child `PROCESS` elements; headers and goal/result come from those elements) lives at [`../relations/process-parent/`](../relations/process-parent/).
 
 ## Files in this folder
 
@@ -28,11 +30,9 @@ notation: process-blueprint
 |---|---|
 | `process_blueprint.id` | Pattern `PROCESS_BLUEPRINT-[<middle>-]<INTEGER>` |
 | `process_blueprint.name` | Display name |
-| `process_blueprint.stages` | Non-empty array of stage entries |
-| `stages[].id` | Pattern `STAGE-[<middle>-]<INTEGER>`; unique within the document |
-| `stages[].name` | Stage name |
-| `stages[].goal` | What the stage should achieve, one short sentence |
-| `stages[].result` | The deliverable that exits the stage, one short sentence |
+| `process_blueprint.stages` | Non-empty array of column entries |
+| `stages[].id` | `STAGE-[<middle>-]<INTEGER>` (sketch) or `PROCESS-[<middle>-]<INTEGER>` (catalogued); unique within the document |
+| `stages[].name` / `goal` / `result` | Required on `STAGE-…` columns. Omit on `PROCESS-…` columns — the preview derives them from the child PROCESS element |
 
 ## Optional fields
 
@@ -45,11 +45,11 @@ notation: process-blueprint
 | `process_blueprint.equipment[]` | Physical instruments — free-form labels in v0.1 |
 | `process_blueprint.information_entities[]` | Data, documents, records — free-form labels in v0.1 |
 
-Every aspect entry has `name` and `stages: [STAGE-…]` (non-empty). An entry's `id` is optional; when present it must match the canonical grammar `<TYPE>-[<middle>-]<INTEGER>`.
+Every aspect entry has `name` and `stages: […]` (non-empty). An entry's `id` is optional; when present it must match the canonical grammar `<TYPE>-[<middle>-]<INTEGER>`.
 
 ## Preview
 
-Open any `.process-blueprint.transitrix.yaml` file in VS Code with Transitrix Studio installed — the preview panel opens automatically showing the value chain as a horizontal grid: stages across the top, goal/result rows above the fixed aspect rows (systems → actors → equipment → information). Entries spanning consecutive stages render as a single pill; entries on non-consecutive stages render as one pill per stage.
+Open any `.process-blueprint.transitrix.yaml` file in VS Code with Transitrix Studio installed — the preview panel opens automatically showing the value chain as a horizontal grid: columns across the top, goal/result rows above the fixed aspect rows (systems → actors → equipment → information). Entries spanning consecutive columns render as a single pill; entries on non-consecutive columns render as one pill per column. A `PROCESS-…` column reads its header and goal/result from the matching PROCESS element under a neighbouring or ancestor `canon/elements/` tree.
 
 ## Canonical reference
 

--- a/tests/fixtures/notation-corpus/relations/process-parent/README.md
+++ b/tests/fixtures/notation-corpus/relations/process-parent/README.md
@@ -1,0 +1,7 @@
+# Catalogued Process Blueprint columns
+
+Order fulfilment as a value chain: receive, pick, and ship are child `PROCESS` elements, not document-local `STAGE-…` sketches. The blueprint lists those processes as columns; `name`, `goal`, and `result` come from the PROCESS files under `canon/elements/`, not from restated view fields.
+
+Composition is the `process_parent` relation (`PROCESS` → `PROCESS`). Column order is the `stages[]` array, not the relation.
+
+The `STAGE-` only sketch remains at [`../../process-blueprint/order-fulfilment.process-blueprint.transitrix.yaml`](../../process-blueprint/order-fulfilment.process-blueprint.transitrix.yaml).

--- a/tests/fixtures/notation-corpus/relations/process-parent/canon/elements/02_business/processes/PROCESS-FULFIL-CHAIN-1.yaml
+++ b/tests/fixtures/notation-corpus/relations/process-parent/canon/elements/02_business/processes/PROCESS-FULFIL-CHAIN-1.yaml
@@ -1,0 +1,22 @@
+notation: process
+id: PROCESS-FULFIL-CHAIN-1
+name: Order fulfilment
+
+goal: "Fulfil a customer order from receipt to confirmed delivery."
+result: "Closed order with captured payment and a delivered shipment."
+
+zone: canon
+example: true
+admitted_at: "2026-08-25"
+admitted_by: "example"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2026-01-01"
+valid_to: null
+
+description: >
+  The enclosing value chain. Its phases are child processes linked by
+  process_parent, not document-local STAGE ids.

--- a/tests/fixtures/notation-corpus/relations/process-parent/canon/elements/02_business/processes/PROCESS-FULFIL-PICK-1.yaml
+++ b/tests/fixtures/notation-corpus/relations/process-parent/canon/elements/02_business/processes/PROCESS-FULFIL-PICK-1.yaml
@@ -1,0 +1,21 @@
+notation: process
+id: PROCESS-FULFIL-PICK-1
+name: Pick and pack
+
+goal: "Assemble the physical order from reserved inventory."
+result: "Packed shipment ready for carrier handover."
+
+zone: canon
+example: true
+admitted_at: "2026-08-25"
+admitted_by: "example"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2026-01-01"
+valid_to: null
+
+description: >
+  Warehouse phase of the fulfilment chain.

--- a/tests/fixtures/notation-corpus/relations/process-parent/canon/elements/02_business/processes/PROCESS-FULFIL-RECEIVE-1.yaml
+++ b/tests/fixtures/notation-corpus/relations/process-parent/canon/elements/02_business/processes/PROCESS-FULFIL-RECEIVE-1.yaml
@@ -1,0 +1,22 @@
+notation: process
+id: PROCESS-FULFIL-RECEIVE-1
+name: Receive order
+
+goal: "Capture a validated customer order."
+result: "Validated order record in OMS."
+
+zone: canon
+example: true
+admitted_at: "2026-08-25"
+admitted_by: "example"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2026-01-01"
+valid_to: null
+
+description: >
+  First phase of the fulfilment chain. The blueprint column id is this
+  process; name, goal, and result are not restated on the view.

--- a/tests/fixtures/notation-corpus/relations/process-parent/canon/elements/02_business/processes/PROCESS-FULFIL-SHIP-1.yaml
+++ b/tests/fixtures/notation-corpus/relations/process-parent/canon/elements/02_business/processes/PROCESS-FULFIL-SHIP-1.yaml
@@ -1,0 +1,21 @@
+notation: process
+id: PROCESS-FULFIL-SHIP-1
+name: Ship
+
+goal: "Hand the shipment to the carrier and notify the customer."
+result: "In-transit shipment with tracking number sent to the customer."
+
+zone: canon
+example: true
+admitted_at: "2026-08-25"
+admitted_by: "example"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2026-01-01"
+valid_to: null
+
+description: >
+  Carrier-handover phase of the fulfilment chain.

--- a/tests/fixtures/notation-corpus/relations/process-parent/canon/relations/REL-FULFIL-PICK-PROCESS-PARENT-1.yaml
+++ b/tests/fixtures/notation-corpus/relations/process-parent/canon/relations/REL-FULFIL-PICK-PROCESS-PARENT-1.yaml
@@ -1,0 +1,17 @@
+notation: relation
+id: REL-FULFIL-PICK-PROCESS-PARENT-1
+type: process_parent
+from: PROCESS-FULFIL-PICK-1
+to: PROCESS-FULFIL-CHAIN-1
+
+zone: canon
+example: true
+admitted_at: "2026-08-25"
+admitted_by: "example"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2026-01-01"
+valid_to: null

--- a/tests/fixtures/notation-corpus/relations/process-parent/canon/relations/REL-FULFIL-RECEIVE-PROCESS-PARENT-1.yaml
+++ b/tests/fixtures/notation-corpus/relations/process-parent/canon/relations/REL-FULFIL-RECEIVE-PROCESS-PARENT-1.yaml
@@ -1,0 +1,17 @@
+notation: relation
+id: REL-FULFIL-RECEIVE-PROCESS-PARENT-1
+type: process_parent
+from: PROCESS-FULFIL-RECEIVE-1
+to: PROCESS-FULFIL-CHAIN-1
+
+zone: canon
+example: true
+admitted_at: "2026-08-25"
+admitted_by: "example"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2026-01-01"
+valid_to: null

--- a/tests/fixtures/notation-corpus/relations/process-parent/canon/relations/REL-FULFIL-SHIP-PROCESS-PARENT-1.yaml
+++ b/tests/fixtures/notation-corpus/relations/process-parent/canon/relations/REL-FULFIL-SHIP-PROCESS-PARENT-1.yaml
@@ -1,0 +1,17 @@
+notation: relation
+id: REL-FULFIL-SHIP-PROCESS-PARENT-1
+type: process_parent
+from: PROCESS-FULFIL-SHIP-1
+to: PROCESS-FULFIL-CHAIN-1
+
+zone: canon
+example: true
+admitted_at: "2026-08-25"
+admitted_by: "example"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2026-01-01"
+valid_to: null

--- a/tests/fixtures/notation-corpus/relations/process-parent/fulfilment-chain.process-blueprint.transitrix.yaml
+++ b/tests/fixtures/notation-corpus/relations/process-parent/fulfilment-chain.process-blueprint.transitrix.yaml
@@ -1,0 +1,35 @@
+notation: process-blueprint
+spec_version: "0.1"
+name: "Order fulfilment — catalogued phases"
+generated_at: "2026-08-25"
+
+process_blueprint:
+  id: PROCESS_BLUEPRINT-FULFIL-CHAIN-1
+  name: "Order fulfilment — catalogued phases"
+  description: >
+    The same value chain as the STAGE-only sketch, with columns naming
+    admitted child processes. name, goal, and result are derived from
+    those PROCESS elements, not restated here.
+  period: "2026"
+  version: "0.1"
+  author: "Valerii Korobeinikov"
+  process: PROCESS-FULFIL-CHAIN-1
+
+  stages:
+    - id: PROCESS-FULFIL-RECEIVE-1
+    - id: PROCESS-FULFIL-PICK-1
+    - id: PROCESS-FULFIL-SHIP-1
+
+  systems:
+    - name: "Order Management System"
+      stages: [PROCESS-FULFIL-RECEIVE-1, PROCESS-FULFIL-PICK-1]
+    - name: "Warehouse Management System"
+      stages: [PROCESS-FULFIL-PICK-1]
+    - name: "Transportation Management System"
+      stages: [PROCESS-FULFIL-SHIP-1]
+
+  actors:
+    - name: "Customer service representative"
+      stages: [PROCESS-FULFIL-RECEIVE-1]
+    - name: "Warehouse operator"
+      stages: [PROCESS-FULFIL-PICK-1, PROCESS-FULFIL-SHIP-1]

--- a/tests/fixtures/notation-corpus/relations/process-parent/transitrix.yaml
+++ b/tests/fixtures/notation-corpus/relations/process-parent/transitrix.yaml
@@ -1,0 +1,8 @@
+# Worked example — notations/examples/relations/process-parent/README.md.
+# Its own catalogue root (MANIFEST.md §4): declares the boundary the
+# uniqueness scope in IDS_AND_REFERENCES.md §4 resolves against.
+transitrix: 1
+methodology_version: "3.7.0"
+notations: [relation, process-blueprint]
+zones: [canon]
+coverage_profile: core


### PR DESCRIPTION
## Summary

- Process Blueprint `PROCESS-` columns take their header and goal/result from the child PROCESS element (`name`; optional `goal` / `result`). Sketch `STAGE-` columns keep authored view fields.
- The compliance lane (and the impact-matrix join at product-stage grain) pins an assertion when `realised_via` names that process or a STEP whose home is that process. Sketch `STAGE-` ids are not a join key.
- Synced the catalogued-column worked example into `tests/fixtures/notation-corpus/relations/process-parent/`. The STAGE-only order-fulfilment blueprint still validates and renders.

Closes the render half of epic THQ-313 (task THQ-315). Validators landed in #563.

## Test plan

- [x] `packages/diagrams` tests (layout, compliance lane, resolve-columns, impact join) — 1742 passed
- [x] `npm run compile`
- [x] STAGE-only `order-fulfilment.process-blueprint.transitrix.yaml` still lays out authored headers
- [x] Catalogued `fulfilment-chain.process-blueprint.transitrix.yaml` headers/goal/result come from PROCESS elements
- [ ] Open the catalogued fixture in the VS Code preview and confirm three columns, aspect pills, and no STAGE- join
