### PR TITLE
feat(docs): prepare goals-tree listing demonstration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- **Listing demonstration transitions to Goals tree.** The recording scenario and fixture now demonstrate a Goals tree with a child goal being added, showing the live preview updating when the YAML is saved. This replaces the prior Blocks demonstration. The GIF itself (`extension/docs/listing.gif`) is ready to be recorded with the updated scenario and fixture. (transitrix-hq#330)
+
 ## [3.5.0] — 2026-08-27
 
 ### Added

--- a/extension/docs/listing-demo.scenario.json
+++ b/extension/docs/listing-demo.scenario.json
@@ -12,19 +12,26 @@
   },
   "fixture": {
     "copy": [
-      { "from": "listing.blocks.transitrix.yaml" }
+      { "from": "listing.goals.transitrix.yaml" }
     ]
   },
+  "_notes": [
+    "Recording: Goals tree with a child goal being added.",
+    "Start: Root goal 'Deliver customer value' with two children ('Improve user experience', 'Reduce operational costs').",
+    "Action: Add a third child goal (e.g., 'Accelerate innovation' with id G-1-3).",
+    "Expected: Preview on right shows the tree expanding with the new branch; labels readable at ~700px width.",
+    "Constraints: light theme, Zen mode (YAML + preview only), no Explorer/Chat, under 2MB GIF, loop under 15s, no machine/path identifiers."
+  ],
   "steps": [
     { "op": "wait", "ms": 1500 },
     { "op": "keys", "keys": "^1" },
     { "op": "wait", "ms": 400 },
-    { "op": "keys", "keys": "^f" },
-    { "op": "wait", "ms": 400 },
-    { "op": "type", "text": "Storefront" },
-    { "op": "keys", "keys": "{ESCAPE}" },
-    { "op": "wait", "ms": 400 },
-    { "op": "type", "text": "Website" },
+    { "op": "keys", "keys": "End" },
+    { "op": "wait", "ms": 300 },
+    { "op": "keys", "keys": "{ENTER}" },
+    { "op": "type", "text": "      - id: G-1-3" },
+    { "op": "keys", "keys": "{ENTER}" },
+    { "op": "type", "text": "        name: \"Accelerate innovation\"" },
     { "op": "wait", "ms": 300 },
     { "op": "keys", "keys": "^s" },
     { "op": "wait", "ms": 4000 }

--- a/extension/docs/listing.goals.transitrix.yaml
+++ b/extension/docs/listing.goals.transitrix.yaml
@@ -1,0 +1,12 @@
+notation: goals
+spec_version: "0.1"
+name: Listing
+
+goals:
+  - id: G-1
+    name: "Deliver customer value"
+    children:
+      - id: G-1-1
+        name: "Improve user experience"
+      - id: G-1-2
+        name: "Reduce operational costs"


### PR DESCRIPTION
## Summary

Prepare the fixture and recording scenario for the Goals-tree listing demonstration (epic THQ-330, outcome item 3).

- Add `listing.goals.transitrix.yaml` with a simple Goals tree: root goal "Deliver customer value" with two children ("Improve user experience", "Reduce operational costs")
- Update `listing-demo.scenario.json` to reference the new goals fixture and document the recording steps
- Include notes explaining what the recording should capture (adding a third child goal, showing the live preview update on save)

## What this prepares

When someone with display access runs the recording scenario, they will generate the replacement GIF that shows:
- YAML on left, live Goals preview on right
- A new child goal ("Accelerate innovation", id G-1-3) added to the tree
- The preview expanding with the new branch when the file is saved

The GIF will be legible at listing width (~700 px), under 2 MB, loop under 15 s, using light editor theme in Zen mode (YAML + preview only, no Explorer/Chat chrome).

## Links

Satisfies THQ-330, outcome item 3 (fixture and scenario preparation). Items 1–2 (description and author link) completed in transitrix-studio#582.

GIF recording blocked on display access; see THQ-338 for the executor-need label that covers this work.

## Test plan

- [x] New fixture file is valid YAML and parseable as Goals notation
- [x] Scenario JSON references the new fixture correctly
- [x] Commit message is clear and links to the epic
- Manual GIF recording: pending display access (see THQ-338)

🤖 Generated with Claude Code