### PR TITLE
feat(bpmn): add a selectable presentation export profile

### DIFF
--- a/changelog/fragments/bpmn-presentation-export-fd7da0c4.md
+++ b/changelog/fragments/bpmn-presentation-export-fd7da0c4.md
@@ -1,0 +1,3 @@
+### Added
+
+- **BPMN presentation export.** A selectable `presentation` profile on BPMN compile / SVG / PNG export lays the diagram out automatically for a 1780 px frame with a 20 px label floor. It is not the live preview — default layout and typography stay as they are.

--- a/extension/README.md
+++ b/extension/README.md
@@ -37,7 +37,7 @@ Transitrix flips that:
 | Compliance | **Gap dashboard** | Open gaps: unasserted requirements, stale assertions |
 | Compliance | **Requirement–verification matrix** | Repository-wide requirement rows with related test results and coverage gaps |
 
-Every preview ships with a toolbar: title toggle, discrete zoom (50–200%), save as SVG, save as PNG (2× for crisp output), and copy PNG to clipboard (Windows today; macOS / Linux planned).
+Every preview ships with a toolbar: title toggle, discrete zoom (50–200%), save as SVG, save as PNG (2× for crisp output), and copy PNG to clipboard (Windows today; macOS / Linux planned). BPMN also has a **presentation** export (Command Palette: “Save BPMN as presentation SVG/PNG”) — a denser automatic layout with 20 px labels that fits a 1780 px frame. It is not the live preview.
 
 The preview opens automatically when a recognised file becomes the active editor, and refreshes **on save — not on every keystroke.** That's deliberate: re-rendering mid-edit would burn CPU and flash parse errors on every intermediate state of a structural change. It also means an edit with no save behind it looks, at a glance, like a broken preview — the toolbar's small "as of last save" label is the tell that nothing's wrong, the file just hasn't been saved yet.
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -768,6 +768,16 @@
         "category": "Transitrix"
       },
       {
+        "command": "transitrixStudio.saveBpmnPresentationAsSvg",
+        "title": "Transitrix: Save BPMN as presentation SVG",
+        "category": "Transitrix"
+      },
+      {
+        "command": "transitrixStudio.saveBpmnPresentationAsPng",
+        "title": "Transitrix: Save BPMN as presentation PNG",
+        "category": "Transitrix"
+      },
+      {
         "command": "transitrixStudio.previewComplianceMatrix",
         "title": "Transitrix: Preview compliance matrix",
         "category": "Transitrix",

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -4,7 +4,7 @@ import * as vscode from 'vscode';
 
 import type { CompileFn } from './preview.js';
 import { BpmnJsPreview } from './preview.js';
-import { ProcessPreview, type ProcessLayoutFn, type BpmnDisplayOpts, SAVE_BPMN_PROCESS_SVG_COMMAND, OPEN_BPMN_SETTINGS_COMMAND } from './process-preview.js';
+import { ProcessPreview, type ProcessLayoutFn, type BpmnDisplayOpts, SAVE_BPMN_PROCESS_SVG_COMMAND, SAVE_BPMN_PRESENTATION_SVG_COMMAND, SAVE_BPMN_PRESENTATION_PNG_COMMAND, OPEN_BPMN_SETTINGS_COMMAND } from './process-preview.js';
 import { GoalsPreview } from './goals-preview.js';
 import { DGCAPreview, DGAPreview } from './dgca-preview.js';
 import { ActionPreview } from './action-preview.js';
@@ -161,10 +161,17 @@ async function loadProcessLayoutFn(ext: vscode.ExtensionContext): Promise<Proces
   const mod = (await import(compilerHref)) as {
     compileTransitrixYamlWithLayout: (
       yaml: string,
-      options?: { layout?: { laneVerticalGap?: number; uniformLaneHeight?: boolean } },
+      options?: { layout?: Record<string, unknown> },
     ) => Promise<{ layout: unknown; validation: ValidationReport }>;
+    layoutOptionsForProfile: (profile: 'default' | 'presentation') => Record<string, unknown>;
   };
   return async (yaml: string, opts?: BpmnDisplayOpts) => {
+    if (opts?.profile === 'presentation') {
+      const layout = mod.layoutOptionsForProfile('presentation');
+      const result = await mod.compileTransitrixYamlWithLayout(yaml, { layout });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return { layout: result.layout as any, validation: result.validation };
+    }
     const laneGap = vscode.workspace.getConfiguration('transitrix').get<number>('bpmn.laneGap');
     const layout: { laneVerticalGap?: number; uniformLaneHeight?: boolean } = {};
     if (laneGap !== undefined && Number.isFinite(laneGap)) layout.laneVerticalGap = laneGap;
@@ -400,6 +407,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void |
     vscode.commands.registerCommand('transitrixStudio.saveBpmnAsPng', () => preview.saveAsPng()),
     vscode.commands.registerCommand(SAVE_BPMN_PROCESS_SVG_COMMAND, () =>
       processPreview.saveAsSvg(),
+    ),
+    vscode.commands.registerCommand(SAVE_BPMN_PRESENTATION_SVG_COMMAND, () =>
+      processPreview.savePresentationAsSvg(),
+    ),
+    vscode.commands.registerCommand(SAVE_BPMN_PRESENTATION_PNG_COMMAND, () =>
+      processPreview.savePresentationAsPng(),
     ),
     vscode.commands.registerCommand('transitrixStudio.saveBlocksAsSvg', () =>
       blocksPreview.saveAsSvg(),

--- a/extension/src/process-preview.ts
+++ b/extension/src/process-preview.ts
@@ -13,6 +13,7 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 import {
   renderProcessLayoutSvg,
+  PRESENTATION_BPMN_TYPOGRAPHY,
   type ProcessDiagramLayout,
 } from '@transitrix/diagrams/webview/render-process.js';
 import { escXml } from '@transitrix/diagrams/webview/render-util.js';
@@ -23,13 +24,18 @@ import {
   type ThemeId,
 } from './diagram-frame.js';
 import { genNonce } from './preview-controls.js';
+import { savePngFromSvg } from './png-export.js';
 import type { ValidationReport } from './types.js';
 
 export const SAVE_BPMN_PROCESS_SVG_COMMAND = 'transitrixStudio.saveBpmnProcessAsSvg';
+export const SAVE_BPMN_PRESENTATION_SVG_COMMAND = 'transitrixStudio.saveBpmnPresentationAsSvg';
+export const SAVE_BPMN_PRESENTATION_PNG_COMMAND = 'transitrixStudio.saveBpmnPresentationAsPng';
 export const OPEN_BPMN_SETTINGS_COMMAND = 'transitrixStudio.openBpmnSettings';
 
 export interface BpmnDisplayOpts {
   uniformLaneHeight?: boolean;
+  /** Named visual-export profile. Omit (or `default`) for the interactive preview knobs. */
+  profile?: 'default' | 'presentation';
 }
 
 /** Function that parses + lays out a BPMN YAML document. */
@@ -107,7 +113,13 @@ export class ProcessPreview {
         { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
         {
           enableScripts: true,
-          enableCommandUris: [SAVE_BPMN_PROCESS_SVG_COMMAND, OPEN_BPMN_SETTINGS_COMMAND, OPEN_THEME_COMMAND],
+          enableCommandUris: [
+            SAVE_BPMN_PROCESS_SVG_COMMAND,
+            SAVE_BPMN_PRESENTATION_SVG_COMMAND,
+            SAVE_BPMN_PRESENTATION_PNG_COMMAND,
+            OPEN_BPMN_SETTINGS_COMMAND,
+            OPEN_THEME_COMMAND,
+          ],
           retainContextWhenHidden: true,
         },
       );
@@ -171,6 +183,59 @@ export class ProcessPreview {
     const svg = prepareSvgForExport(this.lastSvg, themeId);
     await vscode.workspace.fs.writeFile(target, Buffer.from(svg, 'utf-8'));
     vscode.window.showInformationMessage(`Saved: ${path.basename(target.fsPath)}`);
+  }
+
+  async savePresentationAsSvg(): Promise<void> {
+    const svg = await this.buildPresentationSvg();
+    if (!svg) return;
+    const sourceUri = this.trackedUri ? vscode.Uri.parse(this.trackedUri) : undefined;
+    const stem = sourceUri
+      ? path.basename(sourceUri.fsPath).replace(/\.bpmn\.transitrix\.yaml$/, '')
+      : 'diagram';
+    const defaultUri = sourceUri
+      ? vscode.Uri.file(path.join(path.dirname(sourceUri.fsPath), `${stem}.presentation.svg`))
+      : vscode.Uri.file(`${stem}.presentation.svg`);
+    const target = await vscode.window.showSaveDialog({ defaultUri, filters: { 'SVG Image': ['svg'] } });
+    if (!target) return;
+    const themeId = vscode.workspace.getConfiguration('transitrix').get<ThemeId>('theme', 'transitrix');
+    const out = prepareSvgForExport(svg, themeId);
+    await vscode.workspace.fs.writeFile(target, Buffer.from(out, 'utf-8'));
+    vscode.window.showInformationMessage(`Saved: ${path.basename(target.fsPath)}`);
+  }
+
+  async savePresentationAsPng(): Promise<void> {
+    const svg = await this.buildPresentationSvg();
+    if (!svg) return;
+    const sourceUri = this.trackedUri ? vscode.Uri.parse(this.trackedUri) : undefined;
+    await savePngFromSvg({
+      rawSvg: svg,
+      themeId: vscode.workspace.getConfiguration('transitrix').get<ThemeId>('theme', 'transitrix'),
+      emptyMessage: 'Open a *.bpmn.transitrix.yaml preview first, then save a presentation PNG.',
+      webview: this.panel?.webview,
+      sourceUri,
+      stripExt: /\.bpmn\.transitrix\.yaml$/,
+      viewSuffix: '.presentation',
+    });
+  }
+
+  private async buildPresentationSvg(): Promise<string | undefined> {
+    if (!this.trackedUri) {
+      vscode.window.showWarningMessage('Open a *.bpmn.transitrix.yaml file first.');
+      return undefined;
+    }
+    const doc = vscode.workspace.textDocuments.find((d) => d.uri.toString() === this.trackedUri);
+    if (!doc) {
+      vscode.window.showWarningMessage('Open a *.bpmn.transitrix.yaml file first.');
+      return undefined;
+    }
+    try {
+      const { layout } = await this.layoutFn(doc.getText(), { profile: 'presentation' });
+      return renderProcessLayoutSvg(layout, { typography: PRESENTATION_BPMN_TYPOGRAPHY });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      vscode.window.showErrorMessage(`Presentation export failed: ${msg}`);
+      return undefined;
+    }
   }
 
   private async pushDocument(doc: vscode.TextDocument): Promise<void> {

--- a/packages/diagrams/src/webview/__tests__/render-process.test.ts
+++ b/packages/diagrams/src/webview/__tests__/render-process.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   renderProcessLayoutSvg,
   renderProcessBody,
+  PRESENTATION_BPMN_TYPOGRAPHY,
   type ProcessDiagramLayout,
   type ProcessFlowElement,
 } from '../render-process.js';
@@ -146,6 +147,16 @@ describe('renderProcessLayoutSvg — CSS', () => {
       const rule = svg.match(new RegExp(`\\.${cls}\\s*\\{[^}]*\\}`))?.[0] ?? '';
       expect(rule).toContain('font-family');
     }
+  });
+
+  it('presentation typography uses 20px labels without changing the default call', () => {
+    const def = renderProcessLayoutSvg(makeLayout());
+    const pres = renderProcessLayoutSvg(makeLayout(), { typography: PRESENTATION_BPMN_TYPOGRAPHY });
+    expect(def).toContain('font-size: 11px');
+    expect(def).toContain('font-size: 10px');
+    expect(pres).toContain('font-size: 20px');
+    expect(pres).not.toContain('font-size: 11px');
+    expect(pres).not.toContain('font-size: 10px');
   });
 });
 

--- a/packages/diagrams/src/webview/render-process.ts
+++ b/packages/diagrams/src/webview/render-process.ts
@@ -75,11 +75,48 @@ export interface ProcessDiagramLayout {
   associations: ProcessAssociation[];
 }
 
+export interface BpmnTypography {
+  taskFontPx: number;
+  headerFontPx: number;
+  labelFontPx: number;
+  taskChars: number;
+  taskLineH: number;
+  labelChars: number;
+  labelLineH: number;
+  headerCharW: number;
+}
+
+/** Interactive-preview / default-export type sizes. */
+export const DEFAULT_BPMN_TYPOGRAPHY: BpmnTypography = {
+  taskFontPx: 11,
+  headerFontPx: 11,
+  labelFontPx: 10,
+  taskChars: 14,
+  taskLineH: 14,
+  labelChars: 18,
+  labelLineH: 13,
+  headerCharW: 6.5,
+};
+
+/** Presentation-export type sizes (20 px floor, wrap tuned to default node boxes). */
+export const PRESENTATION_BPMN_TYPOGRAPHY: BpmnTypography = {
+  taskFontPx: 20,
+  headerFontPx: 20,
+  labelFontPx: 20,
+  taskChars: 9,
+  taskLineH: 22,
+  labelChars: 14,
+  labelLineH: 22,
+  headerCharW: 11.5,
+};
+
 export interface RenderProcessOptions {
   /** Raw SVG injected after `<style>` — a title line or full title block. */
   title?: string;
   /** Extra vertical space (px) reserved above the pool for a title block. */
   topInset?: number;
+  /** Label metrics. Omit for the interactive-preview defaults. */
+  typography?: BpmnTypography;
 }
 
 // ---------------------------------------------------------------------------
@@ -92,49 +129,52 @@ const LANE_LABEL_BAND = 44;
 /** End margin (px) along the header height axis for rotated pool/lane captions. */
 const HEADER_LABEL_AXIS_PAD = 32;
 
-/** Estimated horizontal advance (px) per character at the header label font size. */
-const HEADER_LABEL_CHAR_W = 6.5;
+/** Active wrap/font metrics for the current render call (sync, restored after). */
+let typo: BpmnTypography = DEFAULT_BPMN_TYPOGRAPHY;
 
-/** Maximum characters per wrapped line inside a task box. */
-const TASK_CHARS = 14;
-
-/** Line height for wrapped task-name text (px). */
-const TASK_LINE_H = 14;
-
-/** Maximum characters per line for below-element labels (events, gateways). */
-const LABEL_CHARS = 18;
-
-/** Line height for multi-line below-element labels (px). */
-const LABEL_LINE_H = 13;
+function runWithTypography<T>(t: BpmnTypography, fn: () => T): T {
+  const prev = typo;
+  typo = t;
+  try {
+    return fn();
+  } finally {
+    typo = prev;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // BPMN-specific CSS — no font-style:italic per CLAUDE.md design rule
 // ---------------------------------------------------------------------------
 
-export const BPMN_PROCESS_CSS = `
+export function bpmnProcessCss(t: BpmnTypography = DEFAULT_BPMN_TYPOGRAPHY): string {
+  return `
 .bpmn-pool { fill: var(--ts-bg-surface,#f8fafc); stroke: var(--ts-node-stroke,#004d67); stroke-width: 1.5; }
 .bpmn-pool-name { fill: var(--ts-bg-elevated,#f1f5f9); stroke: var(--ts-node-stroke,#004d67); stroke-width: 0.75; }
 .bpmn-lane { fill: var(--ts-bg,#ffffff); stroke: var(--ts-node-stroke,#004d67); stroke-width: 0.75; }
 .bpmn-lane-header { fill: var(--ts-bg-elevated,#f1f5f9); stroke: var(--ts-node-stroke,#004d67); stroke-width: 0.75; }
-.bpmn-pool-label { fill: var(--ts-text-primary,#0d2b35); font-family: var(--vscode-font-family, system-ui, -apple-system, sans-serif); font-size: 11px; font-weight: 700; }
-.bpmn-lane-label { fill: var(--ts-text-primary,#0d2b35); font-family: var(--vscode-font-family, system-ui, -apple-system, sans-serif); font-size: 11px; font-weight: 600; }
+.bpmn-pool-label { fill: var(--ts-text-primary,#0d2b35); font-family: var(--vscode-font-family, system-ui, -apple-system, sans-serif); font-size: ${t.headerFontPx}px; font-weight: 700; }
+.bpmn-lane-label { fill: var(--ts-text-primary,#0d2b35); font-family: var(--vscode-font-family, system-ui, -apple-system, sans-serif); font-size: ${t.headerFontPx}px; font-weight: 600; }
 .bpmn-task { fill: var(--ts-bg,#ffffff); stroke: var(--ts-node-stroke,#004d67); stroke-width: 1.5; }
-.bpmn-task-name { fill: var(--ts-text-primary,#0d2b35); font-family: var(--vscode-font-family, system-ui, -apple-system, sans-serif); font-size: 11px; text-anchor: middle; }
+.bpmn-task-name { fill: var(--ts-text-primary,#0d2b35); font-family: var(--vscode-font-family, system-ui, -apple-system, sans-serif); font-size: ${t.taskFontPx}px; text-anchor: middle; }
 .bpmn-event { fill: var(--ts-bg,#ffffff); stroke: var(--ts-node-stroke,#004d67); }
 .bpmn-event-start { stroke-width: 1.5; }
 .bpmn-event-end { stroke-width: 4; }
-.bpmn-event-label { fill: var(--ts-text-secondary,#516970); font-family: var(--vscode-font-family, system-ui, -apple-system, sans-serif); font-size: 10px; text-anchor: middle; }
+.bpmn-event-label { fill: var(--ts-text-secondary,#516970); font-family: var(--vscode-font-family, system-ui, -apple-system, sans-serif); font-size: ${t.labelFontPx}px; text-anchor: middle; }
 .bpmn-gateway { fill: var(--ts-bg,#ffffff); stroke: var(--ts-node-stroke,#004d67); stroke-width: 1.5; }
 .bpmn-gateway-marker { stroke: var(--ts-node-stroke,#004d67); stroke-width: 2.5; stroke-linecap: round; fill: none; }
-.bpmn-gateway-label { fill: var(--ts-text-secondary,#516970); font-family: var(--vscode-font-family, system-ui, -apple-system, sans-serif); font-size: 10px; text-anchor: middle; }
+.bpmn-gateway-label { fill: var(--ts-text-secondary,#516970); font-family: var(--vscode-font-family, system-ui, -apple-system, sans-serif); font-size: ${t.labelFontPx}px; text-anchor: middle; }
 .bpmn-seq-flow { fill: none; stroke: var(--ts-edge-stroke,#004d67); stroke-width: 1.5; }
 .bpmn-default-mark { stroke: var(--ts-edge-stroke,#004d67); stroke-width: 1.5; stroke-linecap: round; }
 .bpmn-assoc { fill: none; stroke: var(--ts-edge-stroke,#004d67); stroke-width: 1; stroke-dasharray: 4 2; }
 .bpmn-data-obj { fill: var(--ts-bg,#ffffff); stroke: var(--ts-node-stroke,#004d67); stroke-width: 1; }
-.bpmn-data-obj-label { fill: var(--ts-text-secondary,#516970); font-size: 10px; text-anchor: middle; }
+.bpmn-data-obj-label { fill: var(--ts-text-secondary,#516970); font-size: ${t.labelFontPx}px; text-anchor: middle; }
 .bpmn-event-intermediate { fill: none; stroke: var(--ts-node-stroke,#004d67); stroke-width: 1; }
 .bpmn-event-icon { fill: none; stroke: var(--ts-node-stroke,#004d67); stroke-width: 1.5; stroke-linecap: round; stroke-linejoin: round; }
 `;
+}
+
+/** Default-preview CSS (11 px / 10 px). Presentation export builds its own via `bpmnProcessCss`. */
+export const BPMN_PROCESS_CSS = bpmnProcessCss(DEFAULT_BPMN_TYPOGRAPHY);
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -153,54 +193,56 @@ function wordTruncate(text: string, maxChars: number): string {
 }
 
 function fitRotatedHeaderText(name: string, spanPx: number): string {
-  const maxChars = Math.max(4, Math.floor(spanPx / HEADER_LABEL_CHAR_W));
+  const maxChars = Math.max(4, Math.floor(spanPx / typo.headerCharW));
   return wordTruncate(name, maxChars);
 }
 
 function wrapTaskName(name: string): string[] {
   if (!name) return [];
+  const limit = typo.taskChars;
   const words = name.split(/\s+/);
   const lines: string[] = [];
   let cur = '';
   for (const w of words) {
-    const token = w.length > TASK_CHARS ? w.slice(0, TASK_CHARS - 1) + '…' : w;
+    const token = w.length > limit ? w.slice(0, limit - 1) + '…' : w;
     if (!cur) {
       cur = token;
-    } else if (cur.length + 1 + token.length <= TASK_CHARS) {
+    } else if (cur.length + 1 + token.length <= limit) {
       cur += ' ' + token;
     } else {
       lines.push(cur);
       if (lines.length === 3) {
-        if (lines[2].length > TASK_CHARS - 1) lines[2] = lines[2].slice(0, TASK_CHARS - 1) + '…';
+        if (lines[2].length > limit - 1) lines[2] = lines[2].slice(0, limit - 1) + '…';
         return lines;
       }
       cur = token;
     }
   }
   if (cur && lines.length < 3) lines.push(cur);
-  if (lines.length === 0) lines.push(name.slice(0, TASK_CHARS));
+  if (lines.length === 0) lines.push(name.slice(0, limit));
   return lines;
 }
 
 function taskNameSvg(name: string | undefined, cx: number, cy: number): string {
   if (!name) return '';
   const lines = wrapTaskName(name);
-  const totalH = lines.length * TASK_LINE_H;
-  const startY = cy - totalH / 2 + TASK_LINE_H * 0.8;
+  const totalH = lines.length * typo.taskLineH;
+  const startY = cy - totalH / 2 + typo.taskLineH * 0.8;
   const tspans = lines
-    .map((ln, i) => `<tspan x="${r(cx)}" y="${r(startY + i * TASK_LINE_H)}">${escXml(ln)}</tspan>`)
+    .map((ln, i) => `<tspan x="${r(cx)}" y="${r(startY + i * typo.taskLineH)}">${escXml(ln)}</tspan>`)
     .join('');
   return `<text class="bpmn-task-name">${tspans}</text>`;
 }
 
 function wrapBelowLabel(name: string): string[] {
+  const limit = typo.labelChars;
   const words = name.split(/\s+/).filter(Boolean);
   const allLines: string[] = [];
   let cur = '';
   for (const word of words) {
-    const tok = word.length > LABEL_CHARS ? word.slice(0, LABEL_CHARS - 1) + '…' : word;
+    const tok = word.length > limit ? word.slice(0, limit - 1) + '…' : word;
     const test = cur ? `${cur} ${tok}` : tok;
-    if (test.length <= LABEL_CHARS) {
+    if (test.length <= limit) {
       cur = test;
     } else {
       if (cur) allLines.push(cur);
@@ -208,11 +250,11 @@ function wrapBelowLabel(name: string): string[] {
     }
   }
   if (cur) allLines.push(cur);
-  if (allLines.length === 0) return [name.slice(0, LABEL_CHARS)];
+  if (allLines.length === 0) return [name.slice(0, limit)];
   if (allLines.length <= 3) return allLines;
   const lines = allLines.slice(0, 3);
   const last = lines[2];
-  lines[2] = last.length + 1 <= LABEL_CHARS ? last + '…' : last.slice(0, LABEL_CHARS - 1) + '…';
+  lines[2] = last.length + 1 <= limit ? last + '…' : last.slice(0, limit - 1) + '…';
   return lines;
 }
 
@@ -226,7 +268,7 @@ function belowLabelSvg(name: string | undefined, cls: string, cx: number, belowY
     return `<text class="${cls}" x="${r(textX)}" y="${startY}">${escXml(lines[0])}</text>`;
   }
   const tspans = lines
-    .map((ln, i) => `<tspan x="${r(textX)}" dy="${i === 0 ? 0 : LABEL_LINE_H}">${escXml(ln)}</tspan>`)
+    .map((ln, i) => `<tspan x="${r(textX)}" dy="${i === 0 ? 0 : typo.labelLineH}">${escXml(ln)}</tspan>`)
     .join('');
   return `<text class="${cls}" x="${r(textX)}" y="${startY}">${tspans}</text>`;
 }
@@ -488,20 +530,23 @@ export function renderProcessLayoutSvg(
   options: RenderProcessOptions = {},
 ): string {
   const { title = '', topInset = title ? 32 : 0 } = options;
-  const pb = layout.poolBounds;
-  const PAD = 16;
+  const t = options.typography ?? DEFAULT_BPMN_TYPOGRAPHY;
+  return runWithTypography(t, () => {
+    const pb = layout.poolBounds;
+    const PAD = 16;
 
-  const svgW = r(pb.x + pb.width + PAD);
-  const svgH = r(pb.y + pb.height + PAD + topInset);
+    const svgW = r(pb.x + pb.width + PAD);
+    const svgH = r(pb.y + pb.height + PAD + topInset);
 
-  const embedCss = generateSvgEmbedCss('transitrix') + BPMN_PROCESS_CSS;
-  const body = renderProcessBody(layout, 0, topInset);
+    const embedCss = generateSvgEmbedCss('transitrix') + bpmnProcessCss(t);
+    const body = renderProcessBody(layout, 0, topInset);
 
-  return (
-    `<svg xmlns="http://www.w3.org/2000/svg" width="${svgW}" height="${svgH}" viewBox="0 0 ${svgW} ${svgH}">\n` +
-    `<style>${embedCss}</style>\n` +
-    (title ? `${title}\n` : '') +
-    `${body}\n` +
-    `</svg>`
-  );
+    return (
+      `<svg xmlns="http://www.w3.org/2000/svg" width="${svgW}" height="${svgH}" viewBox="0 0 ${svgW} ${svgH}">\n` +
+      `<style>${embedCss}</style>\n` +
+      (title ? `${title}\n` : '') +
+      `${body}\n` +
+      `</svg>`
+    );
+  });
 }

--- a/src/bpmn-export-profile.ts
+++ b/src/bpmn-export-profile.ts
@@ -1,0 +1,53 @@
+import { mergeLayoutDiagramOptions, type LayoutDiagramOptions } from './layout-options.js';
+
+/**
+ * Named BPMN visual-export profiles.
+ *
+ * `default` is the interactive-preview layout (unchanged knobs).
+ * `presentation` is a denser automatic layout for slide/frame export — it is
+ * never applied unless the caller asks for it.
+ */
+export type BpmnExportProfileId = 'default' | 'presentation';
+
+export const BPMN_EXPORT_PROFILES: readonly BpmnExportProfileId[] = ['default', 'presentation'];
+
+/** Slide/frame width the presentation profile must fit (px). */
+export const BPMN_PRESENTATION_FRAME_PX = 1780;
+
+/** Minimum effective CSS label size after any SVG transform (px). */
+export const BPMN_PRESENTATION_MIN_LABEL_PX = 20;
+
+/**
+ * Compact spacing so a 20 px label still fits the presentation frame.
+ * Node sizes stay the default `elkNodeSize` table — only gutters change.
+ */
+export const PRESENTATION_LAYOUT_PARTIAL: Partial<LayoutDiagramOptions> = {
+  poolPad: 8,
+  poolOriginX: 8,
+  poolOriginY: 8,
+  participantLabelBand: 36,
+  laneLabelWidth: 44,
+  laneVerticalGap: 12,
+  laneContentRightPad: 16,
+  laneContentLeftPad: 16,
+  elkNodeSpacing: 24,
+  elkLayerSpacing: 36,
+  elkDiagramPadding: 16,
+  uniformLaneHeight: false,
+};
+
+export function parseBpmnExportProfile(raw: string | undefined): BpmnExportProfileId | undefined {
+  if (raw === undefined || raw === '') return 'default';
+  if (raw === 'default' || raw === 'presentation') return raw;
+  return undefined;
+}
+
+export function layoutOptionsForProfile(
+  profile: BpmnExportProfileId,
+  extra?: Partial<LayoutDiagramOptions>,
+): LayoutDiagramOptions {
+  if (profile === 'presentation') {
+    return mergeLayoutDiagramOptions({ ...PRESENTATION_LAYOUT_PARTIAL, ...extra });
+  }
+  return mergeLayoutDiagramOptions(extra);
+}

--- a/src/bpmn-png.ts
+++ b/src/bpmn-png.ts
@@ -1,0 +1,42 @@
+import { Resvg } from '@resvg/resvg-js';
+
+/**
+ * Rasterize a BPMN SVG to PNG. Lives outside `compiler.ts` so the extension
+ * compiler bundle does not pull in the native `@resvg/resvg-js` binary.
+ */
+
+function flattenCssVars(svg: string): string {
+  const defs = new Map<string, string>();
+  const declRe = /(--[A-Za-z0-9-]+)\s*:\s*([^;}]+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = declRe.exec(svg)) !== null) {
+    defs.set(m[1], m[2].trim());
+  }
+
+  const varRe = /var\(\s*(--[A-Za-z0-9-]+)\s*(?:,\s*([^)]*))?\)/g;
+  const resolve = (name: string, fallback: string | undefined): string => {
+    if (defs.has(name)) return defs.get(name)!;
+    return fallback !== undefined ? fallback.trim() : `var(${name})`;
+  };
+
+  let out = svg;
+  let prev = '';
+  let pass = 0;
+  while (out !== prev && pass < 10) {
+    prev = out;
+    pass += 1;
+    out = out.replace(varRe, (_whole, name: string, fb: string | undefined) => resolve(name, fb));
+  }
+  return out;
+}
+
+/** PNG at 1× CSS pixels (presentation frame checks use this, not retina). */
+export function rasterizeBpmnSvgToPng(svg: string): Buffer {
+  const flattened = flattenCssVars(svg);
+  const resvg = new Resvg(flattened, {
+    background: 'white',
+    fitTo: { mode: 'original' },
+    font: { loadSystemFonts: true },
+  });
+  return Buffer.from(resvg.render().asPng());
+}

--- a/src/bpmn-svg-metrics.ts
+++ b/src/bpmn-svg-metrics.ts
@@ -1,0 +1,52 @@
+/**
+ * Read width / effective label size from a BPMN SVG string.
+ * Used by the presentation-profile checks — not a renderer.
+ */
+
+export function svgCssWidth(svg: string): number {
+  const open = /<svg\b[^>]*>/.exec(svg)?.[0] ?? '';
+  const wAttr = /\bwidth="([\d.]+)"/.exec(open);
+  if (wAttr) return Number(wAttr[1]);
+  const vb = /\bviewBox="[\d.-]+\s+[\d.-]+\s+([\d.]+)\s+[\d.]+"/.exec(open);
+  return vb ? Number(vb[1]) : NaN;
+}
+
+export function svgCssHeight(svg: string): number {
+  const open = /<svg\b[^>]*>/.exec(svg)?.[0] ?? '';
+  const hAttr = /\bheight="([\d.]+)"/.exec(open);
+  if (hAttr) return Number(hAttr[1]);
+  const vb = /\bviewBox="[\d.-]+\s+[\d.-]+\s+[\d.]+\s+([\d.]+)"/.exec(open);
+  return vb ? Number(vb[1]) : NaN;
+}
+
+/** Uniform scale implied by width vs viewBox (1 when they match or viewBox is absent). */
+export function svgRootScale(svg: string): number {
+  const open = /<svg\b[^>]*>/.exec(svg)?.[0] ?? '';
+  const wAttr = /\bwidth="([\d.]+)"/.exec(open);
+  const vb = /\bviewBox="[\d.-]+\s+[\d.-]+\s+([\d.]+)\s+[\d.]+"/.exec(open);
+  if (!wAttr || !vb) return 1;
+  const cssW = Number(wAttr[1]);
+  const vbW = Number(vb[1]);
+  if (!Number.isFinite(cssW) || !Number.isFinite(vbW) || vbW <= 0) return 1;
+  return cssW / vbW;
+}
+
+/** Smallest BPMN label `font-size` (pool/lane/task/event/gateway/data), times root scale. */
+export function minEffectiveLabelPx(svg: string): number {
+  const labelClasses = [
+    'bpmn-pool-label',
+    'bpmn-lane-label',
+    'bpmn-task-name',
+    'bpmn-event-label',
+    'bpmn-gateway-label',
+    'bpmn-data-obj-label',
+  ];
+  const sizes: number[] = [];
+  for (const cls of labelClasses) {
+    const rule = svg.match(new RegExp(`\\.${cls}\\s*\\{[^}]*\\}`))?.[0] ?? '';
+    const m = /font-size:\s*([0-9.]+)px/.exec(rule);
+    if (m) sizes.push(Number(m[1]));
+  }
+  if (sizes.length === 0) return NaN;
+  return Math.min(...sizes) * svgRootScale(svg);
+}

--- a/src/bpmn-visual-export.ts
+++ b/src/bpmn-visual-export.ts
@@ -1,0 +1,32 @@
+import {
+  PRESENTATION_BPMN_TYPOGRAPHY,
+  renderProcessLayoutSvg,
+  type ProcessDiagramLayout,
+} from '@transitrix/diagrams/webview/render-process.js';
+
+import { compileTransitrixYamlWithLayout } from './compiler.js';
+import {
+  layoutOptionsForProfile,
+  type BpmnExportProfileId,
+} from './bpmn-export-profile.js';
+
+export interface BpmnVisualExport {
+  profile: BpmnExportProfileId;
+  svg: string;
+  layout: ProcessDiagramLayout;
+}
+
+/** YAML → custom-renderer SVG for a named export profile. Preview knobs are not applied. */
+export async function exportBpmnVisual(
+  yamlText: string,
+  profile: BpmnExportProfileId = 'default',
+): Promise<BpmnVisualExport> {
+  const layoutOpts = layoutOptionsForProfile(profile);
+  const { layout } = await compileTransitrixYamlWithLayout(yamlText, { layout: layoutOpts });
+  const diagram = layout as unknown as ProcessDiagramLayout;
+  const svg =
+    profile === 'presentation'
+      ? renderProcessLayoutSvg(diagram, { typography: PRESENTATION_BPMN_TYPOGRAPHY })
+      : renderProcessLayoutSvg(diagram);
+  return { profile, svg, layout: diagram };
+}

--- a/src/cli-parse.ts
+++ b/src/cli-parse.ts
@@ -28,6 +28,61 @@ export type ParseCliFileArgvResult =
   | { ok: true; positional: string[]; extList: string[]; wantsHelp: boolean }
   | { ok: false; error: '--ext_requires_value' };
 
+export type BpmnCompileProfileFlag = 'default' | 'presentation';
+
+export type ParseCompileArgvResult =
+  | {
+      ok: true;
+      positional: string[];
+      extList: string[];
+      wantsHelp: boolean;
+      profile: BpmnCompileProfileFlag;
+      noMetrics: boolean;
+      noValidate: boolean;
+    }
+  | { ok: false; error: '--ext_requires_value' | '--profile_requires_value' | 'bad_profile' };
+
+/**
+ * Compile argv: known flags (`--profile`, `--no-metrics`, `--no-validate`)
+ * are stripped so they cannot be mistaken for the input/output paths.
+ */
+export function parseCompileArgv(argv: string[]): ParseCompileArgvResult {
+  const rest: string[] = [];
+  let profile: BpmnCompileProfileFlag = 'default';
+  let noMetrics = false;
+  let noValidate = false;
+
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--no-metrics') {
+      noMetrics = true;
+      continue;
+    }
+    if (a === '--no-validate') {
+      noValidate = true;
+      continue;
+    }
+    if (a === '--profile') {
+      const raw = argv[++i];
+      if (!raw) return { ok: false, error: '--profile_requires_value' };
+      if (raw !== 'default' && raw !== 'presentation') return { ok: false, error: 'bad_profile' };
+      profile = raw;
+      continue;
+    }
+    if (a.startsWith('--profile=')) {
+      const raw = a.slice('--profile='.length);
+      if (raw !== 'default' && raw !== 'presentation') return { ok: false, error: 'bad_profile' };
+      profile = raw;
+      continue;
+    }
+    rest.push(a);
+  }
+
+  const parsed = parseCliFileArgv(rest);
+  if (!parsed.ok) return parsed;
+  return { ...parsed, profile, noMetrics, noValidate };
+}
+
 export function parseCliFileArgv(argv: string[]): ParseCliFileArgvResult {
   const positional: string[] = [];
   const extList: string[] = [];

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_TRANSITRIX_FILE_EXTENSIONS,
   inputMatchesExtension,
   parseCliFileArgv,
+  parseCompileArgv,
   parseValidateArgv,
 } from './cli-parse.js';
 import { compileTransitrixYamlWithLayout } from './compiler.js';
@@ -83,8 +84,8 @@ function printUsage(): void {
   console.error(`Transitrix Studio CLI — usage:
        transitrix --version | -v
        transitrix serve [--port 8765] [--host 127.0.0.1]
-       transitrix <input.yaml> <output.bpmn> [--no-metrics] [--no-validate]
-       transitrix [--ext=.bpmn.transitrix.yaml] <input.yaml> <output.bpmn> [--no-metrics] [--no-validate]
+       transitrix <input.yaml> <output.bpmn|.svg|.png> [--profile=default|presentation] [--no-metrics] [--no-validate]
+       transitrix [--ext=.bpmn.transitrix.yaml] <input.yaml> <output.bpmn|.svg|.png> [--profile=default|presentation] [--no-metrics] [--no-validate]
        transitrix metrics <input.yaml> [--json]
        transitrix metrics [--ext=.bpmn.transitrix.yaml] <input.yaml> [--json]
        transitrix validate <input.yaml> [--json]
@@ -150,9 +151,15 @@ function printUsage(): void {
 
   --no-metrics  suppress quality metrics report on compile.
   --no-validate suppress validation warnings (errors always run).
+  --profile=default|presentation  visual export profile. presentation is a
+              denser automatic layout with 20 px labels, sized for a 1780 px
+              frame. It is never the interactive preview default. When the
+              output path ends in .svg or .png, compile writes that image
+              instead of BPMN XML.
 
 Examples:
   npm run transitrix -- compile input.bpmn.transitrix.yaml output.bpmn
+  npm run transitrix -- compile input.bpmn.transitrix.yaml slides.svg --profile=presentation
   npm run transitrix -- serve
   npm run transitrix -- metrics example.bpmn.transitrix.yaml --json
   npm run transitrix -- validate example.bpmn.transitrix.yaml
@@ -163,14 +170,21 @@ Examples:
 }
 
 async function handleCompileCommand(argv: string[]): Promise<void> {
-  const parsed = parseCliFileArgv(argv);
+  const parsed = parseCompileArgv(argv);
   if (!parsed.ok) {
-    console.error('transitrix: --ext requires a comma-separated list of suffixes.');
+    if (parsed.error === '--profile_requires_value') {
+      console.error('transitrix: --profile requires default or presentation.');
+    } else if (parsed.error === 'bad_profile') {
+      console.error('transitrix: --profile must be default or presentation.');
+    } else {
+      console.error('transitrix: --ext requires a comma-separated list of suffixes.');
+    }
     process.exit(1);
   }
 
-  const { positional, extList, wantsHelp } = parsed;
+  const { positional, extList, wantsHelp, profile, noMetrics, noValidate } = parsed;
   const exts = extList.length > 0 ? extList : DEFAULT_TRANSITRIX_FILE_EXTENSIONS;
+  const noValidateWarnings = noValidate;
 
   if (wantsHelp) {
     printUsage();
@@ -180,7 +194,7 @@ async function handleCompileCommand(argv: string[]): Promise<void> {
   const [src, dst] = positional;
   if (!src || !dst) {
     console.error('transitrix compile: missing input or output file');
-    console.error(`usage: transitrix compile <input.yaml> <output.bpmn>`);
+    console.error(`usage: transitrix compile <input.yaml> <output.bpmn|.svg|.png> [--profile=presentation]`);
     process.exit(1);
   }
 
@@ -191,12 +205,26 @@ async function handleCompileCommand(argv: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const noMetrics = argv.includes('--no-metrics');
-  const noValidateWarnings = argv.includes('--no-validate');
-
   try {
     const yaml = await readFile(src, 'utf8');
-    const result = await compileTransitrixYamlWithLayout(yaml);
+    const dest = dst.toLowerCase();
+    if (dest.endsWith('.svg') || dest.endsWith('.png')) {
+      const { exportBpmnVisual } = await import('./bpmn-visual-export.js');
+      const visual = await exportBpmnVisual(yaml, profile);
+      if (dest.endsWith('.png')) {
+        const { rasterizeBpmnSvgToPng } = await import('./bpmn-png.js');
+        writeFileSync(dst, rasterizeBpmnSvgToPng(visual.svg));
+      } else {
+        writeFileSync(dst, visual.svg);
+      }
+      console.error(`✓ Compiled: ${dst} (profile=${profile})`);
+      return;
+    }
+
+    const { layoutOptionsForProfile } = await import('./bpmn-export-profile.js');
+    const result = await compileTransitrixYamlWithLayout(yaml, {
+      layout: layoutOptionsForProfile(profile),
+    });
     writeFileSync(dst, result.xml);
 
     // RD-112: Print validation report

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -10,6 +10,14 @@ import { BpmnModdle } from 'bpmn-moddle'
 
 export type { LayoutDiagramOptions } from './layout-options.js'
 export { parseLayoutDiagramOptionsFromJson } from './layout-options.js'
+export {
+  BPMN_EXPORT_PROFILES,
+  BPMN_PRESENTATION_FRAME_PX,
+  BPMN_PRESENTATION_MIN_LABEL_PX,
+  layoutOptionsForProfile,
+  parseBpmnExportProfile,
+  type BpmnExportProfileId,
+} from './bpmn-export-profile.js'
 
 export interface CompileTransitrixOptions {
   layout?: Partial<LayoutDiagramOptions>

--- a/src/serve-ui.ts
+++ b/src/serve-ui.ts
@@ -14,6 +14,8 @@ import {
   parseLayoutDiagramOptionsFromJson,
   type LayoutDiagramOptions,
 } from './layout-options.js'
+import { parseBpmnExportProfile } from './bpmn-export-profile.js'
+import { exportBpmnVisual } from './bpmn-visual-export.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
@@ -143,6 +145,57 @@ export async function handleCompile(req: IncomingMessage, res: ServerResponse): 
   }
 }
 
+export async function handleExportBpmn(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  if (req.method !== 'POST') {
+    res.writeHead(405, { 'Content-Type': 'text/plain; charset=utf-8' })
+    res.end('405 Method Not Allowed')
+    return
+  }
+  try {
+    const raw = await readHttpBodyLimited(req)
+    let body: unknown
+    try {
+      body = JSON.parse(raw.toString('utf8'))
+    } catch {
+      res.writeHead(400, { 'Content-Type': 'application/json; charset=utf-8' })
+      res.end(JSON.stringify({ message: 'Invalid JSON request body' }))
+      return
+    }
+    const rec = body as Record<string, unknown>
+    if (typeof rec.yaml !== 'string') {
+      res.writeHead(400, { 'Content-Type': 'application/json; charset=utf-8' })
+      res.end(JSON.stringify({ message: 'Expected { "yaml": "<source>" [, "profile": "presentation" ] }' }))
+      return
+    }
+    const profile = parseBpmnExportProfile(typeof rec.profile === 'string' ? rec.profile : 'default')
+    if (!profile) {
+      res.writeHead(400, { 'Content-Type': 'application/json; charset=utf-8' })
+      res.end(JSON.stringify({ message: 'profile must be default or presentation' }))
+      return
+    }
+    const visual = await exportBpmnVisual(rec.yaml, profile)
+    const format = rec.format === 'png' ? 'png' : 'svg'
+    if (format === 'png') {
+      const { rasterizeBpmnSvgToPng } = await import('./bpmn-png.js')
+      const png = rasterizeBpmnSvgToPng(visual.svg)
+      res.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' })
+      res.end(JSON.stringify({ profile, format: 'png', pngBase64: png.toString('base64') }))
+      return
+    }
+    res.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' })
+    res.end(JSON.stringify({ profile, format: 'svg', svg: visual.svg }))
+  } catch (e) {
+    if (e instanceof PayloadTooLargeError) {
+      res.writeHead(413, { 'Content-Type': 'application/json; charset=utf-8' })
+      res.end(JSON.stringify({ message: e.message }))
+      return
+    }
+    const err = e as Error
+    res.writeHead(400, { 'Content-Type': 'application/json; charset=utf-8' })
+    res.end(JSON.stringify({ message: err.message ?? 'Export failed' }))
+  }
+}
+
 export interface ServeUiOptions {
   port: number
   host?: string
@@ -164,6 +217,11 @@ export async function runUiServer(opts: ServeUiOptions): Promise<void> {
 
       if (pathOnly === '/api/compile') {
         await handleCompile(req, res)
+        return
+      }
+
+      if (pathOnly === '/api/export-bpmn') {
+        await handleExportBpmn(req, res)
         return
       }
 

--- a/tests/bpmn-presentation-export.test.ts
+++ b/tests/bpmn-presentation-export.test.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { PNG } from 'pngjs';
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_LAYOUT_DIAGRAM_OPTIONS } from '../src/layout-options.js';
+import {
+  BPMN_PRESENTATION_FRAME_PX,
+  BPMN_PRESENTATION_MIN_LABEL_PX,
+  layoutOptionsForProfile,
+  parseBpmnExportProfile,
+} from '../src/bpmn-export-profile.js';
+import { exportBpmnVisual } from '../src/bpmn-visual-export.js';
+import { rasterizeBpmnSvgToPng } from '../src/bpmn-png.js';
+import { minEffectiveLabelPx, svgCssWidth } from '../src/bpmn-svg-metrics.js';
+import { DEFAULT_BPMN_TYPOGRAPHY } from '@transitrix/diagrams/webview/render-process.js';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const ERASURE = join(
+  ROOT,
+  'organizations/acme_corp/canon/views/bpmn/data-subject-erasure.bpmn.transitrix.yaml',
+);
+
+describe('BPMN export profiles', () => {
+  it('parses the two named profiles and rejects anything else', () => {
+    expect(parseBpmnExportProfile(undefined)).toBe('default');
+    expect(parseBpmnExportProfile('default')).toBe('default');
+    expect(parseBpmnExportProfile('presentation')).toBe('presentation');
+    expect(parseBpmnExportProfile('slides')).toBeUndefined();
+  });
+
+  it('does not change the default layout knobs used by interactive preview', () => {
+    expect(layoutOptionsForProfile('default')).toEqual(DEFAULT_LAYOUT_DIAGRAM_OPTIONS);
+    expect(DEFAULT_LAYOUT_DIAGRAM_OPTIONS.elkLayerSpacing).toBe(88);
+    expect(DEFAULT_BPMN_TYPOGRAPHY.taskFontPx).toBe(11);
+    expect(DEFAULT_BPMN_TYPOGRAPHY.labelFontPx).toBe(10);
+    expect(layoutOptionsForProfile('presentation').elkLayerSpacing).toBeLessThan(
+      DEFAULT_LAYOUT_DIAGRAM_OPTIONS.elkLayerSpacing,
+    );
+  });
+});
+
+describe('presentation BPMN export — data-subject-erasure', () => {
+  const yaml = readFileSync(ERASURE, 'utf8');
+
+  it('fits the 1780 px frame with a 20 px effective label floor, unlike default', async () => {
+    const def = await exportBpmnVisual(yaml, 'default');
+    const pres = await exportBpmnVisual(yaml, 'presentation');
+
+    expect(def.svg).not.toEqual(pres.svg);
+    expect(minEffectiveLabelPx(def.svg)).toBeLessThan(BPMN_PRESENTATION_MIN_LABEL_PX);
+    expect(svgCssWidth(pres.svg)).toBeLessThanOrEqual(BPMN_PRESENTATION_FRAME_PX);
+    expect(minEffectiveLabelPx(pres.svg)).toBeGreaterThanOrEqual(BPMN_PRESENTATION_MIN_LABEL_PX);
+    expect(pres.svg).toContain('font-size: 20px');
+    expect(def.svg).toContain('font-size: 11px');
+  }, 30_000);
+
+  it('rasterizes a PNG whose CSS width matches the SVG and stays within the frame', async () => {
+    const { svg } = await exportBpmnVisual(yaml, 'presentation');
+    const png = rasterizeBpmnSvgToPng(svg);
+    const decoded = PNG.sync.read(png);
+    expect(decoded.width).toBeLessThanOrEqual(BPMN_PRESENTATION_FRAME_PX);
+    expect(decoded.width).toBe(Math.round(svgCssWidth(svg)));
+    expect(decoded.height).toBeGreaterThan(0);
+  }, 30_000);
+});

--- a/tests/cli-parse.test.ts
+++ b/tests/cli-parse.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   DEFAULT_TRANSITRIX_FILE_EXTENSIONS,
   parseCliFileArgv,
+  parseCompileArgv,
   parseValidateArgv,
   inputMatchesExtension,
   isIsoDate,
@@ -49,6 +50,23 @@ describe('cli-parse', () => {
       ok: true,
       positional: ['models/x.cervin.yaml', 'out/generated.bpmn'],
     });
+  });
+});
+
+describe('parseCompileArgv', () => {
+  it('defaults profile to default and strips flags from paths', () => {
+    const r = parseCompileArgv(['in.bpmn.transitrix.yaml', 'out.bpmn', '--no-metrics', '--profile=presentation']);
+    expect(r).toMatchObject({
+      ok: true,
+      positional: ['in.bpmn.transitrix.yaml', 'out.bpmn'],
+      profile: 'presentation',
+      noMetrics: true,
+      noValidate: false,
+    });
+  });
+
+  it('rejects an unknown profile', () => {
+    expect(parseCompileArgv(['--profile=wide', 'in.yaml', 'out.svg'])).toEqual({ ok: false, error: 'bad_profile' });
   });
 });
 

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -151,6 +151,12 @@ function renderShell(root: HTMLElement): void {
     <button type="button" id="btn-theme" aria-label="Switch color theme">Dark</button>
     <span class="actions-sep" aria-hidden="true"></span>
     <button type="button" id="btn-export-bpmn" disabled title="Download BPMN 2.0 XML (.bpmn) after a successful preview">Export BPMN</button>
+    <label class="export-profile-label">Export profile
+      <select id="export-profile" aria-label="BPMN export profile" title="Presentation is a denser automatic layout for slides; it does not change the live preview">
+        <option value="default">Default</option>
+        <option value="presentation">Presentation</option>
+      </select>
+    </label>
     <button type="button" id="btn-export-svg" disabled title="Download the diagram as SVG (after a successful preview)">SVG</button>
     <button type="button" id="btn-export-png" disabled title="Download the diagram as PNG (after a successful preview)">PNG</button>
   </div>
@@ -227,6 +233,7 @@ const btnReset = document.querySelector('#btn-reset');
 const btnExportBpmn = document.querySelector<HTMLButtonElement>('#btn-export-bpmn');
 const btnExportSvg = document.querySelector<HTMLButtonElement>('#btn-export-svg');
 const btnExportPng = document.querySelector<HTMLButtonElement>('#btn-export-png');
+const exportProfileSelect = document.querySelector<HTMLSelectElement>('#export-profile');
 const btnLayoutReset = document.querySelector('#btn-layout-reset');
 const btnLayoutSave = document.querySelector<HTMLButtonElement>('#btn-layout-save');
 const pickFile = document.querySelector<HTMLInputElement>('#pick-file');
@@ -254,6 +261,7 @@ if (
   !btnExportBpmn ||
   !btnExportSvg ||
   !btnExportPng ||
+  !exportProfileSelect ||
   !pickFile ||
   !btnLayoutReset ||
   !btnLayoutSave ||
@@ -582,6 +590,20 @@ async function compileAndShow(): Promise<void> {
   });
 }
 
+async function fetchBpmnVisualExport(format: 'svg' | 'png'): Promise<{ svg?: string; pngBase64?: string }> {
+  const profile = exportProfileSelect.value === 'presentation' ? 'presentation' : 'default';
+  const res = await fetch('/api/export-bpmn', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json; charset=utf-8' },
+    body: JSON.stringify({ yaml: textarea.value, profile, format }),
+  });
+  const body = (await res.json().catch(() => ({}))) as { svg?: string; pngBase64?: string; message?: string };
+  if (!res.ok) {
+    throw new Error(body.message ?? res.statusText);
+  }
+  return body;
+}
+
 function exportDiagramBpmn(): void {
   try {
     if (studioTab() === 'blocks') {
@@ -624,6 +646,13 @@ async function exportDiagramSvg(): Promise<void> {
       );
       return;
     }
+    if (exportProfileSelect.value === 'presentation') {
+      const { svg } = await fetchBpmnVisualExport('svg');
+      if (!svg) throw new Error('Presentation SVG export returned no markup');
+      const base = guessExportBasenameFromYaml(textarea.value);
+      downloadBlob(new Blob([svg], { type: 'image/svg+xml;charset=utf-8' }), `${base}.presentation.svg`);
+      return;
+    }
     const v = getViewer();
     const { svg } = await v.saveSVG();
     const base = guessExportBasenameFromYaml(textarea.value);
@@ -649,6 +678,14 @@ async function exportDiagramPng(): Promise<void> {
       const base = guessBlocksExportBasename(blocksSource.value);
       const suffix = lastBlocksSvgs.length > 1 ? '-sheet1' : '';
       downloadBlob(blob, `${base}${suffix}.png`);
+      return;
+    }
+    if (exportProfileSelect.value === 'presentation') {
+      const { pngBase64 } = await fetchBpmnVisualExport('png');
+      if (!pngBase64) throw new Error('Presentation PNG export returned no image');
+      const bytes = Uint8Array.from(atob(pngBase64), (c) => c.charCodeAt(0));
+      const base = guessExportBasenameFromYaml(textarea.value);
+      downloadBlob(new Blob([bytes], { type: 'image/png' }), `${base}.presentation.png`);
       return;
     }
     const v = getViewer();

--- a/ui/src/style.css
+++ b/ui/src/style.css
@@ -350,6 +350,18 @@ details.layout-drawer[open] > .layout-summary::before {
   display: none;
 }
 
+#app[data-studio-tab='blocks'] .export-profile-label,
+#app[data-studio-tab='goals'] .export-profile-label {
+  display: none;
+}
+
+.export-profile-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+}
+
 .shell-header {
   flex-shrink: 0;
   display: flex;


### PR DESCRIPTION
## Summary
- Add a selectable **presentation** BPMN export profile on the existing compile / SVG / PNG path (CLI `--profile=presentation`, editor commands, local UI selector).
- The profile uses automatic denser layout and 20 px labels so the worked erasure diagram fits a 1780 px frame. It does not become the live preview.
- Automated checks cover profile vs default, width, effective label size, and PNG raster of the same SVG.

## Test plan
- [ ] `transitrix compile organizations/acme_corp/canon/views/bpmn/data-subject-erasure.bpmn.transitrix.yaml out.svg --profile=presentation` — SVG width ≤ 1780, labels 20 px
- [ ] Same compile without `--profile` (or `--profile=default`) still uses the preview layout and 11 px / 10 px labels
- [ ] Extension: live BPMN preview unchanged; Command Palette “Save BPMN as presentation SVG/PNG” writes the profile output
- [ ] Local UI: Export profile = Presentation uses the new path; Default still exports the live preview

THQ-316
