### PR TITLE
chore(release): prepare 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [3.4.0] — 2026-08-25
+
+### Added
+
+- **`ACT-021` when an Action Schedule is scoped by `root_action`.** An ACTION the view would otherwise include that is not that root and not reachable from it via `parent` is omitted from the render with a warning that names both ids. The warning does not fire when `root_action` is absent. Duplicate-id `ACT-004` is unchanged.
+- **BPMN presentation export.** A selectable `presentation` profile on BPMN compile / SVG / PNG export lays the diagram out automatically for a 1780 px frame with a 20 px label floor. It is not the live preview — default layout and typography stay as they are.
+- **Process Blueprint catalogued columns render from the PROCESS element, and the compliance lane joins on that process (or a STEP of it).** A `PROCESS-…` column header and goal / result come from the child process (`name`, optional `goal` / `result`); restated view fields are ignored. Sketch `STAGE-…` columns keep their authored copy. The compliance overlay pins an assertion when `realised_via` names that process or a step whose home is that process, and no longer treats a sketch `STAGE-…` id as a join key. The STAGE-only fulfilment blueprint still renders as before.
+- **Process Blueprint validators admit catalogued `PROCESS-` columns.** A column id may be a document-local `STAGE-…` sketch or an admitted `PROCESS-…`; sketch columns still require `name` / `goal` / `result` on the view (`BP-005`), catalogued columns must not restate those fields (`BP-013`) and must resolve to a `PROCESS` element (`BP-012`). Aspect `stages: […]` arrays accept either form. Composition stays the `process_parent` relation (`PROCESS` → `PROCESS`): self-reference is `REL-007`, a cycle is `REL-008` (warning), and a named parent process with a `PROCESS-` column and no in-effect parent link is `BP-014` (warning — a sketch overlay and a shared subprocess remain well-formed). Existing `STAGE-` only blueprints keep validating.
+- **Requirement–Verification Matrix in the editor.** A Command Palette command opens a repository-wide table of every requirement with its direct parent, related test result, and recorded outcome — including an explicit coverage gap when there is no result (`REQ-VERIF-COVERAGE-001`) or only an unresolved one (`REQ-VERIF-COVERAGE-002`). Saving a requirement or verification file refreshes an open table. Export CSV writes the same rows, in the same order, as the view.
+
+### Changed
+
+- **`.ttrs` headers use `recipe_id` / `recipe_version`.** Fixtures, the document renderer, and `transitrix render` follow methodology 4.0.0: the header fields and the identifiers that carry them (`recipeId`, `parseRecipe`, `recipePath`) no longer use `template` as the name of this object. The vendored renderer is pinned to `v4.0.0`.
+
+### Fixed
+
+- **DGCA projection follows `delivers_changes`.** An Action that links to a Change only through the canonical `delivers_changes` field is included when `view_config.actions.surface` is `derived`, and the preview builds Change-to-Action edges from that field. The older `changes` field and `view_config.activities` remain aliases.
+- **DGA-mode DGCA omits the Changes column.** A `dgca` document with `view_config.layers.changes: off` (and no `changes:` key) renders Driver → Goal → Action. A four-layer DGCA is unchanged.
+- **Release-draft VSIX attach resolves unpublished drafts and uploads through the release-upload host.** The attach job no longer looks up a tag that does not exist until the draft is published, and assets go via `gh release upload` rather than the API host that cannot receive them.
+
+### Packages
+
+- `@transitrix/diagrams` 1.10.0 → 1.11.0 — process-blueprint `PROCESS-` columns, requirement–verification matrix, `ACT-021`, DGCA `delivers_changes` / DGA omit-changes.
+- `@transitrix/cli` 2.5.0 → 2.6.0 — paired bump; BPMN presentation export and `.ttrs` `recipe_id` render path.
+
 ## [3.3.0] — 2026-08-24
 
 ### Added

--- a/changelog/fragments/act-021-root-action-a4acb6e4.md
+++ b/changelog/fragments/act-021-root-action-a4acb6e4.md
@@ -1,3 +1,0 @@
-### Added
-
-- **`ACT-021` when an Action Schedule is scoped by `root_action`.** An ACTION the view would otherwise include that is not that root and not reachable from it via `parent` is omitted from the render with a warning that names both ids. The warning does not fire when `root_action` is absent. Duplicate-id `ACT-004` is unchanged.

--- a/changelog/fragments/bpmn-presentation-export-fd7da0c4.md
+++ b/changelog/fragments/bpmn-presentation-export-fd7da0c4.md
@@ -1,3 +1,0 @@
-### Added
-
-- **BPMN presentation export.** A selectable `presentation` profile on BPMN compile / SVG / PNG export lays the diagram out automatically for a 1780 px frame with a 20 px label floor. It is not the live preview — default layout and typography stay as they are.

--- a/changelog/fragments/dgca-delivers-changes-88dadf82.md
+++ b/changelog/fragments/dgca-delivers-changes-88dadf82.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- **DGCA projection follows `delivers_changes`.** An Action that links to a Change only through the canonical `delivers_changes` field is included when `view_config.actions.surface` is `derived`, and the preview builds Change-to-Action edges from that field. The older `changes` field and `view_config.activities` remain aliases.

--- a/changelog/fragments/dgca-dga-omit-changes-e5883bf8.md
+++ b/changelog/fragments/dgca-dga-omit-changes-e5883bf8.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- **DGA-mode DGCA omits the Changes column.** A `dgca` document with `view_config.layers.changes: off` (and no `changes:` key) renders Driver → Goal → Action. A four-layer DGCA is unchanged.

--- a/changelog/fragments/process-blueprint-catalogued-columns-8c5f94f1.md
+++ b/changelog/fragments/process-blueprint-catalogued-columns-8c5f94f1.md
@@ -1,3 +1,0 @@
-### Added
-
-- **Process Blueprint catalogued columns render from the PROCESS element, and the compliance lane joins on that process (or a STEP of it).** A `PROCESS-…` column header and goal / result come from the child process (`name`, optional `goal` / `result`); restated view fields are ignored. Sketch `STAGE-…` columns keep their authored copy. The compliance overlay pins an assertion when `realised_via` names that process or a step whose home is that process, and no longer treats a sketch `STAGE-…` id as a join key. The STAGE-only fulfilment blueprint still renders as before.

--- a/changelog/fragments/process-blueprint-process-columns-5a51e58a.md
+++ b/changelog/fragments/process-blueprint-process-columns-5a51e58a.md
@@ -1,3 +1,0 @@
-### Added
-
-- **Process Blueprint validators admit catalogued `PROCESS-` columns.** A column id may be a document-local `STAGE-…` sketch or an admitted `PROCESS-…`; sketch columns still require `name` / `goal` / `result` on the view (`BP-005`), catalogued columns must not restate those fields (`BP-013`) and must resolve to a `PROCESS` element (`BP-012`). Aspect `stages: […]` arrays accept either form. Composition stays the `process_parent` relation (`PROCESS` → `PROCESS`): self-reference is `REL-007`, a cycle is `REL-008` (warning), and a named parent process with a `PROCESS-` column and no in-effect parent link is `BP-014` (warning — a sketch overlay and a shared subprocess remain well-formed). Existing `STAGE-` only blueprints keep validating.

--- a/changelog/fragments/requirement-verification-matrix-b0c530f0.md
+++ b/changelog/fragments/requirement-verification-matrix-b0c530f0.md
@@ -1,3 +1,0 @@
-### Added
-
-- **Requirement–Verification Matrix in the editor.** A Command Palette command opens a repository-wide table of every requirement with its direct parent, related test result, and recorded outcome — including an explicit coverage gap when there is no result (`REQ-VERIF-COVERAGE-001`) or only an unresolved one (`REQ-VERIF-COVERAGE-002`). Saving a requirement or verification file refreshes an open table. Export CSV writes the same rows, in the same order, as the view.

--- a/changelog/fragments/ttrs-recipe-id-735b828a.md
+++ b/changelog/fragments/ttrs-recipe-id-735b828a.md
@@ -1,3 +1,0 @@
-### Changed
-
-- **`.ttrs` headers use `recipe_id` / `recipe_version`.** Fixtures, the document renderer, and `transitrix render` follow methodology 4.0.0: the header fields and the identifiers that carry them (`recipeId`, `parseRecipe`, `recipePath`) no longer use `template` as the name of this object. The vendored renderer is pinned to `v4.0.0`.

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "transitrix-studio",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "transitrix-studio",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "license": "MIT",
       "engines": {
         "vscode": "^1.85.0"

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Diagrams as text. Write goals, processes, capabilities, BPMN, and more as plain YAML — 17 notations, live preview in VS Code. Diffable in git. AI-friendly. Open source.",
   "license": "MIT",
   "icon": "icon.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "transitrix-studio",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "transitrix-studio",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -8007,7 +8007,7 @@
     },
     "packages/cli": {
       "name": "@transitrix/cli",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",
@@ -8025,7 +8025,7 @@
     },
     "packages/diagrams": {
       "name": "@transitrix/diagrams",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/cli",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "type": "module",
   "description": "Transitrix CLI ΓÇö compile, validate, and report on Transitrix diagrams (BPMN, Goals, DGCA, ΓÇª) from any shell or CI pipeline.",
   "license": "MIT",

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",


### PR DESCRIPTION
## What changed

Release notes and version bumps for Transitrix Studio **3.4.0**.

- Extension / root: 3.3.0 → 3.4.0
- `@transitrix/diagrams`: 1.10.0 → 1.11.0
- `@transitrix/cli`: 2.5.0 → 2.6.0 (paired; the CLI bundles diagrams source at prepack)

Changelog entries folded from fragments since 3.3.0: requirement–verification matrix, process-blueprint `PROCESS-` columns, BPMN presentation export, `.ttrs` `recipe_id` after methodology 4.0.0, `ACT-021`, DGCA `delivers_changes` / DGA omit-changes, and the release-draft VSIX attach host fix.

**After this PR merges:** create a *draft* GitHub Release `v3.4.0` on the merge commit, dispatch `attach-release-vsix.yml` against that commit with tag `v3.4.0`, then publish the draft. Publishing the GitHub Release ships npm, Open VSX, and the JetBrains plugin. **Do not dispatch `vscode-marketplace-publish.yml` until 2026-09-09.**

## How it is verified

- `npm run build`
- `npm run compile`
- `npm run compile:extension`
- `npm run test:diagrams` (107 files / 1759 tests)
- core vitest: 43 files / 802 tests green in this environment; `tests/cli-migrate.test.ts` integration cases that read a sibling methodology clone are skipped in CI (no clone there) and were not re-run as a gate here
- `git diff --check`
