### PR TITLE
chore: correct JetBrains listing

### DIFF
--- a/intellij/src/main/resources/META-INF/plugin.xml
+++ b/intellij/src/main/resources/META-INF/plugin.xml
@@ -39,8 +39,7 @@
             process blueprints, activity cards, and more.</li>
             <li>Preview panel opens automatically on <code>*.transitrix.yaml</code> files,
             or on demand via right-click → <b>Transitrix: Preview Notation</b>.</li>
-            <li>Powered by the shared <code>@transitrix/diagrams</code> engine —
-            identical output to the VS Code extension.</li>
+            <li>Powered by the shared <code>@transitrix/diagrams</code> engine for live preview of all Transitrix notation formats.</li>
             <li>Open source, MIT licensed.</li>
         </ul>
     ]]></change-notes>


### PR DESCRIPTION
## Summary

The shared `@transitrix/diagrams` engine renders live previews of Transitrix notation files in JetBrains IDEs. VS Code now supports PlantUML rendering via a separate flow; the JetBrains plugin does not have that renderer and never will. Identical output is no longer accurate.

This PR removes the false identical-output claim and clarifies that the plugin uses the shared engine for live preview of all Transitrix notation formats, which is true and the actual value the plugin delivers.

## Acceptance

- `plugin.xml` no longer claims identical output to VS Code in a way that covers `.puml`
- `@transitrix/diagrams` parity for Transitrix notation files remains stated  
- `grep -ril plantuml intellij/` returns nothing — no renderer added

Fixes transitrix-hq#483 (directive transitrix-hq#476).