### PR TITLE
fix(dgca): omit the Changes column when layers.changes is off

### DIFF
--- a/changelog/fragments/dgca-dga-omit-changes-e5883bf8.md
+++ b/changelog/fragments/dgca-dga-omit-changes-e5883bf8.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **DGA-mode DGCA omits the Changes column.** A `dgca` document with `view_config.layers.changes: off` (and no `changes:` key) renders Driver → Goal → Action. A four-layer DGCA is unchanged.

--- a/extension/src/dgca-preview.ts
+++ b/extension/src/dgca-preview.ts
@@ -45,6 +45,7 @@ interface FGCADoc {
   goals: GoalItem[];
   changes?: ChangeItem[];
   activities: ActivityItem[];
+  hideChanges?: boolean;
 }
 
 // ── Column layout ─────────────────────────────────────────────────────────────────────────────────
@@ -438,7 +439,7 @@ export class DGCAPreview {
 
     const { html, svg } = renderChainPreview(
       {
-        notation: 'DGCA', viewNotation: 'dgca', hideChanges: false,
+        notation: 'DGCA', viewNotation: 'dgca', hideChanges: parsedDoc?.hideChanges === true,
         heading: 'DGCA — Driver → Goal → Change → Action',
         saveSvgCommand: 'transitrixStudio.saveDGCAAsSvg',
         savePngCommand: 'transitrixStudio.saveDGCAAsPng',

--- a/packages/diagrams/src/fgca/__tests__/parse-canonical.test.ts
+++ b/packages/diagrams/src/fgca/__tests__/parse-canonical.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import yaml from 'js-yaml';
 import { parseCanonicalFGCA, parseCanonicalFGA } from '../parse-canonical.js';
+import { layoutFGCAPreview } from '../preview-layout.js';
 
 const VALID = {
   notation: 'dgca',
@@ -58,6 +59,28 @@ describe('parseCanonicalFGCA', () => {
     });
     expect(r.valid, JSON.stringify(r.errors)).toBe(true);
     expect(r.parsed?.changes).toEqual([]);
+    expect(r.parsed?.hideChanges).toBe(true);
+  });
+
+  it('DGA-mode preview has three columns (no Changes)', () => {
+    const r = parseCanonicalFGCA({
+      ...VALID,
+      changes: undefined,
+      view_config: { layers: { changes: 'off' } },
+      actions: [
+        { id: 'ACTION-DISCOVERY-1', name: 'Gap assessment', goals: ['GOAL-1'] },
+      ],
+    });
+    expect(r.valid, JSON.stringify(r.errors)).toBe(true);
+    const layout = layoutFGCAPreview(r.parsed!, { hideChanges: r.parsed!.hideChanges });
+    expect(layout.columns.map((c) => c.col)).toEqual(['driver', 'goal', 'activity']);
+  });
+
+  it('four-layer dgca still has a Changes column', () => {
+    const r = parseCanonicalFGCA(VALID);
+    expect(r.parsed?.hideChanges).toBeFalsy();
+    const layout = layoutFGCAPreview(r.parsed!);
+    expect(layout.columns.map((c) => c.col)).toEqual(['driver', 'goal', 'change', 'activity']);
   });
 
   it('FGCA-001: rejects non-object input', () => {

--- a/packages/diagrams/src/fgca/parse-canonical.ts
+++ b/packages/diagrams/src/fgca/parse-canonical.ts
@@ -64,9 +64,10 @@ function asObjectArray(v: unknown): Array<Record<string, unknown>> | null {
   return v.map((el) => (el && typeof el === 'object' ? (el as Record<string, unknown>) : null) as Record<string, unknown>);
 }
 
-/** DGA mode (`view_config.layers.changes: off`) may omit the changes layer. */
-function isChangesLayerOff(raw: Record<string, unknown>): boolean {
-  const vc = raw['view_config'];
+/** DGA mode (`view_config.layers.changes: off`) omits the Changes column. */
+export function isDgcaChangesLayerOff(input: unknown): boolean {
+  if (!input || typeof input !== 'object') return false;
+  const vc = (input as Record<string, unknown>)['view_config'];
   if (!vc || typeof vc !== 'object') return false;
   const layers = (vc as Record<string, unknown>)['layers'];
   if (!layers || typeof layers !== 'object') return false;
@@ -125,7 +126,7 @@ export function parseCanonicalFGCA(input: unknown): CanonicalFGCAResult {
   const factorsRaw = asObjectArray(raw['factors']);
   const goalsRaw = asObjectArray(raw['goals']);
   let changesRaw = asObjectArray(raw['changes']);
-  if (changesRaw === null && raw['changes'] === undefined && isChangesLayerOff(raw)) {
+  if (changesRaw === null && raw['changes'] === undefined && isDgcaChangesLayerOff(raw)) {
     changesRaw = [];
   }
   const activitiesRaw = asObjectArray(raw['actions']);
@@ -331,6 +332,7 @@ export function parseCanonicalFGCA(input: unknown): CanonicalFGCAResult {
     goals: internalGoals,
     changes: internalChanges,
     activities: internalActivities,
+    hideChanges: isDgcaChangesLayerOff(raw),
   };
 
   return { valid: true, errors, warnings, parsed };

--- a/packages/diagrams/src/fgca/resolver.ts
+++ b/packages/diagrams/src/fgca/resolver.ts
@@ -159,5 +159,6 @@ export function resolveFGCA(
     goals: selectedGoals,
     changes: selectedChanges,
     actions: selectedActivities,
+    view_config: viewDoc['view_config'],
   };
 }

--- a/packages/diagrams/src/fgca/validate.ts
+++ b/packages/diagrams/src/fgca/validate.ts
@@ -19,6 +19,8 @@ export interface FGCADoc {
   goals: GoalItem[];
   changes: BdnChangeWithActivities[];
   activities: ActivityItem[];
+  /** DGA mode: omit the Changes column (`view_config.layers.changes: off`). */
+  hideChanges?: boolean;
 }
 
 export function validateFGCADoc(input: unknown): FGCAValidationResult {

--- a/packages/diagrams/src/webview/__tests__/entry-notations.test.ts
+++ b/packages/diagrams/src/webview/__tests__/entry-notations.test.ts
@@ -87,4 +87,18 @@ describe('webview/entry — Step 4 notation coverage', () => {
     expect(r.errors.length).toBeGreaterThan(0);
     expect(r.svg).toBe('');
   });
+
+  it('omits the Changes column when a dgca document is in DGA mode', () => {
+    const off = render('dgca', readFileSync(path.join(EXAMPLES, 'dgca/dga-mode.dgca.transitrix.yaml'), 'utf8'));
+    expect(off.status).toBe('ok');
+    expect(off.errors).toEqual([]);
+    expect(off.svg).toContain('Drivers (D)');
+    expect(off.svg).toContain('Goals (G)');
+    expect(off.svg).toContain('Actions (A)');
+    expect(off.svg).not.toContain('Changes (C)');
+
+    const four = render('dgca', readFileSync(path.join(EXAMPLES, 'dgca/strategy-2026.dgca.transitrix.yaml'), 'utf8'));
+    expect(four.status).toBe('ok');
+    expect(four.svg).toContain('Changes (C)');
+  });
 });

--- a/packages/diagrams/src/webview/render-fgca.ts
+++ b/packages/diagrams/src/webview/render-fgca.ts
@@ -121,7 +121,7 @@ export function renderFgcaSvg(doc: FGCADoc, options: RenderFgcaOptions = {}): st
     nodeSizePreset = 'normal',
     layoutOptions,
   } = options;
-  const hideChanges = variant === 'dga';
+  const hideChanges = variant === 'dga' || doc.hideChanges === true;
   const nodeSize = resolveDgcaNodeSize(parseNodeSizePreset(nodeSizePreset));
 
   const { nodes, edges, columns, width, height } = layoutFGCAPreview(doc, {

--- a/tests/fixtures/notation-corpus/dgca/dga-mode.dgca.transitrix.yaml
+++ b/tests/fixtures/notation-corpus/dgca/dga-mode.dgca.transitrix.yaml
@@ -1,0 +1,18 @@
+notation: dgca
+spec_version: "0.1"
+id: DGCA-DGA-1
+name: "DGA mode — Changes column off"
+view_config:
+  layers:
+    changes: "off"
+factors:
+  - id: FACTOR-1
+    name: "Driver one"
+goals:
+  - id: GOAL-1
+    name: "Outcome one"
+    factors: [FACTOR-1]
+actions:
+  - id: ACTION-DISCOVERY-1
+    name: "Gap assessment"
+    goals: [GOAL-1]


### PR DESCRIPTION
## Summary

- A `dgca` document with `view_config.layers.changes: off` (and no `changes:` key) no longer draws an empty Changes column. Preview and CLI render show Driver → Goal → Action.
- Four-layer DGCA (`layers.changes` on / default) is unchanged. The retired `dga` alias still hides that column the same way.
- Based on `main`, not stacked on #567. Both touch `packages/diagrams/src/fgca/resolver.ts` — merge #567 first if they collide.

## Test plan

- [x] Parser stamps `hideChanges` when `layers.changes` is `off`
- [x] Preview layout has three columns in that mode, four otherwise
- [x] Webview `render('dgca', …)` omits the `Changes (C)` header on the DGA-mode fixture and keeps it on the four-layer example

THQ-327
