### PR TITLE
feat(compliance): add repository-wide requirement-verification matrix view

### DIFF
--- a/changelog/fragments/requirement-verification-matrix-b0c530f0.md
+++ b/changelog/fragments/requirement-verification-matrix-b0c530f0.md
@@ -1,0 +1,3 @@
+### Added
+
+- **Requirement–Verification Matrix in the editor.** A Command Palette command opens a repository-wide table of every requirement with its direct parent, related test result, and recorded outcome — including an explicit coverage gap when there is no result (`REQ-VERIF-COVERAGE-001`) or only an unresolved one (`REQ-VERIF-COVERAGE-002`). Saving a requirement or verification file refreshes an open table. Export CSV writes the same rows, in the same order, as the view.

--- a/extension/README.md
+++ b/extension/README.md
@@ -35,6 +35,7 @@ Transitrix flips that:
 | Compliance | **Compliance matrix** | Products × requirements coverage view |
 | Compliance | **Coverage metric** | Law coverage stats with RAG status |
 | Compliance | **Gap dashboard** | Open gaps: unasserted requirements, stale assertions |
+| Compliance | **Requirement–verification matrix** | Repository-wide requirement rows with related test results and coverage gaps |
 
 Every preview ships with a toolbar: title toggle, discrete zoom (50–200%), save as SVG, save as PNG (2× for crisp output), and copy PNG to clipboard (Windows today; macOS / Linux planned).
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -73,6 +73,7 @@
     "workspaceContains:**/ASSERTION-*.yaml",
     "workspaceContains:**/REQUIREMENT-*.yaml",
     "workspaceContains:**/CONSTRAINT-*.yaml",
+    "workspaceContains:**/VERIFICATION-*.yaml",
     "workspaceContains:**/*.puml",
     "workspaceContains:**/*.plantuml",
     "workspaceContains:**/*.ttrs"
@@ -817,6 +818,24 @@
       {
         "command": "transitrixStudio.exportGapDashboardCsv",
         "title": "Transitrix: Export compliance gaps as CSV",
+        "category": "Transitrix",
+        "icon": "$(export)"
+      },
+      {
+        "command": "transitrixStudio.previewRequirementVerificationMatrix",
+        "title": "Transitrix: Preview requirement–verification matrix",
+        "category": "Transitrix",
+        "icon": "$(graph)"
+      },
+      {
+        "command": "transitrixStudio.refreshRequirementVerificationMatrix",
+        "title": "Transitrix: Refresh requirement–verification matrix",
+        "category": "Transitrix",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "transitrixStudio.exportRequirementVerificationMatrixCsv",
+        "title": "Transitrix: Export requirement–verification matrix as CSV",
         "category": "Transitrix",
         "icon": "$(export)"
       },

--- a/extension/src/compliance-render.ts
+++ b/extension/src/compliance-render.ts
@@ -96,8 +96,9 @@ const COMPLIANCE_CSS = `
 
 /* List (single-product) */
 .cmp-list { border-collapse: collapse; font-size: 12px; width: 100%; max-width: 760px; }
-.cmp-list th, .cmp-list td { border: 1px solid var(--ts-border, #cbd5e1); padding: 6px 12px; text-align: left; }
+.cmp-list th, .cmp-list td { border: 1px solid var(--ts-border, #cbd5e1); padding: 6px 12px; text-align: left; vertical-align: top; }
 .cmp-list th { background: var(--ts-bg-subtle, #f1f5f9); color: var(--ts-text, #0f172a); }
+.cmp-matrix { max-width: 1100px; }
 .cmp-empty { color: var(--ts-text-muted, #64748b); padding: 24px 0; max-width: 640px; }
 
 /* Deadline pill (CV-4) */

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -23,6 +23,7 @@ import { SingleLawPreview } from './single-law-preview.js';
 import { SingleProductPreview } from './single-product-preview.js';
 import { RequirementTracePreview } from './requirement-trace-preview.js';
 import { GapDashboardPreview } from './gap-dashboard-preview.js';
+import { RequirementVerificationMatrixPreview } from './requirement-verification-matrix-preview.js';
 import { CoverageMetricPreview } from './coverage-metric-preview.js';
 import { PlantUMLPreview, isPumlFile } from './plantuml-preview.js';
 import { TtrsPreview, isTtrsFile } from './ttrs-preview.js';
@@ -263,6 +264,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void |
   const singleProductPreview = new SingleProductPreview(context.extensionUri);
   const requirementTracePreview = new RequirementTracePreview(context.extensionUri);
   const gapDashboardPreview = new GapDashboardPreview(context.extensionUri);
+  const requirementVerificationMatrixPreview = new RequirementVerificationMatrixPreview(context.extensionUri);
   const coverageMetricPreview = new CoverageMetricPreview(context.extensionUri);
   const plantumlPreview = new PlantUMLPreview(context.extensionUri);
   const ttrsPreview = new TtrsPreview();
@@ -285,7 +287,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void |
   // Single source of truth for "given this document, which preview handles
   // it" — shared by the unified `transitrix.openPreview` command, the
   // auto-open-on-focus behaviour, and the refresh-on-save cascade. Repo-wide
-  // dashboards (Compliance Matrix, Gap Dashboard) are intentionally absent:
+    // dashboards (Compliance Matrix, Gap Dashboard, Requirement–Verification
+    // Matrix) are intentionally absent: they aren't bound to a specific open
   // they aren't bound to a specific open file, so they keep their own
   // palette-only commands outside this dispatch.
   function resolveNotationPreview(doc: vscode.TextDocument): ResolvedPreview | undefined {
@@ -383,7 +386,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void |
   //     BPMN PNG export; `exportSvg`/`exportBpmn` are still placeholders.
   //   • `transitrixStudio.*` — the broader Studio surface (per-notation
   //     Save/Copy-as-PNG/SVG/refresh commands, plus the repo-wide Compliance
-  //     Matrix and Gap Dashboard, which stay outside the unified Preview
+  //     Matrix, Gap Dashboard, and Requirement–Verification Matrix, which stay outside the unified Preview
   //     command since they aren't bound to a specific open file).
   context.subscriptions.push(
     vscode.commands.registerTextEditorCommand('transitrix.openPreview', openPreviewHandler),
@@ -463,6 +466,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void |
     vscode.commands.registerCommand('transitrixStudio.previewGapDashboard', () => gapDashboardPreview.showOrReveal()),
     vscode.commands.registerCommand('transitrixStudio.refreshGapDashboard', () => gapDashboardPreview.refresh()),
     vscode.commands.registerCommand('transitrixStudio.exportGapDashboardCsv', () => gapDashboardPreview.exportCsv()),
+    vscode.commands.registerCommand('transitrixStudio.previewRequirementVerificationMatrix', () => requirementVerificationMatrixPreview.showOrReveal()),
+    vscode.commands.registerCommand('transitrixStudio.refreshRequirementVerificationMatrix', () => requirementVerificationMatrixPreview.refresh()),
+    vscode.commands.registerCommand('transitrixStudio.exportRequirementVerificationMatrixCsv', () => requirementVerificationMatrixPreview.exportCsv()),
     // Coverage-metric view (strategy#185) — file-driven, opens beside the YAML.
     vscode.commands.registerCommand('transitrixStudio.refreshCoverageMetric', async () => {
       const doc = vscode.window.activeTextEditor?.document;
@@ -540,6 +546,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void |
         void singleProductPreview.refresh();
         void requirementTracePreview.refresh();
         void gapDashboardPreview.refresh();
+        void requirementVerificationMatrixPreview.refresh();
         void coverageMetricPreview.refreshConfig();
       }
     }),
@@ -563,6 +570,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void |
         void singleProductPreview.refresh();
         void requirementTracePreview.refresh();
         void gapDashboardPreview.refresh();
+      }
+      if (/^(REQUIREMENT|VERIFICATION)-.*\.ya?ml$/.test(path.basename(doc.fileName))) {
+        void requirementVerificationMatrixPreview.refresh();
       }
       void resolveNotationPreview(doc)?.refresh();
     }),

--- a/extension/src/requirement-verification-matrix-preview.ts
+++ b/extension/src/requirement-verification-matrix-preview.ts
@@ -1,0 +1,176 @@
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+import { type ThemeId } from '@transitrix/diagrams/theme';
+import { buildComplianceIndex } from '@transitrix/diagrams/compliance';
+import {
+  buildRequirementVerificationMatrix,
+  renderRequirementVerificationMatrixCsv,
+  type RequirementVerificationMatrix,
+  type RequirementVerificationRow,
+} from '@transitrix/diagrams/compliance-verification-matrix';
+import { scanComplianceCanon } from './compliance-scan.js';
+import {
+  complianceShell,
+  escXml,
+  openLink,
+  outcomeBadge,
+} from './compliance-render.js';
+
+const OPEN_FILE_COMMAND = 'transitrixStudio.openComplianceFile';
+const REFRESH_COMMAND = 'transitrixStudio.refreshRequirementVerificationMatrix';
+const EXPORT_CSV_COMMAND = 'transitrixStudio.exportRequirementVerificationMatrixCsv';
+
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function requirementCell(row: RequirementVerificationRow, pathById: Map<string, string>): string {
+  const name = openLink(OPEN_FILE_COMMAND, pathById.get(row.requirementId), escXml(row.requirementLabel), `Open ${row.requirementId}`);
+  return `${name}<div class="cmp-req-id">${escXml(row.requirementId)}</div>`;
+}
+
+function parentCell(row: RequirementVerificationRow, pathById: Map<string, string>): string {
+  if (!row.parentId) return '—';
+  if (row.parentLabel) {
+    const name = openLink(OPEN_FILE_COMMAND, pathById.get(row.parentId), escXml(row.parentLabel), `Open ${row.parentId}`);
+    return `${name}<div class="cmp-req-id">${escXml(row.parentId)}</div>`;
+  }
+  return `<span class="cmp-gap" title="Parent id does not resolve to an admitted requirement">${escXml(row.parentId)}</span>`;
+}
+
+function testResultCell(row: RequirementVerificationRow, pathById: Map<string, string>): string {
+  if (!row.verificationId) return '—';
+  const label = row.verificationLabel ?? row.verificationId;
+  const name = openLink(OPEN_FILE_COMMAND, pathById.get(row.verificationId), escXml(label), `Open ${row.verificationId}`);
+  return `${name}<div class="cmp-req-id">${escXml(row.verificationId)}</div>`;
+}
+
+function outcomeCell(row: RequirementVerificationRow): string {
+  const parts: string[] = [];
+  if (row.verificationOutcome) parts.push(outcomeBadge(row.verificationOutcome));
+  if (row.coverageGap) parts.push(`<span class="cmp-gap">${escXml(row.coverageGap)}</span>`);
+  return parts.length > 0 ? parts.join(' ') : '—';
+}
+
+export class RequirementVerificationMatrixPreview {
+  readonly panelTitle = 'Requirement–Verification Matrix';
+  private panel: vscode.WebviewPanel | undefined;
+  private lastMatrix: RequirementVerificationMatrix | undefined;
+  private lastCsv = '';
+  private pathById = new Map<string, string>();
+
+  constructor(private readonly extensionUri: vscode.Uri) {}
+
+  async showOrReveal(): Promise<void> {
+    if (!this.panel) {
+      this.panel = vscode.window.createWebviewPanel(
+        'requirementVerificationMatrixPreview',
+        this.panelTitle,
+        { viewColumn: vscode.ViewColumn.Active, preserveFocus: false },
+        {
+          enableScripts: false,
+          retainContextWhenHidden: true,
+          enableCommandUris: [OPEN_FILE_COMMAND, REFRESH_COMMAND, EXPORT_CSV_COMMAND, 'transitrixStudio.changeTheme'],
+        },
+      );
+      this.panel.onDidDispose(() => {
+        this.panel = undefined;
+        this.lastMatrix = undefined;
+        this.lastCsv = '';
+      });
+    } else {
+      this.panel.reveal(vscode.ViewColumn.Active, false);
+    }
+    await this.refresh();
+  }
+
+  async refresh(): Promise<void> {
+    if (!this.panel) return;
+    const scan = await scanComplianceCanon();
+    this.pathById = scan.pathById;
+    const index = buildComplianceIndex({
+      requirements: scan.requirements,
+      assertions: scan.assertions,
+      verifications: scan.verifications,
+    });
+    this.lastMatrix = buildRequirementVerificationMatrix(index);
+    this.lastCsv = renderRequirementVerificationMatrixCsv(this.lastMatrix);
+
+    const danglingVerifies = scan.verifications
+      .filter(v => !index.requirementById.has(v.verifies))
+      .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+
+    const themeId = vscode.workspace.getConfiguration('transitrix').get<ThemeId>('theme', 'transitrix');
+    if (!this.panel) return;
+    this.panel.webview.html = this.buildHtml(this.lastMatrix, danglingVerifies, themeId);
+  }
+
+  async exportCsv(): Promise<void> {
+    if (!this.lastCsv) {
+      vscode.window.showWarningMessage('Open the requirement–verification matrix first.');
+      return;
+    }
+    const target = await vscode.window.showSaveDialog({
+      defaultUri: vscode.Uri.file('requirement-verification-matrix.csv'),
+      filters: { CSV: ['csv'] },
+    });
+    if (!target) return;
+    await vscode.workspace.fs.writeFile(target, Buffer.from(this.lastCsv, 'utf-8'));
+    vscode.window.showInformationMessage(`Saved: ${path.basename(target.fsPath)}`);
+  }
+
+  private buildHtml(
+    matrix: RequirementVerificationMatrix,
+    danglingVerifies: Array<{ id: string; verifies: string }>,
+    themeId: ThemeId,
+  ): string {
+    const tableRows = matrix.rows.map(row =>
+      `<tr>
+        <td>${requirementCell(row, this.pathById)}</td>
+        <td>${parentCell(row, this.pathById)}</td>
+        <td>${testResultCell(row, this.pathById)}</td>
+        <td>${outcomeCell(row)}</td>
+      </tr>`,
+    ).join('');
+
+    const table = matrix.rows.length === 0
+      ? `<p class="cmp-empty">No requirements found in this workspace.</p>`
+      : `<table class="cmp-list cmp-matrix">
+          <thead>
+            <tr>
+              <th>Requirement</th>
+              <th>Parent</th>
+              <th>Related test result</th>
+              <th>Outcome</th>
+            </tr>
+          </thead>
+          <tbody>${tableRows}</tbody>
+        </table>`;
+
+    const danglingList = danglingVerifies.map(v =>
+      `<li>${openLink(OPEN_FILE_COMMAND, this.pathById.get(v.id), escXml(v.id), `Open ${v.id}`)}<span class="cmp-meta">${escXml(`verifies ${v.verifies}`)}</span></li>`,
+    ).join('');
+    const findings = danglingVerifies.length === 0
+      ? `<div class="cmp-ok">No dangling VERIFICATION.verifies references.</div>`
+      : `<ul class="cmp-rows">${danglingList}</ul>`;
+
+    const body = `
+      ${table}
+      <div class="cmp-section">
+        <h2>Unresolved verifies <span class="cmp-count">(${danglingVerifies.length})</span></h2>
+        ${findings}
+      </div>`;
+
+    return complianceShell({
+      notation: 'Requirement–verification matrix',
+      title: 'Requirement–Verification Matrix',
+      subtitle: `${matrix.summary.requirements} requirement(s) · ${matrix.summary.verifications} result(s) · ${matrix.summary.gaps} coverage gap(s)`,
+      date: todayIso(),
+      themeId,
+      refreshCommand: REFRESH_COMMAND,
+      themeCommand: 'transitrixStudio.changeTheme',
+      extraButtons: [{ command: EXPORT_CSV_COMMAND, label: 'Export CSV', title: 'Save the matrix as a CSV file' }],
+      bodyHtml: body,
+    });
+  }
+}

--- a/extension/test-e2e/suite/preview-surfaces.test.ts
+++ b/extension/test-e2e/suite/preview-surfaces.test.ts
@@ -183,8 +183,12 @@ describe('preview surfaces render real content (transitrix-hq#143)', function ()
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tx-rvm-'));
     const a = path.join(dir, 'a.csv');
     const b = path.join(dir, 'b.csv');
-    await withSaveDialogTarget(a, () => vscode.commands.executeCommand('transitrixStudio.exportRequirementVerificationMatrixCsv'));
-    await withSaveDialogTarget(b, () => vscode.commands.executeCommand('transitrixStudio.exportRequirementVerificationMatrixCsv'));
+    await withSaveDialogTarget(a, async () => {
+      await vscode.commands.executeCommand('transitrixStudio.exportRequirementVerificationMatrixCsv');
+    });
+    await withSaveDialogTarget(b, async () => {
+      await vscode.commands.executeCommand('transitrixStudio.exportRequirementVerificationMatrixCsv');
+    });
     const bytesA = fs.readFileSync(a);
     const bytesB = fs.readFileSync(b);
     assert.deepStrictEqual(bytesA, bytesB, 'two exports from unchanged state must be byte-identical');

--- a/extension/test-e2e/suite/preview-surfaces.test.ts
+++ b/extension/test-e2e/suite/preview-surfaces.test.ts
@@ -16,6 +16,9 @@
  *    just waits for `webview.html`/message traffic to go quiet.
  */
 import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import * as vscode from 'vscode';
 import {
   captureWebviewPanels,
@@ -23,6 +26,7 @@ import {
   openFixture,
   closeAllEditors,
   ensureExtensionActivated,
+  withSaveDialogTarget,
 } from '../helpers';
 
 const SHELL_LENGTH_FLOOR = 800;
@@ -157,5 +161,37 @@ describe('preview surfaces render real content (transitrix-hq#143)', function ()
     assert.ok(panels.length >= 1, 'expected the gap dashboard panel to open');
     const html = await waitForStableHtml(panels[panels.length - 1]);
     assert.ok(html.length > SHELL_LENGTH_FLOOR, `gap dashboard: webview HTML (${html.length} chars) looks unrendered`);
+  });
+
+  it('renders: requirement–verification matrix (repo-wide, command-triggered)', async () => {
+    const { panels } = await captureWebviewPanels(async () => {
+      await vscode.commands.executeCommand('transitrixStudio.previewRequirementVerificationMatrix');
+    });
+    assert.ok(panels.length >= 1, 'expected the requirement–verification matrix panel to open');
+    const html = await waitForStableHtml(panels[panels.length - 1]);
+    assert.ok(html.length > SHELL_LENGTH_FLOOR, `requirement–verification matrix: webview HTML (${html.length} chars) looks unrendered`);
+    assert.match(html, /REQUIREMENT-MATRIX-PASS-1/, 'passing requirement from the worked fixture');
+    assert.match(html, /REQUIREMENT-MATRIX-NONE-1/, 'no-verification requirement from the worked fixture');
+    assert.match(html, /REQ-VERIF-COVERAGE-001/, 'explicit no-result gap');
+    assert.match(html, /REQ-VERIF-COVERAGE-002/, 'unresolved-verification gap');
+    assert.match(html, /REQUIREMENT-MATRIX-BROKENPARENT-1/, 'broken parent remains visible');
+    assert.match(html, /REQUIREMENT-MATRIX-DOES-NOT-EXIST-1/, 'dangling parent id shown as a finding');
+    assert.match(html, /VERIFICATION-MATRIX-DANGLING-1/, 'dangling verifies remains visible as a finding');
+    assert.match(html, /REQUIREMENT-MATRIX-MULTI-1/, 'requirement with multiple verifications');
+    assert.match(html, /REQUIREMENT-MATRIX-CHILD-1/, 'child with resolvable parent');
+
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tx-rvm-'));
+    const a = path.join(dir, 'a.csv');
+    const b = path.join(dir, 'b.csv');
+    await withSaveDialogTarget(a, () => vscode.commands.executeCommand('transitrixStudio.exportRequirementVerificationMatrixCsv'));
+    await withSaveDialogTarget(b, () => vscode.commands.executeCommand('transitrixStudio.exportRequirementVerificationMatrixCsv'));
+    const bytesA = fs.readFileSync(a);
+    const bytesB = fs.readFileSync(b);
+    assert.deepStrictEqual(bytesA, bytesB, 'two exports from unchanged state must be byte-identical');
+    const text = bytesA.toString('utf8');
+    assert.match(text, /REQ-VERIF-COVERAGE-001/);
+    assert.match(text, /REQ-VERIF-COVERAGE-002/);
+    assert.match(text, /REQUIREMENT-MATRIX-PASS-1/);
+    assert.doesNotMatch(text, /VERIFICATION-MATRIX-DANGLING-1/);
   });
 });

--- a/packages/diagrams/src/compliance-verification-matrix/__tests__/csv.test.ts
+++ b/packages/diagrams/src/compliance-verification-matrix/__tests__/csv.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import yaml from 'js-yaml';
+import { buildComplianceIndex } from '../../compliance/reverse-index.js';
+import { emptyCanon, ingestComplianceDoc } from '../../compliance/classify.js';
+import { buildRequirementVerificationMatrix } from '../build.js';
+import { renderRequirementVerificationMatrixCsv } from '../csv.js';
+
+const fixtures = path.resolve(path.dirname(fileURLToPath(import.meta.url)), 'fixtures');
+function loadAll(dir: string): unknown[] {
+  const full = path.join(fixtures, dir);
+  return readdirSync(full)
+    .filter(f => f.endsWith('.yaml'))
+    .map(f => yaml.load(readFileSync(path.join(full, f), 'utf-8')));
+}
+
+describe('renderRequirementVerificationMatrixCsv', () => {
+  const canon = emptyCanon();
+  for (const doc of [...loadAll('requirement'), ...loadAll('verification')]) {
+    ingestComplianceDoc(canon, doc);
+  }
+  const index = buildComplianceIndex({
+    requirements: canon.requirements,
+    assertions: canon.assertions,
+    verifications: canon.verifications,
+  });
+  const matrix = buildRequirementVerificationMatrix(index);
+  const csv = renderRequirementVerificationMatrixCsv(matrix);
+
+  it('is byte-identical across two serialisations of the same matrix', () => {
+    expect(renderRequirementVerificationMatrixCsv(matrix)).toBe(csv);
+  });
+
+  it('preserves the builder row order', () => {
+    const lines = csv.trimEnd().split('\r\n').slice(1);
+    expect(lines).toHaveLength(matrix.rows.length);
+    for (let i = 0; i < matrix.rows.length; i++) {
+      expect(lines[i]).toContain(`"${matrix.rows[i].requirementId}"`);
+      if (matrix.rows[i].verificationId) {
+        expect(lines[i]).toContain(`"${matrix.rows[i].verificationId}"`);
+      }
+    }
+  });
+
+  it('carries coverage gaps as REQ-VERIF-COVERAGE-001/002, not a new verdict', () => {
+    expect(csv).toContain('REQ-VERIF-COVERAGE-001');
+    expect(csv).toContain('REQ-VERIF-COVERAGE-002');
+  });
+
+  it('keeps a dangling parent id in the parent_id column', () => {
+    expect(csv).toContain('REQUIREMENT-MATRIX-DOES-NOT-EXIST-1');
+  });
+
+  it('does not emit a dangling verifies id as a related_test_result row', () => {
+    expect(csv).not.toContain('VERIFICATION-MATRIX-DANGLING-1');
+  });
+});

--- a/packages/diagrams/src/compliance-verification-matrix/csv.ts
+++ b/packages/diagrams/src/compliance-verification-matrix/csv.ts
@@ -1,0 +1,47 @@
+// Deterministic CSV serialiser for the requirement-verification matrix.
+// Same row order as `buildRequirementVerificationMatrix` (requirement id,
+// then verification id). CRLF line endings, RFC-4180 quoting — the same
+// convention as the Gap Dashboard export.
+
+import type { RequirementVerificationMatrix, RequirementVerificationRow } from './types.js';
+
+const HEADER = [
+  'requirement_id',
+  'requirement_label',
+  'parent_id',
+  'parent_label',
+  'related_test_result_id',
+  'related_test_result_label',
+  'outcome',
+  'coverage_gap',
+] as const;
+
+function csvCell(value: string | undefined): string {
+  const v = value ?? '';
+  return `"${v.replace(/"/g, '""')}"`;
+}
+
+function rowCells(row: RequirementVerificationRow): string[] {
+  return [
+    row.requirementId,
+    row.requirementLabel,
+    row.parentId ?? '',
+    row.parentLabel ?? '',
+    row.verificationId ?? '',
+    row.verificationLabel ?? '',
+    row.verificationOutcome ?? '',
+    row.coverageGap ?? '',
+  ];
+}
+
+/**
+ * Serialise the matrix to CSV. Identical input yields byte-identical output;
+ * the row order is the builder's stable order.
+ */
+export function renderRequirementVerificationMatrixCsv(matrix: RequirementVerificationMatrix): string {
+  const lines = [HEADER.map(h => csvCell(h)).join(',')];
+  for (const row of matrix.rows) {
+    lines.push(rowCells(row).map(csvCell).join(','));
+  }
+  return lines.join('\r\n') + '\r\n';
+}

--- a/packages/diagrams/src/compliance-verification-matrix/index.ts
+++ b/packages/diagrams/src/compliance-verification-matrix/index.ts
@@ -1,4 +1,5 @@
 export { buildRequirementVerificationMatrix } from './build.js';
+export { renderRequirementVerificationMatrixCsv } from './csv.js';
 export type {
   RequirementVerificationMatrix,
   RequirementVerificationMatrixOptions,

--- a/tests/fixtures/notation-corpus/README.md
+++ b/tests/fixtures/notation-corpus/README.md
@@ -22,6 +22,7 @@ One subfolder per diagram format. Open any `*.transitrix.yaml` file in VS Code w
 | [`compliance/`](compliance/) | `*.compliance.transitrix.yaml` | Compliance register | Obligation register |
 | [`compliance-c3/`](compliance-c3/) | `*.compliance-c3.transitrix.yaml` | Compliance C3 | C3 compliance view |
 | [`compliance-impact/`](compliance-impact/) | `*.compliance-impact.transitrix.yaml` | Compliance impact | Obligation × subject matrix with status |
+| [`compliance-verification-matrix/`](compliance-verification-matrix/) | `REQUIREMENT-MATRIX-*.yaml` / `VERIFICATION-MATRIX-*.yaml` | Requirement–verification matrix | Worked fixture for the repository-wide traceability table |
 | [`coverage-metric/`](coverage-metric/) | `*.coverage-metric.transitrix.yaml` | Coverage metric | Assertion-coverage breakdown per regime |
 | [`actor/`](actor/) | `*.actor.transitrix.yaml` | Actor register | Actor elements |
 | [`stakeholder/`](stakeholder/) | `*.stakeholder.transitrix.yaml` | Stakeholder register | Stakeholder elements |

--- a/tests/fixtures/notation-corpus/compliance-verification-matrix/README.md
+++ b/tests/fixtures/notation-corpus/compliance-verification-matrix/README.md
@@ -1,0 +1,5 @@
+# Requirement–verification matrix fixtures
+
+Worked example for the repository-wide Requirement–Verification Matrix preview. Each YAML is an admitted `REQUIREMENT` or `VERIFICATION` covering one acceptance case: passing result, unresolved result, multiple results, child with a resolvable parent, no result, broken `parent`, and dangling `verifies`.
+
+Open **Transitrix: Preview requirement–verification matrix** from the Command Palette in a workspace that contains this folder.

--- a/tests/fixtures/notation-corpus/compliance-verification-matrix/requirement/REQUIREMENT-MATRIX-BROKENPARENT-1.yaml
+++ b/tests/fixtures/notation-corpus/compliance-verification-matrix/requirement/REQUIREMENT-MATRIX-BROKENPARENT-1.yaml
@@ -1,0 +1,22 @@
+# Fixture — parent names a REQUIREMENT that is not admitted in this fixture
+# set (dangling; not currently a validator concern per 15-requirement.md
+# §2.4). Must remain visible on the row as a raw id with no resolved label.
+notation: requirement
+id: REQUIREMENT-MATRIX-BROKENPARENT-1
+name: "Matrix fixture — broken parent reference"
+description: >
+  Worked example: `parent` names an id absent from the fixture's requirement
+  set.
+severity: high
+parent: REQUIREMENT-MATRIX-DOES-NOT-EXIST-1
+
+zone: canon
+admitted_at: "2026-08-01"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2026-08-01"
+valid_to: null

--- a/tests/fixtures/notation-corpus/compliance-verification-matrix/requirement/REQUIREMENT-MATRIX-CHILD-1.yaml
+++ b/tests/fixtures/notation-corpus/compliance-verification-matrix/requirement/REQUIREMENT-MATRIX-CHILD-1.yaml
@@ -1,0 +1,20 @@
+# Fixture — a child with a resolvable direct parent.
+notation: requirement
+id: REQUIREMENT-MATRIX-CHILD-1
+name: "Matrix fixture — child of REQUIREMENT-MATRIX-PASS-1"
+description: >
+  Worked example: same-TYPE decomposition (15-requirement.md §2.4) — this
+  requirement's parent resolves to an admitted REQUIREMENT in the fixture.
+severity: medium
+parent: REQUIREMENT-MATRIX-PASS-1
+
+zone: canon
+admitted_at: "2026-08-01"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2026-08-01"
+valid_to: null

--- a/tests/fixtures/notation-corpus/compliance-verification-matrix/requirement/REQUIREMENT-MATRIX-MULTI-1.yaml
+++ b/tests/fixtures/notation-corpus/compliance-verification-matrix/requirement/REQUIREMENT-MATRIX-MULTI-1.yaml
@@ -1,0 +1,19 @@
+# Fixture — two admitted verifications against the same requirement.
+notation: requirement
+id: REQUIREMENT-MATRIX-MULTI-1
+name: "Matrix fixture — multiple verifications"
+description: >
+  Worked example: two VERIFICATION records, one pass and one fail — must
+  produce two separate matrix rows.
+severity: high
+
+zone: canon
+admitted_at: "2026-08-01"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2026-08-01"
+valid_to: null

--- a/tests/fixtures/notation-corpus/compliance-verification-matrix/requirement/REQUIREMENT-MATRIX-NONE-1.yaml
+++ b/tests/fixtures/notation-corpus/compliance-verification-matrix/requirement/REQUIREMENT-MATRIX-NONE-1.yaml
@@ -1,0 +1,19 @@
+# Fixture — no verification at all (REQ-VERIF-COVERAGE-001).
+notation: requirement
+id: REQUIREMENT-MATRIX-NONE-1
+name: "Matrix fixture — no verification"
+description: >
+  Worked example: zero VERIFICATION records — must still produce exactly one
+  gap row.
+severity: low
+
+zone: canon
+admitted_at: "2026-08-01"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2026-08-01"
+valid_to: null

--- a/tests/fixtures/notation-corpus/compliance-verification-matrix/requirement/REQUIREMENT-MATRIX-OPEN-1.yaml
+++ b/tests/fixtures/notation-corpus/compliance-verification-matrix/requirement/REQUIREMENT-MATRIX-OPEN-1.yaml
@@ -1,0 +1,19 @@
+# Fixture — a verification exists but is not yet closed (REQ-VERIF-COVERAGE-002).
+notation: requirement
+id: REQUIREMENT-MATRIX-OPEN-1
+name: "Matrix fixture — unresolved verification"
+description: >
+  Worked example: exactly one VERIFICATION, still not_yet_run — the
+  REQ-VERIF-COVERAGE-002 case.
+severity: medium
+
+zone: canon
+admitted_at: "2026-08-01"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2026-08-01"
+valid_to: null

--- a/tests/fixtures/notation-corpus/compliance-verification-matrix/requirement/REQUIREMENT-MATRIX-PASS-1.yaml
+++ b/tests/fixtures/notation-corpus/compliance-verification-matrix/requirement/REQUIREMENT-MATRIX-PASS-1.yaml
@@ -1,0 +1,19 @@
+# Fixture — one passing verification.
+notation: requirement
+id: REQUIREMENT-MATRIX-PASS-1
+name: "Matrix fixture — closed, passing verification"
+description: >
+  Worked example for the requirement-verification matrix builder: exactly one
+  VERIFICATION, closed with outcome pass.
+severity: high
+
+zone: canon
+admitted_at: "2026-08-01"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2026-08-01"
+valid_to: null

--- a/tests/fixtures/notation-corpus/compliance-verification-matrix/verification/VERIFICATION-MATRIX-CHILD-1.yaml
+++ b/tests/fixtures/notation-corpus/compliance-verification-matrix/verification/VERIFICATION-MATRIX-CHILD-1.yaml
@@ -1,0 +1,18 @@
+notation: verification
+id: VERIFICATION-MATRIX-CHILD-1
+verifies: REQUIREMENT-MATRIX-CHILD-1
+
+method: test
+protocol: "Protocol run directly against the child requirement — must never be attributed to its parent."
+outcome: pass
+
+zone: canon
+admitted_at: "2026-08-05"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2026-08-05"
+valid_to: null

--- a/tests/fixtures/notation-corpus/compliance-verification-matrix/verification/VERIFICATION-MATRIX-DANGLING-1.yaml
+++ b/tests/fixtures/notation-corpus/compliance-verification-matrix/verification/VERIFICATION-MATRIX-DANGLING-1.yaml
@@ -1,0 +1,21 @@
+# Fixture — verifies names a REQUIREMENT that is not admitted in this fixture
+# set (VERIF-002 in the notation validator). Must never attach to any matrix
+# row and must not affect any other row's cardinality or gap status.
+notation: verification
+id: VERIFICATION-MATRIX-DANGLING-1
+verifies: REQUIREMENT-MATRIX-DOES-NOT-EXIST-2
+
+method: test
+protocol: "Protocol recorded against a requirement id absent from the fixture set."
+outcome: pass
+
+zone: canon
+admitted_at: "2026-08-05"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2026-08-05"
+valid_to: null

--- a/tests/fixtures/notation-corpus/compliance-verification-matrix/verification/VERIFICATION-MATRIX-MULTI-1.yaml
+++ b/tests/fixtures/notation-corpus/compliance-verification-matrix/verification/VERIFICATION-MATRIX-MULTI-1.yaml
@@ -1,0 +1,18 @@
+notation: verification
+id: VERIFICATION-MATRIX-MULTI-1
+verifies: REQUIREMENT-MATRIX-MULTI-1
+
+method: test
+protocol: "First of two protocols run against the matrix fixture's multi-verification requirement."
+outcome: pass
+
+zone: canon
+admitted_at: "2026-08-05"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2026-08-05"
+valid_to: null

--- a/tests/fixtures/notation-corpus/compliance-verification-matrix/verification/VERIFICATION-MATRIX-MULTI-2.yaml
+++ b/tests/fixtures/notation-corpus/compliance-verification-matrix/verification/VERIFICATION-MATRIX-MULTI-2.yaml
@@ -1,0 +1,18 @@
+notation: verification
+id: VERIFICATION-MATRIX-MULTI-2
+verifies: REQUIREMENT-MATRIX-MULTI-1
+
+method: analysis
+protocol: "Second of two protocols run against the matrix fixture's multi-verification requirement."
+outcome: fail
+
+zone: canon
+admitted_at: "2026-08-06"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2026-08-06"
+valid_to: null

--- a/tests/fixtures/notation-corpus/compliance-verification-matrix/verification/VERIFICATION-MATRIX-OPEN-1.yaml
+++ b/tests/fixtures/notation-corpus/compliance-verification-matrix/verification/VERIFICATION-MATRIX-OPEN-1.yaml
@@ -1,0 +1,18 @@
+notation: verification
+id: VERIFICATION-MATRIX-OPEN-1
+verifies: REQUIREMENT-MATRIX-OPEN-1
+
+method: test
+protocol: "Scheduled test protocol for the matrix fixture's open case; not yet executed."
+outcome: not_yet_run
+
+zone: canon
+admitted_at: "2026-08-05"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2026-08-05"
+valid_to: null

--- a/tests/fixtures/notation-corpus/compliance-verification-matrix/verification/VERIFICATION-MATRIX-PASS-1.yaml
+++ b/tests/fixtures/notation-corpus/compliance-verification-matrix/verification/VERIFICATION-MATRIX-PASS-1.yaml
@@ -1,0 +1,22 @@
+notation: verification
+id: VERIFICATION-MATRIX-PASS-1
+verifies: REQUIREMENT-MATRIX-PASS-1
+
+method: test
+protocol: "Run the matrix fixture's pass-path protocol and confirm the acceptance criterion holds."
+result: "Confirmed."
+outcome: pass
+
+performed_at: "2026-08-05"
+performed_by: ROLE-VERIFICATION-ENG-1
+
+zone: canon
+admitted_at: "2026-08-05"
+admitted_by: "v.korobeinikov"
+gate_checks:
+  uniqueness: pass
+  consistency: pass
+  completeness: pass
+
+valid_from: "2026-08-05"
+valid_to: null


### PR DESCRIPTION
## Summary

- Command Palette **Transitrix: Preview requirement–verification matrix** opens a repository-wide table (Requirement, Parent, Related test result, Outcome) from the projection landed in #562. Coverage gaps are `REQ-VERIF-COVERAGE-001` / `-002`; a dangling `parent` stays on the row; a dangling `verifies` is listed as a finding, not attached to a requirement.
- Saving a `REQUIREMENT-` or `VERIFICATION-` file refreshes an open table. Unrelated saves do not.
- **Export CSV** writes the same rows, in the same order, as the view (CRLF, RFC-4180). Two exports of unchanged state are byte-identical.

Task: THQ-311 (epic THQ-308, 2/2).

## Test plan

- [x] Diagrams unit tests for CSV serialisation against the worked fixture
- [x] `npm run compile` and `compile:extension`
- [ ] Extension e2e: command opens the table, fixture cases appear, two CSV exports match
- [ ] Command Palette entry visible; Requirement Trace preview still opens from a requirement file
