### PR TITLE
docs: update marketplace listing — editor-honest one-liner and author URL

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -129,4 +129,4 @@ Studio renders one file at a time — no repository, no setup beyond installing 
 - 🧰 **Source & issues** — [github.com/transitrix/transitrix-studio](https://github.com/transitrix/transitrix-studio)
 - 📚 **Glossary** — see [`glossary.md`](https://github.com/transitrix/transitrix-studio/blob/main/glossary.md) in the repo root for the notation terms used above
 
-Open source. MIT licensed. Built by [Valerii Korobeinikov](https://github.com/transitrix).
+Open source. MIT licensed. Built by [Valerii Korobeinikov](https://github.com/vkgeorgia).

--- a/extension/package.json
+++ b/extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
   "version": "3.4.2",
-  "description": "Diagrams as text. Write goals, processes, capabilities, BPMN, and more as plain YAML — 17 notations, live preview in VS Code. Diffable in git. AI-friendly. Open source.",
+  "description": "Diagrams as text. Write goals, processes, capabilities, BPMN, and more as plain YAML — 17 notations, live preview in your editor. Diffable in git. AI-friendly. Open source.",
   "license": "MIT",
   "icon": "icon.png",
   "galleryBanner": {


### PR DESCRIPTION
## Summary

Updates to the VS Code Marketplace and Open VSX listings per THQ-330:

- Change package.json description from "live preview in VS Code" to "live preview in your editor" to reflect multi-editor support
- Update README footer author link from github.com/transitrix to https://github.com/vkgeorgia (per Strategist decision 2026-08-26)

Satisfies outcome items 1–2 of THQ-330. Item 3 (GIF replacement) remains blocked on display access — see THQ-338/339.

## Test plan

- [ ] Verify package.json description displays correctly in marketplace
- [ ] Verify README footer link resolves to vkgeorgia's profile
- [ ] Confirm CI passes before merge

**From: transitrix-studio.**