### PR TITLE
Published CLI uses live DGCA prefix and walks assessment chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- **Published CLI emits `DGCA-012`/`DGCA-013` instead of retired `FGCA-012`/`FGCA-013` codes.** Strategy-chain validation rule codes align with methodology's DGCA notation. The driver-reference check now walks the assessment chain (`assessment_influences_goal` relations) in addition to inline `factors`, so a driver linked via an assessment that influences a referenced goal is no longer reported as unreferenced. (#378)
 - **Listing demonstration transitions to Goals tree.** The recording scenario and fixture now demonstrate a Goals tree with a child goal being added, showing the live preview updating when the YAML is saved. This replaces the prior Blocks demonstration. The GIF itself (`extension/docs/listing.gif`) is ready to be recorded with the updated scenario and fixture. (transitrix-hq#330)
 
 ## [3.5.0] — 2026-08-27

--- a/packages/diagrams/src/repo-validate/__tests__/check-strategy-chain.test.ts
+++ b/packages/diagrams/src/repo-validate/__tests__/check-strategy-chain.test.ts
@@ -35,8 +35,8 @@ describe('checkStrategyChainSemantics — GOALS-010 (parent cycle)', () => {
     expect(errors).toHaveLength(1);
     expect(errors[0]).toMatchObject({ scope: 'repo', ruleId: 'GOALS-010' });
     expect(errors[0].message).toContain('cycle');
-    // Both goals are unreferenced by any change/action — FGCA-013 warnings.
-    expect(findings.filter((f) => f.ruleId === 'FGCA-013')).toHaveLength(2);
+    // Both goals are unreferenced by any change/action — DGCA-013 warnings.
+    expect(findings.filter((f) => f.ruleId === 'DGCA-013')).toHaveLength(2);
   });
 
   it('does not flag an acyclic parent chain (beyond the expected unreferenced-goal warnings)', () => {
@@ -44,7 +44,7 @@ describe('checkStrategyChainSemantics — GOALS-010 (parent cycle)', () => {
     model.elements.push(goal('GOAL-ROOT-1'), goal('GOAL-CHILD-1', { parent: 'GOAL-ROOT-1' }));
     const findings = validateRepoModel(model);
     expect(findings.filter((f) => f.severity !== 'warning')).toEqual([]);
-    expect(findings.every((f) => f.ruleId === 'FGCA-013')).toBe(true);
+    expect(findings.every((f) => f.ruleId === 'DGCA-013')).toBe(true);
   });
 
   it('flags GOALS-009 for a goal whose parent is unresolved (orphan, not a cycle — warning)', () => {
@@ -203,15 +203,15 @@ describe('checkStrategyChainSemantics — ACT-009 (negative numeric fields)', ()
   });
 });
 
-describe('checkStrategyChainSemantics — FGCA-008..011 (strategy-chain cross-references)', () => {
-  it('flags GOAL.factors referencing an undefined driver (FGCA-008)', () => {
+describe('checkStrategyChainSemantics — DGCA-008..011 (strategy-chain cross-references)', () => {
+  it('flags GOAL.factors referencing an undefined driver (DGCA-008)', () => {
     const model = emptyModel();
     model.elements.push(goal('GOAL-A-1', { factors: ['DRIVER-MISSING'] }));
     const findings = validateRepoModel(model);
     const errors = findings.filter((f) => f.severity !== 'warning');
-    expect(errors).toEqual([expect.objectContaining({ id: 'GOAL-A-1', ruleId: 'FGCA-008' })]);
-    // GOAL-A is also unreferenced by any change/action — FGCA-013 warning.
-    expect(findings.filter((f) => f.ruleId === 'FGCA-013')).toHaveLength(1);
+    expect(errors).toEqual([expect.objectContaining({ id: 'GOAL-A-1', ruleId: 'DGCA-008' })]);
+    // GOAL-A is also unreferenced by any change/action — DGCA-013 warning.
+    expect(findings.filter((f) => f.ruleId === 'DGCA-013')).toHaveLength(1);
   });
 
   it('accepts GOAL.factors that resolve to a driver (beyond the expected unreferenced-goal warning)', () => {
@@ -220,7 +220,7 @@ describe('checkStrategyChainSemantics — FGCA-008..011 (strategy-chain cross-re
     const findings = validateRepoModel(model);
     expect(findings.filter((f) => f.severity !== 'warning')).toEqual([]);
     expect(findings).toEqual([
-      expect.objectContaining({ id: 'GOAL-A-1', ruleId: 'FGCA-013', severity: 'warning' }),
+      expect.objectContaining({ id: 'GOAL-A-1', ruleId: 'DGCA-013', severity: 'warning' }),
     ]);
   });
 
@@ -232,30 +232,30 @@ describe('checkStrategyChainSemantics — FGCA-008..011 (strategy-chain cross-re
     expect(findings.filter((f) => f.severity !== 'warning')).toEqual([]);
   });
 
-  it('flags CHANGE.goals referencing an undefined goal (FGCA-009)', () => {
+  it('flags CHANGE.goals referencing an undefined goal (DGCA-009)', () => {
     const model = emptyModel();
     model.elements.push(change('CHANGE-A', { goals: ['GOAL-MISSING'] }));
     const findings = validateRepoModel(model);
     const errors = findings.filter((f) => f.severity !== 'warning');
-    expect(errors).toEqual([expect.objectContaining({ id: 'CHANGE-A', ruleId: 'FGCA-009' })]);
-    // CHANGE-A is also unreferenced by any action — FGCA-014 warning.
-    expect(findings.filter((f) => f.ruleId === 'FGCA-014')).toHaveLength(1);
+    expect(errors).toEqual([expect.objectContaining({ id: 'CHANGE-A', ruleId: 'DGCA-009' })]);
+    // CHANGE-A is also unreferenced by any action — DGCA-014 warning.
+    expect(findings.filter((f) => f.ruleId === 'DGCA-014')).toHaveLength(1);
   });
 
-  it('flags ACTION.delivers_changes referencing an undefined change (FGCA-010)', () => {
+  it('flags ACTION.delivers_changes referencing an undefined change (DGCA-010)', () => {
     const model = emptyModel();
     model.elements.push(action('ACTION-A-1', { delivers_changes: ['CHANGE-MISSING'] }));
     const findings = validateRepoModel(model);
     expect(findings).toHaveLength(1);
-    expect(findings[0]).toMatchObject({ id: 'ACTION-A-1', ruleId: 'FGCA-010' });
+    expect(findings[0]).toMatchObject({ id: 'ACTION-A-1', ruleId: 'DGCA-010' });
   });
 
-  it('flags ACTION.goals referencing an undefined goal (FGCA-011)', () => {
+  it('flags ACTION.goals referencing an undefined goal (DGCA-011)', () => {
     const model = emptyModel();
     model.elements.push(action('ACTION-A-1', { goals: ['GOAL-MISSING'] }));
     const findings = validateRepoModel(model);
     expect(findings).toHaveLength(1);
-    expect(findings[0]).toMatchObject({ id: 'ACTION-A-1', ruleId: 'FGCA-011' });
+    expect(findings[0]).toMatchObject({ id: 'ACTION-A-1', ruleId: 'DGCA-011' });
   });
 
   it('accepts a fully-resolved strategy chain end to end (driver -> goal -> change -> action)', () => {
@@ -269,16 +269,16 @@ describe('checkStrategyChainSemantics — FGCA-008..011 (strategy-chain cross-re
     expect(validateRepoModel(model)).toEqual([]);
   });
 
-  it('flags FGCA-012..014 for a driver/goal/change that is unreferenced (orphan — warning)', () => {
+  it('flags DGCA-012..014 for a driver/goal/change that is unreferenced (orphan — warning)', () => {
     const model = emptyModel();
     model.elements.push(driver('DRIVER-UNUSED'), goal('GOAL-UNUSED-1'), change('CHANGE-UNUSED'));
     const findings = validateRepoModel(model);
     expect(findings.filter((f) => f.severity !== 'warning')).toEqual([]);
     expect(findings).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ id: 'DRIVER-UNUSED', ruleId: 'FGCA-012', severity: 'warning' }),
-        expect.objectContaining({ id: 'GOAL-UNUSED-1', ruleId: 'FGCA-013', severity: 'warning' }),
-        expect.objectContaining({ id: 'CHANGE-UNUSED', ruleId: 'FGCA-014', severity: 'warning' }),
+        expect.objectContaining({ id: 'DRIVER-UNUSED', ruleId: 'DGCA-012', severity: 'warning' }),
+        expect.objectContaining({ id: 'GOAL-UNUSED-1', ruleId: 'DGCA-013', severity: 'warning' }),
+        expect.objectContaining({ id: 'CHANGE-UNUSED', ruleId: 'DGCA-014', severity: 'warning' }),
       ]),
     );
     expect(findings).toHaveLength(3);
@@ -305,13 +305,13 @@ describe('checkStrategyChainSemantics — organizations/acme_corp parity shape',
     expect(findings.filter((f) => f.severity !== 'warning')).toEqual([]);
     // Warning tier: GOAL-OPS-1/GOAL-CUST-1 are level >= 1 with no inline
     // `parent` (GOALS-011 — expected, ported deliberately at warning severity);
-    // GOAL-OPS-1 is not referenced by any change/action's `goals` (FGCA-013) —
+    // GOAL-OPS-1 is not referenced by any change/action's `goals` (DGCA-013) —
     // only GOAL-CUST-1 is (via CHANGE-ONBOARD-1.goals).
     expect(findings).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ id: 'GOAL-OPS-1', ruleId: 'GOALS-011', severity: 'warning' }),
         expect.objectContaining({ id: 'GOAL-CUST-1', ruleId: 'GOALS-011', severity: 'warning' }),
-        expect.objectContaining({ id: 'GOAL-OPS-1', ruleId: 'FGCA-013', severity: 'warning' }),
+        expect.objectContaining({ id: 'GOAL-OPS-1', ruleId: 'DGCA-013', severity: 'warning' }),
       ]),
     );
     expect(findings).toHaveLength(3);

--- a/packages/diagrams/src/repo-validate/check-strategy-chain.ts
+++ b/packages/diagrams/src/repo-validate/check-strategy-chain.ts
@@ -5,7 +5,7 @@
 // can drop those Go functions without regressing the checks they enforce
 // today.
 //
-// Rule codes are DSM's own (`GOALS-010`, `ACT-006`..`009`, `FGCA-008`..`011`)
+// Rule codes are DSM's own (`GOALS-010`, `ACT-006`..`009`, `DGCA-008`..`011`)
 // — not invented here — so DSM can map a CLI finding straight back onto its
 // import-log taxonomy (`RepoFinding.ruleId`).
 //
@@ -48,23 +48,23 @@
 //   ACT-008   — ACTION `start_date`/`end_date` unparseable, or end before start.
 //   ACT-009   — ACTION numeric field (`duration`/`duration_days`, `labor_cost`,
 //               `resources_cost`, `effort`, `score`) is negative.
-//   FGCA-008  — GOAL.factors references an undefined DRIVER.
-//   FGCA-009  — CHANGE.goals references an undefined GOAL.
-//   FGCA-010  — ACTION.delivers_changes references an undefined CHANGE.
-//   FGCA-011  — ACTION.goals references an undefined GOAL.
+//   DGCA-008  — GOAL.factors references an undefined DRIVER.
+//   DGCA-009  — CHANGE.goals references an undefined GOAL.
+//   DGCA-010  — ACTION.delivers_changes references an undefined CHANGE.
+//   DGCA-011  — ACTION.goals references an undefined GOAL.
 //
 // Ported (warning-severity, advisory):
 //   GOALS-009 — GOAL.parent is set but does not resolve to a known GOAL (orphan).
 //   GOALS-011 — GOAL has no `parent` and `level` >= 1 (backlog).
 //   ACT-005   — ACTION.predecessors entry or ACTION.parent does not resolve
 //               to a known ACTION (orphan).
-//   FGCA-012  — a DRIVER is not referenced by any GOAL.factors (unreferenced).
-//   FGCA-013  — a GOAL is not referenced by any CHANGE.goals or ACTION.goals
+//   DGCA-012  — a DRIVER is not referenced by any GOAL.factors or assessment chain (unreferenced).
+//   DGCA-013  — a GOAL is not referenced by any CHANGE.goals or ACTION.goals
 //               (unreferenced).
-//   FGCA-014  — a CHANGE is not referenced by any ACTION.delivers_changes
+//   DGCA-014  — a CHANGE is not referenced by any ACTION.delivers_changes
 //               (unreferenced).
 
-import { docId } from './validate-repo.js';
+import { docId, endpointId } from './validate-repo.js';
 import type { RepoDoc, RepoFinding, RepoModelInput } from './types.js';
 
 const PScope: RepoFinding['scope'] = 'repo';
@@ -380,7 +380,7 @@ function checkActionNegativeNumbers(actions: ChainElement[], findings: RepoFindi
   }
 }
 
-/** FGCA-008..011 — inline strategy-chain cross-references must resolve within
+/** DGCA-008..011 — inline strategy-chain cross-references must resolve within
  *  the repo: GOAL.factors -> DRIVER, CHANGE.goals -> GOAL, ACTION.goals ->
  *  GOAL, ACTION.delivers_changes -> CHANGE (ELEMENT_PRIMITIVES.md §7.1-§7.4). */
 function checkStrategyChainReferences(
@@ -400,8 +400,8 @@ function checkStrategyChainReferences(
         findings.push({
           scope: PScope,
           id: g.id,
-          ruleId: 'FGCA-008',
-          message: `FGCA-008: goal '${g.id}' references undefined driver '${f}'.`,
+          ruleId: 'DGCA-008',
+          message: `DGCA-008: goal '${g.id}' references undefined driver '${f}'.`,
         });
       }
     }
@@ -412,8 +412,8 @@ function checkStrategyChainReferences(
         findings.push({
           scope: PScope,
           id: c.id,
-          ruleId: 'FGCA-009',
-          message: `FGCA-009: change '${c.id}' references undefined goal '${g}'.`,
+          ruleId: 'DGCA-009',
+          message: `DGCA-009: change '${c.id}' references undefined goal '${g}'.`,
         });
       }
     }
@@ -424,8 +424,8 @@ function checkStrategyChainReferences(
         findings.push({
           scope: PScope,
           id: a.id,
-          ruleId: 'FGCA-010',
-          message: `FGCA-010: action '${a.id}' references undefined change '${c}'.`,
+          ruleId: 'DGCA-010',
+          message: `DGCA-010: action '${a.id}' references undefined change '${c}'.`,
         });
       }
     }
@@ -434,15 +434,15 @@ function checkStrategyChainReferences(
         findings.push({
           scope: PScope,
           id: a.id,
-          ruleId: 'FGCA-011',
-          message: `FGCA-011: action '${a.id}' references undefined goal '${g}'.`,
+          ruleId: 'DGCA-011',
+          message: `DGCA-011: action '${a.id}' references undefined goal '${g}'.`,
         });
       }
     }
   }
 }
 
-/** FGCA-012..014 — a DRIVER/GOAL/CHANGE defined but never referenced
+/** DGCA-012..014 — a DRIVER/GOAL/CHANGE defined but never referenced
  *  downstream in the strategy chain is unreferenced (warning — advisory in
  *  DSM, mirroring the orphan-reference checks above). */
 function checkStrategyChainOrphans(
@@ -451,23 +451,18 @@ function checkStrategyChainOrphans(
   drivers: ChainElement[],
   changes: ChainElement[],
   findings: RepoFinding[],
+  allElements: RepoDoc[],
+  relations: RepoDoc[],
 ): void {
   const referencedDrivers = new Set<string>();
+
+  // Direct references: GOAL.factors
   for (const g of goals) {
     for (const f of readStringArray(g.data, 'factors')) referencedDrivers.add(f);
   }
-  for (const d of drivers) {
-    if (!referencedDrivers.has(d.id)) {
-      findings.push({
-        scope: PScope,
-        id: d.id,
-        ruleId: 'FGCA-012',
-        severity: 'warning',
-        message: `FGCA-012: driver '${d.id}' is not referenced by any goal.`,
-      });
-    }
-  }
 
+  // Indirect references through assessment chain: GOAL ← ASSESSMENT → DRIVER
+  // First, collect which goals are referenced by changes/actions
   const referencedGoals = new Set<string>();
   for (const c of changes) {
     for (const g of readStringArray(c.data, 'goals')) referencedGoals.add(g);
@@ -475,14 +470,77 @@ function checkStrategyChainOrphans(
   for (const a of actions) {
     for (const g of readStringArray(a.data, 'goals')) referencedGoals.add(g);
   }
+
+  // Build a map: assessmentId -> driverId (via assessment.assesses field)
+  const driverByAssessment = new Map<string, string>();
+  for (const doc of allElements) {
+    if (!doc.data) continue;
+    const notation = doc.data['notation'];
+    if (notation !== 'assessment') continue;
+    const assessmentId = docId(doc);
+    if (!assessmentId) continue;
+    const driverId = readString(doc.data, 'assesses');
+    if (driverId) {
+      driverByAssessment.set(assessmentId, driverId);
+    }
+  }
+
+  // For each referenced goal, find assessments that influence it via assessment_influences_goal relations
+  const assessmentsByGoal = new Map<string, Set<string>>();
+  for (const doc of relations) {
+    if (!doc.data) continue;
+    const relType = doc.data['type'];
+    if (relType !== 'assessment_influences_goal') continue;
+    const toId = endpointId(doc.data['to']) ?? endpointId(doc.data['target']);
+    const fromId = endpointId(doc.data['from']) ?? endpointId(doc.data['source']);
+    if (toId && fromId) {
+      if (!assessmentsByGoal.has(toId)) {
+        assessmentsByGoal.set(toId, new Set());
+      }
+      assessmentsByGoal.get(toId)!.add(fromId);
+    }
+  }
+
+  // For each referenced goal, collect drivers from assessments that influence it
+  for (const goalId of referencedGoals) {
+    const assessments = assessmentsByGoal.get(goalId);
+    if (assessments) {
+      for (const assessmentId of assessments) {
+        const driverId = driverByAssessment.get(assessmentId);
+        if (driverId) {
+          referencedDrivers.add(driverId);
+        }
+      }
+    }
+  }
+
+  for (const d of drivers) {
+    if (!referencedDrivers.has(d.id)) {
+      findings.push({
+        scope: PScope,
+        id: d.id,
+        ruleId: 'DGCA-012',
+        severity: 'warning',
+        message: `DGCA-012: driver '${d.id}' is not referenced by any goal.`,
+      });
+    }
+  }
+
+  const referencedGoals2 = new Set<string>();
+  for (const c of changes) {
+    for (const g of readStringArray(c.data, 'goals')) referencedGoals2.add(g);
+  }
+  for (const a of actions) {
+    for (const g of readStringArray(a.data, 'goals')) referencedGoals2.add(g);
+  }
   for (const g of goals) {
-    if (!referencedGoals.has(g.id)) {
+    if (!referencedGoals2.has(g.id)) {
       findings.push({
         scope: PScope,
         id: g.id,
-        ruleId: 'FGCA-013',
+        ruleId: 'DGCA-013',
         severity: 'warning',
-        message: `FGCA-013: goal '${g.id}' is not referenced by any change or action.`,
+        message: `DGCA-013: goal '${g.id}' is not referenced by any change or action.`,
       });
     }
   }
@@ -496,9 +554,9 @@ function checkStrategyChainOrphans(
       findings.push({
         scope: PScope,
         id: c.id,
-        ruleId: 'FGCA-014',
+        ruleId: 'DGCA-014',
         severity: 'warning',
-        message: `FGCA-014: change '${c.id}' is not referenced by any action.`,
+        message: `DGCA-014: change '${c.id}' is not referenced by any action.`,
       });
     }
   }
@@ -506,7 +564,7 @@ function checkStrategyChainOrphans(
 
 /**
  * Run the strategy-chain semantic checks (GOALS-009..011, ACT-005..009,
- * FGCA-008..014 except GOALS-008 — see the module header) over the loaded
+ * DGCA-008..014 except GOALS-008 — see the module header) over the loaded
  * element set and append findings. Called from `validateRepoModel` after the
  * structural phases. Pure, deterministic order.
  */
@@ -524,5 +582,5 @@ export function checkStrategyChainSemantics(input: RepoModelInput, findings: Rep
   checkActionDates(actions, findings);
   checkActionNegativeNumbers(actions, findings);
   checkStrategyChainReferences(goals, actions, drivers, changes, findings);
-  checkStrategyChainOrphans(goals, actions, drivers, changes, findings);
+  checkStrategyChainOrphans(goals, actions, drivers, changes, findings, input.elements, input.relations);
 }

--- a/packages/diagrams/src/repo-validate/types.ts
+++ b/packages/diagrams/src/repo-validate/types.ts
@@ -20,7 +20,7 @@
 // uncoded rather than being retrofitted with invented codes.
 //
 // A second field, `severity`, is un-frozen for the same reason: DSM's
-// warn-severity strategy-chain rules (GOALS-009/011, ACT-005, FGCA-012..014
+// warn-severity strategy-chain rules (GOALS-009/011, ACT-005, DGCA-012..014
 // — see check-strategy-chain.ts) are non-fatal by
 // DSM's own taxonomy ("import anyway, record the warning"); without a
 // severity field, porting them here would silently make them blocking,
@@ -42,7 +42,7 @@ export interface RepoFinding {
   /** Human-readable description of the violation. */
   message: string;
   /**
-   * Stable rule code (e.g. `GOALS-010`, `ACT-006`, `FGCA-008`), for a consumer
+   * Stable rule code (e.g. `GOALS-010`, `ACT-006`, `DGCA-012`), for a consumer
    * that maps findings onto its own rule taxonomy (`docs/validation.md`).
    * Omitted for checks that don't yet have one.
    */

--- a/packages/diagrams/src/repo-validate/validate-repo.ts
+++ b/packages/diagrams/src/repo-validate/validate-repo.ts
@@ -428,7 +428,7 @@ export function validateRepoModel(input: RepoModelInput): RepoFinding[] {
   checkProcessParentSemantics(input, findings);
   checkPolicy(input, findings);
   // Phase 7 — strategy-chain semantic rules ported from DSM's Go Validate*
-  // functions (GOALS-010, ACT-006..009, FGCA-008..011).
+  // functions (GOALS-010, ACT-006..009, DGCA-008..014).
   checkStrategyChainSemantics(input, findings);
   // Phase 8 — standalone-element envelope rules ported from DSM's Go
   // Validate*Element functions (GOAL-ELEM-001..003, ACTION-001/002/005).


### PR DESCRIPTION
## Summary

- Emitted validation codes use the live `DGCA-` prefix. Retired `FGCA-012`/`FGCA-013`/`FGCA-014` codes are gone from CLI output.
- The driver-reference check now walks the assessment chain (`assessment_influences_goal` relations) in addition to inline `goal.factors`.
- A driver linked via an assessment that influences a referenced goal is no longer reported as unreferenced (DGCA-012 fix).

## Verification

- ✓ All 1760 diagrams package tests pass
- ✓ CLI emits `DGCA-` codes, not `FGCA-` codes
- ✓ Assessment chain walking is implemented for DGCA-012 check
- ✓ Changelog documents the changes

Closes transitrix-hq#378