### PR TITLE
Update listing description and author attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- **Listing description and footer attribution.** The extension description emphasizes editor-agnosticism by saying "live preview in your editor" instead of "live preview in VS Code". The footer link points to the author's personal GitHub profile (`github.com/vkgeorgia`) instead of the publisher namespace.
+
 ## [3.4.2] — 2026-08-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md). By submitting a pull request, you agree 
 
 ## Author
 
-Created and maintained by **Valerii Korobeinikov**.
+Created and maintained by [Valerii Korobeinikov](https://github.com/vkgeorgia).
 
 ## License
 

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- **Marketplace listing one-liner** updated to *live preview in your editor* (generic editors, not VS Code specifically). Author name link points to [https://github.com/vkgeorgia](https://github.com/vkgeorgia).
 - **PNG export rasterizes in the preview webview's own canvas** instead of a bundled native rasterizer — `@resvg/resvg-js` is no longer an extension dependency, and the packaged extension ships no `node_modules` at all. No user-visible change to Save .png / Copy PNG.
 - **Packaging drops per-target `.vsix` builds for one universal `.vsix`.** With no native/platform-specific component left in the package (the item above), `vsce package` with no `--target` is now the only packaging path — `scripts/package-extension.mjs` no longer accepts `--target`, and the Marketplace/Open VSX publish workflows each build and publish from a single job instead of a four-runner matrix. The one artefact installs on every VS Code platform, including ones the old matrix never built for (Intel macOS, Windows ARM).
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -129,4 +129,4 @@ Studio renders one file at a time — no repository, no setup beyond installing 
 - 🧰 **Source & issues** — [github.com/transitrix/transitrix-studio](https://github.com/transitrix/transitrix-studio)
 - 📚 **Glossary** — see [`glossary.md`](https://github.com/transitrix/transitrix-studio/blob/main/glossary.md) in the repo root for the notation terms used above
 
-Open source. MIT licensed. Built by [Valerii Korobeinikov](https://github.com/transitrix).
+Open source. MIT licensed. Built by [Valerii Korobeinikov](https://github.com/vkgeorgia).

--- a/extension/package.json
+++ b/extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
   "version": "3.4.2",
-  "description": "Diagrams as text. Write goals, processes, capabilities, BPMN, and more as plain YAML — 17 notations, live preview in VS Code. Diffable in git. AI-friendly. Open source.",
+  "description": "Diagrams as text. Write goals, processes, capabilities, BPMN, and more as plain YAML — 17 notations, live preview in your editor. Diffable in git. AI-friendly. Open source.",
   "license": "MIT",
   "icon": "icon.png",
   "galleryBanner": {


### PR DESCRIPTION
## Summary

Updates marketplace listing metadata to reflect support for multiple editors and corrects author attribution.

## Changes

- **Extension description:** Changed "live preview in VS Code" to "live preview in your editor" to accurately reflect support for Cursor, VSCodium, Windsurf, and other editors
- **Author link:** Updated footer link from github.com/transitrix to github.com/vkgeorgia (personal profile)

## Acceptance

- [x] extension/package.json contains "live preview in your editor"
- [x] Footer name resolves to https://github.com/vkgeorgia

🤖 Generated with Claude Code