### PR TITLE
fix(action): emit ACT-021 when root_action omits an ACTION

### DIFF
--- a/changelog/fragments/act-021-root-action-a4acb6e4.md
+++ b/changelog/fragments/act-021-root-action-a4acb6e4.md
@@ -1,0 +1,3 @@
+### Added
+
+- **`ACT-021` when an Action Schedule is scoped by `root_action`.** An ACTION the view would otherwise include that is not that root and not reachable from it via `parent` is omitted from the render with a warning that names both ids. The warning does not fire when `root_action` is absent. Duplicate-id `ACT-004` is unchanged.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -53,7 +53,7 @@ suite, see below):
   `FGCA-008`..`014`) — see below.
 - **Standalone-element envelope hygiene** (`GOAL-ELEM-002`/`003`,
   `ACTION-001`/`002`/`005`) — see below.
-- **Doc-level grammar** (`GOALS-001`..`007`, `ACT-001`..`003`/`016`,
+- **Doc-level grammar** (`GOALS-001`..`007`, `ACT-001`..`003`/`016`/`021`,
   `FGCA-001`..`007`/`015`) — each notation's own per-file validator, surfaced
   under the `views` array (not `canon`) when the document lives under
   `canon/views/**` — see below.
@@ -186,6 +186,7 @@ in.
 | `GOALS-007` | `goals` | Duplicate `goals[].id` within one document (distinct from the cross-document `checkIdUniqueness` above). |
 | `ACT-001`..`003` | `action` | Document/`notation` shape, activity entry id/name presence. |
 | `ACT-016` | `action` | A milestone (`duration` 0) with both `start_date`/`end_date` pinned must have them equal. |
+| `ACT-021` | `action` | `view_config.scope.root_action` is set and resolves, and an ACTION the view would otherwise include is not that root and not reachable from it via `parent`. Warning; the ACTION is omitted from the render. Distinct from `ACT-004` (duplicate id in this validator). |
 | `FGCA-001`..`007` | `dgca` | Document shape, per-layer entry grammar, cross-reference array grammar. |
 | `FGCA-015` | `dgca` | `factors[].references_constraint` is an array of valid ids. |
 

--- a/packages/diagrams/src/activities/__tests__/resolver.test.ts
+++ b/packages/diagrams/src/activities/__tests__/resolver.test.ts
@@ -276,3 +276,52 @@ describe('resolveAction — trims incidental whitespace on matched fields', () =
     expect(ids).toEqual(['ACTION-WS-1']);
   });
 });
+
+// ── resolveAction — ACT-021 (root_action omit + warn) ─────────────────────
+
+describe('resolveAction — ACT-021', () => {
+  const ELEMENTS = [
+    { notation: 'action', id: 'ACTION-LAUNCH-1', name: 'Platform launch', type: 'Project' },
+    { notation: 'action', id: 'ACTION-LAUNCH-PREP-1', name: 'Launch preparation', type: 'Task', parent: 'ACTION-LAUNCH-1' },
+    { notation: 'action', id: 'ACTION-LAUNCH-COMMS-1', name: 'Launch communications', type: 'Task' },
+  ];
+  const scoped = {
+    notation: 'action',
+    id: 'ACTION_SCHED-LAUNCH-1',
+    name: 'Launch — scoped',
+    view_config: {
+      scope: { root_action: 'ACTION-LAUNCH-1' },
+      schedule: { start_date: '2026-09-01' },
+    },
+  };
+
+  it('omits the unwired child from the render set and warns ACT-021 on it only', () => {
+    const doc = resolveAction(scoped, { elements: ELEMENTS });
+    const ids = (doc['actions'] as Array<{ id: string }>).map((a) => a.id).sort();
+    expect(ids).toEqual(['ACTION-LAUNCH-1', 'ACTION-LAUNCH-PREP-1']);
+    const v = validateActivities(doc);
+    expect(v.valid).toBe(true);
+    const w = v.warnings.filter((x) => x.code === 'ACT-021');
+    expect(w).toHaveLength(1);
+    expect(w[0].message).toContain('ACTION-LAUNCH-COMMS-1');
+    expect(w[0].message).toContain('ACTION-LAUNCH-1');
+    expect(w[0].message).not.toContain('ACTION-LAUNCH-PREP-1');
+    expect(v.errors.some((e) => e.code === 'ACT-004')).toBe(false);
+    expect(v.warnings.some((x) => x.code === 'ACT-004')).toBe(false);
+  });
+
+  it('does not emit ACT-021 when root_action is absent', () => {
+    const unscoped = {
+      ...scoped,
+      view_config: { scope: {}, schedule: { start_date: '2026-09-01' } },
+    };
+    const doc = resolveAction(unscoped, { elements: ELEMENTS });
+    expect((doc['actions'] as Array<{ id: string }>).map((a) => a.id).sort()).toEqual([
+      'ACTION-LAUNCH-1',
+      'ACTION-LAUNCH-COMMS-1',
+      'ACTION-LAUNCH-PREP-1',
+    ]);
+    const v = validateActivities(doc);
+    expect(v.warnings.some((x) => x.code === 'ACT-021')).toBe(false);
+  });
+});

--- a/packages/diagrams/src/activities/__tests__/validate.test.ts
+++ b/packages/diagrams/src/activities/__tests__/validate.test.ts
@@ -104,6 +104,38 @@ describe('validateActivities', () => {
     expect(r.errors.some(e => e.code === 'ACT-004')).toBe(true);
   });
 
+  it('ACT-021 — warns on an authored ACTION outside root_action', () => {
+    const r = validateActivities({
+      notation: 'action',
+      project: { start_date: '2026-09-01' },
+      view_config: { scope: { root_action: 'ACTION-LAUNCH-1' } },
+      actions: [
+        { id: 'ACTION-LAUNCH-1', name: 'Launch', duration: 5 },
+        { id: 'ACTION-LAUNCH-PREP-1', name: 'Prep', parent: 'ACTION-LAUNCH-1', duration: 3 },
+        { id: 'ACTION-LAUNCH-COMMS-1', name: 'Comms', duration: 2 },
+      ],
+    });
+    expect(r.valid).toBe(true);
+    const w = r.warnings.filter(x => x.code === 'ACT-021');
+    expect(w).toHaveLength(1);
+    expect(w[0].message).toContain('ACTION-LAUNCH-COMMS-1');
+    expect(w[0].message).toContain('ACTION-LAUNCH-1');
+    expect(r.errors.some(e => e.code === 'ACT-004')).toBe(false);
+    expect(r.warnings.some(x => x.code === 'ACT-004')).toBe(false);
+  });
+
+  it('ACT-021 — does not fire when root_action is absent', () => {
+    const r = validateActivities({
+      notation: 'action',
+      project: { start_date: '2026-09-01' },
+      actions: [
+        { id: 'ACTION-LAUNCH-1', name: 'Launch', duration: 5 },
+        { id: 'ACTION-LAUNCH-COMMS-1', name: 'Comms', duration: 2 },
+      ],
+    });
+    expect(r.warnings.some(x => x.code === 'ACT-021')).toBe(false);
+  });
+
   it('ACT-005 — rejects unknown predecessor reference', () => {
     const r = validateActivities({
       notation: 'action',

--- a/packages/diagrams/src/activities/resolver.ts
+++ b/packages/diagrams/src/activities/resolver.ts
@@ -12,7 +12,7 @@
  * §2). Filesystem-free — callable from unit tests without vscode.
  */
 
-import { isObject, str, strArray, descendantsOf, stripEnvelope } from '../canon-resolver-utils.js';
+import { isObject, str, strArray, stripEnvelope, reachesRootViaParent } from '../canon-resolver-utils.js';
 
 export interface ActionViewConfig {
   scope?: {
@@ -43,6 +43,10 @@ export interface ActionCanonSources {
    *  to each element's inline `goals[]`. */
   relations?: unknown[];
 }
+
+/** In-memory bag of ACTION ids dropped by `root_action` scoping. Consumed by
+ *  `validateActivities` as `ACT-021`. Not part of the notation. */
+export const ACT_021_OMITTED_KEY = '__act021_omitted';
 
 /** ACTION elements by id. `notation: action` is canonical; `notation: activity`
  *  is the deprecated pre-2026-06-25 alias (elements/24-action.md §"Deprecated
@@ -123,32 +127,26 @@ export function resolveAction(
     return relGoals.length > 0 ? relGoals : strArray(el['goals']);
   }
 
-  // 1. Scope by root_action (this action + its descendants), or the full
-  // catalogue when omitted (§5.1: "Omit to include elements from the full
-  // catalogue (or use goals/type_filter for other scoping)").
-  const rootAction = str(scope['root_action']);
-  let candidateIds: Set<string>;
-  if (rootAction) {
-    candidateIds = allActions.has(rootAction) ? descendantsOf(rootAction, allActions) : new Set();
-  } else {
-    candidateIds = new Set(allActions.keys());
-  }
+  // 1. Other scope fields first — the set the view would otherwise select
+  // (07-action.md §5.1). `root_action` then omits (and warns) rather than
+  // silently intersecting first.
+  let otherwiseIds: Set<string> = new Set(allActions.keys());
 
-  // 2. Narrow by goals — only actions linked to at least one listed GOAL
+  // Narrow by goals — only actions linked to at least one listed GOAL
   // (via an active action_goal relation, or inline goals[] when no relation
   // exists for that action).
   const goalsFilter = strArray(scope['goals']);
   if (goalsFilter.length > 0) {
-    candidateIds = new Set(
-      [...candidateIds].filter((id) => effectiveGoals(id, allActions.get(id)!).some((g) => goalsFilter.includes(g))),
+    otherwiseIds = new Set(
+      [...otherwiseIds].filter((id) => effectiveGoals(id, allActions.get(id)!).some((g) => goalsFilter.includes(g))),
     );
   }
 
-  // 3. Narrow by type_filter — only actions of a listed type.
+  // Narrow by type_filter — only actions of a listed type.
   const typeFilter = strArray(scope['type_filter']);
   if (typeFilter.length > 0) {
-    candidateIds = new Set(
-      [...candidateIds].filter((id) => {
+    otherwiseIds = new Set(
+      [...otherwiseIds].filter((id) => {
         const el = allActions.get(id);
         const t = str(el?.['type']) ?? str(el?.['activity_type']);
         return t !== undefined && typeFilter.includes(t);
@@ -156,13 +154,13 @@ export function resolveAction(
     );
   }
 
-  // 4. Narrow by valid_at — only actions in effect on that date. Actions with
+  // Narrow by valid_at — only actions in effect on that date. Actions with
   // no valid_from are not lifecycle-tracked and are kept (permissive default,
   // matching the resolver's general "missing = not excluded" stance).
   const validAt = str(scope['valid_at']);
   if (validAt) {
-    candidateIds = new Set(
-      [...candidateIds].filter((id) => {
+    otherwiseIds = new Set(
+      [...otherwiseIds].filter((id) => {
         const el = allActions.get(id);
         const from = str(el?.['valid_from']);
         const to = str(el?.['valid_to']);
@@ -171,6 +169,27 @@ export function resolveAction(
         return true;
       }),
     );
+  }
+
+  const rootAction = str(scope['root_action']);
+  let candidateIds: Set<string>;
+  const omittedOutsideRoot: string[] = [];
+  if (rootAction) {
+    if (!allActions.has(rootAction)) {
+      candidateIds = new Set();
+    } else {
+      candidateIds = new Set();
+      for (const id of otherwiseIds) {
+        if (reachesRootViaParent(id, rootAction, allActions)) {
+          candidateIds.add(id);
+        } else {
+          omittedOutsideRoot.push(id);
+        }
+      }
+      omittedOutsideRoot.sort();
+    }
+  } else {
+    candidateIds = otherwiseIds;
   }
 
   // Element fields map onto Activity fields unchanged, except the canonical
@@ -204,5 +223,6 @@ export function resolveAction(
     actions: selectedActions,
   };
   if (Object.keys(project).length > 0) out['project'] = project;
+  if (omittedOutsideRoot.length > 0) out[ACT_021_OMITTED_KEY] = { root: rootAction, ids: omittedOutsideRoot };
   return out;
 }

--- a/packages/diagrams/src/activities/validate.ts
+++ b/packages/diagrams/src/activities/validate.ts
@@ -5,9 +5,61 @@ import type {
   ActivityValidationError,
   ActivityValidationWarning,
 } from './types.js';
+import { isObject, str, reachesRootViaParent } from '../canon-resolver-utils.js';
+import { ACT_021_OMITTED_KEY } from './resolver.js';
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 const VALID_WEEKDAYS = new Set(['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']);
+
+function act021Message(actionId: string, rootId: string): string {
+  return `ACTION "${actionId}" is not "${rootId}" and is not reachable from it via parent`;
+}
+
+function collectAct021FromProjection(raw: Record<string, unknown>): ActivityValidationWarning[] {
+  const bag = raw[ACT_021_OMITTED_KEY];
+  delete raw[ACT_021_OMITTED_KEY];
+  if (!isObject(bag)) return [];
+  const root = str(bag['root']);
+  const ids = Array.isArray(bag['ids']) ? bag['ids'] : [];
+  if (!root) return [];
+  const out: ActivityValidationWarning[] = [];
+  for (const id of ids) {
+    if (typeof id !== 'string' || !id.trim()) continue;
+    out.push({
+      code: 'ACT-021',
+      message: act021Message(id, root),
+      path: 'view_config.scope.root_action',
+    });
+  }
+  return out;
+}
+
+function collectAct021FromAuthored(
+  raw: Record<string, unknown>,
+  actions: unknown[],
+): ActivityValidationWarning[] {
+  const vc = isObject(raw['view_config']) ? raw['view_config'] : undefined;
+  const scope = vc && isObject(vc['scope']) ? vc['scope'] : undefined;
+  const root = scope ? str(scope['root_action']) : undefined;
+  if (!root) return [];
+  const byId = new Map<string, Record<string, unknown>>();
+  for (const el of actions) {
+    if (!isObject(el)) continue;
+    const id = str(el['id']);
+    if (id) byId.set(id, el);
+  }
+  if (!byId.has(root)) return [];
+  const out: ActivityValidationWarning[] = [];
+  for (const id of byId.keys()) {
+    if (reachesRootViaParent(id, root, byId)) continue;
+    out.push({
+      code: 'ACT-021',
+      message: act021Message(id, root),
+      path: 'view_config.scope.root_action',
+    });
+  }
+  return out;
+}
 
 export function validateActivities(input: unknown): ActivityValidationResult {
   const errors: ActivityValidationError[] = [];
@@ -45,6 +97,12 @@ export function validateActivities(input: unknown): ActivityValidationResult {
   }
   // Normalise onto raw.activities for the rest of this function (avoids touching downstream code)
   if (!Array.isArray(raw.activities)) raw.activities = raw.actions;
+
+  const fromProjection = collectAct021FromProjection(raw);
+  warnings.push(...fromProjection);
+  if (fromProjection.length === 0) {
+    warnings.push(...collectAct021FromAuthored(raw, rawArray));
+  }
 
   // ACT-014 / ACT-015: project.calendar validation (run before per-activity loop;
   // surfaces clearly even when activities also have issues).

--- a/packages/diagrams/src/canon-resolver-utils.ts
+++ b/packages/diagrams/src/canon-resolver-utils.ts
@@ -48,6 +48,25 @@ export function descendantsOf(
   return result;
 }
 
+/** Walk `parent` from `id` toward its ancestors until `rootId` or the chain
+ *  ends. Cycle-safe: a cycle is not a path to the root. */
+export function reachesRootViaParent(
+  id: string,
+  rootId: string,
+  all: Map<string, Record<string, unknown>>,
+): boolean {
+  const seen = new Set<string>();
+  let current: string | undefined = id;
+  while (current) {
+    if (current === rootId) return true;
+    if (seen.has(current)) return false;
+    seen.add(current);
+    const el = all.get(current);
+    current = el ? str(el['parent']) : undefined;
+  }
+  return false;
+}
+
 /** Depth of `id` in its `parent` chain within `all` (root = 0, each step up
  *  adds 1). Cycle-safe (a cycle resolves the entering node to depth 0) and
  *  memoized across calls via the shared `memo` map. */


### PR DESCRIPTION
## Summary

- An Action Schedule scoped by `view_config.scope.root_action` no longer drops out-of-tree ACTIONs without a diagnostic.
- `ACT-021` (warning) names the omitted ACTION id and the root. Render set is unchanged: those ACTIONs stay omitted.
- Does not fire when `root_action` is absent. Does not reuse `ACT-004` (duplicate id in this validator).

## Test plan

- [x] Root + two children, one missing `parent` → `ACT-021` on the unwired child only; wired child and root are silent
- [x] No `root_action` → no `ACT-021`; all three remain in the projection
- [x] Authored `actions[]` with the same shape produces the same warning
- [x] Duplicate-id `ACT-004` is unchanged

THQ-329
