### PR TITLE
chore(release): prepare 3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,23 @@
 
 ## Unreleased
 
+## [3.5.0] — 2026-08-27
+
+### Added
+
+- **Repository-scope validation discovers root-level `views/`.** Methodology 4.1.0 made `views/` a sibling of `canon/` the normative layout. `validate --scope=repo` now scans `views/<notation>/` first and falls back to legacy `canon/views/<notation>/`. A tree that still has both layouts fails with `VIEWS-LAYOUT-001` instead of a silently empty Views section. Per-file `validate <path>` is unchanged. (transitrix-hq#340, #578 / #580)
+
+### Fixed
+
+- **Repo-wide compliance scans stay independent of the editor.** Opening a view under an organisation `canon/` tree no longer couples the workspace-wide dashboard walk to whichever file happens to be active. (#577)
+
 ### Changed
 
 - **Listing description and footer attribution.** The extension description emphasizes editor-agnosticism by saying "live preview in your editor" instead of "live preview in VS Code". The footer link points to the author's personal GitHub profile (`github.com/vkgeorgia`) instead of the publisher namespace.
+
+### Packages
+
+- `@transitrix/cli` 2.6.0 → 2.7.0 — root-level `views/` discovery and `VIEWS-LAYOUT-001`. `@transitrix/diagrams` stays 1.11.0 (no production `packages/diagrams/src` change in this span).
 
 ## [3.4.2] — 2026-08-26
 

--- a/changelog/fragments/marketplace-description-1bd98d1c.md
+++ b/changelog/fragments/marketplace-description-1bd98d1c.md
@@ -1,3 +1,0 @@
-### Changed
-
-- **Marketplace listing.** Description and author link updated for clarity and accuracy.

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "3.4.2",
+  "version": "3.5.0",
   "description": "Diagrams as text. Write goals, processes, capabilities, BPMN, and more as plain YAML — 17 notations, live preview in your editor. Diffable in git. AI-friendly. Open source.",
   "license": "MIT",
   "icon": "icon.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "3.4.2",
+  "version": "3.5.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/cli",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "type": "module",
   "description": "Transitrix CLI ΓÇö compile, validate, and report on Transitrix diagrams (BPMN, Goals, DGCA, ΓÇª) from any shell or CI pipeline.",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Bump Studio **3.4.2 → 3.5.0** and `@transitrix/cli` **2.6.0 → 2.7.0** so the root-level `views/` scan (THQ-340, #578 / #580) can actually publish. npm still has 2.6.0 from 2026-08-25, two days before that merge.
- Mixed `canon/views/` + `views/` stays `VIEWS-LAYOUT-001`. `@transitrix/diagrams` stays 1.11.0 (no production `packages/diagrams/src` change in the span).
- CHANGELOG covers #577 (compliance scans) and the listing copy already on `main`.

Valerii gates merge. After merge: draft GitHub Release `v3.5.0` on the merge commit, dispatch `attach-release-vsix.yml`, then publish the draft so `npm-publish.yml` ships `@transitrix/cli@2.7.0`.

## Test plan

- [ ] CI green on this PR
- [ ] After publish: `npm view @transitrix/cli version` is 2.7.0
- [ ] `npx @transitrix/cli@2.7.0 validate --scope=repo` against a tree whose views live at root `views/` shows a Views section