### PR TITLE
Studio — goal-scoped DGCA projection validates against catalogue and renders scope caption

### DIFF
--- a/packages/diagrams/src/fgca/__tests__/parse-canonical.test.ts
+++ b/packages/diagrams/src/fgca/__tests__/parse-canonical.test.ts
@@ -303,6 +303,104 @@ describe('parseCanonicalFGA', () => {
   });
 });
 
+describe('parseCanonicalFGCA — goal-scoped projections', () => {
+  const docWithTwoGoals = {
+    notation: 'dgca',
+    spec_version: '0.1',
+    id: 'FGCA-SCOPE-TEST-1',
+    name: 'Two-goal fixture',
+    factors: [
+      { id: 'DRIVER-A-1', name: 'Driver A' },
+      { id: 'DRIVER-B-1', name: 'Driver B' },
+    ],
+    goals: [
+      { id: 'GOAL-PRIMARY-1', name: 'Primary goal', factors: ['DRIVER-A-1'] },
+      { id: 'GOAL-SECONDARY-1', name: 'Secondary goal', factors: ['DRIVER-B-1'] },
+    ],
+    changes: [
+      { id: 'CHANGE-A-1', name: 'Change for primary', goals: ['GOAL-PRIMARY-1'] },
+      { id: 'CHANGE-B-1', name: 'Change for secondary', goals: ['GOAL-SECONDARY-1'] },
+    ],
+    actions: [
+      { id: 'ACTION-AB-1', name: 'Action serving both', goals: ['GOAL-PRIMARY-1', 'GOAL-SECONDARY-1'] },
+      { id: 'ACTION-B-1', name: 'Action serving secondary only', goals: ['GOAL-SECONDARY-1'] },
+    ],
+  };
+
+  it('suppresses FGCA-011 when action references out-of-scope goal that exists', () => {
+    const outOfScopeGoals = new Set(['GOAL-SECONDARY-1']);
+    const r = parseCanonicalFGCA(docWithTwoGoals, outOfScopeGoals);
+    expect(r.valid, JSON.stringify(r.errors)).toBe(true);
+    // ACTION-AB-1 references GOAL-SECONDARY-1 which is out-of-scope, but shouldn't error
+    expect(r.errors.filter((e) => e.code === 'FGCA-011')).toHaveLength(0);
+  });
+
+  it('sets scopeCaption=true when out-of-scope goals are referenced', () => {
+    const outOfScopeGoals = new Set(['GOAL-SECONDARY-1']);
+    const r = parseCanonicalFGCA(docWithTwoGoals, outOfScopeGoals);
+    expect(r.scopeCaption).toBe(true);
+  });
+
+  it('suppresses FGCA-009 when change references out-of-scope goal that exists', () => {
+    // Create a change that serves an out-of-scope goal
+    const doc = {
+      ...docWithTwoGoals,
+      changes: [
+        { id: 'CHANGE-CROSS-1', name: 'Change serving both goals', goals: ['GOAL-PRIMARY-1', 'GOAL-SECONDARY-1'] },
+      ],
+    };
+    const outOfScopeGoals = new Set(['GOAL-SECONDARY-1']);
+    const r = parseCanonicalFGCA(doc, outOfScopeGoals);
+    expect(r.valid, JSON.stringify(r.errors)).toBe(true);
+    expect(r.errors.filter((e) => e.code === 'FGCA-009')).toHaveLength(0);
+  });
+
+  it('does not set scopeCaption when all referenced goals are in-scope', () => {
+    // When every goal referenced by actions/changes is in the selected set
+    const selectedDoc = {
+      notation: 'dgca',
+      spec_version: '0.1',
+      id: 'FGCA-SINGLE-GOAL-1',
+      name: 'Single-goal selection',
+      factors: [{ id: 'DRIVER-A-1', name: 'Driver A' }],
+      goals: [{ id: 'GOAL-PRIMARY-1', name: 'Primary goal', factors: ['DRIVER-A-1'] }],
+      changes: [{ id: 'CHANGE-A-1', name: 'Change for primary', goals: ['GOAL-PRIMARY-1'] }],
+      actions: [{ id: 'ACTION-A-1', name: 'Action serving primary', goals: ['GOAL-PRIMARY-1'] }],
+    };
+    const outOfScopeGoals = new Set<string>();
+    const r = parseCanonicalFGCA(selectedDoc, outOfScopeGoals);
+    expect(r.valid, JSON.stringify(r.errors)).toBe(true);
+    expect(r.scopeCaption).toBe(false);
+  });
+
+  it('still reports FGCA-011 when action references a goal that does not exist at all', () => {
+    const docMissingGoal = {
+      ...docWithTwoGoals,
+      actions: [
+        { id: 'ACTION-X-1', name: 'Action with bad ref', goals: ['GOAL-NONEXISTENT-1'] },
+      ],
+    };
+    const outOfScopeGoals = new Set(['GOAL-SECONDARY-1']);
+    const r = parseCanonicalFGCA(docMissingGoal, outOfScopeGoals);
+    expect(r.valid).toBe(false);
+    expect(r.errors.some((e) => e.code === 'FGCA-011')).toBe(true);
+  });
+
+  it('suppresses FGCA-008 when goal references out-of-scope factor that exists', () => {
+    const docWithCrossFactor = {
+      ...docWithTwoGoals,
+      goals: [
+        { id: 'GOAL-PRIMARY-1', name: 'Primary goal', factors: ['DRIVER-A-1', 'DRIVER-B-1'] },
+        { id: 'GOAL-SECONDARY-1', name: 'Secondary goal', factors: ['DRIVER-B-1'] },
+      ],
+    };
+    const outOfScopeFactors = new Set(['DRIVER-B-1']);
+    const r = parseCanonicalFGCA(docWithCrossFactor, undefined, outOfScopeFactors);
+    expect(r.valid, JSON.stringify(r.errors)).toBe(true);
+    expect(r.errors.filter((e) => e.code === 'FGCA-008')).toHaveLength(0);
+  });
+});
+
 describe('parseCanonicalFGCA — example file regression', () => {
   const EXAMPLES_DIR = path.resolve(process.cwd(), '..', '..', 'tests', 'fixtures', 'notation-corpus', 'dgca');
   const files = fs.existsSync(EXAMPLES_DIR)

--- a/packages/diagrams/src/fgca/__tests__/resolver.test.ts
+++ b/packages/diagrams/src/fgca/__tests__/resolver.test.ts
@@ -227,6 +227,54 @@ describe('resolveFGCA — empty sources', () => {
   });
 });
 
+// ── resolveFGCA — goal-scoped projections (goals.filter !== 'all') ────────────
+
+describe('resolveFGCA — goal-scoped projections with out-of-scope tracking', () => {
+  it('computes __outOfScopeGoalIds when goals.filter is ids', () => {
+    const viewDoc = {
+      notation: 'dgca',
+      id: 'DGCA-SCOPE-1',
+      name: 'Scoped view',
+      view_config: {
+        goals: { filter: 'ids', ids: ['GOAL-1'] },
+        factors: { surface: 'derived' },
+        changes: { surface: 'derived' },
+        activities: { surface: 'derived' },
+      },
+    };
+    const doc = resolveFGCA(viewDoc, SOURCES) as Record<string, unknown>;
+    expect((doc['goals'] as Array<{ id: string }>).map((g) => g.id)).toEqual(['GOAL-1']);
+    // GOAL-2 and GOAL-3 exist in canon but are not selected
+    expect(doc['__outOfScopeGoalIds']).toBeInstanceOf(Set);
+    expect((doc['__outOfScopeGoalIds'] as Set<string>).has('GOAL-2')).toBe(true);
+    expect((doc['__outOfScopeGoalIds'] as Set<string>).has('GOAL-3')).toBe(true);
+  });
+
+  it('does not set __outOfScopeGoalIds when goals.filter is all', () => {
+    const doc = resolveFGCA(VIEW_DOC, SOURCES) as Record<string, unknown>;
+    expect(doc['__outOfScopeGoalIds']).toBeUndefined();
+  });
+
+  it('parseCanonicalFGCA accepts the resolved doc with out-of-scope ids', () => {
+    const viewDoc = {
+      notation: 'dgca',
+      id: 'DGCA-SCOPE-1',
+      name: 'Scoped view',
+      view_config: {
+        goals: { filter: 'ids', ids: ['GOAL-1'] },
+        factors: { surface: 'derived' },
+        changes: { surface: 'derived' },
+        activities: { surface: 'derived' },
+      },
+    };
+    const resolved = resolveFGCA(viewDoc, SOURCES) as Record<string, unknown>;
+    const outOfScope = resolved['__outOfScopeGoalIds'] as Set<string> | undefined;
+    const r = parseCanonicalFGCA(resolved, outOfScope);
+    expect(r.valid, JSON.stringify(r.errors)).toBe(true);
+    expect(r.parsed?.goals).toHaveLength(1);
+  });
+});
+
 // ── File-based regression — resolver + canon fixture + parseCanonicalFGCA ─────
 
 describe('resolveFGCA — file-based regression against canon fixture', () => {

--- a/packages/diagrams/src/fgca/parse-canonical.ts
+++ b/packages/diagrams/src/fgca/parse-canonical.ts
@@ -247,14 +247,13 @@ export function parseCanonicalFGCA(
         errors.push({ code: 'FGCA-007', message: `${path}.${field}[] entry "${r}" does not match the expected grammar`, path });
         continue;
       }
+      if (outOfScope?.has(r)) {
+        // Reference is out-of-scope: suppress error and mark that we found an out-of-scope reference (for caption).
+        hasOutOfScopeRef = true;
+        out.push(r);
+        continue;
+      }
       if (!targets.has(r)) {
-        if (outOfScope?.has(r)) {
-          // Reference exists in catalogue but is out-of-scope: suppress error
-          // and mark that we found an out-of-scope reference (for caption).
-          hasOutOfScopeRef = true;
-          out.push(r);
-          continue;
-        }
         errors.push({ code, message: `${path}.${field}[] references undeclared element "${r}"`, path });
         continue;
       }

--- a/packages/diagrams/src/fgca/parse-canonical.ts
+++ b/packages/diagrams/src/fgca/parse-canonical.ts
@@ -41,6 +41,8 @@ import { actionChangeLinkField } from './action-change-ids.js';
 export interface CanonicalFGCAResult extends ValidationResult {
   /** On success, the internal-form FGCADoc derived from the canonical input. */
   parsed?: FGCADoc;
+  /** True when a goal-scoped projection should show the scope caption. */
+  scopeCaption?: boolean;
 }
 
 // Canonical ID grammars per IDS_AND_REFERENCES.md §1. The TYPE prefix
@@ -79,8 +81,20 @@ export function isDgcaChangesLayerOff(input: unknown): boolean {
 /**
  * Validate canonical FGCA YAML and, on success, return an internal-form
  * `FGCADoc` ready for `buildFGCALayout`.
+ *
+ * @param input The FGCA document to parse
+ * @param outOfScopeGoalIds When a goal-scoped projection omits goals that exist
+ *        in the catalogue, pass their IDs here to suppress FGCA-011/FGCA-009 errors
+ *        for references to out-of-scope goals. When provided and non-empty, and at least
+ *        one action or change references an out-of-scope goal, `scopeCaption` is set true.
+ * @param outOfScopeFactorIds When a goal-scoped projection omits factors that exist
+ *        in the catalogue, pass their IDs here to suppress FGCA-008 errors.
  */
-export function parseCanonicalFGCA(input: unknown): CanonicalFGCAResult {
+export function parseCanonicalFGCA(
+  input: unknown,
+  outOfScopeGoalIds?: Set<string> | null,
+  outOfScopeFactorIds?: Set<string> | null,
+): CanonicalFGCAResult {
   const errors: ValidationError[] = [];
   const warnings: ValidationWarning[] = [];
 
@@ -204,6 +218,9 @@ export function parseCanonicalFGCA(input: unknown): CanonicalFGCAResult {
 
   if (errors.length > 0) return { valid: false, errors, warnings };
 
+  // Track if any out-of-scope goals/factors are referenced (for scope caption).
+  let hasOutOfScopeRef = false;
+
   // Cross-refs.
   function checkRefArray(
     el: Record<string, unknown>,
@@ -212,6 +229,7 @@ export function parseCanonicalFGCA(input: unknown): CanonicalFGCAResult {
     refRe: RegExp,
     code: string,
     path: string,
+    outOfScope?: Set<string> | null,
   ): string[] {
     const ref = el[field];
     if (ref === undefined || ref === null) return [];
@@ -230,6 +248,13 @@ export function parseCanonicalFGCA(input: unknown): CanonicalFGCAResult {
         continue;
       }
       if (!targets.has(r)) {
+        if (outOfScope?.has(r)) {
+          // Reference exists in catalogue but is out-of-scope: suppress error
+          // and mark that we found an out-of-scope reference (for caption).
+          hasOutOfScopeRef = true;
+          out.push(r);
+          continue;
+        }
         errors.push({ code, message: `${path}.${field}[] references undeclared element "${r}"`, path });
         continue;
       }
@@ -247,7 +272,7 @@ export function parseCanonicalFGCA(input: unknown): CanonicalFGCAResult {
   }));
 
   const internalGoals: GoalItem[] = goals.map((el, i) => {
-    const refIds = checkRefArray(el!, 'factors', factorIds, FACTOR_OR_DRIVER_ID_RE, 'FGCA-008', `goals[${i}]`);
+    const refIds = checkRefArray(el!, 'factors', factorIds, FACTOR_OR_DRIVER_ID_RE, 'FGCA-008', `goals[${i}]`, outOfScopeFactorIds);
     return {
       id: String(el!['id']),
       name: String(el!['name'] ?? ''),
@@ -275,7 +300,7 @@ export function parseCanonicalFGCA(input: unknown): CanonicalFGCAResult {
   }
 
   const internalChanges: BdnChangeWithActivities[] = changes.map((el, i) => {
-    const goalRefs = checkRefArray(el!, 'goals', goalIds, GOAL_ID_RE, 'FGCA-009', `changes[${i}]`);
+    const goalRefs = checkRefArray(el!, 'goals', goalIds, GOAL_ID_RE, 'FGCA-009', `changes[${i}]`, outOfScopeGoalIds);
     // Internal `change.goal_id` is singular; canonical `change.goals` is plural.
     // First goal wins for the singular field; warn (not error) if multiple.
     if (goalRefs.length > 1) {
@@ -296,7 +321,7 @@ export function parseCanonicalFGCA(input: unknown): CanonicalFGCAResult {
   });
 
   const internalActivities: ActivityItem[] = activities.map((el, i) => {
-    const goalRefs = checkRefArray(el!, 'goals', goalIds, GOAL_ID_RE, 'FGCA-011', `actions[${i}]`);
+    const goalRefs = checkRefArray(el!, 'goals', goalIds, GOAL_ID_RE, 'FGCA-011', `actions[${i}]`, outOfScopeGoalIds);
     const typeVal = typeof el!['type'] === 'string' ? el!['type'] : undefined;
     return {
       id: String(el!['id']),
@@ -337,7 +362,13 @@ export function parseCanonicalFGCA(input: unknown): CanonicalFGCAResult {
     hideChanges: isDgcaChangesLayerOff(raw),
   };
 
-  return { valid: true, errors, warnings, parsed };
+  return {
+    valid: true,
+    errors,
+    warnings,
+    parsed,
+    scopeCaption: (outOfScopeGoalIds?.size ?? 0) > 0 && hasOutOfScopeRef,
+  };
 }
 
 const FGA_DOC_ID_RE = /^(FGA|DGA)(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
@@ -345,6 +376,8 @@ const FGA_DOC_ID_RE = /^(FGA|DGA)(-[A-Z0-9][A-Z0-9_]*)*-\d+$/;
 /** On success, the internal-form FGCADoc derived from canonical FGA input. */
 export interface CanonicalFGAResult extends ValidationResult {
   parsed?: FGCADoc;
+  /** True when a goal-scoped projection should show the scope caption. */
+  scopeCaption?: boolean;
 }
 
 /**
@@ -364,7 +397,11 @@ export interface CanonicalFGAResult extends ValidationResult {
  * the canonical FGA path is unit-testable and the library owns the single
  * canon shape — flat form only, no `fga:` wrapper.
  */
-export function parseCanonicalFGA(input: unknown): CanonicalFGAResult {
+export function parseCanonicalFGA(
+  input: unknown,
+  outOfScopeGoalIds?: Set<string> | null,
+  outOfScopeFactorIds?: Set<string> | null,
+): CanonicalFGAResult {
   if (!input || typeof input !== 'object') {
     return { valid: false, errors: [{ code: 'FGA-001', message: 'document root is not an object' }], warnings: [] };
   }
@@ -392,7 +429,7 @@ export function parseCanonicalFGA(input: unknown): CanonicalFGAResult {
   // codes are remapped on the way out. FGCA-009 / 010 / 014 (changes-related)
   // are unreachable here because `changes` is empty.
   const synth = { ...raw, notation: 'dgca', id: 'DGCA-FROM-DGA-1', changes: [] };
-  const r = parseCanonicalFGCA(synth);
+  const r = parseCanonicalFGCA(synth, outOfScopeGoalIds, outOfScopeFactorIds);
   const remap: Record<string, string> = {
     'FGCA-001': 'FGA-001',
     'FGCA-002': 'FGA-002',
@@ -412,5 +449,6 @@ export function parseCanonicalFGA(input: unknown): CanonicalFGAResult {
     errors: r.errors.map((e) => ({ ...e, code: remapCode(e.code) })),
     warnings: r.warnings.map((w) => ({ ...w, code: remapCode(w.code) })),
     parsed: r.parsed,
+    scopeCaption: r.scopeCaption,
   };
 }

--- a/packages/diagrams/src/fgca/resolver.ts
+++ b/packages/diagrams/src/fgca/resolver.ts
@@ -158,6 +158,28 @@ export function resolveFGCA(
     );
   }
 
+  // Collect out-of-scope goals (exist in catalogue but not in selected set).
+  // Used by the validator to suppress errors for references to goals that exist
+  // but are outside the scope.
+  let outOfScopeGoalIds: Set<string> | undefined;
+  if (goalsFilter !== 'all') {
+    // Goal scope is restricted; collect goals that exist but aren't selected.
+    outOfScopeGoalIds = new Set(
+      [...goalElems.keys()].filter((id) => !selectedGoalIds.has(id)),
+    );
+  }
+
+  // Collect out-of-scope factors (exist in catalogue but not in selected set).
+  const selectedFactorIds = new Set(
+    selectedFactors.map((f) => str(f['id'])).filter((x): x is string => x !== undefined),
+  );
+  let outOfScopeFactorIds: Set<string> | undefined;
+  if (goalsFilter !== 'all') {
+    outOfScopeFactorIds = new Set(
+      [...factorElems.keys()].filter((id) => !selectedFactorIds.has(id)),
+    );
+  }
+
   return {
     notation: 'dgca',
     id: viewDoc['id'],
@@ -168,5 +190,7 @@ export function resolveFGCA(
     changes: selectedChanges,
     actions: selectedActivities,
     view_config: viewDoc['view_config'],
+    __outOfScopeGoalIds: outOfScopeGoalIds,
+    __outOfScopeFactorIds: outOfScopeFactorIds,
   };
 }

--- a/packages/diagrams/src/webview/entry.ts
+++ b/packages/diagrams/src/webview/entry.ts
@@ -187,22 +187,44 @@ function dispatchValidate(kind: NotationKind, doc: unknown): RenderResult {
       return r;
     }
     case 'dgca': {
-      const v = parseCanonicalFGCA(doc);
+      const meta = (doc ?? {}) as Record<string, unknown>;
+      const outOfScopeGoalIds = meta['__outOfScopeGoalIds'] instanceof Set
+        ? (meta['__outOfScopeGoalIds'] as Set<string>)
+        : Array.isArray(meta['__outOfScopeGoalIds'])
+          ? new Set(meta['__outOfScopeGoalIds'] as string[])
+          : undefined;
+      const outOfScopeFactorIds = meta['__outOfScopeFactorIds'] instanceof Set
+        ? (meta['__outOfScopeFactorIds'] as Set<string>)
+        : Array.isArray(meta['__outOfScopeFactorIds'])
+          ? new Set(meta['__outOfScopeFactorIds'] as string[])
+          : undefined;
+      const v = parseCanonicalFGCA(doc, outOfScopeGoalIds, outOfScopeFactorIds);
       const r = emptyResult(kind, v.valid ? 'ok' : 'error');
       r.errors.push(...v.errors);
       r.warnings.push(...v.warnings);
       if (v.valid && v.parsed) {
-        r.svg = renderFgcaSvg(v.parsed, { variant: 'dgca' });
+        r.svg = renderFgcaSvg(v.parsed, { variant: 'dgca', scopeCaption: v.scopeCaption });
       }
       return r;
     }
     case 'dga': {
-      const v = parseCanonicalFGA(doc);
+      const meta = (doc ?? {}) as Record<string, unknown>;
+      const outOfScopeGoalIds = meta['__outOfScopeGoalIds'] instanceof Set
+        ? (meta['__outOfScopeGoalIds'] as Set<string>)
+        : Array.isArray(meta['__outOfScopeGoalIds'])
+          ? new Set(meta['__outOfScopeGoalIds'] as string[])
+          : undefined;
+      const outOfScopeFactorIds = meta['__outOfScopeFactorIds'] instanceof Set
+        ? (meta['__outOfScopeFactorIds'] as Set<string>)
+        : Array.isArray(meta['__outOfScopeFactorIds'])
+          ? new Set(meta['__outOfScopeFactorIds'] as string[])
+          : undefined;
+      const v = parseCanonicalFGA(doc, outOfScopeGoalIds, outOfScopeFactorIds);
       const r = emptyResult(kind, v.valid ? 'ok' : 'error');
       r.errors.push(...v.errors);
       r.warnings.push(...v.warnings);
       if (v.valid && v.parsed) {
-        r.svg = renderFgcaSvg(v.parsed, { variant: 'dga' });
+        r.svg = renderFgcaSvg(v.parsed, { variant: 'dga', scopeCaption: v.scopeCaption });
       }
       return r;
     }

--- a/packages/diagrams/src/webview/render-fgca.ts
+++ b/packages/diagrams/src/webview/render-fgca.ts
@@ -110,6 +110,8 @@ export interface RenderFgcaOptions {
   entryCurvature?: number;
   nodeSizePreset?: NodeSizePreset;
   layoutOptions?: Parameters<typeof layoutFGCAPreview>[1];
+  /** Show scope caption when goal-scoped projection omits goals that reference out-of-scope goals. */
+  scopeCaption?: boolean;
 }
 
 export function renderFgcaSvg(doc: FGCADoc, options: RenderFgcaOptions = {}): string {
@@ -120,6 +122,7 @@ export function renderFgcaSvg(doc: FGCADoc, options: RenderFgcaOptions = {}): st
     entryCurvature,
     nodeSizePreset = 'normal',
     layoutOptions,
+    scopeCaption = false,
   } = options;
   const hideChanges = variant === 'dga' || doc.hideChanges === true;
   const nodeSize = resolveDgcaNodeSize(parseNodeSizePreset(nodeSizePreset));
@@ -144,9 +147,16 @@ export function renderFgcaSvg(doc: FGCADoc, options: RenderFgcaOptions = {}): st
     ? `<text class="text-header" x="${PAD}" y="${PAD - 6}">${escXml(title)}</text>`
     : '';
 
+  const captionSvg = scopeCaption
+    ? `<text class="text-caption" x="${PAD}" y="${height + 16}">${escXml('This diagram is shown for the selected goal scope. Actions on it may also serve goals outside that scope.')}</text>`
+    : '';
+
   const embedCss = generateSvgEmbedCss('transitrix');
 
-  return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
+  // Calculate final height including caption if present
+  const finalHeight = scopeCaption ? height + 24 : height;
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${finalHeight}" viewBox="0 0 ${width} ${finalHeight}">
 <style>${embedCss}</style>
 <defs>
   <marker id="arrow" markerWidth="8" markerHeight="8" refX="8" refY="3" orient="auto">
@@ -155,5 +165,6 @@ export function renderFgcaSvg(doc: FGCADoc, options: RenderFgcaOptions = {}): st
 </defs>
 ${titleSvg}
 ${body}
+${captionSvg}
 </svg>`;
 }


### PR DESCRIPTION
## Summary

Goal-scoped DGCA projections now validate without errors when actions/changes reference goals that exist in the catalogue but fall outside the selected goal scope. A caption explains the scope limitation when rendering.

## Acceptance

- Validator suppresses FGCA-011/FGCA-009/FGCA-008 errors for out-of-scope references that exist in the catalogue
- Render output includes caption when goal filter is not 'all' and at least one action/change references an out-of-scope goal
- Existing full-chain (`goals.filter: all`) fixtures remain unchanged with no caption
- Test fixtures: two-goal scenario with cross-referenced action (only first selected), and single-goal scenario (no caption)

## Test plan

✓ Unit tests for `parseCanonicalFGCA` with `outOfScopeGoalIds` parameter
✓ Unit tests for `resolveFGCA` goal-scoped projections tracking out-of-scope elements
✓ Validation succeeds when out-of-scope references exist but are suppressed
✓ `scopeCaption` flag set correctly based on presence of out-of-scope references

🤖 Generated with [Claude Code](https://claude.com/claude-code)