### PR TITLE
feat(ttrs): follow recipe_id after methodology 4.0.0

### DIFF
--- a/changelog/fragments/ttrs-recipe-id-735b828a.md
+++ b/changelog/fragments/ttrs-recipe-id-735b828a.md
@@ -1,0 +1,3 @@
+### Changed
+
+- **`.ttrs` headers use `recipe_id` / `recipe_version`.** Fixtures, the document renderer, and `transitrix render` follow methodology 4.0.0: the header fields and the identifiers that carry them (`recipeId`, `parseRecipe`, `recipePath`) no longer use `template` as the name of this object. The vendored renderer is pinned to `v4.0.0`.

--- a/extension/src/ttrs-preview.ts
+++ b/extension/src/ttrs-preview.ts
@@ -25,7 +25,7 @@ import { readBlocksLeafSize } from './node-size-config.js';
 // Studio's own type contract for the vendored JS, not part of what's fetched.
 import { runPass1 } from '../../vendor/methodology/document-renderer/pass1.mjs';
 
-/** Detects `.ttrs` document-template files (transitrix-hq#56 registered the language). */
+/** Detects `.ttrs` document-recipe files (transitrix-hq#56 registered the language). */
 export function isTtrsFile(doc: vscode.TextDocument): boolean {
   return doc.fileName.endsWith('.ttrs');
 }
@@ -109,7 +109,7 @@ export class TtrsPreview extends StaticPreview {
     try {
       const result = await runPass1({
         text: doc.getText(),
-        templatePath: doc.fileName,
+        recipePath: doc.fileName,
         profile: 'review',
         rasterise: (input) => rasteriseFigure(input, figureEmbeds),
       });

--- a/scripts/vendor-methodology-document-renderer.mjs
+++ b/scripts/vendor-methodology-document-renderer.mjs
@@ -9,7 +9,7 @@
  * preview can both depend on it as a library."
  *
  * Eight files make up the vendored surface: pass1.mjs (the deterministic
- * resolver) and its four imports (parse-template.mjs, repository.mjs,
+ * resolver) and its four imports (parse-recipe.mjs, repository.mjs,
  * ids.mjs, syntax.mjs) — vendored first for the .ttrs preview — plus
  * pass2.mjs (fills instruction slots via a caller-supplied agent hook),
  * render-pdf.mjs (Markdown → PDF, dependency-free) and run-record.mjs (the
@@ -19,8 +19,8 @@
  * own tree.
  *
  * Usage:
- *   node scripts/vendor-methodology-document-renderer.mjs --ref v3.5.0
- *   node scripts/vendor-methodology-document-renderer.mjs --ref v3.5.0 --check
+ *   node scripts/vendor-methodology-document-renderer.mjs --ref v4.0.0
+ *   node scripts/vendor-methodology-document-renderer.mjs --ref v4.0.0 --check
  *
  * --check fetches and reports what would change without writing anything.
  *
@@ -39,7 +39,7 @@ const VENDOR_DIR = path.resolve(HERE, '..', 'vendor', 'methodology', 'document-r
 const SOURCE_REPO = 'transitrix/methodology';
 const SOURCE_DIR = 'packages/document-renderer/src';
 const FILES = [
-  'pass1.mjs', 'parse-template.mjs', 'repository.mjs', 'ids.mjs', 'syntax.mjs',
+  'pass1.mjs', 'parse-recipe.mjs', 'repository.mjs', 'ids.mjs', 'syntax.mjs',
   'pass2.mjs', 'render-pdf.mjs', 'run-record.mjs',
 ];
 

--- a/src/impact.ts
+++ b/src/impact.ts
@@ -34,14 +34,14 @@ import { DOCUMENT_SOURCE_EXTENSION } from './validate-document-source.js';
 import { renderDocumentToDisk } from './render-document.js';
 // Vendored from methodology — see scripts/vendor-methodology-document-renderer.mjs
 // and tests/document-renderer-vendor.test.ts for the integrity check that
-// keeps this import target trustworthy. Only the syntax half (parseTemplate)
+// keeps this import target trustworthy. Only the syntax half (parseRecipe)
 // is needed here; this check never resolves a reference against a repository.
 import {
-  parseTemplate,
-  type TemplateNode,
-  type TemplateReferenceNode,
-  type TemplateInstructNode,
-} from '../vendor/methodology/document-renderer/parse-template.mjs';
+  parseRecipe,
+  type RecipeNode,
+  type RecipeReferenceNode,
+  type RecipeInstructNode,
+} from '../vendor/methodology/document-renderer/parse-recipe.mjs';
 
 export interface ImpactFinding {
   file: string;
@@ -259,19 +259,19 @@ export function computeStagedImpact(root: string): ImpactResult {
  *  a construct would touch, so it cannot claim the document unaffected on the
  *  strength of the plain references alone (epic acceptance requirement 6). A
  *  parse error carries no reference information either — same fallback. */
-function isReferenceNode(node: TemplateNode): node is TemplateReferenceNode {
+function isReferenceNode(node: RecipeNode): node is RecipeReferenceNode {
   return node.type === 'reference';
 }
 
-function isInstructNode(node: TemplateNode): node is TemplateInstructNode {
+function isInstructNode(node: RecipeNode): node is RecipeInstructNode {
   return node.type === 'instruct';
 }
 
 function documentReferencedIds(text: string): { ids: Set<string>; determined: boolean } {
   const ids = new Set<string>();
-  let parsed: ReturnType<typeof parseTemplate>;
+  let parsed: ReturnType<typeof parseRecipe>;
   try {
-    parsed = parseTemplate(text);
+    parsed = parseRecipe(text);
   } catch {
     return { ids, determined: false };
   }

--- a/src/render-document.ts
+++ b/src/render-document.ts
@@ -41,7 +41,7 @@ export interface RenderDocumentOptions {
 
 export interface RenderDocumentResult {
   ok: boolean;
-  templateId: string | null;
+  recipeId: string | null;
   markdownPath: string;
   pdfPath: string;
   runRecordPath: string;
@@ -70,7 +70,7 @@ function gitCommitOf(root: string): string | null {
  * Pass 1 runs `profile: 'strict'` (its own default) — a render persisted to
  * disk fails closed on an unresolved reference rather than rendering it as a
  * visible-but-wrong marker for a reader who may never open the source
- * template to see the warning. That is a deliberate difference from the live
+ * recipe to see the warning. That is a deliberate difference from the live
  * `.ttrs` preview (extension/src/ttrs-preview.ts), which runs `review` so an
  * in-progress document stays viewable while it's being written.
  */
@@ -80,7 +80,7 @@ export async function renderDocumentToDisk(options: RenderDocumentOptions): Prom
   const outDir = options.outDir ? path.resolve(options.outDir) : path.dirname(srcPath);
   const repoRoot = options.root ? path.resolve(options.root) : path.dirname(srcPath);
 
-  const pass1Result = await runPass1({ text, templatePath: srcPath, profile: 'strict' });
+  const pass1Result = await runPass1({ text, recipePath: srcPath, profile: 'strict' });
 
   const pass2Result = pass1Result.header
     ? await runPass2({ markdown: pass1Result.markdown, instructionSlots: pass1Result.instructionSlots })
@@ -114,7 +114,7 @@ export async function renderDocumentToDisk(options: RenderDocumentOptions): Prom
 
   return {
     ok: pass1Result.ok,
-    templateId: pass1Result.header?.template_id ?? null,
+    recipeId: pass1Result.header?.recipe_id ?? null,
     markdownPath,
     pdfPath,
     runRecordPath,

--- a/tests/document-renderer-vendor.test.ts
+++ b/tests/document-renderer-vendor.test.ts
@@ -46,12 +46,12 @@ function loadPin(): VendoredPin {
 }
 
 const EXPECTED_FILES = [
-  'pass1.mjs', 'parse-template.mjs', 'repository.mjs', 'ids.mjs', 'syntax.mjs',
+  'pass1.mjs', 'parse-recipe.mjs', 'repository.mjs', 'ids.mjs', 'syntax.mjs',
   'pass2.mjs', 'render-pdf.mjs', 'run-record.mjs',
 ];
 
 describe('vendor/methodology/document-renderer — integrity', () => {
-  it('VENDORED.json pins exactly the five files the resolver needs', () => {
+  it('VENDORED.json pins exactly the eight files the renderer needs', () => {
     const pin = loadPin();
     expect(Object.keys(pin.files).sort()).toEqual([...EXPECTED_FILES].sort());
   });
@@ -71,7 +71,7 @@ describe('vendor/methodology/document-renderer — integrity', () => {
 });
 
 describe('vendor/methodology/document-renderer — the resolver actually runs', () => {
-  it('runPass1 resolves a repository-optional template with no model references', async () => {
+  it('runPass1 resolves a repository-optional recipe with no model references', async () => {
     const mod = await import(pathToFileURL(path.join(VENDOR_DIR, 'pass1.mjs')).href) as {
       runPass1: (opts: { text: string; profile?: 'strict' | 'review' }) => Promise<{
         ok: boolean;
@@ -83,8 +83,8 @@ describe('vendor/methodology/document-renderer — the resolver actually runs', 
       '---',
       'document: Smoke Test',
       'kind: mrd',
-      'template_id: smoke.mrd',
-      'template_version: "1.0"',
+      'recipe_id: smoke.mrd',
+      'recipe_version: "1.0"',
       '---',
       '# Fixed text only, no model references',
     ].join('\n');
@@ -104,8 +104,8 @@ describe('vendor/methodology/document-renderer — the resolver actually runs', 
       '---',
       'document: Smoke Test',
       'kind: mrd',
-      'template_id: smoke.mrd',
-      'template_version: "1.0"',
+      'recipe_id: smoke.mrd',
+      'recipe_version: "1.0"',
       '---',
       '{{# each REQ }}{{ .title }}{{/ each }}',
     ].join('\n');
@@ -147,7 +147,7 @@ describe('vendor/methodology/document-renderer — pass 2, PDF render, run recor
       serializeRunRecord: (record: Record<string, unknown>) => string;
     };
     const record = mod.buildRunRecord({
-      header: { template_id: 'smoke.mrd', template_version: '1.0' },
+      header: { recipe_id: 'smoke.mrd', recipe_version: '1.0' },
       repositoryCommit: null,
       modelId: null,
       runTimestamp: '2026-08-17T00:00:00.000Z',
@@ -157,7 +157,7 @@ describe('vendor/methodology/document-renderer — pass 2, PDF render, run recor
         { slotId: 'market-size', question: 'q', inputs: [], sufficient: 's', verdict: 'not-attempted', reason: 'no declared inputs', text: null },
       ],
     });
-    expect(record.template_id).toBe('smoke.mrd');
+    expect(record.recipe_id).toBe('smoke.mrd');
     expect(record.run_timestamp).toBe('2026-08-17T00:00:00.000Z');
     expect(record.slots).toHaveLength(1);
     expect((record.slots as Array<Record<string, unknown>>)[0].verdict).toBe('not-attempted');

--- a/tests/fixtures/notation-corpus/documents/kind-mismatch.mrd.ttrs
+++ b/tests/fixtures/notation-corpus/documents/kind-mismatch.mrd.ttrs
@@ -1,8 +1,8 @@
 ---
 document: Software Requirements Specification
 kind: srs
-template_id: platform.srs
-template_version: "1.0"
+recipe_id: platform.srs
+recipe_version: "1.0"
 ---
 
 # Kind disagreement

--- a/tests/fixtures/notation-corpus/documents/product.mrd.ttrs
+++ b/tests/fixtures/notation-corpus/documents/product.mrd.ttrs
@@ -1,13 +1,13 @@
 ---
 document: Market Requirements Document
 kind: mrd
-template_id: product.mrd
-template_version: "1.0"
+recipe_id: product.mrd
+recipe_version: "1.0"
 ---
 
 # Market Requirements Document
 
-Every requirement below is a projection of an admitted element; this template
+Every requirement below is a projection of an admitted element; this recipe
 adds no fact of its own.
 
 The addressable need this document is written against is {{ NEED-1 }}, and the

--- a/tests/impact.test.ts
+++ b/tests/impact.test.ts
@@ -217,13 +217,13 @@ describe('computeStagedImpact (transitrix-hq#89)', () => {
 });
 
 /** A minimal, valid `.ttrs` document source — required header fields only. */
-function ttrsDoc(templateId: string, body: string): string {
+function ttrsDoc(recipeId: string, body: string): string {
   return [
     '---',
     'document: "Test document"',
     'kind: mrd',
-    `template_id: ${templateId}`,
-    'template_version: "1.0"',
+    `recipe_id: ${recipeId}`,
+    'recipe_version: "1.0"',
     '---',
     '',
     body,
@@ -412,8 +412,8 @@ describe('offerDocumentRegeneration (transitrix-hq#182)', () => {
         '---',
         'document: "Test document"',
         'kind: mrd',
-        'template_id: product.mrd',
-        'template_version: "1.0"',
+        'recipe_id: product.mrd',
+        'recipe_version: "1.0"',
         'canon: ../..',
         '---',
         '',

--- a/tests/render-document.test.ts
+++ b/tests/render-document.test.ts
@@ -36,8 +36,8 @@ const NO_REFERENCE_DOC = [
   '---',
   'document: Smoke Test',
   'kind: mrd',
-  'template_id: smoke.mrd',
-  'template_version: "1.0"',
+  'recipe_id: smoke.mrd',
+  'recipe_version: "1.0"',
   '---',
   '# Fixed text only, no model references',
   '',
@@ -52,7 +52,7 @@ describe('renderDocumentToDisk (transitrix-hq#186)', () => {
     const result = await renderDocumentToDisk({ path: join(root, 'product.mrd.ttrs') });
 
     expect(result.ok).toBe(true);
-    expect(result.templateId).toBe('smoke.mrd');
+    expect(result.recipeId).toBe('smoke.mrd');
     expect(result.markdownPath).toBe(join(root, 'product.mrd.md'));
     expect(result.pdfPath).toBe(join(root, 'product.mrd.pdf'));
     expect(result.runRecordPath).toBe(join(root, 'product.mrd.run-record.json'));
@@ -64,7 +64,7 @@ describe('renderDocumentToDisk (transitrix-hq#186)', () => {
     expect(pdf.subarray(0, 5).toString('latin1')).toBe('%PDF-');
 
     const record = JSON.parse(readFileSync(result.runRecordPath, 'utf8'));
-    expect(record.template_id).toBe('smoke.mrd');
+    expect(record.recipe_id).toBe('smoke.mrd');
     expect(record.slots).toEqual([]);
   });
 
@@ -89,8 +89,8 @@ describe('renderDocumentToDisk (transitrix-hq#186)', () => {
       '---',
       'document: Smoke Test',
       'kind: mrd',
-      'template_id: smoke.mrd',
-      'template_version: "1.0"',
+      'recipe_id: smoke.mrd',
+      'recipe_version: "1.0"',
       '---',
       '{{# instruct market-size }}',
       'question: How large is the market?',
@@ -117,8 +117,8 @@ describe('renderDocumentToDisk (transitrix-hq#186)', () => {
       '---',
       'document: Smoke Test',
       'kind: mrd',
-      'template_id: smoke.mrd',
-      'template_version: "1.0"',
+      'recipe_id: smoke.mrd',
+      'recipe_version: "1.0"',
       '---',
       'Cites {{ REQ-1 }}, which has no repository configured to resolve against.',
     ].join('\n');

--- a/tests/ttrs-render.test.ts
+++ b/tests/ttrs-render.test.ts
@@ -67,7 +67,7 @@ describe('renderTtrsResult — no-repository case', () => {
     const result = baseResult({
       markdown: 'See «unresolved: REQ-1».',
       findings: [{ code: 'TTRS-011', state: 'no-repository', flag: null, id: null, file: 'x' }],
-      errors: [{ code: 'TTRS-011', message: 'x.mrd.ttrs: template references a model object but no repository is configured' }],
+      errors: [{ code: 'TTRS-011', message: 'x.mrd.ttrs: recipe references a model object but no repository is configured' }],
     });
     const { bodyContent, errorMsg } = renderTtrsResult(result, new Map());
     expect(bodyContent).toContain('No repository configured');

--- a/vendor/methodology/README.md
+++ b/vendor/methodology/README.md
@@ -41,7 +41,7 @@ in the same change.
 
 Eight source files of `@transitrix/document-renderer`'s render pipeline:
 `pass1.mjs` (the deterministic resolver) and the four modules it imports
-(`parse-template.mjs`, `repository.mjs`, `ids.mjs`, `syntax.mjs`) — vendored
+(`parse-recipe.mjs`, `repository.mjs`, `ids.mjs`, `syntax.mjs`) — vendored
 first for the `.ttrs` preview — plus `pass2.mjs` (fills instruction slots via
 a caller-supplied agent hook), `render-pdf.mjs` (Markdown → PDF, dependency-
 free) and `run-record.mjs` (the provenance stamp), vendored for
@@ -61,7 +61,7 @@ unpinned file, or a hash mismatch is a build failure, never a pass.
 ### Refreshing
 
 ```
-node scripts/vendor-methodology-document-renderer.mjs --ref v3.5.0
+node scripts/vendor-methodology-document-renderer.mjs --ref v4.0.0
 ```
 
 Same fetch-from-tag contract as `vocabulary.yaml` above — never a sibling

--- a/vendor/methodology/document-renderer/VENDORED.json
+++ b/vendor/methodology/document-renderer/VENDORED.json
@@ -1,16 +1,16 @@
 {
   "source_repo": "transitrix/methodology",
-  "source_ref": "v3.5.0",
+  "source_ref": "v4.0.0",
   "source_path": "packages/document-renderer/src",
   "files": {
-    "pass1.mjs": "10de90ea275d74680bbb8586136bbdb59485090cc263edc0d3dfa903a444abc7",
-    "parse-template.mjs": "0109b7ac5edc733e01bb3ec1cd1b8fff10127b06a3d3dc5e33d85a4674065ca0",
-    "repository.mjs": "4b90bfe47507205495ea297d7a666c718058ece3d5569a1403059b7f59260493",
+    "pass1.mjs": "979ba39a35f079695e1fb13546827506184158f2eb68d3cc61d0d4dc5beec040",
+    "parse-recipe.mjs": "c0b587ebf6e13bdd63d42e3683e883f5602f5d8797f92117fab551821b544af8",
+    "repository.mjs": "3fc5f51400b11e23e63a9b4e04f7d1f16e711881c46cca47836f93c83d17c9fd",
     "ids.mjs": "f007b6b1d266b661dcb2a47c91e61c61466af06add68e09f3d8576d05059b084",
-    "syntax.mjs": "b6d1f5bf74d705c262454202289e64475cbaad3e4924e2c89a64660c6de2fd97",
-    "pass2.mjs": "0f27365e60a4982265c7efd3b93fc09465700cbd6191370b8f7e741bc2a6825b",
+    "syntax.mjs": "ffc5b7eb4f399c49a921d1d02388ae5ff6c0d57df408b44cbffdded57b7f6708",
+    "pass2.mjs": "3997579b337099ff7c63781501b90fa0e3cc08a6f906bb196df46157cac600ab",
     "render-pdf.mjs": "c2b9679c9b5420fc211dfeba4e196350da1b92e468b46be7b95cc7b3520f1455",
-    "run-record.mjs": "d972147a246c21c438cf12cf67564e7db473fd4aa60bd763ac75fa0942869b60"
+    "run-record.mjs": "7a1a141260a8b3575815488cc26db66a1808f8902a883953f3802579083ebbab"
   },
-  "vendored_on": "2026-08-16"
+  "vendored_on": "2026-08-25"
 }

--- a/vendor/methodology/document-renderer/parse-recipe.d.mts
+++ b/vendor/methodology/document-renderer/parse-recipe.d.mts
@@ -1,11 +1,11 @@
-// Type contract for the vendored parse-template.mjs — Studio's own, not part
+// Type contract for the vendored parse-recipe.mjs — Studio's own, not part
 // of what vendor-methodology-document-renderer.mjs fetches from methodology
-// (that script only writes the five .mjs files; this file is untouched by
+// (that script only writes the eight .mjs files; this file is untouched by
 // it). Kept intentionally narrow: only the shape src/impact.ts actually
-// reads. The source of truth for the full contract is parse-template.mjs's
+// reads. The source of truth for the full contract is parse-recipe.mjs's
 // own JSDoc and methodology/notations/views/documents/DIRECTIVE_LANGUAGE.md.
 
-export interface TemplateReferenceNode {
+export interface RecipeReferenceNode {
   type: 'reference';
   id: string;
   fields: string[];
@@ -13,7 +13,7 @@ export interface TemplateReferenceNode {
 
 /** `each` / `trace` / the `.field` row reference — constructs the language
  *  defines that this pass declines to resolve. `construct` names which one. */
-export interface TemplateUnimplementedNode {
+export interface RecipeUnimplementedNode {
   type: 'unimplemented';
   construct: string;
 }
@@ -21,7 +21,7 @@ export interface TemplateUnimplementedNode {
 /** `{{# instruct <slot-id> }} … {{/ instruct }}` — `inputs` is the slot's own
  *  `inputs:` field, already comma-split and trimmed by the parser; each entry
  *  names a model-object id the slot reads. */
-export interface TemplateInstructNode {
+export interface RecipeInstructNode {
   type: 'instruct';
   slotId: string | undefined;
   question: string | undefined;
@@ -34,34 +34,34 @@ export interface TemplateInstructNode {
  *  `figref`, `error`) — untyped here because src/impact.ts reads none of
  *  their fields, only whether a node is a reference, an instruct slot, or
  *  unimplemented. */
-export interface TemplateOtherNode {
+export interface RecipeOtherNode {
   type: string;
   [key: string]: unknown;
 }
 
-export type TemplateNode =
-  | TemplateReferenceNode
-  | TemplateUnimplementedNode
-  | TemplateInstructNode
-  | TemplateOtherNode;
+export type RecipeNode =
+  | RecipeReferenceNode
+  | RecipeUnimplementedNode
+  | RecipeInstructNode
+  | RecipeOtherNode;
 
-export interface TemplateHeader {
+export interface RecipeHeader {
   document: string;
   kind: string;
-  template_id: string;
-  template_version: string;
+  recipe_id: string;
+  recipe_version: string;
   canon: string | null;
 }
 
-export interface TemplateParseError {
+export interface RecipeParseError {
   code: string;
   message: string;
 }
 
-export interface ParseTemplateResult {
-  header: TemplateHeader | null;
-  ast: TemplateNode[];
-  errors: TemplateParseError[];
+export interface ParseRecipeResult {
+  header: RecipeHeader | null;
+  ast: RecipeNode[];
+  errors: RecipeParseError[];
 }
 
-export function parseTemplate(text: string): ParseTemplateResult;
+export function parseRecipe(text: string): ParseRecipeResult;

--- a/vendor/methodology/document-renderer/parse-recipe.mjs
+++ b/vendor/methodology/document-renderer/parse-recipe.mjs
@@ -1,4 +1,4 @@
-// `.ttrs` document-template parser — syntax only.
+// `.ttrs` document-recipe parser — syntax only.
 //
 // A `.ttrs` file is prose with directives, not a mapping. It carries a YAML
 // front-matter header and a body made of four slot kinds:
@@ -9,7 +9,7 @@
 //                           / `{{ figref … }}` (cross-reference)
 //   instruction slot        `{{# instruct <slot-id> }} … {{/ instruct }}`
 //
-// Scope of this module: syntax. It turns a template's text into a header object
+// Scope of this module: syntax. It turns a recipe's text into a header object
 // and a body AST. It resolves nothing against a repository and renders nothing —
 // that is pass1.mjs, built on top of this AST.
 //
@@ -23,12 +23,12 @@
 //             names and declines, never silently drops and never reports as
 //             though the author mistyped something
 //
-// Folding the second into the first would tell an author their valid template
+// Folding the second into the first would tell an author their valid recipe
 // is a typo.
 //
 // Zero runtime dependencies outside this package. The grammar itself — front
 // matter, header scalars, the id/field-path split — lives in syntax.mjs, shared
-// with the view engine's skeleton parser: one notation, one parser. What stays
+// with the view engine's recipe parser: one notation, one parser. What stays
 // here is what pass 1 alone decides: its construct set and its error codes.
 
 import { isValidId } from './ids.mjs';
@@ -41,23 +41,23 @@ import {
 
 // `<basename>.<kind>.ttrs` — the middle segment is the document kind, so the
 // existing extension/parent-folder lint applies to it unchanged.
-const TEMPLATE_FILENAME = /^[^.]+\.([a-z0-9-]+)\.ttrs$/;
+const RECIPE_FILENAME = /^[^.]+\.([a-z0-9-]+)\.ttrs$/;
 
 const SLOT_ID = /^[a-z0-9][a-z0-9-]*$/;
 
-const REQUIRED_HEADER_FIELDS = ['document', 'kind', 'template_id', 'template_version'];
+const REQUIRED_HEADER_FIELDS = ['document', 'kind', 'recipe_id', 'recipe_version'];
 
 // Returns the document kind declared by a `.ttrs` filename, or undefined when the
 // name is not of that shape. Exported so a caller can check it against the header's
 // `kind:` without re-deriving the pattern.
-export function templateKindFromFilename(name) {
-  const m = TEMPLATE_FILENAME.exec(String(name));
+export function recipeKindFromFilename(name) {
+  const m = RECIPE_FILENAME.exec(String(name));
   return m ? m[1] : undefined;
 }
 
 // ── Header ───────────────────────────────────────────────────────────────
 // `canon:` is deliberately optional — the repository is an optional input. A
-// template naming no model object and no derived figure renders standalone.
+// recipe naming no model object and no derived figure renders standalone.
 
 function parseHeader(headerText) {
   const errors = [];
@@ -79,8 +79,8 @@ function parseHeader(headerText) {
     header: {
       document: fields.document,
       kind: fields.kind,
-      template_id: fields.template_id,
-      template_version: fields.template_version,
+      recipe_id: fields.recipe_id,
+      recipe_version: fields.recipe_version,
       canon: fields.canon ?? null,
     },
     errors,
@@ -360,14 +360,14 @@ function classify(rawContent, errors) {
 
 // ── Entry point ──────────────────────────────────────────────────────────
 
-export function parseTemplate(text) {
+export function parseRecipe(text) {
   const errors = [];
   const m = FRONT_MATTER.exec(String(text));
   if (!m) {
     return {
       header: null,
       ast: [],
-      errors: [{ code: 'TTRS-001', message: 'template has no `---` front-matter header' }],
+      errors: [{ code: 'TTRS-001', message: 'recipe has no `---` front-matter header' }],
     };
   }
 

--- a/vendor/methodology/document-renderer/pass1.d.mts
+++ b/vendor/methodology/document-renderer/pass1.d.mts
@@ -1,6 +1,6 @@
 // Type contract for the vendored pass1.mjs — Studio's own, not part of what
 // vendor-methodology-document-renderer.mjs fetches from methodology (that
-// script only writes the five .mjs files; this file is untouched by it).
+// script only writes the eight .mjs files; this file is untouched by it).
 // Kept intentionally narrow: only the shape extension/src/ttrs-preview.ts and
 // tests/document-renderer-vendor.test.ts actually read. The source of truth
 // for the full contract is pass1.mjs's own JSDoc and
@@ -9,8 +9,8 @@
 export interface Pass1Header {
   document: string;
   kind: string;
-  template_id: string;
-  template_version: string;
+  recipe_id: string;
+  recipe_version: string;
   canon: string | null;
 }
 
@@ -61,7 +61,7 @@ export interface RasteriseInput {
 
 export interface RunPass1Options {
   text: string;
-  templatePath?: string;
+  recipePath?: string;
   repositoryRoot?: string | null;
   rasterise?: (input: RasteriseInput) => string;
   profile?: 'strict' | 'review';

--- a/vendor/methodology/document-renderer/pass1.mjs
+++ b/vendor/methodology/document-renderer/pass1.mjs
@@ -1,7 +1,7 @@
 // Pass 1 — the deterministic half of the document renderer.
 //
 // Resolves every model-object reference and every derived figure in a `.ttrs`
-// template. Runs and is testable with NO agent present: nothing in this module
+// recipe. Runs and is testable with NO agent present: nothing in this module
 // calls a model, and nothing in it may. Instruction slots are pass 2's job and
 // are copied through untouched, so an unfilled section is visible in the output
 // rather than silently blank.
@@ -30,7 +30,7 @@
 //   unresolved         ⚑U  TTRS-010  no object with that id in the repository
 //   not-admitted       ⚑A  TTRS-014  it exists, but admission_state isn't active
 //   out-of-validity    ⚑V  TTRS-015  [valid_from, valid_to] misses the render date
-//   no-repository      —   TTRS-011  the template cites canon; none is configured
+//   no-repository      —   TTRS-011  the recipe cites canon; none is configured
 //
 // The worst defect this guards against is not a missing reference — it is a
 // reference that resolves and renders as plainly correct text when the object
@@ -47,7 +47,7 @@
 import { existsSync } from 'node:fs';
 import { dirname, isAbsolute, join, resolve as resolvePath } from 'node:path';
 
-import { parseTemplate, templateKindFromFilename } from './parse-template.mjs';
+import { parseRecipe, recipeKindFromFilename } from './parse-recipe.mjs';
 import { buildRepositoryIndex } from './repository.mjs';
 
 // Rendered in place of a reference that did not land in `ok`. The run has already
@@ -72,7 +72,7 @@ const SUSPICION_NOT_COMPUTED = {
     'link suspicion (⚑S) is not computed in pass 1: it is out of scope by the '
     + 'rendered-documents decision, it is derived from commit history rather than '
     + 'read from a file, and CONTRACT.md §16.2 scopes it to REL/claim records '
-    + 'rather than the element references a template cites.',
+    + 'rather than the element references a recipe cites.',
 };
 
 // Field consulted, in order, when a reference names no field path of its own.
@@ -125,12 +125,12 @@ function traverse(entry, fields, index) {
 // needs them in.
 function recordState(node, state, ctx) {
   const { code, label, flag } = STATES[state];
-  ctx.findings.push({ code, state, flag, id: node.id, file: ctx.templateLabel });
+  ctx.findings.push({ code, state, flag, id: node.id, file: ctx.recipeLabel });
   ctx.states[state] = (ctx.states[state] ?? 0) + 1;
   if (ctx.profile === 'strict') {
     ctx.errors.push({
       code,
-      message: `${ctx.templateLabel}: model-object reference "${node.id}" is ${label}`,
+      message: `${ctx.recipeLabel}: model-object reference "${node.id}" is ${label}`,
     });
   }
 }
@@ -142,7 +142,7 @@ function renderReference(node, index, ctx) {
   if (state !== 'ok') {
     recordState(node, state, ctx);
     // In review the value is shown WITH its flag, so a reader sees both what the
-    // template meant and that it is not usable. In strict it never renders as
+    // recipe meant and that it is not usable. In strict it never renders as
     // its bare value — a wrong-but-plausible render is the defect being guarded
     // against, and it is worse than a visibly missing one.
     if (ctx.profile === 'review' && entry) {
@@ -166,7 +166,7 @@ function renderReference(node, index, ctx) {
     : 'does not resolve — the field path is not present on that object';
   ctx.errors.push({
     code: 'TTRS-010',
-    message: `${ctx.templateLabel}: model-object reference "${path}" ${detail}`,
+    message: `${ctx.recipeLabel}: model-object reference "${path}" ${detail}`,
   });
   return UNRESOLVED_MARKER(path);
 }
@@ -233,7 +233,7 @@ function renderFigref(node, ctx, errors) {
   if (number === undefined) {
     errors.push({
       code: 'TTRS-012',
-      message: `figref "${node.name}" names no figure declared earlier in this template`,
+      message: `figref "${node.name}" names no figure declared earlier in this recipe`,
     });
     return UNRESOLVED_MARKER(node.name);
   }
@@ -241,11 +241,11 @@ function renderFigref(node, ctx, errors) {
 }
 
 /**
- * Run pass 1 over a `.ttrs` template.
+ * Run pass 1 over a `.ttrs` recipe.
  *
  * @param {object} options
- * @param {string} options.text            template source
- * @param {string} [options.templatePath]  path the source came from — enables the
+ * @param {string} options.text            recipe source
+ * @param {string} [options.recipePath]    path the source came from — enables the
  *                                         filename/`kind:` cross-check and gives
  *                                         figure paths a base directory
  * @param {string} [options.repositoryRoot] canon root; overrides the header's `canon:`.
@@ -264,13 +264,13 @@ function renderFigref(node, ctx, errors) {
  * @returns {Promise<{ok, markdown, header, instructionSlots, figures, errors, findings, states, suspicion, profile, renderDate}>}
  */
 export async function runPass1({
-  text, templatePath, repositoryRoot, rasterise, profile = 'strict', renderDate,
+  text, recipePath, repositoryRoot, rasterise, profile = 'strict', renderDate,
 } = {}) {
   if (profile !== 'strict' && profile !== 'review') {
     throw new Error(`runPass1: profile must be "strict" or "review", got "${profile}"`);
   }
   const date = renderDate ?? todayIso();
-  const { header, ast, errors } = parseTemplate(text);
+  const { header, ast, errors } = parseRecipe(text);
 
   const emptyResult = (hdr) => ({
     ok: false,
@@ -288,12 +288,12 @@ export async function runPass1({
 
   if (header === null) return emptyResult(null);
 
-  if (templatePath) {
-    const kindFromName = templateKindFromFilename(basename(templatePath));
+  if (recipePath) {
+    const kindFromName = recipeKindFromFilename(basename(recipePath));
     if (kindFromName === undefined) {
       errors.push({
         code: 'TTRS-013',
-        message: `"${templatePath}" is not named <basename>.<kind>.ttrs`,
+        message: `"${recipePath}" is not named <basename>.<kind>.ttrs`,
       });
     } else if (header.kind && kindFromName !== header.kind) {
       errors.push({
@@ -306,36 +306,36 @@ export async function runPass1({
   // The repository is an optional input. Resolve which root we have, if any.
   const explicit = repositoryRoot !== undefined;
   let canonRoot = explicit ? repositoryRoot : header.canon;
-  if (canonRoot && !explicit && templatePath) {
-    canonRoot = resolvePath(join(dirname(templatePath), canonRoot));
+  if (canonRoot && !explicit && recipePath) {
+    canonRoot = resolvePath(join(dirname(recipePath), canonRoot));
   }
 
   // The fourth state, and the only one that is about configuration rather than
   // canon. Named in the same breath as the other three so a caller reading the
   // findings never has to look in two places for "why did nothing resolve".
-  const templateLabel = templatePath ? basename(templatePath) : '<template>';
+  const recipeLabel = recipePath ? basename(recipePath) : '<recipe>';
   const noRepository = !canonRoot && needsRepository(ast);
   if (noRepository) {
     errors.push({
       code: 'TTRS-011',
-      message: `${templateLabel}: template references a model object but no repository is configured`,
+      message: `${recipeLabel}: recipe references a model object but no repository is configured`,
     });
   }
 
   const index = await buildRepositoryIndex(canonRoot);
 
   const ctx = {
-    baseDir: templatePath ? dirname(templatePath) : null,
+    baseDir: recipePath ? dirname(recipePath) : null,
     exists: (p) => existsSync(p),
     rasterise: rasterise ?? null,
     figures: [],
     figureNumbers: new Map(),
     profile,
     renderDate: date,
-    templateLabel,
+    recipeLabel,
     errors,
     findings: noRepository
-      ? [{ code: 'TTRS-011', state: 'no-repository', flag: null, id: null, file: templateLabel }]
+      ? [{ code: 'TTRS-011', state: 'no-repository', flag: null, id: null, file: recipeLabel }]
       : [],
     states: noRepository ? { 'no-repository': 1 } : {},
   };

--- a/vendor/methodology/document-renderer/pass2.mjs
+++ b/vendor/methodology/document-renderer/pass2.mjs
@@ -123,7 +123,7 @@ export async function runPass2({ markdown, instructionSlots, fill } = {}) {
     throw new Error(
       `pass2: markdown carries ${spans.length} instruction slot(s) but `
       + `instructionSlots lists ${instructionSlots.length} — pass 2 must run `
-      + 'against the markdown pass 1 produced for the same template',
+      + 'against the markdown pass 1 produced for the same recipe',
     );
   }
   for (let i = 0; i < spans.length; i++) {

--- a/vendor/methodology/document-renderer/repository.mjs
+++ b/vendor/methodology/document-renderer/repository.mjs
@@ -1,12 +1,12 @@
 // Repository index — the deterministic half of what pass 1 resolves against.
 //
-// A template's `canon:` header names a `canon/` directory. This module walks it
+// A recipe's `canon:` header names a `canon/` directory. This module walks it
 // once into an id → object map so every reference in one render pass shares a
 // single index. Top-level scalars only: a model-object reference substitutes a
 // field's text, it does not traverse into nested structure.
 //
 // The repository is an OPTIONAL input. `buildRepositoryIndex(null)` is not an
-// error — it yields an empty index, and pass 1 decides whether the template
+// error — it yields an empty index, and pass 1 decides whether the recipe
 // actually needed one.
 //
 // Own hand-rolled field extraction, no shared cross-package runtime import —

--- a/vendor/methodology/document-renderer/run-record.d.mts
+++ b/vendor/methodology/document-renderer/run-record.d.mts
@@ -5,8 +5,8 @@
 // and the 2026-08-12 instruction-slot ADR.
 
 export interface RunRecordHeader {
-  template_id: string;
-  template_version: string;
+  recipe_id: string;
+  recipe_version: string;
 }
 
 /** Structurally what pass2.mjs's `slotResults` entries carry — kept local
@@ -45,8 +45,8 @@ export interface RunRecordSlot {
 }
 
 export interface RunRecord {
-  template_id: string;
-  template_version: string;
+  recipe_id: string;
+  recipe_version: string;
   repository_commit: string | null;
   model_id: string | null;
   run_timestamp: string;

--- a/vendor/methodology/document-renderer/run-record.mjs
+++ b/vendor/methodology/document-renderer/run-record.mjs
@@ -3,7 +3,7 @@
 //
 // What it must carry:
 //
-//   template id and version, repository commit, model id, run timestamp
+//   recipe id and version, repository commit, model id, run timestamp
 //   (ISO 8601), and per instruction slot the instruction text and the text
 //   it produced — every slot, including those that produced nothing.
 //
@@ -23,7 +23,7 @@
 /**
  * @param {object} options
  * @param {object} options.header          pass 1's `header` — carries
- *                                          `template_id` and `template_version`
+ *                                          `recipe_id` and `recipe_version`
  * @param {string} [options.repositoryCommit] the commit the repository was
  *                                          read at; `null` when no repository
  *                                          was configured for this run
@@ -41,11 +41,11 @@ export function buildRunRecord({
   header, repositoryCommit = null, modelId = null, runTimestamp, renderDate, profile, slotResults = [],
 } = {}) {
   if (!header) {
-    throw new TypeError('buildRunRecord: header is required — pass 1 must have parsed the template');
+    throw new TypeError('buildRunRecord: header is required — pass 1 must have parsed the recipe');
   }
   return {
-    template_id: header.template_id,
-    template_version: header.template_version,
+    recipe_id: header.recipe_id,
+    recipe_version: header.recipe_version,
     repository_commit: repositoryCommit,
     model_id: modelId,
     run_timestamp: runTimestamp ?? new Date().toISOString(),
@@ -53,7 +53,7 @@ export function buildRunRecord({
     profile,
     // Every slot pass 1 found, in document order — including one that
     // produced nothing. A slot absent from this list would be indistinguishable
-    // from a slot that was never in the template at all.
+    // from a slot that was never in the recipe at all.
     slots: slotResults.map((s) => ({
       slot_id: s.slotId,
       question: s.question,

--- a/vendor/methodology/document-renderer/syntax.mjs
+++ b/vendor/methodology/document-renderer/syntax.mjs
@@ -1,7 +1,7 @@
 // Shared syntax primitives of the document directive language.
 //
-// `.ttrs` templates and the view engine's skeleton files are one notation with two
-// current implementations (parse-template.mjs here, parse-skeleton.mjs in
+// `.ttrs` recipes and the view engine's recipe files are one notation with two
+// current implementations (parse-recipe.mjs here, parse-recipe.mjs in
 // @transitrix/document-view-engine). The two differ in which constructs they
 // implement and in how they report errors — but the pieces below are the grammar
 // itself, and were carried as byte-identical copies in both. One notation, one


### PR DESCRIPTION
## Summary

- Vendors `@transitrix/document-renderer` from methodology `v4.0.0` (`parse-recipe.mjs`).
- `.ttrs` headers, fixtures, `transitrix render`, impact, and the preview follow `recipe_id` / `recipe_version`. Identifiers that only carried those fields (`recipeId`, `parseRecipe`, `recipePath`) rename with them.
- `--template` on `validate` (RACI grid) is unchanged — that is a different object.

## Test plan

- [x] Vendor integrity hashes match `v4.0.0`
- [x] `runPass1` accepts a recipe-header smoke document
- [x] `renderDocumentToDisk` writes a run-record with `recipe_id`
- [x] Impact `.ttrs` coverage tests pass

THQ-281
