### PR TITLE
feat(validate): emit DGCA-REPO-008..014 codes with FGCA aliases

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -32,7 +32,7 @@ runtime. It scans `<root>/canon/elements/**` (elements) and
 
 Repo-scope checks (parity reference: the `acme_corp` worked example, which
 passes with zero **error**-severity findings from the checks below — it does
-carry `GOALS-011`/`FGCA-013` **warnings** from the strategy-chain rules
+carry `GOALS-011`/`DGCA-REPO-013` **warnings** from the strategy-chain rules
 described below, plus pre-existing findings from the separate compliance
 suite, see below):
 
@@ -50,7 +50,7 @@ suite, see below):
   warning). lint.py ships this phase as a no-op stub; Studio is ahead of the
   Python tool here — these findings are TypeScript-only.
 - **Strategy-chain semantics** (`GOALS-009`..`011`, `ACT-005`..`009`,
-  `FGCA-008`..`014`) — see below.
+  `DGCA-REPO-008`..`014`) — see below.
 - **Standalone-element envelope hygiene** (`GOAL-ELEM-002`/`003`,
   `ACTION-001`/`002`/`005`) — see below.
 - **Doc-level grammar** (`GOALS-001`..`007`, `ACT-001`..`003`/`016`/`021`,
@@ -58,7 +58,7 @@ suite, see below):
   under the `views` array (not `canon`) when the document lives under
   `canon/views/**` — see below.
 
-### Strategy-chain semantic rules (`GOALS-*` / `ACT-*` / `FGCA-*`)
+### Strategy-chain semantic rules (`GOALS-*` / `ACT-*` / `DGCA-REPO-*`)
 
 Ported from DSM's Go `Validate*` functions (`api02/internal/importer/
 {goals,activities,fgca}.go` in `transitrix-dsm`) onto the standalone-element
@@ -80,13 +80,13 @@ DSM's own `Issue.Severity` classification for that rule.
 | `ACT-007` | error | An ACTION element lists itself in its own `predecessors`. |
 | `ACT-008` | error | An ACTION element's `start_date`/`end_date` is not a valid `YYYY-MM-DD` date, or `end_date` is before `start_date` (equal is allowed — e.g. a milestone). |
 | `ACT-009` | error | An ACTION element's `duration` (or the `duration_days` alias), `labor_cost`, `resources_cost`, `effort`, or `score` is negative. |
-| `FGCA-008` | error | A GOAL's `factors` references a DRIVER id that does not resolve to a DRIVER element. |
-| `FGCA-009` | error | A CHANGE's `goals` references a GOAL id that does not resolve to a GOAL element. |
-| `FGCA-010` | error | An ACTION's `delivers_changes` references a CHANGE id that does not resolve to a CHANGE element. |
-| `FGCA-011` | error | An ACTION's `goals` references a GOAL id that does not resolve to a GOAL element. |
-| `FGCA-012` | warning | A DRIVER is not referenced by any GOAL's `factors` (unreferenced). |
-| `FGCA-013` | warning | A GOAL is not referenced by any CHANGE's or ACTION's `goals` (unreferenced). |
-| `FGCA-014` | warning | A CHANGE is not referenced by any ACTION's `delivers_changes` (unreferenced). |
+| `DGCA-REPO-008` | error | A GOAL's `factors` references a DRIVER id that does not resolve to a DRIVER element. _(Alias: `FGCA-008`, deprecated at 5.0.0)_ |
+| `DGCA-REPO-009` | error | A CHANGE's `goals` references a GOAL id that does not resolve to a GOAL element. _(Alias: `FGCA-009`, deprecated at 5.0.0)_ |
+| `DGCA-REPO-010` | error | An ACTION's `delivers_changes` references a CHANGE id that does not resolve to a CHANGE element. _(Alias: `FGCA-010`, deprecated at 5.0.0)_ |
+| `DGCA-REPO-011` | error | An ACTION's `goals` references a GOAL id that does not resolve to a GOAL element. _(Alias: `FGCA-011`, deprecated at 5.0.0)_ |
+| `DGCA-REPO-012` | warning | A DRIVER is not referenced by any GOAL's `factors` or assessment chain (unreferenced). _(Alias: `FGCA-012`, deprecated at 5.0.0)_ |
+| `DGCA-REPO-013` | warning | A GOAL is not referenced by any CHANGE's or ACTION's `goals` (unreferenced). _(Alias: `FGCA-013`, deprecated at 5.0.0)_ |
+| `DGCA-REPO-014` | warning | A CHANGE is not referenced by any ACTION's `delivers_changes` (unreferenced). _(Alias: `FGCA-014`, deprecated at 5.0.0)_ |
 
 **`GOALS-008` is the one DSM rule still not ported, at either severity.** Both
 of its cases ("type not declared in `goal_types`" and "level doesn't match
@@ -114,12 +114,14 @@ legitimately omit it. `organizations/acme_corp`'s own `GOAL-CUST-1`/
 `GOAL-OPS-1`/`GOAL-EU-1` are exactly this shape (level 1, no `parent` on the
 element) and do surface `GOALS-011` warnings. That is accepted, not a defect:
 warnings are advisory and non-blocking, unlike the error tier this repo held
-the line on when these rules were first scoped. Similarly, `FGCA-012`..`014`
+the line on when these rules were first scoped. Similarly, `DGCA-REPO-012`..`014`
 read only the inline `factors`/`goals`/`delivers_changes` arrays (the same
-fields `FGCA-008`..`011` already read) — a repo wiring the strategy chain
-through `REL` files instead (e.g. `action_goal`, per `elements/24-action.md`
-§3) will see `FGCA-013`/`014` warnings on elements that are, in fact, wired
-via a relation this validator doesn't yet cross-reference. This is a known
+fields `DGCA-REPO-008`..`011` already read); note that `DGCA-REPO-012` also
+walks the assessment chain via `assessment_influences_goal` relations — a repo
+wiring the strategy chain through other `REL` file types instead (e.g. `action_goal`,
+per `elements/24-action.md` §3) will see `DGCA-REPO-013`/`014` warnings on
+elements that are, in fact, wired via a relation this validator doesn't yet
+cross-reference. This is a known
 gap shared with the pre-existing error-tier rules, not a regression
 introduced by the warning tier.
 

--- a/packages/diagrams/src/repo-validate/__tests__/check-strategy-chain.test.ts
+++ b/packages/diagrams/src/repo-validate/__tests__/check-strategy-chain.test.ts
@@ -35,8 +35,8 @@ describe('checkStrategyChainSemantics — GOALS-010 (parent cycle)', () => {
     expect(errors).toHaveLength(1);
     expect(errors[0]).toMatchObject({ scope: 'repo', ruleId: 'GOALS-010' });
     expect(errors[0].message).toContain('cycle');
-    // Both goals are unreferenced by any change/action — DGCA-013 warnings.
-    expect(findings.filter((f) => f.ruleId === 'DGCA-013')).toHaveLength(2);
+    // Both goals are unreferenced by any change/action — DGCA-REPO-013 warnings.
+    expect(findings.filter((f) => f.ruleId === 'DGCA-REPO-013')).toHaveLength(2);
   });
 
   it('does not flag an acyclic parent chain (beyond the expected unreferenced-goal warnings)', () => {
@@ -44,7 +44,7 @@ describe('checkStrategyChainSemantics — GOALS-010 (parent cycle)', () => {
     model.elements.push(goal('GOAL-ROOT-1'), goal('GOAL-CHILD-1', { parent: 'GOAL-ROOT-1' }));
     const findings = validateRepoModel(model);
     expect(findings.filter((f) => f.severity !== 'warning')).toEqual([]);
-    expect(findings.every((f) => f.ruleId === 'DGCA-013')).toBe(true);
+    expect(findings.every((f) => f.ruleId === 'DGCA-REPO-013')).toBe(true);
   });
 
   it('flags GOALS-009 for a goal whose parent is unresolved (orphan, not a cycle — warning)', () => {
@@ -203,15 +203,15 @@ describe('checkStrategyChainSemantics — ACT-009 (negative numeric fields)', ()
   });
 });
 
-describe('checkStrategyChainSemantics — DGCA-008..011 (strategy-chain cross-references)', () => {
-  it('flags GOAL.factors referencing an undefined driver (DGCA-008)', () => {
+describe('checkStrategyChainSemantics — DGCA-REPO-008..011 (strategy-chain cross-references)', () => {
+  it('flags GOAL.factors referencing an undefined driver (DGCA-REPO-008)', () => {
     const model = emptyModel();
     model.elements.push(goal('GOAL-A-1', { factors: ['DRIVER-MISSING'] }));
     const findings = validateRepoModel(model);
     const errors = findings.filter((f) => f.severity !== 'warning');
-    expect(errors).toEqual([expect.objectContaining({ id: 'GOAL-A-1', ruleId: 'DGCA-008' })]);
-    // GOAL-A is also unreferenced by any change/action — DGCA-013 warning.
-    expect(findings.filter((f) => f.ruleId === 'DGCA-013')).toHaveLength(1);
+    expect(errors).toEqual([expect.objectContaining({ id: 'GOAL-A-1', ruleId: 'DGCA-REPO-008', aliases: ['FGCA-008'] })]);
+    // GOAL-A is also unreferenced by any change/action — DGCA-REPO-013 warning.
+    expect(findings.filter((f) => f.ruleId === 'DGCA-REPO-013')).toHaveLength(1);
   });
 
   it('accepts GOAL.factors that resolve to a driver (beyond the expected unreferenced-goal warning)', () => {
@@ -220,7 +220,7 @@ describe('checkStrategyChainSemantics — DGCA-008..011 (strategy-chain cross-re
     const findings = validateRepoModel(model);
     expect(findings.filter((f) => f.severity !== 'warning')).toEqual([]);
     expect(findings).toEqual([
-      expect.objectContaining({ id: 'GOAL-A-1', ruleId: 'DGCA-013', severity: 'warning' }),
+      expect.objectContaining({ id: 'GOAL-A-1', ruleId: 'DGCA-REPO-013', severity: 'warning' }),
     ]);
   });
 
@@ -237,9 +237,9 @@ describe('checkStrategyChainSemantics — DGCA-008..011 (strategy-chain cross-re
     model.elements.push(change('CHANGE-A', { goals: ['GOAL-MISSING'] }));
     const findings = validateRepoModel(model);
     const errors = findings.filter((f) => f.severity !== 'warning');
-    expect(errors).toEqual([expect.objectContaining({ id: 'CHANGE-A', ruleId: 'DGCA-009' })]);
+    expect(errors).toEqual([expect.objectContaining({ id: 'CHANGE-A', ruleId: 'DGCA-REPO-009' })]);
     // CHANGE-A is also unreferenced by any action — DGCA-014 warning.
-    expect(findings.filter((f) => f.ruleId === 'DGCA-014')).toHaveLength(1);
+    expect(findings.filter((f) => f.ruleId === 'DGCA-REPO-014')).toHaveLength(1);
   });
 
   it('flags ACTION.delivers_changes referencing an undefined change (DGCA-010)', () => {
@@ -247,7 +247,7 @@ describe('checkStrategyChainSemantics — DGCA-008..011 (strategy-chain cross-re
     model.elements.push(action('ACTION-A-1', { delivers_changes: ['CHANGE-MISSING'] }));
     const findings = validateRepoModel(model);
     expect(findings).toHaveLength(1);
-    expect(findings[0]).toMatchObject({ id: 'ACTION-A-1', ruleId: 'DGCA-010' });
+    expect(findings[0]).toMatchObject({ id: 'ACTION-A-1', ruleId: 'DGCA-REPO-010' });
   });
 
   it('flags ACTION.goals referencing an undefined goal (DGCA-011)', () => {
@@ -255,7 +255,7 @@ describe('checkStrategyChainSemantics — DGCA-008..011 (strategy-chain cross-re
     model.elements.push(action('ACTION-A-1', { goals: ['GOAL-MISSING'] }));
     const findings = validateRepoModel(model);
     expect(findings).toHaveLength(1);
-    expect(findings[0]).toMatchObject({ id: 'ACTION-A-1', ruleId: 'DGCA-011' });
+    expect(findings[0]).toMatchObject({ id: 'ACTION-A-1', ruleId: 'DGCA-REPO-011' });
   });
 
   it('accepts a fully-resolved strategy chain end to end (driver -> goal -> change -> action)', () => {
@@ -269,16 +269,16 @@ describe('checkStrategyChainSemantics — DGCA-008..011 (strategy-chain cross-re
     expect(validateRepoModel(model)).toEqual([]);
   });
 
-  it('flags DGCA-012..014 for a driver/goal/change that is unreferenced (orphan — warning)', () => {
+  it('flags DGCA-REPO-012..014 for a driver/goal/change that is unreferenced (orphan — warning) with deprecated FGCA aliases', () => {
     const model = emptyModel();
     model.elements.push(driver('DRIVER-UNUSED'), goal('GOAL-UNUSED-1'), change('CHANGE-UNUSED'));
     const findings = validateRepoModel(model);
     expect(findings.filter((f) => f.severity !== 'warning')).toEqual([]);
     expect(findings).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ id: 'DRIVER-UNUSED', ruleId: 'DGCA-012', severity: 'warning' }),
-        expect.objectContaining({ id: 'GOAL-UNUSED-1', ruleId: 'DGCA-013', severity: 'warning' }),
-        expect.objectContaining({ id: 'CHANGE-UNUSED', ruleId: 'DGCA-014', severity: 'warning' }),
+        expect.objectContaining({ id: 'DRIVER-UNUSED', ruleId: 'DGCA-REPO-012', severity: 'warning', aliases: ['FGCA-012'] }),
+        expect.objectContaining({ id: 'GOAL-UNUSED-1', ruleId: 'DGCA-REPO-013', severity: 'warning', aliases: ['FGCA-013'] }),
+        expect.objectContaining({ id: 'CHANGE-UNUSED', ruleId: 'DGCA-REPO-014', severity: 'warning', aliases: ['FGCA-014'] }),
       ]),
     );
     expect(findings).toHaveLength(3);
@@ -305,13 +305,13 @@ describe('checkStrategyChainSemantics — organizations/acme_corp parity shape',
     expect(findings.filter((f) => f.severity !== 'warning')).toEqual([]);
     // Warning tier: GOAL-OPS-1/GOAL-CUST-1 are level >= 1 with no inline
     // `parent` (GOALS-011 — expected, ported deliberately at warning severity);
-    // GOAL-OPS-1 is not referenced by any change/action's `goals` (DGCA-013) —
+    // GOAL-OPS-1 is not referenced by any change/action's `goals` (DGCA-REPO-013) —
     // only GOAL-CUST-1 is (via CHANGE-ONBOARD-1.goals).
     expect(findings).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ id: 'GOAL-OPS-1', ruleId: 'GOALS-011', severity: 'warning' }),
         expect.objectContaining({ id: 'GOAL-CUST-1', ruleId: 'GOALS-011', severity: 'warning' }),
-        expect.objectContaining({ id: 'GOAL-OPS-1', ruleId: 'DGCA-013', severity: 'warning' }),
+        expect.objectContaining({ id: 'GOAL-OPS-1', ruleId: 'DGCA-REPO-013', severity: 'warning' }),
       ]),
     );
     expect(findings).toHaveLength(3);

--- a/packages/diagrams/src/repo-validate/check-strategy-chain.ts
+++ b/packages/diagrams/src/repo-validate/check-strategy-chain.ts
@@ -5,7 +5,7 @@
 // can drop those Go functions without regressing the checks they enforce
 // today.
 //
-// Rule codes are DSM's own (`GOALS-010`, `ACT-006`..`009`, `DGCA-008`..`011`)
+// Rule codes are DSM's own (`GOALS-010`, `ACT-006`..`009`, `DGCA-REPO-008`..`014`)
 // — not invented here — so DSM can map a CLI finding straight back onto its
 // import-log taxonomy (`RepoFinding.ruleId`).
 //
@@ -42,27 +42,30 @@
 // `canon/views/goals/**`'s `goal_types[]` into the repo-scope model.
 //
 // Ported (error-severity, blocking):
-//   GOALS-010 — GOAL `parent` chain contains a cycle.
-//   ACT-006   — ACTION `predecessors` graph contains a cycle.
-//   ACT-007   — ACTION lists itself as its own predecessor.
-//   ACT-008   — ACTION `start_date`/`end_date` unparseable, or end before start.
-//   ACT-009   — ACTION numeric field (`duration`/`duration_days`, `labor_cost`,
-//               `resources_cost`, `effort`, `score`) is negative.
-//   DGCA-008  — GOAL.factors references an undefined DRIVER.
-//   DGCA-009  — CHANGE.goals references an undefined GOAL.
-//   DGCA-010  — ACTION.delivers_changes references an undefined CHANGE.
-//   DGCA-011  — ACTION.goals references an undefined GOAL.
+//   GOALS-010     — GOAL `parent` chain contains a cycle.
+//   ACT-006       — ACTION `predecessors` graph contains a cycle.
+//   ACT-007       — ACTION lists itself as its own predecessor.
+//   ACT-008       — ACTION `start_date`/`end_date` unparseable, or end before start.
+//   ACT-009       — ACTION numeric field (`duration`/`duration_days`, `labor_cost`,
+//                   `resources_cost`, `effort`, `score`) is negative.
+//   DGCA-REPO-008 — GOAL.factors references an undefined DRIVER.
+//   DGCA-REPO-009 — CHANGE.goals references an undefined GOAL.
+//   DGCA-REPO-010 — ACTION.delivers_changes references an undefined CHANGE.
+//   DGCA-REPO-011 — ACTION.goals references an undefined GOAL.
 //
 // Ported (warning-severity, advisory):
-//   GOALS-009 — GOAL.parent is set but does not resolve to a known GOAL (orphan).
-//   GOALS-011 — GOAL has no `parent` and `level` >= 1 (backlog).
-//   ACT-005   — ACTION.predecessors entry or ACTION.parent does not resolve
-//               to a known ACTION (orphan).
-//   DGCA-012  — a DRIVER is not referenced by any GOAL.factors or assessment chain (unreferenced).
-//   DGCA-013  — a GOAL is not referenced by any CHANGE.goals or ACTION.goals
-//               (unreferenced).
-//   DGCA-014  — a CHANGE is not referenced by any ACTION.delivers_changes
-//               (unreferenced).
+//   GOALS-009     — GOAL.parent is set but does not resolve to a known GOAL (orphan).
+//   GOALS-011     — GOAL has no `parent` and `level` >= 1 (backlog).
+//   ACT-005       — ACTION.predecessors entry or ACTION.parent does not resolve
+//                   to a known ACTION (orphan).
+//   DGCA-REPO-012 — a DRIVER is not referenced by any GOAL.factors or assessment chain (unreferenced).
+//   DGCA-REPO-013 — a GOAL is not referenced by any CHANGE.goals or ACTION.goals
+//                   (unreferenced).
+//   DGCA-REPO-014 — a CHANGE is not referenced by any ACTION.delivers_changes
+//                   (unreferenced).
+//
+// Backward compatibility (read path only):
+//   FGCA-008..014 — deprecated aliases for DGCA-REPO-008..014, removed at 5.0.0.
 
 import { docId, endpointId } from './validate-repo.js';
 import type { RepoDoc, RepoFinding, RepoModelInput } from './types.js';
@@ -400,8 +403,9 @@ function checkStrategyChainReferences(
         findings.push({
           scope: PScope,
           id: g.id,
-          ruleId: 'DGCA-008',
-          message: `DGCA-008: goal '${g.id}' references undefined driver '${f}'.`,
+          ruleId: 'DGCA-REPO-008',
+          aliases: ['FGCA-008'],
+          message: `DGCA-REPO-008: goal '${g.id}' references undefined driver '${f}'.`,
         });
       }
     }
@@ -412,8 +416,9 @@ function checkStrategyChainReferences(
         findings.push({
           scope: PScope,
           id: c.id,
-          ruleId: 'DGCA-009',
-          message: `DGCA-009: change '${c.id}' references undefined goal '${g}'.`,
+          ruleId: 'DGCA-REPO-009',
+          aliases: ['FGCA-009'],
+          message: `DGCA-REPO-009: change '${c.id}' references undefined goal '${g}'.`,
         });
       }
     }
@@ -424,8 +429,9 @@ function checkStrategyChainReferences(
         findings.push({
           scope: PScope,
           id: a.id,
-          ruleId: 'DGCA-010',
-          message: `DGCA-010: action '${a.id}' references undefined change '${c}'.`,
+          ruleId: 'DGCA-REPO-010',
+          aliases: ['FGCA-010'],
+          message: `DGCA-REPO-010: action '${a.id}' references undefined change '${c}'.`,
         });
       }
     }
@@ -434,8 +440,9 @@ function checkStrategyChainReferences(
         findings.push({
           scope: PScope,
           id: a.id,
-          ruleId: 'DGCA-011',
-          message: `DGCA-011: action '${a.id}' references undefined goal '${g}'.`,
+          ruleId: 'DGCA-REPO-011',
+          aliases: ['FGCA-011'],
+          message: `DGCA-REPO-011: action '${a.id}' references undefined goal '${g}'.`,
         });
       }
     }
@@ -519,9 +526,10 @@ function checkStrategyChainOrphans(
       findings.push({
         scope: PScope,
         id: d.id,
-        ruleId: 'DGCA-012',
+        ruleId: 'DGCA-REPO-012',
         severity: 'warning',
-        message: `DGCA-012: driver '${d.id}' is not referenced by any goal.`,
+        aliases: ['FGCA-012'],
+        message: `DGCA-REPO-012: driver '${d.id}' is not referenced by any goal.`,
       });
     }
   }
@@ -538,9 +546,10 @@ function checkStrategyChainOrphans(
       findings.push({
         scope: PScope,
         id: g.id,
-        ruleId: 'DGCA-013',
+        ruleId: 'DGCA-REPO-013',
         severity: 'warning',
-        message: `DGCA-013: goal '${g.id}' is not referenced by any change or action.`,
+        aliases: ['FGCA-013'],
+        message: `DGCA-REPO-013: goal '${g.id}' is not referenced by any change or action.`,
       });
     }
   }
@@ -554,9 +563,10 @@ function checkStrategyChainOrphans(
       findings.push({
         scope: PScope,
         id: c.id,
-        ruleId: 'DGCA-014',
+        ruleId: 'DGCA-REPO-014',
         severity: 'warning',
-        message: `DGCA-014: change '${c.id}' is not referenced by any action.`,
+        aliases: ['FGCA-014'],
+        message: `DGCA-REPO-014: change '${c.id}' is not referenced by any action.`,
       });
     }
   }
@@ -564,7 +574,7 @@ function checkStrategyChainOrphans(
 
 /**
  * Run the strategy-chain semantic checks (GOALS-009..011, ACT-005..009,
- * DGCA-008..014 except GOALS-008 — see the module header) over the loaded
+ * DGCA-REPO-008..014 except GOALS-008 — see the module header) over the loaded
  * element set and append findings. Called from `validateRepoModel` after the
  * structural phases. Pure, deterministic order.
  */

--- a/packages/diagrams/src/repo-validate/types.ts
+++ b/packages/diagrams/src/repo-validate/types.ts
@@ -42,7 +42,7 @@ export interface RepoFinding {
   /** Human-readable description of the violation. */
   message: string;
   /**
-   * Stable rule code (e.g. `GOALS-010`, `ACT-006`, `DGCA-012`), for a consumer
+   * Stable rule code (e.g. `GOALS-010`, `ACT-006`, `DGCA-REPO-012`), for a consumer
    * that maps findings onto its own rule taxonomy (`docs/validation.md`).
    * Omitted for checks that don't yet have one.
    */
@@ -54,6 +54,13 @@ export interface RepoFinding {
    * `'warning'` today (`docs/validation.md` § repo-scope rule list).
    */
   severity?: 'error' | 'warning';
+  /**
+   * Deprecated aliases for the `ruleId`, if any. Used for backward compatibility
+   * when a rule code is renamed. E.g., `DGCA-REPO-012` has alias `FGCA-012`.
+   * Removed in a major version (the removal release is listed in the methodology
+   * vocabulary under `deprecated_rule_codes`).
+   */
+  aliases?: string[];
 }
 
 /** A parsed canon document fed to the repo validator. IO (the filesystem walk)


### PR DESCRIPTION
## Summary

Update repo-scope strategy-chain validation to emit DGCA-REPO-prefixed codes (DGCA-REPO-008..014) instead of DGCA/FGCA codes, aligning with methodology 4.3.0 vocabulary update (transitrix-hq#416).

## Changes

- Rename all strategy-chain codes from DGCA to DGCA-REPO in check-strategy-chain.ts
- Add optional `aliases` field to RepoFinding type for deprecated code references
- Include FGCA-008..014 aliases in all findings for backward compatibility through 5.0.0
- Update docs/validation.md with new code names and deprecation notes
- Note that DGCA-REPO-012 also walks assessment_influences_goal relations
- Update all tests to expect DGCA-REPO codes with FGCA aliases

## Test plan

- Strategy-chain validation tests updated to verify DGCA-REPO codes and FGCA aliases
- Backward compatibility: consumers suppressing FGCA codes can map to aliases field in findings
- Repo-scope validator maintains all existing error detection logic with new code names

Closes transitrix-hq#418.

🤖 Generated with Claude Code