### PR TITLE
feat(dgca): render ACTION scale level as badge beside node name

### DIFF
--- a/packages/diagrams/src/fgca/preview-layout.ts
+++ b/packages/diagrams/src/fgca/preview-layout.ts
@@ -32,6 +32,7 @@ export interface FGCAPreviewActivity {
   id: number | string;
   name: string;
   goal_id?: number | string | null;
+  type?: string;
 }
 
 /** Structural input the preview layout needs — a subset of the parsed DGCA/DGA doc. */
@@ -104,6 +105,7 @@ export interface FGCAPreviewNode {
   y: number;
   label: string;
   col: FGCAPreviewColumn;
+  type?: string;
 }
 export interface FGCAPreviewEdge {
   sx: number;
@@ -154,11 +156,11 @@ export function layoutFGCAPreview(
     ? ['driver', 'goal', 'activity']
     : ['driver', 'goal', 'change', 'activity'];
   const changes = doc.changes ?? [];
-  const colItems: Record<FGCAPreviewColumn, Array<{ id: string; label: string }>> = {
+  const colItems: Record<FGCAPreviewColumn, Array<{ id: string; label: string; type?: string }>> = {
     driver:   doc.factors.map(f => ({ id: `driver_${f.id}`,     label: f.name })),
     goal:     doc.goals.map(g   => ({ id: `goal_${g.id}`,       label: g.name })),
     change:   changes.map(c     => ({ id: `change_${c.id}`,     label: c.name })),
-    activity: doc.activities.map(a => ({ id: `activity_${a.id}`, label: a.name })),
+    activity: doc.activities.map(a => ({ id: `activity_${a.id}`, label: a.name, type: a.type })),
   };
 
   // Build predecessor map: for each node, which node IDs in the previous column
@@ -198,9 +200,9 @@ export function layoutFGCAPreview(
   // Nodes with no predecessors sort last (Infinity barycenter) so they don't
   // displace connected nodes.
   function barycentricSort(
-    items: Array<{ id: string; label: string }>,
+    items: Array<{ id: string; label: string; type?: string }>,
     yCenters: Map<string, number>,
-  ): Array<{ id: string; label: string }> {
+  ): Array<{ id: string; label: string; type?: string }> {
     return [...items].sort((a, b) => {
       const pA = (predecessors.get(a.id) ?? []).map(p => yCenters.get(p) ?? 0).filter(v => v > 0);
       const pB = (predecessors.get(b.id) ?? []).map(p => yCenters.get(p) ?? 0).filter(v => v > 0);
@@ -222,7 +224,7 @@ export function layoutFGCAPreview(
     const items = ci === 0 ? colItems[col] : barycentricSort(colItems[col], yCenters);
     let y = FGCA_PAD + FGCA_HEADER_H + rowGap;
     for (const item of items) {
-      const node: FGCAPreviewNode = { id: item.id, x, y, label: item.label, col };
+      const node: FGCAPreviewNode = { id: item.id, x, y, label: item.label, col, type: item.type };
       nodes.push(node);
       nodeMap.set(item.id, node);
       yCenters.set(item.id, y + nodeHeight / 2);

--- a/packages/diagrams/src/webview/render-fgca.ts
+++ b/packages/diagrams/src/webview/render-fgca.ts
@@ -89,10 +89,14 @@ export function renderFgcaBody(
         idMaxLines: 1,
       });
       const textSvg = emitCenteredTextSvg(specs, n.x + nodeWidth / 2, escXml);
+      const typeBadge = n.type && n.col === 'activity'
+        ? `<text class="text-id" x="${n.x + nodeWidth - 6}" y="${n.y + 10}" text-anchor="end" dominant-baseline="hanging" font-size="10">${escXml(n.type)}</text>`
+        : '';
       return [
         `<rect class="diagram-node layer-${n.col}" x="${n.x}" y="${n.y}" width="${nodeWidth}" height="${nodeHeight}" rx="8"/>`,
         textSvg,
-      ].join('\n');
+        typeBadge,
+      ].filter(Boolean).join('\n');
     })
     .join('\n');
 


### PR DESCRIPTION
## Summary

The DGCA chain view now displays the action type (Initiative / Programme / Project / Task) as a small label in the top-right corner of each action node, without requiring additional fields or configuration. The type is read from the `type` field on each activity and renders only when present.

## Test plan

- All 1764 diagram tests pass, including the preview-layout tests
- Builds successfully with no type errors
- Nodes without `type` render normally without crashing
- Only activities in the action column show the type badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)