### PR TITLE
chore(release): prepare 3.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.4.2] — 2026-08-26
+
+### Fixed
+
+- **Compliance views scan `canon/` and `codex/`, not every YAML in the workspace.** Opening a view under an organisation `canon/` tree ingests that tree and its sibling `codex/` — the same roots the CLI uses. Palette-opened dashboards still search those folders and skip `node_modules`, `.archive`, `packages`, and test fixtures. Duplicate artefact ids are labelled as duplicates, not as unrecognized notation, and a compliance-impact preview uses the opened view file as its config.
+
 ## [3.4.1] — 2026-08-26
 
 ### Fixed

--- a/changelog/fragments/compliance-scan-canon-codex-a34f712e.md
+++ b/changelog/fragments/compliance-scan-canon-codex-a34f712e.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- **Compliance views scan `canon/` and `codex/`, not every YAML in the workspace.** Opening a view under an organisation `canon/` tree ingests that tree and its sibling `codex/` — the same roots the CLI uses. Palette-opened dashboards still search those folders and skip `node_modules`, `.archive`, `packages`, and test fixtures. Duplicate artefact ids are labelled as duplicates, not as unrecognized notation, and a compliance-impact preview uses the opened view file as its config.

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "transitrix-studio",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "transitrix-studio",
-      "version": "3.4.1",
+      "version": "3.4.2",
       "license": "MIT",
       "engines": {
         "vscode": "^1.85.0"

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "Diagrams as text. Write goals, processes, capabilities, BPMN, and more as plain YAML — 17 notations, live preview in VS Code. Diffable in git. AI-friendly. Open source.",
   "license": "MIT",
   "icon": "icon.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "transitrix-studio",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "transitrix-studio",
-      "version": "3.4.1",
+      "version": "3.4.2",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
## Summary
- Release notes and version bump for Transitrix Studio **3.4.2**.
- Extension / root: 3.4.1 → 3.4.2
- `@transitrix/diagrams` stays 1.11.0 and `@transitrix/cli` stays 2.6.0 (no library or CLI source change since 3.4.1)
- Changelog folded from the fragment: compliance views scan `canon/` and `codex/`, duplicate ids are labelled as duplicates, and the opened compliance-impact file is the view config.

Tracks THQ-335.

**After this PR merges:** create a *draft* GitHub Release `v3.4.2` on the merge commit, dispatch `attach-release-vsix.yml` against that commit with tag `v3.4.2`, then publish the draft. Publishing ships Open VSX and JetBrains; npm publish will skip both packages. **Do not dispatch `vscode-marketplace-publish.yml` until 2026-09-09.** A `v3.4.1` draft already exists on the previous patch commit — publish that one first if it is not out yet.

## Test plan
- [ ] CHANGELOG heading is `## [3.4.2]` and matches package versions
- [ ] CI green

Made with [Cursor](https://cursor.com)