### PR TITLE
fix(extension): keep repo-wide compliance scans independent of the editor

### DIFF
--- a/extension/src/compliance-scan.ts
+++ b/extension/src/compliance-scan.ts
@@ -66,11 +66,17 @@ export function classifyScanMiss(parsed: unknown, duplicateGrew: boolean): ScanM
   return 'unrecognized';
 }
 
-export function shortWorkspacePath(fsPath: string, workspaceRoot: string): string {
-  if (workspaceRoot && fsPath.startsWith(workspaceRoot)) {
-    return fsPath.slice(workspaceRoot.length).replace(/^[\\/]/, '');
-  }
-  return fsPath;
+/**
+ * Workspace-relative display path. Uses `path.relative` so a sibling whose
+ * name only shares a prefix with the root (e.g. `repo-copy` vs `repo`) is
+ * not treated as nested. Cross-drive and parent-traversal paths stay absolute.
+ * On Windows, `path.relative` compares case-insensitively.
+ */
+export function shortWorkspacePath(fsPath: string, workspaceRoot?: string): string {
+  if (!workspaceRoot) return fsPath;
+  const rel = path.relative(path.resolve(workspaceRoot), path.resolve(fsPath));
+  if (rel === '..' || rel.startsWith(`..${path.sep}`) || path.isAbsolute(rel)) return fsPath;
+  return rel;
 }
 
 export function complianceScanWarnings(scan: ScannedCanon): string[] {
@@ -83,8 +89,9 @@ export function complianceScanWarnings(scan: ScannedCanon): string[] {
 /**
  * Scans `canon/` + `codex/` for compliance artefacts. When `fromFile` sits
  * under a `canon/` tree, only that tree and its sibling `codex/` are read.
- * Otherwise the workspace is searched for those folders, excluding tooling
- * trees. Unreadable/unparseable files and non-artefacts are skipped.
+ * Callers that omit `fromFile` always get a workspace-wide scan — the active
+ * editor is not consulted. Unreadable/unparseable files and non-artefacts
+ * are skipped.
  */
 export async function scanComplianceCanon(fromFile?: vscode.Uri): Promise<ScannedCanon> {
   const canon = emptyCanon();
@@ -92,8 +99,7 @@ export async function scanComplianceCanon(fromFile?: vscode.Uri): Promise<Scanne
   const skippedNotations: Array<{ shortPath: string; notation: string }> = [];
   const skippedDuplicates: Array<{ shortPath: string; id: string }> = [];
 
-  const fromPath = fromFile?.fsPath ?? vscode.window.activeTextEditor?.document.uri.fsPath;
-  const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? '';
+  const fromPath = fromFile?.fsPath;
   const uris = await collectScanUris(resolveComplianceScanScope(fromPath));
 
   for (const uri of uris) {
@@ -106,7 +112,8 @@ export async function scanComplianceCanon(fromFile?: vscode.Uri): Promise<Scanne
     }
     const dupBefore = canon.duplicateIds.length;
     const id = ingestComplianceDoc(canon, parsed);
-    const shortPath = shortWorkspacePath(uri.fsPath, workspaceRoot);
+    const folderRoot = vscode.workspace.getWorkspaceFolder(uri)?.uri.fsPath;
+    const shortPath = shortWorkspacePath(uri.fsPath, folderRoot);
     if (id) {
       pathById.set(id, uri.fsPath);
       continue;

--- a/tests/compliance-scan.test.ts
+++ b/tests/compliance-scan.test.ts
@@ -99,6 +99,28 @@ describe('shortWorkspacePath', () => {
   it('returns the original path when the file is outside the workspace', () => {
     expect(shortWorkspacePath(join('', 'other', 'x.yaml'), join('', 'repo'))).toBe(join('', 'other', 'x.yaml'));
   });
+
+  it('does not treat a sibling whose name starts with the root name as inside', () => {
+    const root = join('', 'repo');
+    const sibling = join('', 'repo-copy', 'canon', 'x.yaml');
+    expect(shortWorkspacePath(sibling, root)).toBe(sibling);
+  });
+
+  it('returns the original path when no workspace root is given', () => {
+    const file = join('', 'repo', 'canon', 'x.yaml');
+    expect(shortWorkspacePath(file)).toBe(file);
+    expect(shortWorkspacePath(file, '')).toBe(file);
+  });
+
+  it('rejects a path on a different Windows drive', () => {
+    if (process.platform !== 'win32') return;
+    expect(shortWorkspacePath('D:\\other\\x.yaml', 'C:\\repo')).toBe('D:\\other\\x.yaml');
+  });
+
+  it('strips a Windows root regardless of drive-letter case', () => {
+    if (process.platform !== 'win32') return;
+    expect(shortWorkspacePath('C:\\Repo\\canon\\x.yaml', 'c:\\repo')).toBe(join('canon', 'x.yaml'));
+  });
 });
 
 describe('complianceScanWarnings', () => {


### PR DESCRIPTION
## Summary
- Unanchored compliance views (Compliance Matrix, Gap Dashboard, Requirement-Verification Matrix) no longer inherit the active editor, so they scan every `canon/` and `codex/` tree in the workspace.
- Workspace-relative display paths use `path.relative` and the file's own workspace folder, so a sibling directory that only shares a name prefix is not treated as nested, and multi-root folders are not collapsed onto the first root.

Fixes THQ-342.

## Test plan
- [ ] `npx vitest run tests/compliance-scan.test.ts` (19 tests)
- [ ] `npm run compile:extension`
- [ ] Open Compliance Matrix / Gap Dashboard / Requirement-Verification Matrix with a file under one `canon/` tree focused — the view still covers the whole workspace
- [ ] Open a single-law / requirement-trace preview from a file under `canon/` — that view stays scoped to that tree
