### PR TITLE
fix(dgca): follow delivers_changes in projection and parse

### DIFF
--- a/changelog/fragments/dgca-delivers-changes-88dadf82.md
+++ b/changelog/fragments/dgca-delivers-changes-88dadf82.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **DGCA projection follows `delivers_changes`.** An Action that links to a Change only through the canonical `delivers_changes` field is included when `view_config.actions.surface` is `derived`, and the preview builds Change-to-Action edges from that field. The older `changes` field and `view_config.activities` remain aliases.

--- a/packages/diagrams/src/fgca/__tests__/parse-canonical.test.ts
+++ b/packages/diagrams/src/fgca/__tests__/parse-canonical.test.ts
@@ -168,6 +168,24 @@ describe('parseCanonicalFGCA', () => {
     expect(r.valid).toBe(true);
     expect(r.parsed?.changes[0].activity_ids).toHaveLength(2);
   });
+
+  it('populates change.activity_ids from canonical delivers_changes', () => {
+    const r = parseCanonicalFGCA({
+      ...VALID,
+      actions: [{ id: 'ACTION-1', name: 'Ship', delivers_changes: ['CHANGE-1'] }],
+    });
+    expect(r.valid, JSON.stringify(r.errors)).toBe(true);
+    expect(r.parsed?.changes[0].activity_ids).toEqual(['ACTION-1']);
+  });
+
+  it('FGCA-010: rejects delivers_changes referencing an undefined change', () => {
+    const r = parseCanonicalFGCA({
+      ...VALID,
+      actions: [{ id: 'ACTION-1', name: 'A', delivers_changes: ['CHANGE-99'] }],
+    });
+    expect(r.valid).toBe(false);
+    expect(r.errors.some((e) => e.code === 'FGCA-010')).toBe(true);
+  });
 });
 
 // The "FGCA preview blank / FGA no edges" regression

--- a/packages/diagrams/src/fgca/__tests__/resolver.test.ts
+++ b/packages/diagrams/src/fgca/__tests__/resolver.test.ts
@@ -181,6 +181,35 @@ describe('resolveFGCA — action/activity notation alias', () => {
   });
 });
 
+// ── resolveFGCA — canonical delivers_changes ─────────────────────────────────
+
+describe('resolveFGCA — delivers_changes', () => {
+  it('includes an Action linked only via delivers_changes when actions.surface is derived', () => {
+    const elements = [
+      { notation: 'driver', id: 'FACTOR-1', name: 'Market pressure' },
+      { notation: 'goal', id: 'GOAL-1', name: 'Grow revenue', factors: ['FACTOR-1'] },
+      { notation: 'change', id: 'CHANGE-1', name: 'Launch product', goals: ['GOAL-1'] },
+      { notation: 'action', id: 'ACTION-1', name: 'Ship the launch', delivers_changes: ['CHANGE-1'] },
+    ];
+    const viewDoc = {
+      notation: 'dgca',
+      id: 'DGCA-1',
+      name: 'Projection',
+      view_config: {
+        goals: { filter: 'all' },
+        factors: { surface: 'derived' },
+        changes: { surface: 'derived' },
+        actions: { surface: 'derived' },
+      },
+    };
+    const doc = resolveFGCA(viewDoc, { elements, relations: [] });
+    expect((doc['actions'] as Array<{ id: string }>).map((a) => a.id)).toEqual(['ACTION-1']);
+    const r = parseCanonicalFGCA(doc);
+    expect(r.valid, JSON.stringify(r.errors)).toBe(true);
+    expect(r.parsed?.changes[0].activity_ids).toEqual(['ACTION-1']);
+  });
+});
+
 // ── resolveFGCA — empty / degenerate inputs ───────────────────────────────────
 
 describe('resolveFGCA — empty sources', () => {

--- a/packages/diagrams/src/fgca/action-change-ids.ts
+++ b/packages/diagrams/src/fgca/action-change-ids.ts
@@ -1,0 +1,13 @@
+/**
+ * Action → Change linkage on an element record.
+ *
+ * Canonical field is `delivers_changes` (Action element spec). `changes` is
+ * the pre-rename alias still present on older fixtures and inline docs.
+ */
+export function actionChangeLinkField(
+  el: Record<string, unknown>,
+): 'delivers_changes' | 'changes' {
+  return Object.prototype.hasOwnProperty.call(el, 'delivers_changes')
+    ? 'delivers_changes'
+    : 'changes';
+}

--- a/packages/diagrams/src/fgca/parse-canonical.ts
+++ b/packages/diagrams/src/fgca/parse-canonical.ts
@@ -8,7 +8,7 @@
  * - Typed string IDs per `IDS_AND_REFERENCES.md` (`FACTOR-1`,
  *   `GOAL-RET-1`, `CHANGE-1`, `ACTION-ONBOARD-1` (legacy `ACTIVITY-*` accepted).
  * - Plural canonical-direction cross-references: `goal.factors`,
- *   `change.goals`, `activity.changes`, `activity.goals`.
+ *   `change.goals`, `action.delivers_changes`, `action.goals`.
  * - Per-notation validation codes `FGCA-001 … FGCA-015`.
  *
  * Returns the validation result plus, on success, an internal `FGCADoc`
@@ -36,6 +36,7 @@ import type {
   ValidationWarning,
   ValidationResult,
 } from '../validation-types.js';
+import { actionChangeLinkField } from './action-change-ids.js';
 
 export interface CanonicalFGCAResult extends ValidationResult {
   /** On success, the internal-form FGCADoc derived from the canonical input. */
@@ -253,11 +254,12 @@ export function parseCanonicalFGCA(input: unknown): CanonicalFGCAResult {
     };
   });
 
-  // Build a reverse mapping: which changes does each activity reference (via
-  // canonical activity.changes)? Used to populate the internal `change.activity_ids`.
+  // Build a reverse mapping: which changes does each action deliver (via
+  // canonical `delivers_changes`, or the pre-rename `changes` alias)?
   const activityChangesByCanonicalActivityId = new Map<string, string[]>();
   activities.forEach((el, i) => {
-    const refIds = checkRefArray(el!, 'changes', changeIds, CHANGE_ID_RE, 'FGCA-010', `activities[${i}]`);
+    const field = actionChangeLinkField(el!);
+    const refIds = checkRefArray(el!, field, changeIds, CHANGE_ID_RE, 'FGCA-010', `activities[${i}]`);
     activityChangesByCanonicalActivityId.set(String(el!['id']), refIds);
   });
 

--- a/packages/diagrams/src/fgca/resolver.ts
+++ b/packages/diagrams/src/fgca/resolver.ts
@@ -7,6 +7,8 @@
  * string IDs.  Filesystem-free — callable from unit tests without vscode.
  */
 
+import { actionChangeLinkField } from './action-change-ids.js';
+
 export interface FGCAViewConfig {
   goals?: {
     filter?: 'all' | 'ids' | 'tags';
@@ -15,6 +17,8 @@ export interface FGCAViewConfig {
   };
   factors?: { surface?: 'derived' | 'all' };
   changes?: { surface?: 'derived' | 'all' };
+  /** Canonical projection key. `activities` remains a deprecated alias. */
+  actions?: { surface?: 'derived' | 'all' };
   activities?: { surface?: 'derived' | 'all' };
   display?: { depth?: number | null; collapsed?: string[] };
 }
@@ -69,8 +73,8 @@ export function isFGCAViewDoc(parsed: unknown): boolean {
  * to pass to `parseCanonicalFGCA`.
  *
  * Cross-reference fields (`goal.factors[]`, `change.goals[]`,
- * `action.changes[]`) are carried from the canon elements unchanged; the
- * resolver decides which elements to include, not how they are shaped.
+ * `action.delivers_changes[]`) are carried from the canon elements unchanged;
+ * the resolver decides which elements to include, not how they are shaped.
  */
 export function resolveFGCA(
   viewDoc: unknown,
@@ -84,7 +88,11 @@ export function resolveFGCA(
   const goalsConf = isObject(vc['goals']) ? vc['goals'] : {};
   const factorsConf = isObject(vc['factors']) ? vc['factors'] : {};
   const changesConf = isObject(vc['changes']) ? vc['changes'] : {};
-  const activitiesConf = isObject(vc['activities']) ? vc['activities'] : {};
+  const actionsConf = isObject(vc['actions'])
+    ? vc['actions']
+    : isObject(vc['activities'])
+      ? vc['activities']
+      : {};
 
   const factorElemsLegacy = collectByNotation(sources.elements, 'factor');
   const factorElemsNew = collectByNotation(sources.elements, 'driver');
@@ -139,13 +147,13 @@ export function resolveFGCA(
     selectedChanges.map((c) => str(c['id'])).filter((x): x is string => x !== undefined),
   );
 
-  // 4. Select activities: derived = reference ≥1 selected change or goal (degenerate FGA link)
+  // 4. Select actions: derived = delivers ≥1 selected change, or (DGA) a selected goal
   let selectedActivities: Array<Record<string, unknown>>;
-  if (str(activitiesConf['surface']) === 'all') {
+  if (str(actionsConf['surface']) === 'all') {
     selectedActivities = [...activityElems.values()];
   } else {
     selectedActivities = [...activityElems.values()].filter((a) =>
-      strArray(a['changes']).some((cid) => selectedChangeIds.has(cid)) ||
+      strArray(a[actionChangeLinkField(a)]).some((cid) => selectedChangeIds.has(cid)) ||
       strArray(a['goals']).some((gid) => selectedGoalIds.has(gid)),
     );
   }


### PR DESCRIPTION
## Summary

- DGCA canon projection includes Actions that link to Changes only via `delivers_changes` (no direct `goals` required).
- Canonical parse builds Change-to-Action edges from `delivers_changes`; the older `changes` field remains an alias.
- `view_config.actions` is the projection key; `view_config.activities` still works as the deprecated alias.

## Test plan

- [x] Resolver includes an Action with only `delivers_changes` when `actions.surface: derived`
- [x] Parser populates `change.activity_ids` from `delivers_changes`
- [x] `FGCA-010` still fires on an undeclared Change id
- [x] Existing fixtures that use `changes` / `activities` still resolve

THQ-326
