### PR TITLE
chore(release): prepare 3.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.4.1] — 2026-08-26
+
+### Fixed
+
+- **`@transitrix/cli` prepack keeps `@resvg/resvg-js` external.** BPMN PNG compile uses that native addon; esbuild has no `.node` loader, so the package declares the dependency and lets npm install it per platform.
+- **Closing the Compliance Impact Matrix no longer reopens it immediately.** Auto-open treated the YAML becoming active again (the usual result of closing the webview) as a fresh file open. The matrix now opens beside the view-config file, and auto-open skips that same document until you switch away and back or reopen the tab. The toolbar Preview command is unchanged.
+
 ## [3.4.0] — 2026-08-25
 
 ### Added

--- a/changelog/fragments/cli-resvg-external-d73d6ca0.md
+++ b/changelog/fragments/cli-resvg-external-d73d6ca0.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- **`@transitrix/cli` prepack keeps `@resvg/resvg-js` external.** BPMN PNG compile uses that native addon; esbuild has no `.node` loader, so the package declares the dependency and lets npm install it per platform.

--- a/changelog/fragments/compliance-impact-preview-reopen-43471163.md
+++ b/changelog/fragments/compliance-impact-preview-reopen-43471163.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- **Closing the Compliance Impact Matrix no longer reopens it immediately.** Auto-open treated the YAML becoming active again (the usual result of closing the webview) as a fresh file open. The matrix now opens beside the view-config file, and auto-open skips that same document until you switch away and back or reopen the tab. The toolbar Preview command is unchanged.

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "transitrix-studio",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "transitrix-studio",
-      "version": "3.4.0",
+      "version": "3.4.1",
       "license": "MIT",
       "engines": {
         "vscode": "^1.85.0"

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "Diagrams as text. Write goals, processes, capabilities, BPMN, and more as plain YAML — 17 notations, live preview in VS Code. Diffable in git. AI-friendly. Open source.",
   "license": "MIT",
   "icon": "icon.png",

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -277,10 +277,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<void |
   const ttrsPreview = new TtrsPreview();
 
   // Skip auto-open when the same document merely regained focus (typical
-  // case: the user closed the preview webview). Cleared when the active
-  // editor becomes a different file, so coming back still auto-opens, and
-  // when the document is closed, so a later re-open of the same path does too.
+  // case: the user closed the preview webview). A later show of the same
+  // path after it left the visible set — tab closed, then reopened — still
+  // auto-opens. `onDidCloseTextDocument` is not used: VS Code keeps the
+  // document cached after `closeAllEditors`, so that event never fires.
   let lastAutoOpenedPreviewUri: string | undefined;
+  let lastVisibleEditorUris = new Set(
+    vscode.window.visibleTextEditors.map((e) => e.document.uri.toString()),
+  );
 
   async function openBpmnPreviewForDocument(doc: vscode.TextDocument): Promise<void> {
     const renderer = vscode.workspace.getConfiguration('transitrix').get<string>('bpmnRenderer', 'custom');
@@ -603,15 +607,19 @@ export async function activate(context: vscode.ExtensionContext): Promise<void |
     vscode.window.onDidChangeActiveTextEditor((editor) => {
       if (!editor) return;
       const uri = editor.document.uri.toString();
-      if (lastAutoOpenedPreviewUri && lastAutoOpenedPreviewUri !== uri) {
-        lastAutoOpenedPreviewUri = undefined;
-      }
-      void autoOpenPreviewForDocument(editor.document);
+      // Skip only when this document was already on screen (closing the
+      // webview restores it). `onDidCloseTextDocument` does not fire when
+      // `closeAllEditors` merely hides a tab — the document stays cached —
+      // so a later show of the same path must still auto-open.
+      const regainedFocus = lastVisibleEditorUris.has(uri);
+      void autoOpenPreviewForDocument(editor.document, { regainedFocus });
     }),
-    vscode.workspace.onDidCloseTextDocument((doc) => {
-      if (lastAutoOpenedPreviewUri === doc.uri.toString()) {
+    vscode.window.onDidChangeVisibleTextEditors((editors) => {
+      const next = new Set(editors.map((e) => e.document.uri.toString()));
+      if (lastAutoOpenedPreviewUri && !next.has(lastAutoOpenedPreviewUri)) {
         lastAutoOpenedPreviewUri = undefined;
       }
+      lastVisibleEditorUris = next;
     }),
   );
 
@@ -622,7 +630,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void |
     void autoOpenPreviewForDocument(vscode.window.activeTextEditor.document);
   }
 
-  async function autoOpenPreviewForDocument(doc: vscode.TextDocument): Promise<void> {
+  async function autoOpenPreviewForDocument(
+    doc: vscode.TextDocument,
+    opts: { regainedFocus?: boolean } = {},
+  ): Promise<void> {
     if (doc.uri.scheme !== 'file') return;
     if (!vscode.workspace.getConfiguration('transitrix').get<boolean>('preview.autoOpenOnFileOpen', true)) return;
     const resolved = resolveNotationPreview(doc);
@@ -631,7 +642,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void |
     // Closing the webview restores this document as the active editor, which
     // is not a new open — skip so the panel does not immediately come back.
     // The toolbar Preview command still goes through `openPreviewHandler`.
-    if (lastAutoOpenedPreviewUri === uri) return;
+    if (opts.regainedFocus && lastAutoOpenedPreviewUri === uri) return;
     lastAutoOpenedPreviewUri = uri;
     await resolved.open();
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "transitrix-studio",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "transitrix-studio",
-      "version": "3.4.0",
+      "version": "3.4.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
## What changed

Release notes and version bump for Transitrix Studio **3.4.1**.

- Extension / root: 3.4.0 → 3.4.1
- `@transitrix/diagrams` stays 1.11.0 (no `packages/diagrams/src` change since 3.4.0)
- `@transitrix/cli` stays 2.6.0 (already on the registry, including the `@resvg/resvg-js` prepack fix)

Changelog folded from fragments since 3.4.0: Compliance Impact Matrix no longer reopens on close, and CLI prepack keeps `@resvg/resvg-js` external.

Tracks THQ-333.

**After this PR merges:** create a *draft* GitHub Release `v3.4.1` on the merge commit, dispatch `attach-release-vsix.yml` against that commit with tag `v3.4.1`, then publish the draft. Publishing the GitHub Release ships Open VSX and the JetBrains plugin; npm publish will skip both packages (already at these versions). **Do not dispatch `vscode-marketplace-publish.yml` until 2026-09-09.**

## How it is verified

- `npm run build`
- `npm run compile`
- `npm run compile:extension`
- `npm run test:diagrams` (107 files / 1759 tests)
- core vitest: 44 files / 803 tests green; `tests/cli-migrate.test.ts` cases that read a sibling methodology clone failed locally (recipes there have moved on) and are skipped in CI; two `--include-model` cases timed out locally and were not used as a gate
- `git diff --check`
