### PR TITLE
chore(extension): update marketplace listing identity lines

### DIFF
--- a/changelog/fragments/marketplace-description-1bd98d1c.md
+++ b/changelog/fragments/marketplace-description-1bd98d1c.md
@@ -1,0 +1,3 @@
+### Changed
+
+- **Marketplace listing.** Description and author link updated for clarity and accuracy.

--- a/extension/README.md
+++ b/extension/README.md
@@ -129,4 +129,4 @@ Studio renders one file at a time — no repository, no setup beyond installing 
 - 🧰 **Source & issues** — [github.com/transitrix/transitrix-studio](https://github.com/transitrix/transitrix-studio)
 - 📚 **Glossary** — see [`glossary.md`](https://github.com/transitrix/transitrix-studio/blob/main/glossary.md) in the repo root for the notation terms used above
 
-Open source. MIT licensed. Built by [Valerii Korobeinikov](https://github.com/transitrix).
+Open source. MIT licensed. Built by [Valerii Korobeinikov](https://github.com/vkgeorgia).

--- a/extension/package.json
+++ b/extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
   "version": "3.4.2",
-  "description": "Diagrams as text. Write goals, processes, capabilities, BPMN, and more as plain YAML — 17 notations, live preview in VS Code. Diffable in git. AI-friendly. Open source.",
+  "description": "Diagrams as text. Write goals, processes, capabilities, BPMN, and more as plain YAML — 17 notations, live preview in your editor. Diffable in git. AI-friendly. Open source.",
   "license": "MIT",
   "icon": "icon.png",
   "galleryBanner": {


### PR DESCRIPTION
## Summary
Update the packaged extension description and README author attribution for the marketplace listing, per THQ-336.

- **`extension/package.json` `description`:** Changed "live preview in VS Code" to "live preview in your editor" (editor-agnostic wording).
- **`extension/README.md` footer:** Updated author GitHub link from `https://github.com/transitrix` to `https://github.com/vkgeorgia`.
- Added changelog fragment for the user-visible description change.

## Test plan
- Grep confirms `package.json` now contains "live preview in your editor"
- Grep confirms README footer points to `https://github.com/vkgeorgia`
- No other README files carry the footer pattern

Relates to THQ-336 (epic THQ-330).

Generated with Claude Code