### PR TITLE
fix: ACT-013 counts parent as valid connection in orphan check

### DIFF
--- a/packages/diagrams/src/activities/__tests__/validate.test.ts
+++ b/packages/diagrams/src/activities/__tests__/validate.test.ts
@@ -300,6 +300,21 @@ describe('validateActivities', () => {
     expect(orphanWarnings.some(w => w.message.includes('A-002'))).toBe(true);
   });
 
+  it('ACT-013 — does not warn on activity with parent (counted as connection)', () => {
+    const r = validateActivities({
+      notation: 'action',
+      actions: [
+        { id: 'A-001', name: 'Parent', duration: 1 },
+        { id: 'A-002', name: 'Child (parented, not orphan)', duration: 1, parent: 'A-001' },
+        { id: 'A-003', name: 'Unconnected', duration: 1 },
+      ],
+    });
+    expect(r.valid).toBe(true);
+    const orphanWarnings = r.warnings.filter(w => w.code === 'ACT-013');
+    expect(orphanWarnings.some(w => w.message.includes('A-002'))).toBe(false);
+    expect(orphanWarnings.some(w => w.message.includes('A-003'))).toBe(true);
+  });
+
   it('full valid example passes with no errors', () => {
     const r = validateActivities({
       notation: 'action',

--- a/packages/diagrams/src/activities/validate.ts
+++ b/packages/diagrams/src/activities/validate.ts
@@ -292,7 +292,9 @@ export function validateActivities(input: unknown): ActivityValidationResult {
     }
   }
 
-  // ACT-013: orphan activities (warning only)
+  // ACT-013: orphan activities (warning only). An activity is structurally orphan
+  // if it has no connections to the rest of the graph. Valid connections are:
+  // predecessors, successors, parent, or goals (direct or via delivers_changes).
   const successorIds = new Set<string>();
   for (const a of doc.activities) {
     for (const pred of (a.predecessors ?? [])) successorIds.add(pred);
@@ -302,10 +304,11 @@ export function validateActivities(input: unknown): ActivityValidationResult {
     const hasSuccessors = successorIds.has(a.id);
     const hasGoals = Array.isArray(a.goals) && a.goals.length > 0;
     const hasPredecessors = Array.isArray(a.predecessors) && a.predecessors.length > 0;
-    if (doc.activities.length > 1 && !hasSuccessors && !hasGoals && !hasPredecessors) {
+    const hasParent = typeof a.parent === 'string' && a.parent.length > 0;
+    if (doc.activities.length > 1 && !hasSuccessors && !hasGoals && !hasPredecessors && !hasParent) {
       warnings.push({
         code: 'ACT-013',
-        message: `Activity "${a.id}" appears to be structurally orphan (no predecessors, successors, or goals)`,
+        message: `Activity "${a.id}" appears to be structurally orphan (no predecessors, successors, parent, or goals)`,
         path: `activities[${i}]`,
       });
     }


### PR DESCRIPTION
## Summary

Fixed ACT-013 orphan activity check to count `parent` as a valid structural connection, preventing validly-parented activities from being incorrectly flagged as structurally orphan.

## Changes

- **packages/diagrams/src/activities/validate.ts**: Added `hasParent` check to ACT-013 logic
- **packages/diagrams/src/activities/__tests__/validate.test.ts**: Added test case verifying parented activities are not flagged as orphan

## Related

Addresses FB-0004 (feedback record in transitrix-hq/operations/feedback.md):
> An ACTION element's `predecessors` graph contains a cycle. A work-package element [...] reported as disconnected, and the only way to silence the warning is to restore the redundant direct goal link.

Activities with a parent connection are now correctly recognized as structurally connected.

## Test coverage

All 1760 diagram tests pass. New test case verifies:
- Activity with parent is NOT flagged as orphan (even without predecessors/successors/goals)
- Activity without any connections IS still flagged as orphan

🤖 Generated with Claude Code