### PR TITLE
feat: implement validator truthiness and skipped notation reporting

### DIFF
--- a/packages/diagrams/src/activities/validate.ts
+++ b/packages/diagrams/src/activities/validate.ts
@@ -216,8 +216,9 @@ export function validateActivities(input: unknown): ActivityValidationResult {
     }
 
     // ACT-011: warn if no duration (duration_days is accepted as an alias)
+    // Network view is unaffected; this is only about CPM/Gantt rendering.
     if ((act.duration === undefined || act.duration === null) && (act.duration_days === undefined || act.duration_days === null)) {
-      warnings.push({ code: 'ACT-011', message: `Activity "${id}" has no duration — cannot participate in CPM analysis`, path });
+      warnings.push({ code: 'ACT-011', message: `Activity "${id}" has no duration — Gantt view and CPM analysis will exclude it. Network view is unaffected.`, path });
     }
   }
 

--- a/src/cli-parse.ts
+++ b/src/cli-parse.ts
@@ -133,6 +133,7 @@ export type ParseValidateArgvResult =
       author: string | undefined;
       validFrom: string | undefined;
       dryRun: boolean;
+      strict: boolean;
       positional: string[];
       extList: string[];
       wantsHelp: boolean;
@@ -170,6 +171,7 @@ export function parseValidateArgv(argv: string[]): ParseValidateArgvResult {
   let author: string | undefined;
   let validFrom: string | undefined;
   let dryRun = false;
+  let strict = false;
   const rest: string[] = [];
 
   for (let i = 0; i < argv.length; i++) {
@@ -215,6 +217,10 @@ export function parseValidateArgv(argv: string[]): ParseValidateArgvResult {
       dryRun = true;
       continue;
     }
+    if (a === '--strict') {
+      strict = true;
+      continue;
+    }
     if (a === '--author') {
       const v = argv[++i];
       if (v === undefined) return { ok: false, error: '--author_requires_value' };
@@ -253,6 +259,7 @@ export function parseValidateArgv(argv: string[]): ParseValidateArgvResult {
     author,
     validFrom,
     dryRun,
+    strict,
     positional: parsed.positional,
     extList: parsed.extList,
     wantsHelp: parsed.wantsHelp,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -91,7 +91,7 @@ function printUsage(): void {
        transitrix validate <input.yaml> [--json]
        transitrix validate [--ext=.bpmn.transitrix.yaml] <input.yaml> [--json]
        transitrix validate <input.yaml> --fix [--author <name>] [--valid-from <YYYY-MM-DD>] [--root <dir>] [--dry-run]
-       transitrix validate --scope=repo [--root <dir>] [--json] [--include-model]
+       transitrix validate --scope=repo [--root <dir>] [--strict] [--json] [--include-model]
        transitrix export-compliance [--format md|pdf] [--scope law:<ID>|product:<ID>|gap] [--output <path>] [--root <dir>]
        transitrix impact [--root <dir>] [--json]
        transitrix render <input.ttrs> [--out <dir>] [--root <dir>] [--json]
@@ -533,7 +533,7 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const { scope, root, template, fix, positional, extList, wantsHelp } = parsed;
+  const { scope, root, template, fix, strict, positional, extList, wantsHelp } = parsed;
 
   if (fix && scope === 'repo') {
     console.error('transitrix validate: --fix is only supported for file scope (a single file), not --scope=repo.');
@@ -552,7 +552,7 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
 
   if (wantsHelp) {
     console.error(`usage: transitrix validate <input.yaml> [--json] [--template <name>] [--fix [--author <name>] [--root <dir>] [--dry-run]] (file scope, default)`);
-    console.error(`       transitrix validate --scope=repo [--root <dir>] [--json] [--include-model]`);
+    console.error(`       transitrix validate --scope=repo [--root <dir>] [--strict] [--json] [--include-model]`);
     console.error('');
     console.error('file scope — single-file structural/semantic validation (default).');
     console.error('             BPMN, or any diagram notation routed by its notation: field');
@@ -577,6 +577,7 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
     console.error('             --dry-run previews the fix without writing.');
     console.error('repo scope — whole-canon checks (referential integrity, atomicity,');
     console.error('             id uniqueness, policy) over <root> (default: cwd).');
+    console.error('             --strict treats skipped notation files as errors instead of warnings.');
     console.error('             --include-model (with --json) also emits the resolved');
     console.error('             canon/elements/** and canon/relations/** records it parsed,');
     console.error('             as { model: { elements: [...], relations: [...] } } — for a');
@@ -588,7 +589,7 @@ async function handleValidateCommand(argv: string[]): Promise<void> {
   // Repo scope (#141): whole-canon checks on the @transitrix/diagrams model.
   if (scope === 'repo') {
     const repoRoot = root ?? process.cwd();
-    const result = runRepoValidate(repoRoot);
+    const result = runRepoValidate(repoRoot, { strict });
     // --include-model: also emit the resolved element/relation records the
     // canon walk already parsed, for a non-JS consumer (DSM) that wants the
     // model without a second parser. Opt-in so the default --scope=repo

--- a/src/repo-validate.ts
+++ b/src/repo-validate.ts
@@ -463,6 +463,15 @@ export function runViewValidate(
     }
 
     if (!isFileValidatableNotation(notation)) {
+      // Report skipped notations as findings (FB-0006): a notation the validator
+      // cannot read should fail loudly (or at least produce a finding), not silently pass.
+      findings.push({
+        file: doc.path,
+        notation,
+        ruleId: 'NOTATION-SKIP-001',
+        severity: 'warning',
+        message: `Notation "${notation}" is not yet validated by the CLI — check it in the Transitrix Studio preview.`,
+      });
       skipped.push({ file: doc.path, notation });
       continue;
     }
@@ -1027,12 +1036,24 @@ export function runLinkSuspicionCheck(root: string, model: RepoModelInput): View
 
 /** Load the canon model under `root` and run the repo-scope checks: canon
  *  cross-references plus per-file notation sweep over canon/views/** and codex/**. */
-export function runRepoValidate(root: string): RepoScopeResult {
+export interface RunRepoValidateOptions {
+  strict?: boolean;
+}
+
+export function runRepoValidate(root: string, options?: RunRepoValidateOptions): RepoScopeResult {
   const ctx = buildRepoValidateContext(root);
   const model = loadRepoModel(root);
   const canon = validateRepoModel(model);
   const { findings: viewNotations, skipped } = runViewValidate(root, ctx, model);
-  const views = [...viewNotations, ...runDocumentSourceValidate(root)];
+  let views = [...viewNotations, ...runDocumentSourceValidate(root)];
+
+  // If --strict is set, convert skipped notation warnings to errors
+  if (options?.strict) {
+    views = views.map((v) =>
+      v.ruleId === 'NOTATION-SKIP-001' ? { ...v, severity: 'error' as const } : v,
+    );
+  }
+
   const codex = runCodexValidate(root);
   const compliance = [
     ...runComplianceValidate(root, ctx),


### PR DESCRIPTION
## Summary

Addresses epics THQ-363 and THQ-364:

- **THQ-363**: Every rule the validator enforces is written in the specification
  - Fix ACT-011 message to clarify it applies only to Gantt/CPM rendering, not network view
  
- **THQ-364**: A notation the validator cannot read fails loudly
  - Report skipped notation files as NOTATION-SKIP-001 findings (warning severity)
  - Add --strict flag to treat skipped notations as errors instead of warnings
  - Update CLI help text to document the new --strict flag

## Changes

1. **packages/diagrams/src/activities/validate.ts**
   - ACT-011: Updated message to clarify "Gantt view and CPM analysis will exclude it. Network view is unaffected."

2. **src/cli-parse.ts**
   - Added strict: boolean field to ParseValidateArgvResult
   - Added parsing for --strict flag in parseValidateArgv()

3. **src/cli.ts**
   - Extract and pass strict flag from parsed args to runRepoValidate()
   - Update usage and help text to document --strict flag
   - Add --strict to repo-scope validate usage line

4. **src/repo-validate.ts**
   - Added RunRepoValidateOptions interface with strict option
   - Updated runRepoValidate() to accept options parameter
   - Convert NOTATION-SKIP-001 warnings to errors when --strict is set
   - Added NOTATION-SKIP-001 finding for each skipped notation file

## Testing

The changes enable:
- transitrix validate --scope=repo --strict to fail on any notation files the CLI cannot validate
- Default behavior unchanged: skipped files are warnings and do not fail the run
- ACT-011 now correctly describes which views are affected

## Remaining Work

Cross-project coordination (methodology scope):
- Add instances of all published notations to the worked example so removing a notation implementation breaks tests
- Ensure all validator rule codes (ACT-001 through ACT-021) appear in methodology specification

Generated with Claude Code