### PR TITLE
Preview resolves canon from adopter manifest (normative layout)

### DIFF
--- a/extension/src/canon-loader.ts
+++ b/extension/src/canon-loader.ts
@@ -1,4 +1,5 @@
 import * as path from 'node:path';
+import * as fs from 'node:fs';
 import * as vscode from 'vscode';
 import yaml from 'js-yaml';
 import { coerceDatesToIsoStrings } from '@transitrix/diagrams/yaml-normalize.js';
@@ -53,11 +54,42 @@ export interface CanonIndex {
 // ── Path-pure helpers (no vscode runtime — directly unit-testable) ─────────
 
 /**
- * Walk up from `filePath` up to 16 ancestor levels looking for a directory
- * literally named `canon`. Returns the absolute path of that directory, or
- * undefined when no such ancestor exists.
+ * Walk up from `filePath` up to 16 ancestor levels looking for the adopter
+ * manifest `transitrix.yaml`. Returns the directory containing the manifest,
+ * or undefined when no such ancestor exists.
+ */
+function findModelRootPath(filePath: string): string | undefined {
+  let dir = path.dirname(filePath);
+  for (let i = 0; i < 16; i++) {
+    const manifestPath = path.join(dir, 'transitrix.yaml');
+    try {
+      if (fs.statSync(manifestPath).isFile()) {
+        return dir;
+      }
+    } catch {
+      // File does not exist or is not accessible; continue walking
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return undefined;
+}
+
+/**
+ * Walk up from `filePath` up to 16 ancestor levels looking for the canonical
+ * store root. First attempts to resolve from the adopter manifest (transitrix.yaml);
+ * falls back to looking for a directory literally named `canon` for backward compatibility.
+ * Returns the absolute path of the canon directory, or undefined when no root is found.
  */
 export function findCanonRootPath(filePath: string): string | undefined {
+  // Primary path: resolve from adopter manifest (transitrix.yaml)
+  const modelRoot = findModelRootPath(filePath);
+  if (modelRoot) {
+    return path.join(modelRoot, 'canon');
+  }
+
+  // Fallback: walk up looking for a directory literally named `canon` (legacy layout)
   let dir = path.dirname(filePath);
   for (let i = 0; i < 16; i++) {
     if (path.basename(dir) === 'canon') return dir;

--- a/tests/canon-loader.test.ts
+++ b/tests/canon-loader.test.ts
@@ -62,6 +62,27 @@ describe('findCanonRootPath', () => {
     expect(findCanonRootPath(filePath)).toBe(['', 'org', 'canon'].join(sep));
   });
 
+  it('resolves canon/ from the model root (transitrix.yaml) for normative layout', () => {
+    // Use the process-parent fixture which has transitrix.yaml at the model root
+    const modelRoot = join(
+      import.meta.dirname ?? __dirname,
+      'fixtures',
+      'notation-corpus',
+      'relations',
+      'process-parent',
+    );
+    // Simulate a file under views/dgca/ at the same model root
+    const filePath = join(modelRoot, 'views', 'dgca', 'model.yaml');
+    const result = findCanonRootPath(filePath);
+    // Should resolve to <modelRoot>/canon via the transitrix.yaml manifest
+    expect(result).toBe(join(modelRoot, 'canon'));
+  });
+
+  it('still resolves from legacy layout when transitrix.yaml is not present', () => {
+    const filePath = ['', 'org', 'canon', 'elements', 'activities', 'ACT-1.yaml'].join(sep);
+    expect(findCanonRootPath(filePath)).toBe(['', 'org', 'canon'].join(sep));
+  });
+
   it('returns undefined when no ancestor is named canon/', () => {
     const filePath = ['', 'org', 'views', 'activity-card', 'my-card.yaml'].join(sep);
     expect(findCanonRootPath(filePath)).toBeUndefined();


### PR DESCRIPTION
## Summary

Fixes preview rendering for files under `views/` by resolving the canonical store root from the adopter manifest (`transitrix.yaml`) instead of walking up looking for a `canon/` directory ancestor.

## Changes

- **`findCanonRootPath`** now searches for `transitrix.yaml` as the model boundary, then locates `canon/` as a sibling
- Fallback behavior preserves backward compatibility for repositories using the legacy layout
- All nine preview modules that share this resolver benefit from the fix

## Acceptance

✓ Opening a projection view at `views/dgca/*.yaml` loads canon and renders  
✓ Files under `canon/elements/` still resolve (legacy compatibility)  
✓ All nine preview modules pick up the fix via the shared import  
✓ Unit tests cover both normative and legacy layouts

Closes transitrix-hq#457

🤖 Generated with [Claude Code](https://claude.com/claude-code)