### PR TITLE
fix(cli): keep @resvg/resvg-js external in the npm bundle

### DIFF
--- a/changelog/fragments/cli-resvg-external-d73d6ca0.md
+++ b/changelog/fragments/cli-resvg-external-d73d6ca0.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **`@transitrix/cli` prepack keeps `@resvg/resvg-js` external.** BPMN PNG compile uses that native addon; esbuild has no `.node` loader, so the package declares the dependency and lets npm install it per platform.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1229,7 +1229,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
       "integrity": "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==",
-      "dev": true,
       "license": "MPL-2.0",
       "engines": {
         "node": ">= 10"
@@ -1256,7 +1255,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1273,7 +1271,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1290,7 +1287,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1307,7 +1303,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1324,7 +1319,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1341,7 +1335,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -1361,7 +1354,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "libc": [
         "musl"
       ],
@@ -1381,7 +1373,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -1401,7 +1392,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "libc": [
         "musl"
       ],
@@ -1421,7 +1411,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1438,7 +1427,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1455,7 +1443,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8010,6 +7997,7 @@
       "version": "2.6.0",
       "license": "MIT",
       "dependencies": {
+        "@resvg/resvg-js": "^2.6.2",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "bpmn-moddle": "^10.1.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,6 +38,7 @@
     "prepack": "node ../../scripts/build-cli-package.mjs"
   },
   "dependencies": {
+    "@resvg/resvg-js": "^2.6.2",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
     "bpmn-moddle": "^10.1.0",

--- a/scripts/build-cli-package.mjs
+++ b/scripts/build-cli-package.mjs
@@ -49,8 +49,10 @@ await fs.mkdir(schemaOut, { recursive: true });
 
 // Mirrors packages/cli/package.json "dependencies". Kept external so npm
 // resolves them at install time (ajv has dynamic require patterns that
-// esbuild cannot reliably inline).
-const RUNTIME_DEPS_EXTERNAL = COMPILER_RUNTIME_EXTERNALS;
+// esbuild cannot reliably inline). `@resvg/resvg-js` is the native PNG
+// rasterizer used only by `compile … .png` — bundling it pulls a `.node`
+// addon esbuild cannot load.
+const RUNTIME_DEPS_EXTERNAL = [...COMPILER_RUNTIME_EXTERNALS, '@resvg/resvg-js'];
 
 const sharedBuildOptions = {
   bundle: true,

--- a/tests/cli-package-build.test.ts
+++ b/tests/cli-package-build.test.ts
@@ -1,0 +1,28 @@
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const cliPkg = JSON.parse(readFileSync(join(repoRoot, 'packages/cli/package.json'), 'utf8')) as {
+  dependencies: Record<string, string>;
+};
+
+describe('@transitrix/cli package assembly', () => {
+  it('declares @resvg/resvg-js so PNG compile can resolve the native addon', () => {
+    expect(cliPkg.dependencies['@resvg/resvg-js']).toMatch(/^\^?2\./);
+  });
+
+  it('prepack leaves @resvg/resvg-js external and does not emit a .node binary', () => {
+    const r = spawnSync(process.execPath, [join(repoRoot, 'scripts/build-cli-package.mjs')], {
+      encoding: 'utf8',
+      cwd: repoRoot,
+    });
+    expect(r.status, r.stderr || r.stdout).toBe(0);
+
+    const bundled = readFileSync(join(repoRoot, 'packages/cli/dist/cli.js'), 'utf8');
+    expect(bundled).toMatch(/@resvg\/resvg-js/);
+    expect(bundled).not.toMatch(/\.node['"]/);
+  });
+});


### PR DESCRIPTION
## What changed

`@transitrix/cli` `prepack` no longer tries to bundle `@resvg/resvg-js`. BPMN PNG compile (`transitrix compile … .png`) imports that native addon; esbuild has no `.node` loader, so the 3.4.0 npm publish failed on the CLI step after `@transitrix/diagrams@1.11.0` had already gone up. The CLI package now declares the dependency and leaves it external for npm to install per platform.

CLI version stays **2.6.0** — that version never reached the registry. After this merges, re-run `npm — publish packages` via `workflow_dispatch` (tag `v3.4.0` is already published; diagrams will skip as already on the registry).

Do not dispatch `vscode-marketplace-publish.yml`.

## How it is verified

- `node scripts/build-cli-package.mjs` (assembles; no `.node` loader error)
- `npx vitest run tests/cli-package-build.test.ts`
