### PR TITLE
Support root-level views/ layout for derived projections

### DIFF
--- a/organizations/acme_corp/views/README.md
+++ b/organizations/acme_corp/views/README.md
@@ -1,0 +1,44 @@
+# `canon/views/`
+
+Composite diagrams and aggregations over architecture elements. Atomic ArchiMate elements live in `canon/elements/<layer>/`; everything that aggregates, filters, or visualises elements lives here.
+
+See [`method/methodology.md` §6](../../../method/methodology.md) for the full notation kit and rationale.
+
+## Subfolder map
+
+| Folder | Notation | File extension | What it holds |
+| --- | --- | --- | --- |
+| [`goals/`](goals/) | Goals tree | `*.goals.transitrix.yaml` | Hierarchical goals trees |
+| [`dgca/`](dgca/) | DGCA chain (4-layer) | `*.dgca.transitrix.yaml` | Driver → Goal → Change → Action |
+| [`dgca/`](dgca/) | DGA chain (3-layer) | `*.dgca.transitrix.yaml` with `view_config.layers.changes: off` | Driver → Goal → Action (no Changes layer) |
+| [`capabilities/`](capabilities/) | Capabilities map | `*.capability-map.transitrix.yaml` | Capability hierarchies with maturity overlay |
+| [`processmap/`](processmap/) | Process landscape map | `*.process-map.transitrix.yaml` | Top-level process catalogues |
+| [`bpmn/`](bpmn/) | Process diagram (BPMN) | `*.bpmn.transitrix.yaml` | Detailed process flows |
+| [`fga/`](fga/) | ~~FGA chain~~ **deprecated** | ~~`*.fga.transitrix.yaml`~~ | Stub only — see [`fga/README.md`](fga/); use [`dgca/`](dgca/) |
+| [`blocks/`](blocks/) | Nested block diagrams | `*.blocks.transitrix.yaml` | Recursive `block` tree rendered as nested containers |
+| [`action/`](action/) | Action network | `*.action.transitrix.yaml` | PSND (Action-on-Node) with Gantt projection and critical path |
+| [`products/`](products/) | Products view | `*.products.transitrix.yaml` | Filtered views over Product elements |
+| [`applications/`](applications/) | Applications view | `*.applications.transitrix.yaml` | Filtered views over Application elements |
+| [`scenarios/`](scenarios/) | Scenarios | `*.scenarios.transitrix.yaml` | Alternative strategic development paths |
+| [`process-blueprint/`](process-blueprint/) | Process Blueprint | `*.process-blueprint.transitrix.yaml` | Wide value-chain blueprint with stage aspects |
+| [`action-card/`](action-card/) | Action card | `*.action-card.transitrix.yaml` | Single-project narrative card with milestones |
+| [`compliance-impact/`](compliance-impact/) | Compliance impact | `*.compliance-impact.transitrix.yaml` | Obligation × subject matrix with status |
+| [`coverage-metric/`](coverage-metric/) | Coverage metric | `*.coverage-metric.transitrix.yaml` | Assertion-coverage breakdown per regime |
+| [`issues/`](issues/) | Issues register | `*.issues.transitrix.yaml` | Issue register with parent/child nesting |
+
+## Naming
+
+File names use `kebab-case` or descriptive `[DOMAIN]-[CONTEXT]` prefixes. Examples:
+
+```
+canon/views/goals/eu-strategy.goals.transitrix.yaml
+canon/views/dgca/eu-expansion.dgca.transitrix.yaml
+canon/views/capabilities/customer-domain.capability-map.transitrix.yaml
+canon/views/bpmn/order-fulfillment.bpmn.transitrix.yaml
+canon/views/action/gdpr-remediation.action.transitrix.yaml
+canon/views/products/active-portfolio.products.transitrix.yaml
+```
+
+## What does NOT go here
+
+Atomic elements — Goals, Capabilities, BusinessProcesses (thin metadata files), Products, ApplicationComponents, etc. — stay in `canon/elements/<layer>/`. The view in `canon/views/products/` is a *filter expression* over many Product elements, each of which lives in `canon/elements/02_business/<id>.yaml`.

--- a/organizations/acme_corp/views/action-card/README.md
+++ b/organizations/acme_corp/views/action-card/README.md
@@ -1,0 +1,19 @@
+# `canon/views/action-card/`
+
+Single-project narrative cards. Each card binds to one project Action (`project: ACTION-…`) and adds narrative milestones; the motivation chain and child actions are pulled by reference from the DGCA/DGA and Action documents rather than duplicated.
+
+## File convention
+
+`*.action-card.transitrix.yaml`
+
+See [`notations/views/18-action-card.md`](../../../../../notations/views/18-action-card.md) for the full spec.
+
+## Lifecycle
+
+The card is a view, not an element — it carries no lifecycle. The project Action it binds to and any `delivers_changes: [CHANGE-…]` it names bear their lifecycle on their own canonical files.
+
+## See also
+
+- [`notations/views/18-action-card.md`](../../../../../notations/views/18-action-card.md) — the notation spec
+- [`notations/examples/action-card/`](../../../../../notations/examples/action-card/) — worked example
+- [`../action/`](../action/) — the action network the card's project lives in

--- a/organizations/acme_corp/views/action-card/eu-gdpr-remediation.action-card.transitrix.yaml
+++ b/organizations/acme_corp/views/action-card/eu-gdpr-remediation.action-card.transitrix.yaml
@@ -1,0 +1,37 @@
+# Single-project narrative card for the GDPR remediation programme.
+# Notation spec: notations/views/18-action-card.md. Binds to a project Action
+# and adds narrative milestones; the motivation chain and child actions are
+# pulled by reference from the DGCA and Action documents, not duplicated here.
+
+notation: action-card
+spec_version: "0.1"
+
+action_card:
+  id: ACTION_CARD-GDPR-REMEDIATION-1
+  project: ACTION-GDPR-REMEDIATION-1
+
+  description: >
+    Programme of work closing the EU data-protection gaps surfaced by the 2026
+    gap assessment: extending the erasure pipeline to the cold-storage archive,
+    standing up data-subject-request handling, and reworking onboarding consent.
+    Spans 2026-Q2 through 2026-Q4 and clears the supervisory-authority pre-audit.
+
+  milestones:
+    - id: MILESTONE-GDPR-ERASURE-CLOSED-1
+      name: "Cold-storage archive erasure gap closed"
+      date: "2026-09-15"
+      description: >
+        Erasure pipeline extended to the 7-year order-history archive, moving
+        ASSERTION-ECOMM-GDPR-ERASURE-1 out of non_compliant. Hard gate for the
+        pre-audit.
+      delivers_changes:
+        - CHANGE-GDPR-COMPLIANCE-1
+
+    - id: MILESTONE-GDPR-PREAUDIT-1
+      name: "Supervisory-authority pre-audit cleared"
+      date: "2026-10-31"
+      description: >
+        Data Protection Officer presents closed gaps and the DSR workflow to the
+        supervisory authority; EU go-live proceeds under the new regime.
+      delivers_changes:
+        - CHANGE-GDPR-COMPLIANCE-1

--- a/organizations/acme_corp/views/action/README.md
+++ b/organizations/acme_corp/views/action/README.md
@@ -1,0 +1,68 @@
+# `canon/views/action/`
+
+Project schedule as an **Action-on-Node** precedence network (PSND), with an optional Gantt timeline projection. Actions reference Action, Goal, and Change elements.
+
+## File convention
+
+`*.action.transitrix.yaml`
+
+See [`notations/views/07-action.md`](../../../../../notations/views/07-action.md) for the full spec — including PSND semantics, the critical-path computation, and the Gantt projection contract.
+
+## Skeleton
+
+```yaml
+notation: action
+spec_version: "0.1"
+
+actions:
+  - id: ACTION-DISCOVERY-1
+    name: "Discovery & research"
+    duration_days: 10
+    start_date: "2026-06-01"       # work-timeline field — when the action is planned to start
+    predecessors: []
+    goals: [GOAL-CUST-1]
+    valid_from: "2026-05-26"       # element-lifecycle field (CONTRACT.md §7) — when this action entry is admitted as a planning artefact; distinct from start_date
+    valid_to: null
+
+  - id: ACTION-DESIGN-1
+    name: "Solution design"
+    duration_days: 14
+    predecessors: [ACTION-DISCOVERY-1]
+    goals: [GOAL-CUST-1]
+    valid_from: "2026-05-26"
+    valid_to: null
+
+  - id: ACTION-BUILD-1
+    name: "Build & test"
+    duration_days: 30
+    predecessors: [ACTION-DESIGN-1]
+    delivers_changes: [CHANGE-ONBOARD-1]
+    valid_from: "2026-05-26"
+    valid_to: null
+
+  - id: ACTION-LAUNCH-1
+    name: "Launch"
+    duration_days: 5
+    predecessors: [ACTION-BUILD-1]
+    delivers_changes: [CHANGE-ONBOARD-1]
+    valid_from: "2026-05-26"
+    valid_to: null
+```
+
+Actions form a DAG via `predecessors:`. The renderer computes Early Start / Late Finish / slack and highlights the critical path in both the PSND view and the Gantt projection. Transitrix Studio renders both views; the toolbar switches between them.
+
+`valid_from` / `valid_to` are required on every inline action per [`notations/CONTRACT.md`](../../../../../notations/CONTRACT.md) §7 and are **distinct** from `start_date` / `end_date`: the lifecycle fields say *when this action entry is admitted to the plan*, while the schedule fields say *when the work is planned to happen*. Both coexist; the action document itself carries no lifecycle.
+
+## Cross-references
+
+- `goals: [GOAL-…]` — Goal IDs from the goals tree / DGCA or DGA chain.
+- `delivers_changes: [CHANGE-…]` — Change IDs from the DGCA chain.
+- `predecessors: [ACTION-…]` — other action IDs in the same file.
+
+All IDs follow the canonical `<TYPE>-[<middle>-]<INTEGER>` grammar from [`notations/IDS_AND_REFERENCES.md`](../../../../../notations/IDS_AND_REFERENCES.md).
+
+## See also
+
+- [`notations/views/07-action.md`](../../../../../notations/views/07-action.md) — the notation spec
+- [`notations/examples/action/platform-launch.action.transitrix.yaml`](../../../../../notations/examples/action/platform-launch.action.transitrix.yaml) — worked example
+- `method/methodology.md` §6 — notation kit

--- a/organizations/acme_corp/views/action/gdpr-remediation.dgca.transitrix.yaml
+++ b/organizations/acme_corp/views/action/gdpr-remediation.dgca.transitrix.yaml
@@ -1,0 +1,148 @@
+# Action-on-Node network (PSND) — the GDPR remediation programme schedule.
+# Notation spec: notations/views/07-action.md. Inline actions carry
+# CONTRACT.md §7 lifecycle, distinct from the schedule fields (start_date / duration_days).
+#
+# WBS hierarchy (type + parent):
+#   Initiative: ACTION-EU-COMPLIANCE-1
+#     Programme: ACTION-GDPR-REMEDIATION-1
+#       Project: ACTION-GDPR-GAP-1
+#       Project: ACTION-GDPR-ERASURE-PIPELINE-1   ← phase; dates roll up from Tasks below
+#         Task: ACTION-GDPR-ERASURE-ARCHIVE-1
+#         Task: ACTION-GDPR-ERASURE-VALIDATE-1
+#       Project: ACTION-GDPR-DSR-WORKFLOW-1
+#       Project: ACTION-GDPR-CONSENT-1
+#       Project: ACTION-GDPR-AUDIT-1
+#
+# predecessors: chain is independent of parent: and drives CPM / Gantt as before.
+
+notation: action
+spec_version: "0.1"
+
+title: "GDPR Remediation Programme 2026"
+description: |
+  Critical path for closing the EU data-protection gaps surfaced by the 2026
+  gap assessment — including the cold-storage archive erasure gap that holds
+  ASSERTION-ECOMM-GDPR-ERASURE-1 in a non_compliant state.
+version: "0.2"
+date: "2026-07-03"
+author: "Acme Compliance Office"
+
+project:
+  start_date: "2026-03-01"
+
+actions:
+  # ---- Initiative (top of WBS) -------------------------------------------
+  # No duration / dates — rolls up from all children.
+  - id: ACTION-EU-COMPLIANCE-1
+    name: "EU Data Protection Compliance Initiative"
+    type: Initiative
+    goals: [GOAL-EU-1]
+    owner: ROLE-DPO-1
+    valid_from: "2026-01-01"
+    valid_to: null
+
+  # ---- Programme ---------------------------------------------------------
+  # No duration / dates — rolls up from Project children.
+  - id: ACTION-GDPR-REMEDIATION-1
+    name: "GDPR Remediation 2026"
+    type: Programme
+    parent: ACTION-EU-COMPLIANCE-1
+    goals: [GOAL-EU-1]
+    owner: ROLE-DPO-1
+    valid_from: "2026-03-01"
+    valid_to: null
+
+  # ---- Projects ----------------------------------------------------------
+
+  - id: ACTION-GDPR-GAP-1
+    name: "GDPR & NIS2 gap assessment"
+    type: Project
+    parent: ACTION-GDPR-REMEDIATION-1
+    duration_days: 15
+    start_date: "2026-03-01"
+    predecessors: []
+    goals: [GOAL-EU-1]
+    owner: ROLE-DPO-1
+    valid_from: "2026-05-26"
+    valid_to: null
+
+  # Phase with Task children below — omits duration / dates per validation rule 017.
+  - id: ACTION-GDPR-ERASURE-PIPELINE-1
+    name: "Extend erasure pipeline to cold-storage archive"
+    type: Project
+    parent: ACTION-GDPR-REMEDIATION-1
+    predecessors: [ACTION-GDPR-GAP-1]
+    goals: [GOAL-EU-1]
+    delivers_changes: [CHANGE-EU-CRM-1]
+    owner: ROLE-TECH-1
+    valid_from: "2026-05-26"
+    valid_to: null
+
+  - id: ACTION-GDPR-DSR-WORKFLOW-1
+    name: "Stand up data-subject-request workflow"
+    type: Project
+    parent: ACTION-GDPR-REMEDIATION-1
+    duration_days: 20
+    start_date: "2026-06-15"
+    predecessors: [ACTION-GDPR-GAP-1]
+    goals: [GOAL-EU-1]
+    owner: ROLE-DPO-1
+    valid_from: "2026-05-26"
+    valid_to: null
+
+  - id: ACTION-GDPR-CONSENT-1
+    name: "Rework onboarding consent capture"
+    type: Project
+    parent: ACTION-GDPR-REMEDIATION-1
+    duration_days: 18
+    start_date: "2026-06-20"
+    predecessors: [ACTION-GDPR-GAP-1]
+    goals: [GOAL-EU-1]
+    delivers_changes: [CHANGE-ONBOARD-1]
+    owner: ROLE-SALES-1
+    valid_from: "2026-05-26"
+    valid_to: null
+
+  - id: ACTION-GDPR-AUDIT-1
+    name: "Supervisory-authority pre-audit"
+    type: Project
+    parent: ACTION-GDPR-REMEDIATION-1
+    duration_days: 5
+    start_date: "2026-08-15"
+    predecessors:
+      - ACTION-GDPR-ERASURE-PIPELINE-1
+      - ACTION-GDPR-DSR-WORKFLOW-1
+      - ACTION-GDPR-CONSENT-1
+    goals: [GOAL-EU-1]
+    owner: ROLE-DPO-1
+    valid_from: "2026-05-26"
+    valid_to: null
+
+  # ---- Tasks (children of ACTION-GDPR-ERASURE-PIPELINE-1) ---------------
+  # Demonstrates the fourth WBS level. Together span the 30 days that
+  # ERASURE-PIPELINE-1 previously carried as its own duration.
+
+  - id: ACTION-GDPR-ERASURE-ARCHIVE-1
+    name: "Extend archive storage erasure path"
+    type: Task
+    parent: ACTION-GDPR-ERASURE-PIPELINE-1
+    duration_days: 20
+    start_date: "2026-06-15"
+    predecessors: [ACTION-GDPR-GAP-1]
+    goals: [GOAL-EU-1]
+    delivers_changes: [CHANGE-EU-CRM-1]
+    owner: ROLE-TECH-1
+    valid_from: "2026-06-10"
+    valid_to: null
+
+  - id: ACTION-GDPR-ERASURE-VALIDATE-1
+    name: "Validate erasure pipeline end-to-end"
+    type: Task
+    parent: ACTION-GDPR-ERASURE-PIPELINE-1
+    duration_days: 10
+    start_date: "2026-07-10"
+    predecessors: [ACTION-GDPR-ERASURE-ARCHIVE-1]
+    goals: [GOAL-EU-1]
+    owner: ROLE-TECH-1
+    valid_from: "2026-06-10"
+    valid_to: null

--- a/organizations/acme_corp/views/applications/README.md
+++ b/organizations/acme_corp/views/applications/README.md
@@ -1,0 +1,61 @@
+# `canon/views/applications/`
+
+Applications catalogue — a curated catalogue of the applications and integrations in operation. Each entry references an Application element under `canon/elements/03_application/applications/` and carries the display attributes used to render the catalogue.
+
+## File convention
+
+`*.applications.transitrix.yaml`
+
+## Skeleton
+
+```yaml
+notation: applications
+spec_version: "0.1"
+
+applications_catalogue:
+  id: "APPLICATIONS_CAT-1"
+  name: "Acme Corp Applications Catalogue"
+  description: "Applications and integrations in operation at Acme Corp"
+  version: "1.0"
+  updated_at: "2026-05-26"
+
+  applications:
+    - app_id: "APPLICATION-OMS-1"               # → canon/elements/03_application/applications/APPLICATION-OMS-1.yaml
+      name: "Order Management System"
+      type: "application"               # application | integration | platform | data_store
+      domain: "Operations"
+      owner_role: "ROLE-TECH-1"
+      vendor: "Internal"
+      status: "Active"                  # operational state: Draft | Active | Deprecated | Decommissioning
+      maturity: 3
+      description: "Core system for order lifecycle management"
+      capabilities: ["CAPABILITY-V1"]
+      products: ["PRODUCT-ECOMM-1"]
+      integrations:                     # nested integration descriptors share the parent app's lifecycle — no own valid_from/valid_to
+        - target: "APPLICATION-CRM-1"
+          direction: "outbound"
+          protocol: "REST"
+          description: "Sends order events to CRM"
+      valid_from: "2026-05-26"          # CONTRACT.md §7 — required on every inline applications-catalogue entry, regardless of `type`; distinct from operational `status`
+      valid_to: null
+
+    - app_id: "APPLICATION-CRM-1"
+      name: "CRM System"
+      type: "application"
+      domain: "Sales"
+      owner_role: "ROLE-SALES-1"
+      vendor: "Salesforce"
+      status: "Active"
+      description: "Customer relationship and sales pipeline management"
+      valid_from: "2026-05-26"
+      valid_to: null
+```
+
+`capabilities` and `products` hold **element IDs**, not display names. Integrations may be inlined (as above) or modelled as their own `type: integration` entries.
+
+`valid_from` / `valid_to` are required on every inline applications-catalogue entry per [`notations/CONTRACT.md`](../../../../../notations/CONTRACT.md) §7, regardless of `type` (`application` / `integration` / `platform` / `data_store`). They are distinct from the per-entry `status` field (operational state). Per-application nested `integrations[]` descriptors share the parent's lifecycle and carry no `valid_from` / `valid_to` of their own; when an integration is promoted to a top-level `type: integration` entry, it becomes a first-class lifecycle-bearing element with its own dates.
+
+## See also
+
+- `notations/views/10-applications.md` — applications-catalogue notation reference (full field table)
+- `canon/elements/03_application/applications/` — where individual Application elements live

--- a/organizations/acme_corp/views/applications/eu-portfolio.applications.transitrix.yaml
+++ b/organizations/acme_corp/views/applications/eu-portfolio.applications.transitrix.yaml
@@ -1,0 +1,45 @@
+# Applications catalogue — systems supporting the EU portfolio, with the OMS → CRM
+# integration that propagates erasure events. Notation spec: notations/views/10-applications.md.
+# Each inline entry carries CONTRACT.md §7 lifecycle; nested integrations share the parent's.
+
+notation: applications
+spec_version: "0.1"
+
+applications_catalogue:
+  id: APPLICATIONS_CAT-EU-1
+  name: "Acme Corp — EU Applications Portfolio"
+  description: "Applications and integrations in operation for the EU portfolio."
+  version: "1.0"
+  updated_at: "2026-06-10"
+
+  applications:
+    - app_id: APPLICATION-OMS-1
+      name: "Order Management System"
+      type: "application"
+      domain: "Operations"
+      status: "Active"
+      # owner_role, vendor, maturity are time-varying — they live in
+      # APPLICATION-OMS-1.history.yaml (CONTRACT.md §9), not inline.
+      description: "Core system for order lifecycle management; holds active-order personal data."
+      capabilities: ["CAPABILITY-V1"]
+      products: ["PRODUCT-ECOMM-1"]
+      integrations:
+        - target: "APPLICATION-CRM-1"
+          direction: "outbound"
+          protocol: "REST"
+          description: "Propagates order and erasure events to CRM"
+      valid_from: "2026-05-26"
+      valid_to: null
+
+    - app_id: APPLICATION-CRM-1
+      name: "CRM System"
+      type: "application"
+      domain: "Sales"
+      status: "Active"
+      # owner_role, vendor, maturity are time-varying — they live in
+      # APPLICATION-CRM-1.history.yaml (CONTRACT.md §9), not inline.
+      description: "Customer relationship and consent management; holds contact and consent personal data."
+      capabilities: ["CAPABILITY-V2"]
+      products: ["PRODUCT-ECOMM-1"]
+      valid_from: "2026-05-26"
+      valid_to: null

--- a/organizations/acme_corp/views/blocks/README.md
+++ b/organizations/acme_corp/views/blocks/README.md
@@ -1,0 +1,61 @@
+# `canon/views/blocks/`
+
+Nested block diagrams — multi-level container layouts where you want to show *what contains what* (an application landscape, a platform decomposition, an infrastructure zone map). Rendered as nested boxes by Transitrix Studio's native TypeScript renderer.
+
+## File convention
+
+`*.blocks.transitrix.yaml`
+
+The notation is structured YAML: a `nested_blocks:` root with a recursive `block` tree (`id`, `name`, optional `description`, optional `children[]`). See [`notations/views/08-blocks.md`](../../../../../notations/views/08-blocks.md) for the full spec.
+
+## Skeleton
+
+```yaml
+notation: blocks
+spec_version: "0.1"
+
+nested_blocks:
+  id: BLOCKS-ARCH-1
+  name: "Application architecture"
+  description: "Top-level container layout."
+
+  blocks:
+    - id: APPLICATION_LAYER
+      name: "Application Layer"
+      children:
+        - id: FRONTEND
+          name: "Frontend"
+        - id: BACKEND
+          name: "Backend"
+    - id: DATA_LAYER
+      name: "Data Layer"
+      children:
+        - id: POSTGRESQL
+          name: "PostgreSQL"
+        - id: REDIS_CACHE
+          name: "Redis Cache"
+```
+
+Multiple independent top-level blocks in `nested_blocks.blocks[]` render as separate diagram sections, stacked in array order.
+
+## Nesting depth
+
+Recommended maximum: **5 levels** (root = level 1). The validator warns at depth 6+ (`BL-008`); inner boxes get too small to read.
+
+## Cross-references
+
+A block's `id` MAY use the canonical `<TYPE>-…-<INTEGER>` form to cross-link into an organisational catalogue (`APPLICATION-OMS-1`, `CAPABILITY-V1.2`). Otherwise it is a document-local label and is accepted as-is. See [`notations/IDS_AND_REFERENCES.md`](../../../../../notations/IDS_AND_REFERENCES.md).
+
+## Lifecycle
+
+When `block.id` cross-links into the catalogue (canonical `<TYPE>-…-<INTEGER>` form), the primitive lifecycle ([`notations/CONTRACT.md`](../../../../../notations/CONTRACT.md) §7) is borne by the target element's own file — the block here is a layout placement, not a separate element. When `block.id` is a document-local label, there is no canonical element to bear lifecycle and the block carries none. The nested_blocks document itself carries no lifecycle either — it is a view.
+
+## Tooling
+
+Rendered natively by Transitrix Studio — no external binaries required. The previous Python + `svgbob_cli` pipeline was retired in Studio 1.1.0.
+
+## See also
+
+- [`notations/views/08-blocks.md`](../../../../../notations/views/08-blocks.md) — the notation spec
+- [`notations/examples/blocks/architecture.blocks.transitrix.yaml`](../../../../../notations/examples/blocks/architecture.blocks.transitrix.yaml) — worked example
+- `method/methodology.md` §6 — notation kit

--- a/organizations/acme_corp/views/blocks/personal-data-landscape.blocks.transitrix.yaml
+++ b/organizations/acme_corp/views/blocks/personal-data-landscape.blocks.transitrix.yaml
@@ -1,0 +1,46 @@
+# Nested block diagram — where personal data lives across Acme systems. This is
+# the data-residency / erasure-scope map behind the GDPR coverage metric: the
+# cold-storage archive (bottom-right) is the known erasure gap.
+# Notation spec: notations/views/08-blocks.md. Document-local labels bear no
+# lifecycle; canonical-id blocks (APPLICATION-…) bear it on their element file.
+
+notation: blocks
+spec_version: "0.1"
+
+nested_blocks:
+  id: BLOCKS-PERSONAL-DATA-1
+  name: "Personal-data landscape"
+  description: "Systems and stores holding EU-resident personal data, grouped by erasure reachability."
+  version: "0.1"
+  date: "2026-06-10"
+  author: "Acme Compliance Office"
+
+  blocks:
+    - id: ACTIVE_SYSTEMS
+      name: "Active systems (erasure-reachable, in 30-day window)"
+      children:
+        - id: APPLICATION-OMS-1
+          name: "Order Management System"
+          children:
+            - id: OMS_ORDERS
+              name: "Active orders"
+            - id: OMS_PAYMENTS
+              name: "Payment tokens"
+        - id: APPLICATION-CRM-1
+          name: "CRM System"
+          children:
+            - id: CRM_CONTACTS
+              name: "Customer contacts"
+            - id: CRM_CONSENT
+              name: "Consent records"
+
+    - id: ARCHIVE
+      name: "Cold storage (7-year fiscal retention — KNOWN ERASURE GAP)"
+      children:
+        - id: ORDER_ARCHIVE
+          name: "Order history archive"
+          children:
+            - id: ARCHIVE_PII
+              name: "Personal data (not erasure-reachable)"
+            - id: ARCHIVE_INVOICES
+              name: "Invoices"

--- a/organizations/acme_corp/views/bpmn/README.md
+++ b/organizations/acme_corp/views/bpmn/README.md
@@ -1,0 +1,26 @@
+# `canon/views/bpmn/`
+
+Detailed BPMN 2.0 process flow diagrams. Each file describes the internal flow of a single BusinessProcess element (the thin metadata for which lives at `canon/elements/02_business/<PROCESS_ID>.yaml`).
+
+Compiled from text-native YAML DSL to BPMN 2.0 XML by **Transitrix Studio**.
+
+## File convention
+
+`*.bpmn.transitrix.yaml`
+
+## Templates
+
+Two starting templates ship with the methodology:
+
+- `.templates/bpmn/process_template.bpmn.transitrix.yaml` — basic single-pool, single-lane process.
+- `.templates/bpmn/advanced-process-with-lanes.bpmn.transitrix.yaml` — multi-lane, multi-stage process with KPIs.
+
+## Lifecycle
+
+BPMN files use **file-local labels** for their nodes (`POOL-…`, `GW-…`, `TASK-…`, `SF-…`, `SE-…`, `EE-…`) — per [`notations/IDS_AND_REFERENCES.md`](../../../../../notations/IDS_AND_REFERENCES.md) §3.3 these are not canonical elements. Neither the BPMN nodes nor the BPMN file itself carries the primitive lifecycle ([`notations/CONTRACT.md`](../../../../../notations/CONTRACT.md) §7). The lifecycle of the process this BPMN represents lives on its corresponding `PROCESS-…` element in [`../processmap/`](../processmap/) — the BPMN is the detailed flow, not the lifecycle bearer.
+
+## See also
+
+- `method/methodology.md` §6.4 — BPMN process diagrams
+- `method/bpmn-notation-kit/` — full BPMN DSL spec, rules, and examples
+- `canon/elements/02_business/` — thin BusinessProcess element files

--- a/organizations/acme_corp/views/bpmn/data-subject-erasure.bpmn.transitrix.yaml
+++ b/organizations/acme_corp/views/bpmn/data-subject-erasure.bpmn.transitrix.yaml
@@ -1,0 +1,104 @@
+# Detailed BPMN flow for PROCESS-DSR-HANDLE-1 — GDPR right-to-erasure (Art. 17).
+# Compiled to BPMN 2.0 XML by Transitrix Studio. Node ids are file-local labels
+# (POOL-/LANE-/SE-/TASK-/GW-/EE-) per IDS_AND_REFERENCES.md §3.3 — not canonical
+# elements, so this file bears no primitive lifecycle.
+
+notation: bpmn
+spec_version: "0.1"
+
+process:
+  id: PROCESS-DSR-HANDLE-1
+  name: "Data Subject Erasure Request (GDPR Art. 17)"
+  pools:
+    - id: POOL-DSR
+      name: "Data Subject Request Handling"
+      lanes:
+        - id: LANE-SUPPORT
+          name: "Customer Support"
+          performed_by_role: ROLE-CS-1
+          elements:
+            - id: SE-REQUEST
+              type: startEvent
+              name: "Erasure request received"
+            - id: TASK-VERIFY-IDENTITY
+              type: userTask
+              name: "Verify data-subject identity"
+              supported_by_application: APPLICATION-CRM-1   # identity lookup via CRM
+            - id: GW-VERIFIED
+              type: exclusiveGateway
+              name: "Identity verified?"
+            - id: TASK-REJECT
+              type: userTask
+              name: "Reject request & notify subject"
+            - id: EE-REJECTED
+              type: endEvent
+              name: "Request rejected"
+            - id: TASK-CONFIRM
+              type: userTask
+              name: "Confirm erasure & notify subject"
+        - id: LANE-DPO
+          name: "Data Protection Officer"
+          performed_by_role: ROLE-DPO-1
+          elements:
+            - id: TASK-LOG-REQUEST
+              type: task
+              name: "Log request in DSR register"
+            - id: GW-ARCHIVE
+              type: exclusiveGateway
+              name: "Personal data in cold-storage archive?"
+            - id: TASK-FLAG-GAP
+              type: task
+              name: "Flag archive exception for manual review"
+            - id: GW-CONFIRM-JOIN
+              type: exclusiveGateway
+              name: "Erasure path joined"
+            - id: TASK-RECORD-CLOSURE
+              type: task
+              name: "Record completion within 30-day window"
+            - id: EE-CLOSED
+              type: endEvent
+              name: "Request closed & evidenced"
+        - id: LANE-OPS
+          name: "Operations & Engineering"
+          performed_by_role: ROLE-OPS-1
+          supported_by_application: APPLICATION-OMS-1      # lane default: OMS orchestrates erasure
+          elements:
+            - id: TASK-LOCATE
+              type: task
+              name: "Locate personal data across systems"
+            - id: TASK-ERASE-ACTIVE
+              type: task
+              name: "Erase from active OMS & CRM"
+  flows:
+    - from: SE-REQUEST
+      to: TASK-VERIFY-IDENTITY
+    - from: TASK-VERIFY-IDENTITY
+      to: GW-VERIFIED
+    - from: GW-VERIFIED
+      to: TASK-REJECT
+      default: true
+    - from: TASK-REJECT
+      to: EE-REJECTED
+    - from: GW-VERIFIED
+      to: TASK-LOG-REQUEST
+      condition: "identity verified"
+    - from: TASK-LOG-REQUEST
+      to: TASK-LOCATE
+    - from: TASK-LOCATE
+      to: TASK-ERASE-ACTIVE
+    - from: TASK-ERASE-ACTIVE
+      to: GW-ARCHIVE
+    - from: GW-ARCHIVE
+      to: TASK-FLAG-GAP
+      condition: "data present in 7-year archive (known gap)"
+    - from: GW-ARCHIVE
+      to: GW-CONFIRM-JOIN
+      default: true
+    - from: TASK-FLAG-GAP
+      to: GW-CONFIRM-JOIN
+    - from: GW-CONFIRM-JOIN
+      to: TASK-CONFIRM
+    - from: TASK-CONFIRM
+      to: TASK-RECORD-CLOSURE
+    - from: TASK-RECORD-CLOSURE
+      to: EE-CLOSED

--- a/organizations/acme_corp/views/c4component/application-containers.c4.md
+++ b/organizations/acme_corp/views/c4component/application-containers.c4.md
@@ -1,0 +1,55 @@
+<!--
+  Mermaid complementary view — Application layer: software container context.
+  Renders in VS Code with Markdown Preview Mermaid Support (bierner.markdown-mermaid).
+
+  Derived from:
+    - canon/views/applications/eu-portfolio.applications.transitrix.yaml
+        OMS (APPLICATION-OMS-1): Internal, domain=Operations, products=[PRODUCT-ECOMM-1],
+          integration outbound REST → CRM (propagates order & erasure events).
+        CRM (APPLICATION-CRM-1): Salesforce, domain=Sales, products=[PRODUCT-ECOMM-1].
+    - canon/elements/02_business/roles/ — ROLE-SALES-1, ROLE-OPS-1
+    - canon/elements/02_business/processes/PROCESS-ORD-FULFILL-1.yaml
+        participants referencing ROLE-SALES-1 and ROLE-OPS-1
+
+  Not a duplicate of the Applications catalogue view: the catalogue shows the full
+  attribute sheet (lifecycle, vendor, maturity) and the catalogue-wide integration
+  descriptor. This C4 container view projects the same systems as a context diagram —
+  who uses what, and how containers interconnect.
+-->
+
+# Application Containers — Acme Corp EU Portfolio
+
+Application-layer view showing the two software containers that drive the EU portfolio
+and how actors interact with them. Derived from the applications catalogue and the
+order-fulfilment process participants.
+
+```mermaid
+C4Container
+    title Application containers — Acme Corp EU portfolio
+
+    Person(customer, "Customer", "Places orders; subject of data-subject rights (GDPR Art. 17)")
+    Person(sales, "Sales Rep (ROLE-SALES-1)", "Validates orders; manages CRM contacts")
+    Person(ops, "Operations (ROLE-OPS-1)", "Fulfils orders; runs GDPR erasure sweeps")
+
+    System_Boundary(acme, "Acme Corp — EU digital portfolio (PRODUCT-ECOMM-1)") {
+        Container(oms, "Order Management System", "Web Application — Internal (APPLICATION-OMS-1)", "Order lifecycle: intake, validation, routing, fulfilment. Holds active-order personal data.")
+        Container(crm, "CRM System", "Salesforce Platform (APPLICATION-CRM-1)", "Customer relationship and consent management. Holds contact and consent personal data.")
+    }
+
+    Rel(customer, oms, "Places and tracks orders", "HTTPS")
+    Rel(sales, oms, "Validates and manages orders")
+    Rel(ops, oms, "Fulfils orders; initiates erasure sweeps")
+    Rel(sales, crm, "Manages customer contacts and consent")
+    Rel(oms, crm, "Propagates order and erasure events", "REST / outbound")
+```
+
+## Model references
+
+| Element | Source |
+|---|---|
+| `APPLICATION-OMS-1` — Order Management System, Internal | `eu-portfolio.applications.transitrix.yaml` |
+| `APPLICATION-CRM-1` — CRM System, Salesforce | `eu-portfolio.applications.transitrix.yaml` |
+| `ROLE-SALES-1` — Sales Rep | `canon/elements/02_business/roles/` |
+| `ROLE-OPS-1` — Operations | `canon/elements/02_business/roles/` |
+| OMS → CRM REST outbound integration | `eu-portfolio.applications.transitrix.yaml` (integrations block) |
+| Product boundary `PRODUCT-ECOMM-1` | `canon/elements/02_business/products/PRODUCT-ECOMM-1.yaml` |

--- a/organizations/acme_corp/views/c4deployment/technology-deployment.c4.md
+++ b/organizations/acme_corp/views/c4deployment/technology-deployment.c4.md
@@ -1,0 +1,61 @@
+<!--
+  Mermaid complementary view — Technology layer: deployment environment.
+  Renders in VS Code with Markdown Preview Mermaid Support (bierner.markdown-mermaid).
+
+  Derived from:
+    - canon/views/applications/eu-portfolio.applications.transitrix.yaml
+        APPLICATION-OMS-1: vendor="Internal" → self-hosted application server.
+        APPLICATION-CRM-1: vendor="Salesforce" → Salesforce cloud platform.
+        OMS → CRM outbound REST integration.
+    - canon/elements/04_technology/equipment/EQUIPMENT-SCANNER-1.yaml
+        type: device, description: "Handheld barcode scanner used in the warehouse —
+        Pick & pack and Ship stages of the order-fulfilment value chain."
+
+  Deployment zones are derived from element metadata:
+    "Salesforce Platform" — from vendor="Salesforce" on APPLICATION-CRM-1.
+    "Internal application server" — from vendor="Internal" on APPLICATION-OMS-1.
+    "Warehouse (on-premise)" — from EQUIPMENT-SCANNER-1 description and type=device.
+
+  Not a duplicate of the C4 container view: that view shows actors and software
+  containers and their interactions. This deployment view projects the same containers
+  onto the physical/cloud hosting topology — where each system actually runs.
+-->
+
+# Technology Deployment — Acme Corp EU Systems
+
+Technology-layer view of where the EU portfolio applications are deployed. Deployment
+zones are derived from vendor metadata and equipment placement recorded in element files.
+
+```mermaid
+C4Deployment
+    title Technology deployment — Acme Corp EU systems
+
+    Deployment_Node(cloud, "Salesforce Cloud", "vendor: Salesforce (APPLICATION-CRM-1)") {
+        Deployment_Node(sfplatform, "Salesforce Platform") {
+            Container(crm, "CRM System", "Salesforce (APPLICATION-CRM-1)", "Customer relationship and consent management")
+        }
+    }
+
+    Deployment_Node(internal, "Internal hosting", "vendor: Internal (APPLICATION-OMS-1)") {
+        Deployment_Node(appserver, "Application Server") {
+            Container(oms, "Order Management System", "Web Application (APPLICATION-OMS-1)", "Order lifecycle management; active-order personal data")
+        }
+    }
+
+    Deployment_Node(warehouse, "Warehouse — on-premise", "EQUIPMENT-SCANNER-1 placement") {
+        Container(scanner, "Barcode Scanner", "IoT device (EQUIPMENT-SCANNER-1)", "Inventory scanning for pick-and-pack and ship stages")
+    }
+
+    Rel(oms, crm, "Propagates order and erasure events", "REST / outbound")
+    Rel(scanner, oms, "Inventory scan events", "Local network")
+```
+
+## Model references
+
+| Deployment node | Derived from |
+|---|---|
+| Salesforce Cloud | `APPLICATION-CRM-1.vendor: "Salesforce"` in `eu-portfolio.applications.transitrix.yaml` |
+| Internal application server | `APPLICATION-OMS-1.vendor: "Internal"` in `eu-portfolio.applications.transitrix.yaml` |
+| Warehouse (on-premise) | `EQUIPMENT-SCANNER-1.description` — warehouse context; `type: device` |
+| OMS → CRM integration | `eu-portfolio.applications.transitrix.yaml` (integrations block, REST outbound) |
+| Scanner → OMS | `EQUIPMENT-SCANNER-1` linked to `PROCESS-ORD-FULFILL-1` pick-and-pack stages |

--- a/organizations/acme_corp/views/c4infrastructure/network-zones.md
+++ b/organizations/acme_corp/views/c4infrastructure/network-zones.md
@@ -1,0 +1,72 @@
+<!--
+  Mermaid complementary view — Technology layer: network zone topology.
+  Renders in VS Code with Markdown Preview Mermaid Support (bierner.markdown-mermaid).
+
+  Derived from:
+    - canon/views/applications/eu-portfolio.applications.transitrix.yaml
+        APPLICATION-OMS-1: domain="Operations", vendor="Internal" → internal network zone.
+        APPLICATION-CRM-1: domain="Sales", vendor="Salesforce" → external SaaS zone.
+        OMS → CRM outbound REST integration → cross-zone channel.
+    - canon/elements/04_technology/equipment/EQUIPMENT-SCANNER-1.yaml
+        type: device → warehouse local-area network zone.
+    - canon/assertions/ASSERTION-ECOMM-GDPR-CONSENT-1.yaml (and siblings)
+        subject: PRODUCT-ECOMM-1 → customer-facing internet zone implied.
+
+  Zone topology:
+    Internet zone — customer browser reaching the OMS (HTTPS, order placement).
+    Internal zone — OMS application server (vendor="Internal").
+    Salesforce cloud zone — CRM SaaS (vendor="Salesforce"); OMS integrates outbound.
+    Warehouse zone — scanner device on local network, feeds inventory events to OMS.
+
+  Not a duplicate of the C4 deployment view: the deployment view shows hosting nodes
+  and container placement. This infrastructure view projects the same systems as a
+  network-zone diagram — which zones exist, what traffic crosses zone boundaries, and
+  what security surface each connection represents.
+-->
+
+# Network Zones — Acme Corp EU Infrastructure
+
+Technology-layer view of the network topology. Zones and cross-zone connections are
+derived from application vendor metadata, equipment placement, and process participants.
+
+```mermaid
+flowchart TB
+    subgraph Internet["Internet zone (customer-facing)"]
+        direction TB
+        CUST[Customer browser]
+    end
+
+    subgraph Internal["Internal network (Operations)"]
+        direction TB
+        OMS["Order Management System\n(APPLICATION-OMS-1 — vendor: Internal)"]
+    end
+
+    subgraph SaaS["Salesforce Cloud (external SaaS)"]
+        direction TB
+        CRM["CRM System\n(APPLICATION-CRM-1 — vendor: Salesforce)"]
+    end
+
+    subgraph Warehouse["Warehouse LAN (on-premise)"]
+        direction TB
+        SCAN["Barcode Scanner\n(EQUIPMENT-SCANNER-1 — device)"]
+    end
+
+    CUST -->|"HTTPS — order placement\n(PROCESS-ORD-FULFILL-1 step 1)"| OMS
+    OMS -->|"REST outbound — order & erasure events\n(eu-portfolio.applications: integrations)"| CRM
+    SCAN -->|"Scan events — pick & pack stage\n(EQUIPMENT-SCANNER-1 → OMS)"| OMS
+```
+
+## Model references
+
+| Zone | Derived from |
+|---|---|
+| Internet zone | Implied by PRODUCT-ECOMM-1 (digital_product, customer-facing) and GDPR consent assertions |
+| Internal network | `APPLICATION-OMS-1.vendor: "Internal"` — self-hosted, Operations domain |
+| Salesforce Cloud | `APPLICATION-CRM-1.vendor: "Salesforce"` — external SaaS |
+| Warehouse LAN | `EQUIPMENT-SCANNER-1.type: device`; description: warehouse placement |
+
+| Cross-zone connection | Source |
+|---|---|
+| Internet → Internal (HTTPS) | `PROCESS-ORD-FULFILL-1.flow.steps[0]` — startEvent (customer-initiated) |
+| Internal → SaaS (REST) | `eu-portfolio.applications.transitrix.yaml` OMS integrations block |
+| Warehouse → Internal (local) | `EQUIPMENT-SCANNER-1` feeds pick-and-pack (`STEP-ORD-FULFILL-4`) |

--- a/organizations/acme_corp/views/capabilities/README.md
+++ b/organizations/acme_corp/views/capabilities/README.md
@@ -1,0 +1,71 @@
+# `canon/views/capabilities/`
+
+Capability maps — a hierarchical view of business capabilities with a CMM maturity overlay. Each capability addressed here resolves to a Capability element under `canon/elements/02_business/capabilities/`.
+
+## File convention
+
+`*.capability-map.transitrix.yaml`
+
+## Skeleton
+
+```yaml
+notation: capability-map
+spec_version: "0.1"
+
+capability_map:
+  id: "CAPABILITY_MAP-CUSTOMER-1"
+  name: "Customer-Domain Capabilities"
+  description: "Customer-facing capabilities with current and target maturity"
+  assessment_date: "2026-05-26"
+
+  capabilities:
+    - id: "CAPABILITY-V1"               # → canon/elements/02_business/capabilities/CAPABILITY-V1.yaml
+      name: "Order Management"
+      type: "domain"                    # domain | supporting
+      current_maturity: 2
+      target_maturity: 3
+      target_date: "2026-12-31"
+      owner_role: "ROLE-OPS-1"
+      business_process: "PROCESS-ORD-FULFILL-1"
+      applications:
+        - "APPLICATION-OMS-1"
+        - "APPLICATION-CRM-1"
+      valid_from: "2026-05-26"          # CONTRACT.md §7 — required on every inline capability, recursively
+      valid_to: null
+      children:
+        - id: "CAPABILITY-V1.1"
+          name: "Order Intake"
+          type: "domain"
+          current_maturity: 3
+          target_maturity: 3
+          valid_from: "2026-05-26"
+          valid_to: null
+        - id: "CAPABILITY-V1.2"
+          name: "Order Fulfilment"
+          type: "domain"
+          current_maturity: 2
+          target_maturity: 3
+          target_date: "2026-09-30"
+          valid_from: "2026-05-26"
+          valid_to: null
+    - id: "CAPABILITY-V2"
+      name: "Customer Relationship"
+      type: "domain"
+      current_maturity: 2
+      target_maturity: 3
+      owner_role: "ROLE-SALES-1"
+      applications:
+        - "APPLICATION-CRM-1"
+      valid_from: "2026-05-26"
+      valid_to: null
+```
+
+`CAPABILITY-V1` / `CAPABILITY-V1.1` are canonical capability IDs (V/H sub-grammar per [`notations/IDS_AND_REFERENCES.md`](../../../../../notations/IDS_AND_REFERENCES.md) §2); **every** capability, including children, carries `type` (required). The maturity history of an individual capability lives on its element file, not here.
+
+`valid_from` / `valid_to` are required on every inline capability (recursively, including nested `children[]`) per [`notations/CONTRACT.md`](../../../../../notations/CONTRACT.md) §7. The capability-map document itself does not carry a lifecycle field. The notation-spec's "Planned" / "Active" / "Retired" state vocabulary ([`notations/views/05-capability-map.md`](../../../../../notations/views/05-capability-map.md) §7) is a *derived view* over `valid_from` / `valid_to` + today's date — not a separate stored mechanism.
+
+## See also
+
+- `notations/views/05-capability-map.md` — capability-map notation reference (CMM maturity, V/H addressing, full field table)
+- `.templates/capability-map_template.yaml` — copy-and-fill template
+- `canon/elements/02_business/capabilities/` — where individual Capability elements live

--- a/organizations/acme_corp/views/capabilities/compliance-domain.capability-map.transitrix.yaml
+++ b/organizations/acme_corp/views/capabilities/compliance-domain.capability-map.transitrix.yaml
@@ -1,0 +1,74 @@
+# Capability map — core domains plus the cross-cutting Compliance & Data
+# Protection capability, with CMMI maturity overlay. Notation spec:
+# notations/views/05-capability-map.md. Every inline capability (recursively)
+# carries `type` and CONTRACT.md §7 lifecycle.
+
+notation: capability-map
+spec_version: "0.1"
+title: "Acme Corp — Capability Map with Compliance Overlay"
+description: "Core business capabilities and the cross-cutting compliance capability, with current and target CMMI maturity."
+version: "1.0"
+date: "2026-06-10"
+
+capability_map:
+  id: CAPABILITY_MAP-COMPLIANCE-1
+  name: "Compliance-Domain Capability Map"
+  description: "Business capabilities with current and target maturity, highlighting the data-protection gap."
+  assessment_date: "2026-06-10"
+
+  capabilities:
+    - id: V1
+      name: "Order Management"
+      type: domain
+      current_maturity: 2
+      target_maturity: 3
+      target_date: "2026-12-31"
+      owner_role: ROLE-OPS-1
+      business_process: PROCESS-ORD-FULFILL-1
+      applications:
+        - APPLICATION-OMS-1
+        - APPLICATION-CRM-1
+      valid_from: "2026-05-26"
+      valid_to: null
+      children:
+        - id: V1.1
+          name: "Order Intake"
+          type: domain
+          current_maturity: 3
+          target_maturity: 3
+          valid_from: "2026-05-26"
+          valid_to: null
+        - id: V1.2
+          name: "Order Fulfilment"
+          type: domain
+          current_maturity: 2
+          target_maturity: 3
+          target_date: "2026-09-30"
+          valid_from: "2026-05-26"
+          valid_to: null
+
+    - id: V2
+      name: "Customer Relationship Management"
+      type: domain
+      current_maturity: 2
+      target_maturity: 3
+      owner_role: ROLE-SALES-1
+      applications:
+        - APPLICATION-CRM-1
+      valid_from: "2026-05-26"
+      valid_to: null
+
+    - id: H1
+      name: "Compliance & Data Protection"
+      type: supporting
+      description: >
+        Cross-cutting capability covering GDPR/NIS2 obligations: data-subject
+        rights, breach reporting, and data residency. Lowest current maturity —
+        the focus of the 2026 remediation programme.
+      current_maturity: 1
+      target_maturity: 3
+      target_date: "2026-12-31"
+      owner_role: ROLE-DPO-1
+      business_process: PROCESS-DSR-HANDLE-1
+      valid_from: "2026-05-26"
+      valid_to: null

--- a/organizations/acme_corp/views/compliance-impact/eu-compliance.compliance-impact.transitrix.yaml
+++ b/organizations/acme_corp/views/compliance-impact/eu-compliance.compliance-impact.transitrix.yaml
@@ -1,0 +1,29 @@
+# Compliance-impact view — acme_corp EU (GDPR + NIS2).
+# Opens in Transitrix Studio; notation spec: notations/views/21-compliance-impact.md.
+
+notation: compliance-impact
+spec_version: "0.1"
+
+view:
+  report_type: product
+  id: COMPLIANCE_IMPACT-ACME-EU-1
+  name: "acme_corp — EU Compliance Impact (GDPR + NIS2)"
+  description: >
+    Obligation × product matrix scoped to the EU jurisdiction (GDPR and NIS2).
+    Shows which regulatory requirements bind each product and the current
+    compliance status. Gaps (no assertion) appear as empty cells.
+    Deadline decorations indicate overdue or imminent remediation targets.
+  snapshot_at: "2026-06-10"
+
+  subjects:
+    products:
+      - PRODUCT-ECOMM-1
+      - PRODUCT-SUPPORT-1
+
+  obligations:
+    filter:
+      derived_from_codex:
+        - LAW-GDPR-1
+        - LAW-NIS2-1
+
+  order_rows_by: id

--- a/organizations/acme_corp/views/coverage-metric/eu-coverage.coverage-metric.transitrix.yaml
+++ b/organizations/acme_corp/views/coverage-metric/eu-coverage.coverage-metric.transitrix.yaml
@@ -1,0 +1,33 @@
+# Coverage-metric view — acme_corp EU (GDPR + NIS2).
+# Opens in Transitrix Studio; notation spec: notations/views/22-coverage-metric.md.
+
+notation: coverage-metric
+spec_version: "0.1"
+
+coverage_metric:
+  id: COVERAGE_METRIC-ACME-EU-1
+  name: "acme_corp — EU Coverage Metric (GDPR + NIS2)"
+  description: >
+    Measures assertion coverage per law for acme_corp EU compliance.
+    Groups requirements by their source codex and shows the proportion
+    that are compliant, partial, under review, non-compliant, or gap
+    (no assertion filed).
+  date: "2026-06-10"
+  version: "0.1"
+  author: "v.korobeinikov"
+
+  scope:
+    jurisdictions:
+      - eu
+    codex:
+      - LAW-GDPR-1
+      - LAW-NIS2-1
+    subjects:
+      products:
+        - PRODUCT-ECOMM-1
+        - PRODUCT-SUPPORT-1
+
+  thresholds:
+    green: 0.80
+    amber: 0.50
+    red: 0.00

--- a/organizations/acme_corp/views/dgca/README.md
+++ b/organizations/acme_corp/views/dgca/README.md
@@ -1,0 +1,92 @@
+# `canon/views/dgca/`
+
+Driver → Goal → Change → Action chains. Strategy-to-execution scaffold: drivers justify focus, goals set direction, changes define the transformation, actions deliver. Each layer references atomic elements stored elsewhere.
+
+Layer toggle: individual columns can be disabled via `view_config.layers`. The DGA variant (`layers.changes: off`) maps actions directly to goals without an intermediate change step.
+
+## File convention
+
+`*.dgca.transitrix.yaml`
+
+## Skeleton — full DGCA (4 layers)
+
+```yaml
+notation: dgca
+spec_version: "0.1"
+
+id: DGCA-EU-1
+name: "EU Expansion 2026"
+description: "Driver → Goal → Change → Activity chain for EU market entry."
+period: "2026"
+date: "2026-05-26"
+author: "Acme Strategy Office"
+
+factors:
+  - id: DRIVER-EU-REG-1           # → canon/elements/01_motivation/factors/DRIVER-EU-REG-1.yaml
+    name: "EU regulatory window for market entry"   # neutral driver — findings live on ASSESSMENTs
+    type: external
+    category: legal               # PESTLE — external only
+    references_constraint: [CONSTRAINT-GDPR-RESIDENCY-1]   # → canon/elements/01_motivation/constraints/
+    valid_from: "2026-05-26"      # CONTRACT.md §7 — required on every inline element
+    valid_to: null
+
+goals:
+  - id: GOAL-EU-1
+    name: "Operational presence in 3 EU markets by Q4"
+    factors: [DRIVER-EU-REG-1]
+    valid_from: "2026-05-26"
+    valid_to: null
+
+changes:
+  - id: CHANGE-EU-CRM-1
+    name: "Stand up EU-localised CRM and payment processing"
+    goals: [GOAL-EU-1]
+    valid_from: "2026-05-26"
+    valid_to: null
+
+actions:
+  - id: ACTION-CRM-EU-1
+    name: "Implement EU-localised CRM rollout"
+    changes: [CHANGE-EU-CRM-1]
+    valid_from: "2026-05-26"
+    valid_to: null
+```
+
+## Skeleton — DGA mode (Changes layer off)
+
+```yaml
+notation: dgca
+spec_version: "0.1"
+
+view_config:
+  layers:
+    changes: off          # Driver → Goal → Action; changes[] may be omitted
+
+factors:
+  - id: DRIVER-1
+    name: "..."
+    type: external
+    valid_from: "2026-05-26"
+    valid_to: null
+
+goals:
+  - id: GOAL-1
+    name: "..."
+    factors: [DRIVER-1]
+    valid_from: "2026-05-26"
+    valid_to: null
+
+actions:
+  - id: ACTION-1
+    name: "..."
+    goals: [GOAL-1]       # direct link — no changes[] needed
+    valid_from: "2026-05-26"
+    valid_to: null
+```
+
+`valid_from` / `valid_to` are required on every inline element per [`notations/CONTRACT.md`](../../../../../notations/CONTRACT.md) §7. The DGCA document itself does not carry a lifecycle field — it is a view, not an element.
+
+## See also
+
+- `method/methodology.md` §6.2 — DGCA notation
+- `notations/views/02-dgca.md` — canonical spec

--- a/organizations/acme_corp/views/dgca/eu-compliance-dga.dgca.transitrix.yaml
+++ b/organizations/acme_corp/views/dgca/eu-compliance-dga.dgca.transitrix.yaml
@@ -1,0 +1,62 @@
+# DGCA chain (DGA mode) — direct driver → goal → activity for the compliance workstream,
+# where the transformation step is implicit. Notation spec: notations/views/02-dgca.md.
+
+notation: dgca
+spec_version: "0.1"
+
+id: DGCA-COMPLIANCE-DGA-1
+name: "EU Compliance 2026 — DGA view"
+description: >
+  Driver → Goal → Activity chain for the GDPR/NIS2 compliance workstream.
+  Changes layer disabled — activities map directly to the compliance goal.
+period: "2026"
+date: "2026-06-10"
+author: "Acme Compliance Office"
+
+view_config:
+  layers:
+    changes: off          # DGA mode — Driver → Goal → Activity
+
+factors:
+  - id: DRIVER-EU-REG-1
+    name: "EU regulatory window for market entry"
+    type: external
+    category: legal
+    references_constraint: [CONSTRAINT-GDPR-RESIDENCY-1]
+    valid_from: "2026-05-26"
+    valid_to: null
+
+goals:
+  - id: GOAL-EU-1
+    name: "Launch in 3 EU markets under full GDPR/NIS2 compliance"
+    factors: [DRIVER-EU-REG-1]
+    valid_from: "2026-05-26"
+    valid_to: null
+
+changes: []
+
+actions:
+  - id: ACTION-DISCOVERY-1
+    name: "GDPR & NIS2 gap assessment"
+    goals: [GOAL-EU-1]
+    owner: ROLE-DPO-1
+    status: "Done"
+    due_date: "2026-03-31"
+    valid_from: "2026-05-26"
+    valid_to: null
+  - id: ACTION-CRM-EU-1
+    name: "Implement EU-localised CRM rollout"
+    goals: [GOAL-EU-1]
+    owner: ROLE-SALES-1
+    status: "In Progress"
+    due_date: "2026-09-30"
+    valid_from: "2026-05-26"
+    valid_to: null
+  - id: ACTION-GDPR-DSR-WORKFLOW-1
+    name: "Stand up data-subject-request handling"
+    goals: [GOAL-EU-1]
+    owner: ROLE-DPO-1
+    status: "In Progress"
+    due_date: "2026-08-31"
+    valid_from: "2026-05-26"
+    valid_to: null

--- a/organizations/acme_corp/views/dgca/eu-expansion.dgca.transitrix.yaml
+++ b/organizations/acme_corp/views/dgca/eu-expansion.dgca.transitrix.yaml
@@ -1,0 +1,67 @@
+# DGCA chain — EU market entry under GDPR/NIS2.
+# Notation spec: notations/views/02-dgca.md. Inline elements carry CONTRACT.md §7
+# lifecycle; the view itself does not.
+
+notation: dgca
+spec_version: "0.1"
+
+id: DGCA-EU-1
+name: "EU Expansion 2026 — compliance-driven"
+description: >
+  Driver → Goal → Change → Activity chain for EU market entry. The closing EU
+  regulatory window drives a market-presence goal; the required transformation is
+  an EU-localised, GDPR-conformant platform; activities deliver it.
+period: "2026"
+date: "2026-06-10"
+author: "Acme Strategy Office"
+
+factors:
+  - id: DRIVER-EU-REG-1
+    name: "EU regulatory window for market entry"
+    type: external
+    category: legal
+    references_constraint: [CONSTRAINT-GDPR-RESIDENCY-1]
+    valid_from: "2026-05-26"
+    valid_to: null
+  - id: DRIVER-COMP-1
+    name: "Competitive pressure"
+    type: external
+    category: economic
+    valid_from: "2026-05-26"
+    valid_to: null
+
+goals:
+  - id: GOAL-EU-1
+    name: "Launch in 3 EU markets"
+    factors: [DRIVER-EU-REG-1, DRIVER-COMP-1]
+    valid_from: "2026-05-26"
+    valid_to: null
+
+changes:
+  - id: CHANGE-EU-CRM-1
+    name: "Stand up EU-localised CRM and payment processing"
+    goals: [GOAL-EU-1]
+    valid_from: "2026-05-26"
+    valid_to: null
+  - id: CHANGE-ONBOARD-1
+    name: "Rework customer onboarding for GDPR consent capture"
+    goals: [GOAL-EU-1]
+    valid_from: "2026-05-26"
+    valid_to: null
+
+actions:
+  - id: ACTION-CRM-EU-1
+    name: "Implement EU-localised CRM rollout"
+    changes: [CHANGE-EU-CRM-1]
+    valid_from: "2026-05-26"
+    valid_to: null
+  - id: ACTION-BUILD-1
+    name: "Build & test EU compliance controls"
+    changes: [CHANGE-EU-CRM-1, CHANGE-ONBOARD-1]
+    valid_from: "2026-05-26"
+    valid_to: null
+  - id: ACTION-LAUNCH-1
+    name: "Launch in EU markets"
+    changes: [CHANGE-EU-CRM-1]
+    valid_from: "2026-05-26"
+    valid_to: null

--- a/organizations/acme_corp/views/er/domain-entities.er.md
+++ b/organizations/acme_corp/views/er/domain-entities.er.md
@@ -1,0 +1,76 @@
+<!--
+  Mermaid complementary view — Application layer: core domain entity model.
+  Renders in VS Code with Markdown Preview Mermaid Support (bierner.markdown-mermaid).
+
+  Derived from:
+    - canon/elements/02_business/products/PRODUCT-ECOMM-1.yaml
+        processes: [PROCESS-ORD-FULFILL-1] — Product → Process relationship.
+    - canon/elements/03_application/applications/APPLICATION-OMS-1.yaml
+        products: [PRODUCT-ECOMM-1] — Application manages Product.
+        description: "Core system for the order lifecycle" — OMS entity domain = Orders.
+    - canon/elements/03_application/applications/APPLICATION-CRM-1.yaml
+        description: "Customer-relationship and consent management" — CRM entity domain = Customers.
+    - canon/views/applications/eu-portfolio.applications.transitrix.yaml
+        integrations: OMS outbound → CRM (REST) — Application ↔ Application relationship.
+    - canon/elements/02_business/processes/PROCESS-ORD-FULFILL-1.yaml
+        flow.steps[] — 7 steps → Process contains Steps.
+    - canon/assertions/ASSERTION-ECOMM-GDPR-CONSENT-1.yaml
+        subject: PRODUCT-ECOMM-1, about: REQUIREMENT-GDPR-CONSENT-1 — consent is a Customer attribute.
+
+  Entity types (CUSTOMER, ORDER, PRODUCT, PROCESS, APPLICATION) correspond to the
+  Transitrix TYPE vocabulary used by elements in this repository. Relationships are
+  model facts (fields on element files), not inferred business logic.
+
+  Not a duplicate of the Applications catalogue view: the catalogue shows application
+  attributes and integrations. This ER view projects the cross-layer domain model —
+  how the business domain entities relate across the element graph.
+-->
+
+# Domain Entities — Core Model
+
+Application-layer entity-relationship view of the Acme Corp domain model. All
+relationships are derived from explicit field values on element files.
+
+```mermaid
+erDiagram
+    CUSTOMER ||--o{ ORDER : places
+    ORDER }|--|| PRODUCT : "relates to"
+    PRODUCT ||--|{ PROCESS : "executed via"
+    PROCESS ||--o{ STEP : contains
+    APPLICATION ||--o{ PRODUCT : supports
+    APPLICATION ||--o{ APPLICATION : "integrates with"
+    CUSTOMER {
+        string id PK "managed by APPLICATION-CRM-1"
+        string consent_status "ASSERTION-ECOMM-GDPR-CONSENT-1 subject"
+    }
+    ORDER {
+        string id PK "managed by APPLICATION-OMS-1"
+        string status "Received | Validating | Picking | BackorderHold | Shipped | Closed"
+    }
+    PRODUCT {
+        string id PK "e.g. PRODUCT-ECOMM-1"
+        string type "digital_product | service | platform | bundle"
+        string domain "Digital | Operations"
+    }
+    PROCESS {
+        string id PK "e.g. PROCESS-ORD-FULFILL-1"
+        string name "Order Fulfilment"
+        int maturity "1-5"
+    }
+    APPLICATION {
+        string id PK "APPLICATION-OMS-1 | APPLICATION-CRM-1"
+        string vendor "Internal | Salesforce"
+        string domain "Operations | Sales"
+    }
+```
+
+## Model references
+
+| Relationship | Source field |
+|---|---|
+| `CUSTOMER` places `ORDER` | `APPLICATION-CRM-1` domain (Sales/CRM); GDPR assertions on customer subjects |
+| `ORDER` relates to `PRODUCT` | `APPLICATION-OMS-1.products: [PRODUCT-ECOMM-1]` |
+| `PRODUCT` executed via `PROCESS` | `PRODUCT-ECOMM-1.processes: [PROCESS-ORD-FULFILL-1]` |
+| `PROCESS` contains `STEP` | `PROCESS-ORD-FULFILL-1.flow.steps[]` (7 steps) |
+| `APPLICATION` supports `PRODUCT` | `APPLICATION-OMS-1.products: [PRODUCT-ECOMM-1]` |
+| `APPLICATION` integrates with `APPLICATION` | `eu-portfolio.applications.transitrix.yaml` OMS → CRM outbound REST |

--- a/organizations/acme_corp/views/fga/README.md
+++ b/organizations/acme_corp/views/fga/README.md
@@ -1,0 +1,7 @@
+# `canon/views/fga/` — Deprecated
+
+> **This folder is superseded.** FGA (`*.fga.transitrix.yaml`) is replaced by DGCA with `view_config.layers.changes: off`.
+>
+> See [`../dgca/`](../dgca/) for the current examples. The FGA example has been moved to [`../dgca/eu-compliance-dga.dgca.transitrix.yaml`](../dgca/eu-compliance-dga.dgca.transitrix.yaml).
+
+`fga` was the pre-2026-06 notation key for the Driver → Goal → Activity (3-layer) chain. It is now expressed as `notation: dgca` with `view_config.layers.changes: off`.

--- a/organizations/acme_corp/views/goals/README.md
+++ b/organizations/acme_corp/views/goals/README.md
@@ -1,0 +1,56 @@
+# `canon/views/goals/`
+
+Hierarchical goals trees. Each tree references Goal elements stored atomically under `canon/elements/01_motivation/`.
+
+## File convention
+
+`*.goals.transitrix.yaml`
+
+## Skeleton
+
+```yaml
+notation: goals
+spec_version: "0.1"
+
+id: GOALS-STRATEGY-2026
+name: "Acme Corp — Strategy 2026 Goals Tree"
+description: "Goal hierarchy for the 2026 EU-expansion plan."
+period: "2026"
+date: "2026-05-26"
+author: "Acme Strategy Office"
+
+goal_types:                       # contiguous levels from 0 (GOALS-013); static vocabulary, no lifecycle
+  - { name: "Strategy",       level: 0 }
+  - { name: "Strategic Goal", level: 1 }
+
+goals:
+  - id: GOAL-REVENUE-1            # → canon/elements/01_motivation/goals/GOAL-REVENUE-1.yaml
+    name: "Triple revenue in 3 years"
+    type: "Strategy"
+    level: 0
+    # root — no parent
+    valid_from: "2026-05-26"      # CONTRACT.md §7 — required on every inline goal
+    valid_to: null
+  - id: GOAL-EU-1
+    name: "Launch in 3 EU markets"
+    type: "Strategic Goal"
+    level: 1                       # parent is level 0 → strict N+1 (GOALS-012)
+    parent: GOAL-REVENUE-1
+    valid_from: "2026-05-26"
+    valid_to: null
+  - id: GOAL-OPS-1
+    name: "Cut support response time by half"
+    type: "Strategic Goal"
+    level: 1
+    parent: GOAL-REVENUE-1
+    valid_from: "2026-05-26"
+    valid_to: null
+```
+
+`valid_from` / `valid_to` are required on every inline goal entry per [`notations/CONTRACT.md`](../../../../../notations/CONTRACT.md) §7. The `goal_types[]` entries are a static vocabulary, not elements, and do not carry lifecycle. The goals-tree document itself carries no lifecycle either — it is a view, not an element.
+
+## See also
+
+- `method/methodology.md` §6.1 — notation locations
+- `method/methodology.md` §9 — naming conventions
+- `canon/elements/01_motivation/` — where individual Goal elements live

--- a/organizations/acme_corp/views/goals/eu-strategy.dgca.transitrix.yaml
+++ b/organizations/acme_corp/views/goals/eu-strategy.dgca.transitrix.yaml
@@ -1,0 +1,62 @@
+# Goals tree — 2026 EU-expansion plan with the compliance goal as a first-class
+# strategic goal. Notation spec: notations/views/04-goals.md. Inline goals carry
+# CONTRACT.md §7 lifecycle.
+
+notation: goals
+spec_version: "0.1"
+
+id: GOALS-STRATEGY-2026
+name: "Acme Corp — Strategy 2026 Goals Tree"
+description: "Goal hierarchy for the 2026 EU-expansion plan, including the regulatory-compliance branch."
+period: "2026"
+date: "2026-06-10"
+author: "Acme Strategy Office"
+
+goal_types:
+  - { name: "Strategy",       level: 0 }
+  - { name: "Strategic Goal", level: 1 }
+  - { name: "Project Goal",   level: 2 }
+
+goals:
+  - id: GOAL-REVENUE-1
+    name: "Triple revenue by 2028"
+    type: "Strategy"
+    level: 0
+    valid_from: "2026-05-26"
+    valid_to: null
+
+  - id: GOAL-EU-1
+    name: "Launch in 3 EU markets"
+    type: "Strategic Goal"
+    level: 1
+    parent: GOAL-REVENUE-1
+    valid_from: "2026-05-26"
+    valid_to: null
+
+  - id: GOAL-EU-COMPLIANCE-1
+    name: "Achieve full GDPR & NIS2 compliance"
+    type: "Project Goal"
+    level: 2
+    parent: GOAL-EU-1
+    description: >
+      Satisfy all GDPR and NIS2 obligations applicable to EU-resident customers
+      before go-live: data-subject rights, breach reporting, and data residency.
+      Gate condition for the EU launch.
+    valid_from: "2026-05-26"
+    valid_to: null
+
+  - id: GOAL-CUST-1
+    name: "Raise customer satisfaction"
+    type: "Strategic Goal"
+    level: 1
+    parent: GOAL-REVENUE-1
+    valid_from: "2026-05-26"
+    valid_to: null
+
+  - id: GOAL-OPS-1
+    name: "Operational excellence"
+    type: "Strategic Goal"
+    level: 1
+    parent: GOAL-REVENUE-1
+    valid_from: "2026-05-26"
+    valid_to: null

--- a/organizations/acme_corp/views/journey/order-fulfilment.journey.md
+++ b/organizations/acme_corp/views/journey/order-fulfilment.journey.md
@@ -1,0 +1,51 @@
+<!--
+  Mermaid complementary view — Business layer: customer journey through order fulfilment.
+  Renders in VS Code with Markdown Preview Mermaid Support (bierner.markdown-mermaid).
+
+  Derived from:
+    - canon/elements/02_business/processes/PROCESS-ORD-FULFILL-1.yaml
+        flow.steps[] — the canonical step sequence, including the in-stock / out-of-stock
+        gateway (STEP-ORD-FULFILL-3); participants ROLE-SALES-1 (Sales) and
+        ROLE-OPS-1 (Operations).
+
+  Not a duplicate of the BPMN or process-map views: those show the process graph from
+  the business-analyst / operations perspective. This journey projects the same steps
+  as customer experience — phases, actors visible to the customer, satisfaction signal —
+  a Business-layer read complementary to the process graph.
+-->
+
+# Order Fulfilment — Customer Journey
+
+Business-layer view of the order-fulfilment process as experienced by the customer.
+Sections correspond to phases of `PROCESS-ORD-FULFILL-1`; actors are the roles visible
+at each phase. Satisfaction scores are derived from the process outcome: the in-stock
+path closes at high satisfaction; the backorder branch carries a delayed-fulfilment dip.
+
+```mermaid
+journey
+    title Order Fulfilment — Customer View
+    section Place & Validate
+        Place order online: 5: Customer
+        Order validated by Sales: 4: Sales, Customer
+    section Fulfilment (in-stock)
+        Items picked and packed: 4: Operations
+        Order dispatched: 5: Operations, Customer
+        Order closed: 5: Customer
+    section Backorder path
+        Backorder notification sent: 2: Sales, Customer
+        Order closed on fulfilment: 3: Customer
+```
+
+## Model references
+
+| Journey phase | Step | Element |
+|---|---|---|
+| Place order online | `STEP-ORD-FULFILL-1` | startEvent — performed by `ROLE-SALES-1` (Sales) |
+| Order validated | `STEP-ORD-FULFILL-2` | userTask "Validate Order" — `ROLE-SALES-1`, `APPLICATION-OMS-1` |
+| Routing gateway | `STEP-ORD-FULFILL-3` | exclusiveGateway "In stock?" — `ROLE-OPS-1` |
+| Items picked and packed | `STEP-ORD-FULFILL-4` | task "Pick and Pack" — `ROLE-OPS-1`, `APPLICATION-OMS-1` |
+| Order dispatched | `STEP-ORD-FULFILL-5` | task "Ship Order" — `ROLE-OPS-1` |
+| Backorder notification | `STEP-ORD-FULFILL-6` | userTask "Notify Customer of Backorder" — `ROLE-SALES-1`, `APPLICATION-OMS-1` |
+| Order closed | `STEP-ORD-FULFILL-7` | endEvent — `ROLE-OPS-1` |
+
+Process: `PROCESS-ORD-FULFILL-1` · Flow source: `flow.steps[]` + `flow.sequence[]`

--- a/organizations/acme_corp/views/process-blueprint/README.md
+++ b/organizations/acme_corp/views/process-blueprint/README.md
@@ -1,0 +1,23 @@
+# `canon/views/process-blueprint/`
+
+Wide value-chain blueprint — stages laid out left-to-right, each carrying its goal, result, and supporting aspects (systems, actors, equipment, information entities).
+
+## File convention
+
+`*.process-blueprint.transitrix.yaml`
+
+See [`notations/views/13-process-blueprint.md`](../../../../../notations/views/13-process-blueprint.md) for the full spec.
+
+## Lifecycle
+
+The blueprint's per-aspect arrays split for lifecycle purposes:
+
+- **Canonical-TYPE arrays** — `equipment[]` (`EQUIPMENT`, catalogued at `canon/elements/04_technology/equipment/`) and `business_objects[]` (`BUSINESS_OBJECT`, catalogued at `canon/elements/02_business/business-objects/`), both registered in [`notations/IDS_AND_REFERENCES.md`](../../../../../notations/IDS_AND_REFERENCES.md) §3.1 and promoted to standalone elements (ADR 2026-06-08). An entry that carries an `id` resolves to the matching catalogue record; a free-form entry without an `id` stays document-local. Each entry carries `valid_from` and `valid_to` per [`notations/CONTRACT.md`](../../../../../notations/CONTRACT.md) §7. Note: the field was previously named `information_entities[]` (`INFORMATION_ENTITY`) — the deprecated alias is accepted for one release (validator emits `BOBJ-D001`).
+- **Document-local arrays** — `stages[]`, `systems[]`, `actors[]`. These use document-local identifiers (e.g. `STAGE-1`) that are not registered as canonical TYPEs and so carry no lifecycle of their own. When a `systems[]` or `actors[]` entry is intended to reference a registered element (an `APPLICATION-…` or `ROLE-…`), the lifecycle lives on that target's canonical file.
+
+The process-blueprint document itself carries no lifecycle.
+
+## See also
+
+- [`notations/examples/process-blueprint/`](../../../../../notations/examples/process-blueprint/) — worked example
+- `method/methodology.md` §6 — notation kit

--- a/organizations/acme_corp/views/process-blueprint/order-fulfilment.process-blueprint.transitrix.yaml
+++ b/organizations/acme_corp/views/process-blueprint/order-fulfilment.process-blueprint.transitrix.yaml
@@ -1,0 +1,81 @@
+# Value-chain blueprint for order fulfilment — defines the STAGE-1..STAGE-5 that
+# ASSERTION-ECOMM-GDPR-ERASURE-1 references via `realised_via`. Notation spec:
+# notations/views/13-process-blueprint.md. stages/systems/actors are document-local;
+# business_objects[] carry CONTRACT.md §7 lifecycle.
+
+notation: process-blueprint
+spec_version: "0.1"
+
+process_blueprint:
+  id: PROCESS_BLUEPRINT-FULFIL-1
+  name: "Order fulfilment — operational blueprint"
+  description: |
+    End-to-end order fulfilment value chain. Personal data is captured at
+    STAGE-1, read at STAGE-3, and transmitted to the carrier at STAGE-4 — the
+    three stages a GDPR erasure request must reach (see
+    ASSERTION-ECOMM-GDPR-ERASURE-1).
+  period: "2026"
+  version: "0.1"
+  date: "2026-06-10"
+  author: "Acme Compliance Office"
+  process: PROCESS-ORD-FULFILL-1
+
+  stages:
+    - id: STAGE-1
+      name: "Receive order"
+      goal: "Capture a validated customer order with consent recorded."
+      result: "Validated order in OMS with personal data captured and consent logged."
+    - id: STAGE-2
+      name: "Allocate inventory"
+      goal: "Reserve stock to satisfy the order."
+      result: "Reservation lines linked to the order."
+    - id: STAGE-3
+      name: "Pick & pack"
+      goal: "Assemble the physical order; personal data read from CRM for labelling."
+      result: "Packed shipment scanned out and ready for carrier handover."
+    - id: STAGE-4
+      name: "Ship"
+      goal: "Hand the shipment to the carrier; personal data transmitted on the label."
+      result: "In-transit shipment with tracking number sent to the customer."
+    - id: STAGE-5
+      name: "Confirm delivery & close"
+      goal: "Confirm delivery, settle payment, and archive the order."
+      result: "Closed order; record written to the 7-year cold-storage archive."
+
+  systems:
+    - id: APPLICATION-OMS-1
+      name: "Order Management System"
+      stages: [STAGE-1, STAGE-2, STAGE-3, STAGE-4, STAGE-5]
+    - id: APPLICATION-CRM-1
+      name: "CRM System"
+      stages: [STAGE-1, STAGE-3]
+
+  actors:
+    - id: ROLE-CS-1
+      name: "Customer Support Lead"
+      stages: [STAGE-1, STAGE-5]
+    - id: ROLE-OPS-1
+      name: "Operations Lead"
+      stages: [STAGE-2, STAGE-3, STAGE-4]
+    - id: ROLE-DPO-1
+      name: "Data Protection Officer"
+      stages: [STAGE-1, STAGE-5]
+
+  lane_config:
+    compliance: true              # Show derived compliance lane from canon assertions
+
+  business_objects:
+    - id: BUSINESS_OBJECT-CUST-ORDER-1
+      name: "Customer order"
+      stages: [STAGE-1, STAGE-2, STAGE-3, STAGE-4, STAGE-5]
+      valid_from: "2026-05-26"
+      valid_to: null
+    - name: "Personal data record"
+      description: "EU-resident personal data; subject to GDPR erasure across STAGE-1, STAGE-3, STAGE-4."
+      stages: [STAGE-1, STAGE-3, STAGE-4]
+      valid_from: "2026-05-26"
+      valid_to: null
+    - name: "Consent record"
+      stages: [STAGE-1]
+      valid_from: "2026-05-26"
+      valid_to: null

--- a/organizations/acme_corp/views/processmap/README.md
+++ b/organizations/acme_corp/views/processmap/README.md
@@ -1,0 +1,76 @@
+# `canon/views/processmap/`
+
+Process landscape maps — a top-level catalogue of the organisation's processes, grouped by Operating / Supporting / Management. Each process referenced here resolves to a BusinessProcess element under `canon/elements/02_business/processes/`. Detailed flow diagrams (BPMN) live in `canon/views/bpmn/`.
+
+## File convention
+
+`*.process-map.transitrix.yaml`
+
+## Skeleton
+
+```yaml
+notation: process-map
+spec_version: "0.1"
+
+process_map:
+  id: "PM-ACME-1"
+  name: "Acme Corp — Process Landscape"
+  description: "Top-level catalogue of operating, supporting, and management processes"
+  version: "1.0"
+  updated_at: "2026-05-26"
+
+  groups:                               # groups are organisational containers, not elements — no lifecycle on the group itself
+    - id: "GRP-OPERATING"
+      name: "Operating Processes"
+      type: "operating"                 # operating | supporting | management
+      processes:
+        - process_id: "PROCESS-ORD-FULFILL-1"   # → canon/elements/02_business/processes/PROCESS-ORD-FULFILL-1.yaml
+          name: "Order Fulfilment"
+          owner_role: "ROLE-OPS-1"
+          capability: "CAPABILITY-V1"
+          maturity: 2
+          status: "Active"                    # operational state: Draft | Active | Deprecated
+          bpmn_file: "canon/views/bpmn/order-fulfilment.bpmn.transitrix.yaml"
+          valid_from: "2026-05-26"            # CONTRACT.md §7 — required on every inline process; distinct from operational `status`
+          valid_to: null
+        - process_id: "PROCESS-CUST-ONBOARD-1"
+          name: "Customer Onboarding"
+          owner_role: "ROLE-SALES-1"
+          capability: "CAPABILITY-V2"
+          maturity: 1
+          status: "Draft"
+          valid_from: "2026-05-26"
+          valid_to: null
+
+    - id: "GRP-SUPPORTING"
+      name: "Supporting Processes"
+      type: "supporting"
+      processes:
+        - process_id: "PROCESS-CS-RESOLVE-1"
+          name: "Customer Support Resolution"
+          owner_role: "ROLE-CS-1"
+          status: "Active"
+          valid_from: "2026-05-26"
+          valid_to: null
+
+    - id: "GRP-MANAGEMENT"
+      name: "Management Processes"
+      type: "management"
+      processes:
+        - process_id: "PROCESS-STRAT-PLAN-1"
+          name: "Annual Strategy Planning"
+          owner_role: "ROLE-EXEC-1"
+          status: "Active"
+          valid_from: "2026-05-26"
+          valid_to: null
+```
+
+`process_id`, `owner_role`, and `capability` hold **element / capability IDs**, not display names.
+
+`valid_from` / `valid_to` are required on every inline process entry per [`notations/CONTRACT.md`](../../../../../notations/CONTRACT.md) §7 and are distinct from the per-process `status` (`Draft` / `Active` / `Deprecated`) which is an operational state. Process groups (`groups[]`) are organisational containers, not elements, and carry no lifecycle of their own; the process-map document itself carries none either.
+
+## See also
+
+- `notations/views/06-process-map.md` — process-map notation reference (full field table)
+- `canon/views/bpmn/` — detailed flow diagrams for individual processes
+- `canon/elements/02_business/processes/` — where individual BusinessProcess elements live

--- a/organizations/acme_corp/views/processmap/enterprise.process-map.transitrix.yaml
+++ b/organizations/acme_corp/views/processmap/enterprise.process-map.transitrix.yaml
@@ -1,0 +1,71 @@
+# Process landscape — operating / supporting / management groups, including the
+# compliance (data-subject-request) process. Notation spec: notations/views/06-process-map.md.
+# Each inline process carries CONTRACT.md §7 lifecycle, distinct from operational `status`.
+
+notation: process-map
+spec_version: "0.1"
+
+process_map:
+  id: PM-ACME-1
+  name: "Acme Corp — Process Landscape"
+  description: "Top-level catalogue of operating, supporting, and management processes."
+  version: "1.0"
+  updated_at: "2026-06-24"
+
+  groups:
+    - id: GRP-OPERATING
+      name: "Operating Processes"
+      type: operating
+      description: "Core processes that deliver value to customers."
+      processes:
+        - process_id: PROCESS-ORD-FULFILL-1
+          name: "Order Fulfilment"
+          owner_role: ROLE-OPS-1
+          capability: CAPABILITY-V1
+          # maturity — time-varying, resolved from PROCESS-ORD-FULFILL-1.history.yaml
+          status: "Active"
+          valid_from: "2026-05-26"
+          valid_to: null
+        - process_id: PROCESS-CUST-ONBOARD-1
+          name: "Customer Onboarding"
+          owner_role: ROLE-SALES-1
+          capability: CAPABILITY-V2
+          # maturity — time-varying, resolved from PROCESS-CUST-ONBOARD-1.history.yaml
+          status: "Active"
+          valid_from: "2026-05-26"
+          valid_to: null
+
+    - id: GRP-SUPPORTING
+      name: "Supporting Processes"
+      type: supporting
+      description: "Internal enablers for operating processes."
+      processes:
+        - process_id: PROCESS-CS-RESOLVE-1
+          name: "Customer Support Resolution"
+          owner_role: ROLE-CS-1
+          status: "Active"
+          # maturity — time-varying, resolved from PROCESS-CS-RESOLVE-1.history.yaml
+          valid_from: "2026-05-26"
+          valid_to: null
+
+    - id: GRP-MANAGEMENT
+      name: "Management Processes"
+      type: management
+      description: "Governance, planning, and regulatory oversight."
+      processes:
+        - process_id: PROCESS-STRAT-PLAN-1
+          name: "Annual Strategy Planning"
+          owner_role: ROLE-EXEC-1
+          status: "Active"
+          # maturity — time-varying, resolved from PROCESS-STRAT-PLAN-1.history.yaml
+          valid_from: "2026-05-26"
+          valid_to: null
+        - process_id: PROCESS-DSR-HANDLE-1
+          name: "Data Subject Request Handling"
+          owner_role: ROLE-DPO-1
+          capability: CAPABILITY-H1
+          # maturity — time-varying, resolved from PROCESS-DSR-HANDLE-1.history.yaml
+          status: "Active"
+          bpmn_file: "canon/views/bpmn/data-subject-erasure.bpmn.transitrix.yaml"
+          valid_from: "2026-05-26"
+          valid_to: null

--- a/organizations/acme_corp/views/products/README.md
+++ b/organizations/acme_corp/views/products/README.md
@@ -1,0 +1,55 @@
+# `canon/views/products/`
+
+Products catalogue — a curated catalogue of the products and services the organisation offers. Each entry references a Product element under `canon/elements/02_business/products/` and carries the display attributes used to render the catalogue.
+
+## File convention
+
+`*.products.transitrix.yaml`
+
+## Skeleton
+
+```yaml
+notation: products
+spec_version: "0.1"
+
+products_catalogue:
+  id: "PRODUCTS_CAT-1"
+  name: "Acme Corp Products Catalogue"
+  description: "Products and services offered by Acme Corp"
+  version: "1.0"
+  updated_at: "2026-05-26"
+
+  products:
+    - product_id: "PRODUCT-ECOMM-1"        # → canon/elements/02_business/products/PRODUCT-ECOMM-1.yaml
+      name: "E-Commerce Platform"
+      type: "digital_product"           # digital_product | service | platform | bundle
+      domain: "Digital"
+      owner_role: "ROLE-PROD-1"
+      status: "Active"                  # operational state: Draft | Active | Deprecated
+      maturity: 3
+      description: "Online storefront and order management for end customers"
+      capabilities: ["CAPABILITY-V1", "CAPABILITY-V2"]
+      processes: ["PROCESS-ORD-FULFILL-1"]
+      supporting_apps: ["APPLICATION-OMS-1", "APPLICATION-CRM-1"]
+      valid_from: "2026-05-26"          # CONTRACT.md §7 — required on every inline product; distinct from operational `status`
+      valid_to: null
+
+    - product_id: "PRODUCT-SUPPORT-1"
+      name: "Customer Support Service"
+      type: "service"
+      domain: "Operations"
+      owner_role: "ROLE-CS-1"
+      status: "Active"
+      description: "Tier-1 and Tier-2 support for customers via chat, email, and phone"
+      valid_from: "2026-05-26"
+      valid_to: null
+```
+
+`capabilities`, `processes`, and `supporting_apps` hold **element IDs** (`CAPABILITY-V1`, `PROC-…`, `APP-…`), not display names — the catalogue references the elements, it does not duplicate them.
+
+`valid_from` / `valid_to` are required on every inline product entry per [`notations/CONTRACT.md`](../../../../../notations/CONTRACT.md) §7 and are distinct from the per-product `status` field (`Active` / `Deprecated`), which is an operational state. The products-catalogue document itself does not carry a lifecycle field.
+
+## See also
+
+- `notations/views/09-products.md` — products-catalogue notation reference (full field table)
+- `canon/elements/02_business/products/` — where individual Product elements live

--- a/organizations/acme_corp/views/products/eu-portfolio.products.transitrix.yaml
+++ b/organizations/acme_corp/views/products/eu-portfolio.products.transitrix.yaml
@@ -1,0 +1,41 @@
+# Products catalogue — the EU-facing portfolio that the compliance views bind to.
+# Notation spec: notations/views/09-products.md. Each inline product carries
+# CONTRACT.md §7 lifecycle, distinct from operational `status`.
+
+notation: products
+spec_version: "0.1"
+
+products_catalogue:
+  id: PRODUCTS_CAT-EU-1
+  name: "Acme Corp — EU Products Portfolio"
+  description: "Products and services in scope for EU GDPR/NIS2 compliance."
+  version: "1.0"
+  updated_at: "2026-06-10"
+
+  products:
+    - product_id: PRODUCT-ECOMM-1
+      name: "E-Commerce Platform"
+      type: "digital_product"
+      domain: "Digital"
+      owner_role: ROLE-PROD-1
+      status: "Active"
+      maturity: 3
+      description: "Online storefront and order management for end customers; primary GDPR data controller surface."
+      capabilities: ["CAPABILITY-V1", "CAPABILITY-V2", "CAPABILITY-H1"]
+      processes: ["PROCESS-ORD-FULFILL-1", "PROCESS-DSR-HANDLE-1"]
+      supporting_apps: ["APPLICATION-OMS-1", "APPLICATION-CRM-1"]
+      valid_from: "2026-05-26"
+      valid_to: null
+
+    - product_id: PRODUCT-SUPPORT-1
+      name: "Customer Support Service"
+      type: "service"
+      domain: "Operations"
+      owner_role: ROLE-CS-1
+      status: "Active"
+      maturity: 2
+      description: "Tier-1 and Tier-2 support; first point of contact for data-subject requests."
+      capabilities: ["CAPABILITY-H1"]
+      processes: ["PROCESS-CS-RESOLVE-1", "PROCESS-DSR-HANDLE-1"]
+      valid_from: "2026-05-26"
+      valid_to: null

--- a/organizations/acme_corp/views/quadrant/README.md
+++ b/organizations/acme_corp/views/quadrant/README.md
@@ -1,0 +1,24 @@
+# `canon/views/quadrant/`
+
+Mermaid quadrant charts — strategic-planning views derived from the canonical
+model. Render in VS Code with
+[Markdown Preview Mermaid Support](https://marketplace.visualstudio.com/items?itemName=bierner.markdown-mermaid).
+No Transitrix Studio required.
+
+## File convention
+
+`*.quadrant.md`
+
+## Coverage
+
+Quadrant views project **portfolio positioning** — placing goals, capabilities,
+or changes on a 2 × 2 matrix to support prioritisation. They complement the
+Goals tree, DGCA/DGA chains, and Scenarios (native notation) without duplicating them.
+
+**Hard rule:** no Mermaid version of Goals, Capability Map, DGCA/DGA, Process Map,
+BPMN, or Gantt — those are native notation and must not be duplicated.
+
+## See also
+
+- `canon/views/goals/` — Goals tree (native notation)
+- `canon/views/dgca/` — Driver → Goal → Change → Action (4-layer) and Driver → Goal → Action (3-layer DGA mode)

--- a/organizations/acme_corp/views/quadrant/strategy-goals.quadrant.md
+++ b/organizations/acme_corp/views/quadrant/strategy-goals.quadrant.md
@@ -1,0 +1,52 @@
+<!--
+  Mermaid complementary view — Strategy layer: goal portfolio positioning.
+  Renders in VS Code with Markdown Preview Mermaid Support (bierner.markdown-mermaid).
+
+  Derived from:
+    - canon/views/goals/eu-strategy.dgca.transitrix.yaml
+        goal hierarchy: id, name, type (level 0/1/2), parent linkage.
+        Y-axis (Strategic Importance): goal level — level 0 (Strategy) = highest;
+          level 1 (Strategic Goal) = high; level 2 (Project Goal) = medium.
+        X-axis (Implementation Urgency): inferred from goal type and description —
+          a project goal described as an explicit gate condition for a near-term
+          milestone ranks most urgent; a 2028-horizon strategy goal ranks least.
+
+  Not a duplicate of the Goals tree: the goals tree shows hierarchy.
+  This quadrant projects goals onto a prioritisation matrix.
+-->
+
+# Strategy 2026 — Goal Portfolio
+
+Strategy-layer view of the 2026 goal portfolio. Goals are positioned by
+strategic importance (derived from hierarchy level) and implementation urgency
+(derived from goal type and gate-condition status).
+
+Source: `eu-strategy.dgca.transitrix.yaml`
+
+```mermaid
+quadrantChart
+    title 2026 Goal Portfolio — Importance × Urgency
+    x-axis Low Urgency --> High Urgency
+    y-axis Lower Importance --> Higher Importance
+    quadrant-1 Do first
+    quadrant-2 Shape long term
+    quadrant-3 Revisit later
+    quadrant-4 Manage and watch
+    Triple revenue by 2028 (GOAL-REVENUE-1): [0.15, 0.90]
+    Raise customer satisfaction (GOAL-CUST-1): [0.38, 0.72]
+    Operational excellence (GOAL-OPS-1): [0.45, 0.58]
+    Launch in 3 EU markets (GOAL-EU-1): [0.70, 0.80]
+    GDPR & NIS2 compliance (GOAL-EU-COMPLIANCE-1): [0.88, 0.65]
+```
+
+## Model references
+
+| Goal | Level | Type | Position rationale |
+|---|---|---|---|
+| `GOAL-REVENUE-1` | 0 | Strategy | Highest importance (root goal); 2028 horizon = low urgency |
+| `GOAL-EU-1` | 1 | Strategic Goal | EU launch gate — near-term, very high impact |
+| `GOAL-EU-COMPLIANCE-1` | 2 | Project Goal | Explicit gate condition for `GOAL-EU-1`; most urgent |
+| `GOAL-CUST-1` | 1 | Strategic Goal | Medium-horizon; high but not gate-critical |
+| `GOAL-OPS-1` | 1 | Strategic Goal | Ongoing operational; moderate urgency and importance |
+
+Goal hierarchy source: `eu-strategy.dgca.transitrix.yaml`

--- a/organizations/acme_corp/views/sankey/compliance-obligations.sankey.md
+++ b/organizations/acme_corp/views/sankey/compliance-obligations.sankey.md
@@ -1,0 +1,51 @@
+<!--
+  Mermaid complementary view — Business layer: compliance-obligation flow by regulation and subject.
+  Renders in VS Code with Markdown Preview Mermaid Support (bierner.markdown-mermaid).
+
+  Derived from:
+    - canon/assertions/ASSERTION-ECOMM-GDPR-CONSENT-1.yaml       — GDPR × PRODUCT-ECOMM-1
+    - canon/assertions/ASSERTION-ECOMM-GDPR-ERASURE-1.yaml        — GDPR × PRODUCT-ECOMM-1
+    - canon/assertions/ASSERTION-ECOMM-GDPR-PORTABILITY-1.yaml    — GDPR × PRODUCT-ECOMM-1
+    - canon/assertions/ASSERTION-ECOMM-NIS2-INCIDENT-1.yaml       — NIS2 × PRODUCT-ECOMM-1
+    - canon/assertions/ASSERTION-SUPPORT-GDPR-ERASURE-1.yaml      — GDPR × PRODUCT-SUPPORT-1
+    - canon/assertions/ASSERTION-CRM-DATA-ERASURE-1.yaml          — data erasure × CAPABILITY-V2
+    - canon/assertions/ASSERTION-MOBILE-DATA-ERASURE-1.yaml       — data erasure × PRODUCT-MOBILE-1
+    - canon/assertions/ASSERTION-ONBOARD-DATA-ERASURE-1.yaml      — data erasure × PROCESS-CUST-ONBOARD-1
+
+  Edge values = assertion count per (regulation, subject) pair.
+
+  Not a duplicate of the compliance-impact view: that view is a native Transitrix
+  obligation × subject status matrix (pass/partial/gap per cell). This Sankey
+  projects the same data as a flow diagram — how many obligations each regulation
+  routes to each subject — giving a volume/weight read of compliance exposure.
+-->
+
+# Compliance Obligations — Regulation-to-Subject Flow
+
+Business-layer view of the compliance obligation landscape. Each flow carries the
+count of active assertions linking a regulation (or internal policy) to a product,
+capability, or process subject.
+
+```mermaid
+sankey-beta
+GDPR,E-Commerce Platform,3
+NIS2,E-Commerce Platform,1
+GDPR,Support Portal,1
+Data erasure policy,CRM (capability),1
+Data erasure policy,Mobile product,1
+Data erasure policy,Onboarding process,1
+```
+
+## Model references
+
+| Source (regulation / policy) | Target (subject) | Count | Assertions |
+|---|---|---|---|
+| GDPR | E-Commerce Platform (`PRODUCT-ECOMM-1`) | 3 | consent, erasure, portability |
+| NIS2 | E-Commerce Platform (`PRODUCT-ECOMM-1`) | 1 | incident reporting |
+| GDPR | Support Portal (`PRODUCT-SUPPORT-1`) | 1 | erasure |
+| Data erasure policy | CRM (`CAPABILITY-V2`) | 1 | `ASSERTION-CRM-DATA-ERASURE-1` |
+| Data erasure policy | Mobile product (`PRODUCT-MOBILE-1`) | 1 | `ASSERTION-MOBILE-DATA-ERASURE-1` |
+| Data erasure policy | Onboarding process (`PROCESS-CUST-ONBOARD-1`) | 1 | `ASSERTION-ONBOARD-DATA-ERASURE-1` |
+
+GDPR obligations reference `REQUIREMENT-GDPR-*`; data-erasure policy obligations reference
+`REQUIREMENT-DATA-ERASURE-1` (internal policy requirement, not tagged with a regulation prefix).

--- a/organizations/acme_corp/views/scenarios/README.md
+++ b/organizations/acme_corp/views/scenarios/README.md
@@ -1,0 +1,18 @@
+# `canon/views/scenarios/`
+
+Alternative strategic development paths — each scenario scopes its own goals, capabilities, activities, products, processes, and applications.
+
+## File convention
+
+`*.scenarios.transitrix.yaml`
+
+See [`notations/views/11-scenarios.md`](../../../../../notations/views/11-scenarios.md) for the full spec.
+
+## Lifecycle
+
+Every inline scenario entry (`SCENARIO` canonical TYPE per [`notations/IDS_AND_REFERENCES.md`](../../../../../notations/IDS_AND_REFERENCES.md) §3.1) carries `valid_from` and `valid_to` in its frontmatter per [`notations/CONTRACT.md`](../../../../../notations/CONTRACT.md) §7. These mark the period the scenario itself is admitted as a planning consideration — distinct from any time horizon the scenario's narrative may describe (e.g. "scenario for 2027"). The scenario-scoped goals / capabilities / activities / products / processes / applications are references to other canonical elements; their lifecycle lives on each target's own canonical file. The scenarios document itself carries no lifecycle.
+
+## See also
+
+- [`notations/examples/scenarios/`](../../../../../notations/examples/scenarios/) — worked examples
+- `method/methodology.md` §6 — notation kit

--- a/organizations/acme_corp/views/scenarios/eu-go-live.scenarios.transitrix.yaml
+++ b/organizations/acme_corp/views/scenarios/eu-go-live.scenarios.transitrix.yaml
@@ -1,0 +1,51 @@
+# Scenario — EU go-live under full GDPR/NIS2 compliance. Notation spec:
+# notations/views/11-scenarios.md. The inline scenario entry carries CONTRACT.md §7
+# lifecycle; the referenced goals/capabilities/actions/products/processes/apps
+# carry theirs on their own element files.
+
+notation: scenarios
+spec_version: "0.1"
+title: "EU Go-Live 2026"
+description: "Target scenario: live in three EU markets with all compliance gaps closed."
+version: "1.0"
+date: "2026-06-10"
+
+scenario:
+  id: SCENARIO-EU-GOLIVE-1
+  name: "EU Go-Live 2026"
+  description: "Three EU markets live with GDPR/NIS2 obligations fully satisfied and the erasure-archive gap closed."
+  status: Active
+  created_at: "2026-06-10"
+  valid_from: "2026-05-26"
+  valid_to: null
+
+  vision: |
+    By Q4 2026 Acme Corp operates in three EU markets. Every data-subject request
+    is fulfilled within the statutory window across both active systems and the
+    cold-storage archive, and the supervisory-authority pre-audit is cleared.
+
+  goals:
+    - goal_id: GOAL-EU-1
+    - goal_id: GOAL-REVENUE-1
+
+  capabilities:
+    - capability_id: CAPABILITY-V1
+    - capability_id: CAPABILITY-V2
+    - capability_id: CAPABILITY-H1
+
+  actions:
+    - activity_id: ACTION-CRM-EU-1
+    - activity_id: ACTION-GDPR-ERASURE-PIPELINE-1
+    - activity_id: ACTION-GDPR-DSR-WORKFLOW-1
+
+  products:
+    - product_id: PRODUCT-ECOMM-1
+    - product_id: PRODUCT-SUPPORT-1
+
+  processes:
+    - process_id: PROCESS-ORD-FULFILL-1
+    - process_id: PROCESS-DSR-HANDLE-1
+
+  applications:
+    - app_id: APPLICATION-OMS-1
+    - app_id: APPLICATION-CRM-1

--- a/organizations/acme_corp/views/sequence/README.md
+++ b/organizations/acme_corp/views/sequence/README.md
@@ -1,0 +1,25 @@
+# `canon/views/sequence/`
+
+Mermaid sequence diagrams — Application-layer interaction views derived from
+the canonical model. Render in VS Code with
+[Markdown Preview Mermaid Support](https://marketplace.visualstudio.com/items?itemName=bierner.markdown-mermaid).
+No Transitrix Studio required.
+
+## File convention
+
+`*.sequence.md`
+
+## Coverage
+
+Sequence views project **message exchanges between applications** at the
+Application layer. They complement BPMN process flows (which show business
+lanes and tasks) without duplicating them: BPMN shows who does what; a
+sequence view shows which application sends what to which.
+
+**Hard rule:** no Mermaid version of BPMN, Goals, Capability Map, Process Map,
+or Gantt — those are native notation and must not be duplicated.
+
+## See also
+
+- `canon/views/applications/` — application catalogue (source for integrations)
+- `canon/views/bpmn/` — process flows (BPMN native notation)

--- a/organizations/acme_corp/views/sequence/order-erasure-interaction.sequence.md
+++ b/organizations/acme_corp/views/sequence/order-erasure-interaction.sequence.md
@@ -1,0 +1,54 @@
+<!--
+  Mermaid complementary view — Application layer: application interaction.
+  Renders in VS Code with Markdown Preview Mermaid Support (bierner.markdown-mermaid).
+
+  Derived from:
+    - canon/views/applications/eu-portfolio.applications.transitrix.yaml
+        OMS → CRM outbound REST integration (propagates order and erasure events)
+    - canon/views/bpmn/data-subject-erasure.bpmn.transitrix.yaml
+        TASK-ERASE-ACTIVE — "Erase from active OMS & CRM"
+
+  Not a duplicate of the BPMN view: the BPMN shows the task flow across
+  business lanes (Support / DPO / Ops). This sequence projects the
+  application-to-application message exchange at the technical layer.
+-->
+
+# Order & GDPR Erasure — Application Interaction
+
+Application-layer view of the GDPR Art. 17 erasure sweep: how the Order
+Management System and CRM coordinate once a verified erasure request is in
+flight.
+
+The OMS-to-CRM propagation is an explicit model fact — a REST outbound
+integration recorded in the applications catalogue
+(`eu-portfolio.applications.transitrix.yaml`).
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor CS as Customer Support
+    participant OMS as OMS (APPLICATION-OMS-1)
+    participant CRM as CRM System (APPLICATION-CRM-1)
+
+    note over CS,CRM: GDPR Art. 17 erasure — active-system sweep (PROCESS-DSR-HANDLE-1)
+
+    CS->>OMS: Locate personal data across active orders
+    OMS-->>CS: Active-order records identified
+
+    CS->>OMS: Erase from active-order database
+    OMS->>CRM: Propagate erasure event (REST / outbound)
+    CRM-->>OMS: Erasure acknowledged
+    OMS-->>CS: Active systems erased — confirmed
+```
+
+## Model references
+
+| Participant | Element |
+|---|---|
+| OMS | `APPLICATION-OMS-1` — Order Management System (Operations) |
+| CRM | `APPLICATION-CRM-1` — CRM System (Sales) |
+
+| Relationship | Source |
+|---|---|
+| OMS → CRM, REST outbound, propagates order and erasure events | `eu-portfolio.applications.transitrix.yaml` |
+| Erasure step (TASK-ERASE-ACTIVE — "Erase from active OMS & CRM") | `data-subject-erasure.bpmn.transitrix.yaml` |

--- a/organizations/acme_corp/views/state/README.md
+++ b/organizations/acme_corp/views/state/README.md
@@ -1,0 +1,25 @@
+# `canon/views/state/`
+
+Mermaid state diagrams — Application-layer lifecycle views derived from the
+canonical model. Render in VS Code with
+[Markdown Preview Mermaid Support](https://marketplace.visualstudio.com/items?itemName=bierner.markdown-mermaid).
+No Transitrix Studio required.
+
+## File convention
+
+`*.state.md`
+
+## Coverage
+
+State views project **lifecycle stages of application-managed objects** (an
+order, a data-subject request) at the Application layer. They complement
+process views (BPMN, Process Blueprint) without duplicating them: BPMN shows
+the task flow; a state diagram shows the object's status transitions.
+
+**Hard rule:** no Mermaid version of BPMN, Goals, Capability Map, Process Map,
+or Gantt — those are native notation and must not be duplicated.
+
+## See also
+
+- `canon/elements/02_business/processes/` — PROCESS elements (source model)
+- `canon/views/bpmn/` — process flows (BPMN native notation)

--- a/organizations/acme_corp/views/state/order-lifecycle.state.md
+++ b/organizations/acme_corp/views/state/order-lifecycle.state.md
@@ -1,0 +1,50 @@
+<!--
+  Mermaid complementary view — Application layer: order object lifecycle.
+  Renders in VS Code with Markdown Preview Mermaid Support (bierner.markdown-mermaid).
+
+  Derived from:
+    - canon/elements/02_business/processes/PROCESS-ORD-FULFILL-1.yaml
+        flow.steps[] and flow.sequence[] — the canonical order-fulfilment
+        process graph, including the in-stock / out-of-stock gateway.
+    - canon/elements/03_application/applications/APPLICATION-OMS-1.yaml
+        supported_by_application reference on PROCESS-ORD-FULFILL-1 steps
+        (STEP-ORD-FULFILL-2 Validate, -4 Pick and Pack, -6 Notify Backorder).
+
+  Not a duplicate of the BPMN view: PROCESS-ORD-FULFILL-1 has no bpmn_file.
+  This state diagram projects the order object's lifecycle as managed by
+  APPLICATION-OMS-1.
+-->
+
+# Order Lifecycle — Application State Machine
+
+Application-layer view of how the Order Management System manages order status
+from intake to close-out. States and transitions are derived directly from the
+order-fulfilment process graph (`PROCESS-ORD-FULFILL-1.yaml`).
+
+```mermaid
+stateDiagram-v2
+    direction LR
+    [*] --> Received : order placed
+    Received --> Validating : OMS receives
+    Validating --> Picking : in stock
+    Validating --> BackorderHold : out of stock
+    Picking --> Shipped : picked, packed & dispatched (OMS)
+    BackorderHold --> NotificationSent : customer notified (OMS)
+    Shipped --> Closed
+    NotificationSent --> Closed
+    Closed --> [*]
+```
+
+## Model references
+
+| State | Derived from |
+|---|---|
+| Received | `STEP-ORD-FULFILL-1` — startEvent (Sales) |
+| Validating | `STEP-ORD-FULFILL-2` — "Validate Order" (`APPLICATION-OMS-1`) |
+| Picking | `STEP-ORD-FULFILL-4` — "Pick and Pack" (`APPLICATION-OMS-1`) |
+| BackorderHold | `STEP-ORD-FULFILL-3` gateway, out-of-stock branch |
+| Shipped | `STEP-ORD-FULFILL-5` — "Ship Order" |
+| NotificationSent | `STEP-ORD-FULFILL-6` — "Notify Customer of Backorder" (`APPLICATION-OMS-1`) |
+| Closed | `STEP-ORD-FULFILL-7` — endEvent |
+
+Process: `PROCESS-ORD-FULFILL-1` · OMS application: `APPLICATION-OMS-1`

--- a/organizations/acme_corp/views/timeline/onboarding-rework.timeline.md
+++ b/organizations/acme_corp/views/timeline/onboarding-rework.timeline.md
@@ -1,0 +1,60 @@
+<!--
+  Mermaid complementary view — Implementation & Migration layer: programme milestones.
+  Renders in VS Code with Markdown Preview Mermaid Support (bierner.markdown-mermaid).
+
+  Derived from:
+    - canon/elements/05_implementation/actions/ACTION-DISCOVERY-1.yaml
+        start_date: "2026-06-01", duration_days: 10
+    - canon/elements/05_implementation/actions/ACTION-DESIGN-1.yaml
+        duration_days: 14, predecessors: [ACTION-DISCOVERY-1]
+    - canon/elements/05_implementation/actions/ACTION-BUILD-1.yaml
+        duration_days: 30, predecessors: [ACTION-DESIGN-1]
+    - canon/elements/05_implementation/actions/ACTION-LAUNCH-1.yaml
+        duration_days: 5, predecessors: [ACTION-BUILD-1]
+
+  Milestone dates are computed from the action chain:
+    Discovery start:  2026-06-01 (explicit start_date on ACTION-DISCOVERY-1)
+    Design start:     2026-06-11 (Discovery + 10 d)
+    Build start:      2026-06-25 (Design + 14 d)
+    Launch start:     2026-07-25 (Build + 30 d)
+    Programme close:  2026-07-30 (Launch + 5 d)
+
+  Not a duplicate of the Action Network (Gantt): the native Action Network notation
+  shows the full action-on-node network with predecessors, durations, and critical path.
+  This timeline projects the same chain as high-level delivery milestones — for
+  executive status and stakeholder communication.
+-->
+
+# Onboarding Rework — Programme Milestones
+
+Implementation & Migration view of the customer-onboarding rework programme.
+Milestones are derived from the action dependency chain
+(`ACTION-DISCOVERY-1` → `ACTION-DESIGN-1` → `ACTION-BUILD-1` → `ACTION-LAUNCH-1`).
+
+```mermaid
+timeline
+    title Onboarding Rework — Delivery Milestones
+    section Q2 2026
+        1 Jun : Discovery & research
+                (ACTION-DISCOVERY-1, 10 d)
+        11 Jun : Solution design
+                 (ACTION-DESIGN-1, 14 d)
+        25 Jun : Build & test
+                 (ACTION-BUILD-1, 30 d)
+    section Q3 2026
+        25 Jul : Launch
+                 (ACTION-LAUNCH-1, 5 d)
+        30 Jul : Programme close
+```
+
+## Model references
+
+| Milestone | Date | Source action | Duration |
+|---|---|---|---|
+| Discovery start | 2026-06-01 | `ACTION-DISCOVERY-1` (explicit `start_date`) | 10 d |
+| Design start | 2026-06-11 | `ACTION-DESIGN-1` (`predecessors: [ACTION-DISCOVERY-1]`) | 14 d |
+| Build start | 2026-06-25 | `ACTION-BUILD-1` (`predecessors: [ACTION-DESIGN-1]`) | 30 d |
+| Launch | 2026-07-25 | `ACTION-LAUNCH-1` (`predecessors: [ACTION-BUILD-1]`) | 5 d |
+| Programme close | 2026-07-30 | Computed end of Launch | — |
+
+Goal served: `GOAL-CUST-1` (Raise customer satisfaction) via `ACTION-DISCOVERY-1` + `ACTION-DESIGN-1`

--- a/src/repo-validate.ts
+++ b/src/repo-validate.ts
@@ -69,16 +69,20 @@ import { validateProcess } from './validator.js';
  *  Mirrors lint.py, which skips `.templates/` and `.validators/`. */
 const SKIP_SEGMENTS = new Set(['node_modules', '.templates', '.validators']);
 
-/** Where the document-source walk looks: the three zone folders, plus the
- *  repository's own top level (`null`). Wide enough that a `.ttrs` file put
- *  somewhere other than its registered folder is still found — that is the whole
- *  point of the placement check — and narrow enough that a repository's test
- *  fixtures and documentation are not mistaken for model content. */
+/** Where the document-source walk looks: the three zone folders plus
+ *  root-level views/ (normative layout), the legacy canon/views/ path,
+ *  and the repository's own top level (`null`). Wide enough that a `.ttrs`
+ *  file put somewhere other than its registered folder is still found —
+ *  that is the whole point of the placement check — and narrow enough that
+ *  a repository's test fixtures and documentation are not mistaken for
+ *  model content. */
 const DOCUMENT_SOURCE_SEARCH_ROOTS: ReadonlyArray<string | null> = [
   null,
   'canon',
   'field',
   'codex',
+  'views',
+  path.join('canon', 'views'),
 ];
 
 function segments(rel: string): string[] {
@@ -243,21 +247,56 @@ export function buildRepoValidateContext(root: string): RepoValidateContext {
   };
 }
 
-/** Collect the raw text of every YAML doc under `<root>/canon/views/**`.
+/** Detect if a repo has both legacy `canon/views/` and normative `views/`
+ *  layouts present. Returns the diagnostic code when both exist, or null
+ *  when only one (or neither) is present. */
+export function detectMixedViewsLayout(root: string): string | null {
+  let hasLegacy = false;
+  let hasNormative = false;
+  try {
+    readdirSync(path.join(root, 'canon', 'views'));
+    hasLegacy = true;
+  } catch {
+    // Expected: legacy path may not exist
+  }
+  try {
+    readdirSync(path.join(root, 'views'));
+    hasNormative = true;
+  } catch {
+    // Expected: normative path may not exist
+  }
+  return hasLegacy && hasNormative ? 'VIEWS-LAYOUT-001' : null;
+}
+
+/** Collect the raw text of every YAML doc under the normative `<root>/views/**`
+ *  or legacy `<root>/canon/views/**` layout. Normative layout takes precedence;
+ *  mixed layouts are detected separately and reported as `VIEWS-LAYOUT-001`.
  *  Exported for `impact.ts` (transitrix-hq#89), which needs the same raw
  *  per-file walk to classify each view document's resolvability without
  *  duplicating this directory walk. */
 export function loadViewDocs(root: string): Array<{ path: string; text: string }> {
   const docs: Array<{ path: string; text: string }> = [];
+
+  // Try normative layout first (root-level views/)
   let entries: string[] = [];
+  let viewsRoot = 'views';
+  let foundNormative = false;
   try {
-    entries = readdirSync(path.join(root, 'canon', 'views'), { recursive: true }) as string[];
+    entries = readdirSync(path.join(root, 'views'), { recursive: true }) as string[];
+    foundNormative = true;
   } catch {
-    return docs;
+    // Normative path doesn't exist; try legacy
+    try {
+      entries = readdirSync(path.join(root, 'canon', 'views'), { recursive: true }) as string[];
+      viewsRoot = path.join('canon', 'views');
+    } catch {
+      return docs;
+    }
   }
+
   for (const rel of entries) {
     if (typeof rel !== 'string' || !isYaml(rel) || shouldSkip(rel)) continue;
-    const fullRel = path.join('canon', 'views', rel);
+    const fullRel = path.join(viewsRoot, rel);
     let text: string;
     try {
       text = readFileSync(path.join(root, fullRel), 'utf-8');
@@ -327,9 +366,10 @@ export function runDocumentSourceValidate(root: string): ViewFinding[] {
   return findings;
 }
 
-/** Validate every Group A notation file under canon/views/** with the same
- *  per-notation validator the VS Code preview uses, so a repo-scope run surfaces
- *  the per-file errors an adopter would otherwise read off each preview. */
+/** Validate every Group A notation file under canon/views/** or views/**
+ *  with the same per-notation validator the VS Code preview uses, so a
+ *  repo-scope run surfaces the per-file errors an adopter would otherwise
+ *  read off each preview. Detects mixed layouts and reports the diagnostic. */
 export function runViewValidate(
   root: string,
   ctx?: RepoValidateContext,
@@ -340,6 +380,21 @@ export function runViewValidate(
 } {
   const findings: ViewFinding[] = [];
   const skipped: Array<{ file: string; notation: string }> = [];
+
+  // Detect mixed layouts (both canon/views/ and views/ present)
+  const mixedLayoutCode = detectMixedViewsLayout(root);
+  if (mixedLayoutCode) {
+    findings.push({
+      file: mixedLayoutCode === 'VIEWS-LAYOUT-001' ? 'views/' : 'canon/views/',
+      notation: 'layout',
+      ruleId: mixedLayoutCode,
+      severity: 'error',
+      message:
+        'Repository contains both canon/views/ (legacy) and views/ (normative) layouts. ' +
+        'Migrate all files to views/ and remove canon/views/. ' +
+        'See CONTRACT.md §14 for the transition path.',
+    });
+  }
   // Canon elements/relations for projection-form resolution (dgca:
   // view_config.goals/factors/changes/activities; action: §4 of
   // 07-action.md; goals: §4 of 04-goals.md). Reuses `preloadedModel` when the

--- a/src/validate-document-source.ts
+++ b/src/validate-document-source.ts
@@ -26,9 +26,11 @@ export const DOCUMENT_SOURCE_EXTENSION = '.ttrs';
 /** The near-miss: one keystroke away, and a different, widely used format. */
 export const DOCUMENT_SOURCE_NEAR_MISS_EXTENSION = '.trs';
 
-/** The registered folder for document sources, mirroring how every other view
- *  notation takes a folder of its own under `canon/views/`. */
-export const DOCUMENT_SOURCE_FOLDER = 'canon/views/documents';
+/** The normative registered folder for document sources. */
+export const DOCUMENT_SOURCE_FOLDER = 'views/documents';
+
+/** The legacy folder path, supported during transition. */
+const DOCUMENT_SOURCE_FOLDER_LEGACY = 'canon/views/documents';
 
 /** `<basename>.<kind>.ttrs` — exactly two dots, the middle segment is the kind. */
 const DOCUMENT_SOURCE_FILENAME = /^[^.]+\.([a-z0-9-]+)\.ttrs$/;
@@ -125,14 +127,16 @@ export function checkDocumentSourcePath(rel: string): DocumentSourceFinding[] {
   }
 
   const folder = file.slice(0, file.length - base.length).replace(/\/$/, '');
-  if (folder !== DOCUMENT_SOURCE_FOLDER) {
+  const isValidFolder = folder === DOCUMENT_SOURCE_FOLDER || folder === DOCUMENT_SOURCE_FOLDER_LEGACY;
+  if (!isValidFolder) {
     findings.push({
       file,
       ruleId: 'HDR-003',
       severity: 'error',
       message:
         `A "${DOCUMENT_SOURCE_EXTENSION}" document source belongs in ` +
-        `${DOCUMENT_SOURCE_FOLDER}/, not ${folder === '' ? 'the repository root' : `${folder}/`}.`,
+        `${DOCUMENT_SOURCE_FOLDER}/ (or the legacy ${DOCUMENT_SOURCE_FOLDER_LEGACY}/ during transition), ` +
+        `not ${folder === '' ? 'the repository root' : `${folder}/`}.`,
     });
   }
 

--- a/tests/repo-validate-views.test.ts
+++ b/tests/repo-validate-views.test.ts
@@ -9,10 +9,12 @@ import {
   runViewValidate,
   runRepoValidate,
   repoScopeHasErrors,
+  detectMixedViewsLayout,
 } from '../src/repo-validate.js';
 
 // Phase A.2: `validate --scope=repo` sweeps every
-// notation file under canon/views/** with the same validators the preview uses.
+// notation file under views/** (normative) or canon/views/** (legacy) with
+// the same validators the preview uses.
 
 const corpus = join(
   dirname(fileURLToPath(import.meta.url)),
@@ -30,20 +32,20 @@ function copyCorpus(root: string, rel: string, corpusRel: string): void {
   write(root, rel, readFileSync(join(corpus, corpusRel), 'utf8'));
 }
 
-describe('repo-scope views sweep (#258)', () => {
+describe('repo-scope views sweep — normative layout (#258, transitrix-hq#340)', () => {
   let root: string;
 
   beforeAll(() => {
     root = mkdtempSync(join(tmpdir(), 'tx-views-'));
     // A clean Group A file, a deliberately broken one, a BPMN file (validated via
     // the IR pipeline), a Group B file, and Group C compliance views (covered
-    // since #518 C1).
-    copyCorpus(root, 'canon/views/goals/good.goals.transitrix.yaml', 'goals/strategy-2026.goals.transitrix.yaml');
-    write(root, 'canon/views/goals/bad.goals.transitrix.yaml', 'notation: goals\nid: x\nname: Bad\ngoals: []\n');
-    copyCorpus(root, 'canon/views/bpmn/ok.bpmn.transitrix.yaml', 'bpmn/simple-approval.bpmn.transitrix.yaml');
-    copyCorpus(root, 'canon/views/applications/p.applications.transitrix.yaml', 'applications/portfolio-2026.applications.transitrix.yaml');
-    copyCorpus(root, 'canon/views/coverage-metric/c.coverage-metric.transitrix.yaml', 'coverage-metric/eu-coverage.coverage-metric.transitrix.yaml');
-    copyCorpus(root, 'canon/views/compliance-impact/ci.compliance-impact.view.yaml', 'compliance-impact/gdpr-nis2.compliance-impact.view.yaml');
+    // since #518 C1). Using normative views/ layout.
+    copyCorpus(root, 'views/goals/good.goals.transitrix.yaml', 'goals/strategy-2026.goals.transitrix.yaml');
+    write(root, 'views/goals/bad.goals.transitrix.yaml', 'notation: goals\nid: x\nname: Bad\ngoals: []\n');
+    copyCorpus(root, 'views/bpmn/ok.bpmn.transitrix.yaml', 'bpmn/simple-approval.bpmn.transitrix.yaml');
+    copyCorpus(root, 'views/applications/p.applications.transitrix.yaml', 'applications/portfolio-2026.applications.transitrix.yaml');
+    copyCorpus(root, 'views/coverage-metric/c.coverage-metric.transitrix.yaml', 'coverage-metric/eu-coverage.coverage-metric.transitrix.yaml');
+    copyCorpus(root, 'views/compliance-impact/ci.compliance-impact.view.yaml', 'compliance-impact/gdpr-nis2.compliance-impact.view.yaml');
   });
 
   afterAll(() => {
@@ -101,10 +103,10 @@ describe('repo-scope views sweep — clean tree passes (#258)', () => {
 
   beforeAll(() => {
     root = mkdtempSync(join(tmpdir(), 'tx-views-clean-'));
-    copyCorpus(root, 'canon/views/goals/good.goals.transitrix.yaml', 'goals/strategy-2026.goals.transitrix.yaml');
-    copyCorpus(root, 'canon/views/applications/p.applications.transitrix.yaml', 'applications/portfolio-2026.applications.transitrix.yaml');
-    copyCorpus(root, 'canon/views/coverage-metric/c.coverage-metric.transitrix.yaml', 'coverage-metric/eu-coverage.coverage-metric.transitrix.yaml');
-    copyCorpus(root, 'canon/views/compliance-impact/ci.compliance-impact.view.yaml', 'compliance-impact/gdpr-nis2.compliance-impact.view.yaml');
+    copyCorpus(root, 'views/goals/good.goals.transitrix.yaml', 'goals/strategy-2026.goals.transitrix.yaml');
+    copyCorpus(root, 'views/applications/p.applications.transitrix.yaml', 'applications/portfolio-2026.applications.transitrix.yaml');
+    copyCorpus(root, 'views/coverage-metric/c.coverage-metric.transitrix.yaml', 'coverage-metric/eu-coverage.coverage-metric.transitrix.yaml');
+    copyCorpus(root, 'views/compliance-impact/ci.compliance-impact.view.yaml', 'compliance-impact/gdpr-nis2.compliance-impact.view.yaml');
     // C3 cross-doc refs: codex + product subjects referenced by the compliance views.
     copyCorpus(root, 'codex/external/EU/LAW-GDPR-1.yaml', 'codex/external/EU/LAW-GDPR-1.yaml');
     copyCorpus(root, 'codex/external/EU/LAW-NIS2-1.yaml', 'codex/external/EU/LAW-NIS2-1.yaml');
@@ -163,7 +165,7 @@ describe('repo-scope views sweep — action canon-projection form (#619)', () =>
     );
     write(
       root,
-      'canon/views/action/gdpr-remediation.action.transitrix.yaml',
+      'views/action/gdpr-remediation.action.transitrix.yaml',
       [
         'notation: action',
         'spec_version: "0.1"',
@@ -218,7 +220,7 @@ describe('repo-scope views sweep — dgca canon-projection form', () => {
     );
     write(
       root,
-      'canon/views/dgca/strategy.dgca.transitrix.yaml',
+      'views/dgca/strategy.dgca.transitrix.yaml',
       [
         'notation: dgca',
         'spec_version: "0.1"',
@@ -269,7 +271,7 @@ describe('repo-scope views sweep — goals canon-projection form', () => {
     );
     write(
       root,
-      'canon/views/goals/strategy.goals.transitrix.yaml',
+      'views/goals/strategy.goals.transitrix.yaml',
       [
         'notation: goals',
         'spec_version: "0.1"',
@@ -326,7 +328,7 @@ describe('repo-scope views sweep — unquoted canon element dates (valid_at filt
     );
     write(
       root,
-      'canon/views/action/schedule.action.transitrix.yaml',
+      'views/action/schedule.action.transitrix.yaml',
       [
         'notation: action',
         'spec_version: "0.1"',
@@ -412,7 +414,7 @@ describe('repo-scope process-blueprint PROCESS- columns', () => {
     );
     write(
       root,
-      'canon/views/process-blueprint/chain.process-blueprint.transitrix.yaml',
+      'views/process-blueprint/chain.process-blueprint.transitrix.yaml',
       [
         'notation: process-blueprint',
         'process_blueprint:',
@@ -428,7 +430,7 @@ describe('repo-scope process-blueprint PROCESS- columns', () => {
     );
     write(
       root,
-      'canon/views/process-blueprint/unresolved.process-blueprint.transitrix.yaml',
+      'views/process-blueprint/unresolved.process-blueprint.transitrix.yaml',
       [
         'notation: process-blueprint',
         'process_blueprint:',
@@ -459,5 +461,78 @@ describe('repo-scope process-blueprint PROCESS- columns', () => {
     const result = runRepoValidate(root);
     const unresolved = result.views.filter((f) => f.file.endsWith('unresolved.process-blueprint.transitrix.yaml'));
     expect(unresolved.some((f) => f.ruleId === 'BP-012' && f.severity === 'error')).toBe(true);
+  });
+});
+
+describe('repo-scope views sweep — legacy canon/views/ path compatibility (transitrix-hq#340)', () => {
+  let root: string;
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), 'tx-views-legacy-'));
+    // Test that the legacy canon/views/ path still works during the transition period
+    copyCorpus(root, 'canon/views/goals/good.goals.transitrix.yaml', 'goals/strategy-2026.goals.transitrix.yaml');
+    write(root, 'canon/views/goals/bad.goals.transitrix.yaml', 'notation: goals\nid: x\nname: Bad\ngoals: []\n');
+    copyCorpus(root, 'canon/views/applications/p.applications.transitrix.yaml', 'applications/portfolio-2026.applications.transitrix.yaml');
+  });
+
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('discovers views in legacy canon/views/ when normative views/ is absent', () => {
+    const { findings } = runViewValidate(root);
+    const bad = findings.filter((f) => f.file.endsWith('bad.goals.transitrix.yaml'));
+    expect(bad.length).toBeGreaterThan(0);
+    expect(bad.every((f) => f.notation === 'goals')).toBe(true);
+  });
+
+  it('does not report a mixed-layout error when only legacy path is present', () => {
+    const { findings } = runViewValidate(root);
+    const mixedLayout = findings.filter((f) => f.ruleId === 'VIEWS-LAYOUT-001');
+    expect(mixedLayout).toEqual([]);
+  });
+});
+
+describe('repo-scope views sweep — mixed-layout detection (transitrix-hq#340)', () => {
+  let root: string;
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), 'tx-views-mixed-'));
+    // Create both legacy and normative paths
+    copyCorpus(root, 'canon/views/goals/good.goals.transitrix.yaml', 'goals/strategy-2026.goals.transitrix.yaml');
+    copyCorpus(root, 'views/applications/p.applications.transitrix.yaml', 'applications/portfolio-2026.applications.transitrix.yaml');
+  });
+
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('detects when both canon/views/ and views/ are present', () => {
+    const code = detectMixedViewsLayout(root);
+    expect(code).toBe('VIEWS-LAYOUT-001');
+  });
+
+  it('reports VIEWS-LAYOUT-001 error when both layouts exist', () => {
+    const { findings } = runViewValidate(root);
+    const mixed = findings.filter((f) => f.ruleId === 'VIEWS-LAYOUT-001');
+    expect(mixed.length).toBe(1);
+    expect(mixed[0].severity).toBe('error');
+    expect(mixed[0].message).toContain('both canon/views/');
+    expect(mixed[0].message).toContain('views/');
+    expect(mixed[0].message).toContain('Migrate all files');
+  });
+
+  it('does not report mixed-layout error when only normative path exists', () => {
+    const tmpClean = mkdtempSync(join(tmpdir(), 'tx-views-normative-only-'));
+    try {
+      copyCorpus(tmpClean, 'views/goals/good.goals.transitrix.yaml', 'goals/strategy-2026.goals.transitrix.yaml');
+      const code = detectMixedViewsLayout(tmpClean);
+      expect(code).toBe(null);
+      const { findings } = runViewValidate(tmpClean);
+      const mixed = findings.filter((f) => f.ruleId === 'VIEWS-LAYOUT-001');
+      expect(mixed).toEqual([]);
+    } finally {
+      rmSync(tmpClean, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

Implement support for root-level `views/` directory as the normative layout for derived projections (views, diagrams, documents), while maintaining backwards compatibility with legacy `canon/views/` during transition.

- Repository-scope validation discovers views from both `views/` (preferred) and `canon/views/` (legacy)
- References in view documents resolve against `canon/` — views are never canonical state
- Mixed layouts (both paths present) trigger VIEWS-LAYOUT-001 diagnostic
- Document source folder (HDR-003) accepts both paths during transition
- Example fixtures in `organizations/acme_corp/` migrated to normative layout

## Acceptance

- [x] `validate --scope=repo` accepts root-level `views/` layout
- [x] Mixed layout (`canon/views/` + `views/`) fails with VIEWS-LAYOUT-001
- [x] Positive tests for normative layout discovery
- [x] Negative tests for mixed placement
- [x] Legacy path support verified
- [x] No production glob assumes views under `canon/views/` only

## Related

- Implements THQ-340
- Depends on THQ-337 (methodology contract for root-level views)

🤖 Generated with [Claude Code](https://claude.com/claude-code)