### PR TITLE
fix(extension): stop compliance-impact preview reopening on close

### DIFF
--- a/changelog/fragments/compliance-impact-preview-reopen-43471163.md
+++ b/changelog/fragments/compliance-impact-preview-reopen-43471163.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Closing the Compliance Impact Matrix no longer reopens it immediately.** Auto-open treated the YAML becoming active again (the usual result of closing the webview) as a fresh file open. The matrix now opens beside the view-config file, and auto-open skips that same document until you switch away and back or reopen the tab. The toolbar Preview command is unchanged.

--- a/extension/src/compliance-impact-preview.ts
+++ b/extension/src/compliance-impact-preview.ts
@@ -287,7 +287,10 @@ export class ComplianceImpactPreview {
       this.panel = vscode.window.createWebviewPanel(
         'complianceImpactPreview',
         this.panelTitle,
-        { viewColumn: vscode.ViewColumn.Active, preserveFocus: false },
+        // Beside, like every other file-bound preview. Active would replace the
+        // view-config YAML in the same group; closing the matrix then restores
+        // that editor and auto-open recreates the panel in a loop.
+        { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
         {
           enableScripts: true,
           retainContextWhenHidden: true,
@@ -303,7 +306,7 @@ export class ComplianceImpactPreview {
         this.canon = undefined;
       });
     } else {
-      this.panel.reveal(vscode.ViewColumn.Active, false);
+      this.panel.reveal(vscode.ViewColumn.Beside, true);
     }
     await this.refresh();
   }

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -276,6 +276,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void |
   const plantumlPreview = new PlantUMLPreview(context.extensionUri);
   const ttrsPreview = new TtrsPreview();
 
+  // Skip auto-open when the same document merely regained focus (typical
+  // case: the user closed the preview webview). Cleared when the active
+  // editor becomes a different file, so coming back still auto-opens, and
+  // when the document is closed, so a later re-open of the same path does too.
+  let lastAutoOpenedPreviewUri: string | undefined;
+
   async function openBpmnPreviewForDocument(doc: vscode.TextDocument): Promise<void> {
     const renderer = vscode.workspace.getConfiguration('transitrix').get<string>('bpmnRenderer', 'custom');
     if (renderer === 'custom') {
@@ -595,7 +601,17 @@ export async function activate(context: vscode.ExtensionContext): Promise<void |
     // which used to pop a preview panel per notation type touched by anything
     // that reads file content, not just the user actually looking at a file.
     vscode.window.onDidChangeActiveTextEditor((editor) => {
-      if (editor) void autoOpenPreviewForDocument(editor.document);
+      if (!editor) return;
+      const uri = editor.document.uri.toString();
+      if (lastAutoOpenedPreviewUri && lastAutoOpenedPreviewUri !== uri) {
+        lastAutoOpenedPreviewUri = undefined;
+      }
+      void autoOpenPreviewForDocument(editor.document);
+    }),
+    vscode.workspace.onDidCloseTextDocument((doc) => {
+      if (lastAutoOpenedPreviewUri === doc.uri.toString()) {
+        lastAutoOpenedPreviewUri = undefined;
+      }
     }),
   );
 
@@ -609,7 +625,15 @@ export async function activate(context: vscode.ExtensionContext): Promise<void |
   async function autoOpenPreviewForDocument(doc: vscode.TextDocument): Promise<void> {
     if (doc.uri.scheme !== 'file') return;
     if (!vscode.workspace.getConfiguration('transitrix').get<boolean>('preview.autoOpenOnFileOpen', true)) return;
-    await resolveNotationPreview(doc)?.open();
+    const resolved = resolveNotationPreview(doc);
+    if (!resolved) return;
+    const uri = doc.uri.toString();
+    // Closing the webview restores this document as the active editor, which
+    // is not a new open — skip so the panel does not immediately come back.
+    // The toolbar Preview command still goes through `openPreviewHandler`.
+    if (lastAutoOpenedPreviewUri === uri) return;
+    lastAutoOpenedPreviewUri = uri;
+    await resolved.open();
   }
 
   if (process.env.TX_E2E_TESTING === '1') {


### PR DESCRIPTION
## Summary

Closing the Compliance Impact Matrix no longer recreates the panel. Auto-open treated the view-config YAML becoming active again (the usual result of closing the webview) as a fresh file open, and the matrix was created in the same editor group as that YAML, so closing it was the only way back — and immediately opened another copy.

- The matrix opens beside the source, like the other file-bound previews.
- Auto-open skips that same document until the active editor actually changes, the tab is closed and reopened, or the toolbar Preview command is used.

Tracks THQ-332.

Candidate for a **3.4.1** patch after this merges. A release PR cannot be stacked on this branch; it has to wait for `main`. That patch would also fold the already-landed CLI `@resvg/resvg-js` fragment.

## Test plan

- [ ] Open a `*.compliance-impact.{view,transitrix}.yaml` — matrix appears beside the file.
- [ ] Close the matrix — it stays closed; the YAML remains visible.
- [ ] Click the toolbar Preview button — matrix opens again.
- [ ] Close it, switch to a different file, switch back — auto-open fires again.
- [ ] Close the YAML tab and reopen it — auto-open fires again.
