### PR TITLE
Show collapse toggle on expanded parent nodes in goal-tree and capability-map

### DIFF
--- a/changelog/fragments/goal-tree-collapse-toggle-0b6285aa.md
+++ b/changelog/fragments/goal-tree-collapse-toggle-0b6285aa.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Goal-tree and capability-map collapse toggle is visible on expanded parents.** The ± button on a node with children was gated on `hasHiddenChildren`, which is only true after the subtree is already hidden — so a fully expanded tree never showed the control. The toggle now appears whenever the node has children (minus to collapse, plus to expand), matching the static capability-tree SVG renderer.

--- a/docs/internal/extraction/goals.md
+++ b/docs/internal/extraction/goals.md
@@ -209,6 +209,7 @@ interface LaidOutNode {
   height: number;
   data: Goal;            // original goal
   isCollapsedRoot: boolean;
+  hasChildren: boolean;
   hasHiddenChildren: boolean;
 }
 
@@ -248,7 +249,7 @@ Visual contract:
 - Hover-highlight of potential parent during drag.
 - Level-based card fill colour (from `theme.goalLevelColors`, default 0..7 palette).
 - Factor indicators: green up-caret (positive/opportunity), red down-caret (risk/negative). Click reveals inline panel above/below.
-- Collapse indicator on nodes with hidden children.
+- Collapse / expand toggle on nodes that have children.
 - React Flow controls: pan, zoom, fit-view, MiniMap.
 - Backlog sidebar (left, collapsible 50/250 px) when `showBacklog` and tree contains backlog goals.
 

--- a/packages/diagrams/src/capability-map/CapabilityCardNode.tsx
+++ b/packages/diagrams/src/capability-map/CapabilityCardNode.tsx
@@ -17,6 +17,7 @@ export interface CapabilityCardNodeData {
   maturityColours: Record<number, string>;
   readOnly: boolean;
   isDropTarget: boolean;
+  hasChildren: boolean;
   hasHiddenChildren: boolean;
   isCollapsed: boolean;
   onAddChild: (parentId: number) => void;
@@ -25,7 +26,7 @@ export interface CapabilityCardNodeData {
 }
 
 const CapabilityCardNode = memo(({ data }: { data: CapabilityCardNodeData }) => {
-  const { capability, theme, maturityColours, readOnly, isDropTarget, hasHiddenChildren, isCollapsed } = data;
+  const { capability, theme, maturityColours, readOnly, isDropTarget, hasChildren, hasHiddenChildren, isCollapsed } = data;
   const maturity = latestMaturityLevel(capability);
   const dotColour = maturity !== undefined ? maturityColours[maturity] : undefined;
 
@@ -119,11 +120,11 @@ const CapabilityCardNode = memo(({ data }: { data: CapabilityCardNodeData }) => 
         </button>
       )}
 
-      {hasHiddenChildren && (
+      {(hasChildren || hasHiddenChildren) && (
         <button
           type="button"
-          aria-label={isCollapsed ? 'Expand branch' : 'Collapse branch'}
-          title={isCollapsed ? 'Expand branch' : 'Collapse branch'}
+          aria-label={isCollapsed || hasHiddenChildren ? 'Expand branch' : 'Collapse branch'}
+          title={isCollapsed || hasHiddenChildren ? 'Expand branch' : 'Collapse branch'}
           onClick={(e) => {
             e.stopPropagation();
             data.onToggleCollapse(capability.id);
@@ -131,10 +132,11 @@ const CapabilityCardNode = memo(({ data }: { data: CapabilityCardNodeData }) => 
           style={{
             position: 'absolute', top: '50%', right: -8, transform: 'translateY(-50%)',
             width: 16, height: 16, borderRadius: '50%', border: `1px solid ${theme.cardBorderColor}`,
-            background: '#ffffff', color: theme.cardBorderColor, fontSize: 11, lineHeight: '14px', padding: 0, cursor: 'pointer',
+            background: '#ffffff', color: theme.cardBorderColor, fontSize: 11, lineHeight: '14px', padding: 0,
+            cursor: 'pointer', zIndex: 10,
           }}
         >
-          {isCollapsed ? '+' : '−'}
+          {isCollapsed || hasHiddenChildren ? '+' : '−'}
         </button>
       )}
     </div>

--- a/packages/diagrams/src/capability-map/CapabilityMapView.tsx
+++ b/packages/diagrams/src/capability-map/CapabilityMapView.tsx
@@ -161,6 +161,7 @@ function CapabilityMapViewInner({
         maturityColours,
         readOnly,
         isDropTarget: hoveredId === n.id,
+        hasChildren: n.hasChildren,
         hasHiddenChildren: n.hasHiddenChildren,
         isCollapsed: collapsedIds.has(n.id),
         onAddChild,

--- a/packages/diagrams/src/capability-map/__tests__/CapabilityMapView.test.tsx
+++ b/packages/diagrams/src/capability-map/__tests__/CapabilityMapView.test.tsx
@@ -105,6 +105,29 @@ describe('CapabilityMapView', () => {
     expect(screen.queryByLabelText('Delete capability')).toBeNull();
   });
 
+  it('shows a collapse toggle on capabilities with children, not on leaves', async () => {
+    render(<CapabilityMapView map={makeMap()} />);
+    await waitFor(() => expect(screen.getByText('Customer Acquisition')).toBeTruthy());
+    const parent = document.querySelector('.react-flow__node[data-id="1"]');
+    expect(parent!.querySelector('[aria-label="Collapse branch"]')).toBeTruthy();
+    const leaf = document.querySelector('.react-flow__node[data-id="3"]');
+    expect(leaf!.querySelector('[aria-label="Collapse branch"]')).toBeNull();
+    expect(leaf!.querySelector('[aria-label="Expand branch"]')).toBeNull();
+  });
+
+  it('collapsing a capability hides descendants and the toggle becomes Expand', async () => {
+    render(<CapabilityMapView map={makeMap()} />);
+    await waitFor(() => expect(screen.getByText('Lead Qualification')).toBeTruthy());
+    const parent = document.querySelector('.react-flow__node[data-id="1"]')!;
+    parent.querySelector('[aria-label="Collapse branch"]')!
+      .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await waitFor(() => {
+      expect(screen.queryByText('Lead Qualification')).toBeNull();
+      expect(screen.queryByText('Inbound Lead Scoring')).toBeNull();
+    });
+    expect(parent.querySelector('[aria-label="Expand branch"]')).toBeTruthy();
+  });
+
   it('fires onChange with kind "addChild" when the add-child button is clicked', async () => {
     const onChange = vi.fn<(e: CapabilityMapChange) => void>();
     render(<CapabilityMapView map={makeMap()} onChange={onChange} />);

--- a/packages/diagrams/src/capability-map/__tests__/dsm-layout.test.ts
+++ b/packages/diagrams/src/capability-map/__tests__/dsm-layout.test.ts
@@ -40,8 +40,19 @@ describe('layoutCapabilityMap', () => {
   it('marks a node as having hidden children when its subtree is collapsed', () => {
     const layout = layoutCapabilityMap(map(), { hideCollapsed: [2] });
     const cap2 = layout.nodes.find((n) => n.id === 2)!;
+    expect(cap2.hasChildren).toBe(true);
     expect(cap2.hasHiddenChildren).toBe(true);
     expect(layout.nodes.some((n) => n.id === 3)).toBe(false); // hidden subtree omitted
+  });
+
+  it('marks parent capabilities as hasChildren while expanded', () => {
+    const layout = layoutCapabilityMap(map());
+    const byId = new Map(layout.nodes.map((n) => [n.id, n]));
+    expect(byId.get(1)!.hasChildren).toBe(true);
+    expect(byId.get(2)!.hasChildren).toBe(true);
+    expect(byId.get(3)!.hasChildren).toBe(false);
+    expect(byId.get(4)!.hasChildren).toBe(false);
+    expect(byId.get(1)!.hasHiddenChildren).toBe(false);
   });
 
   it('returns just the root when there are no on-diagram capabilities', () => {

--- a/packages/diagrams/src/capability-map/dsm-layout.ts
+++ b/packages/diagrams/src/capability-map/dsm-layout.ts
@@ -79,12 +79,13 @@ export function layoutCapabilityMap(map: CapabilityMap, options: LayoutOptions =
     const cap = byId.get(id)!;
     const allChildIds = children.get(id) ?? [];
     const childIds = allChildIds.filter((c) => !hiddenSubtrees.has(c));
+    const hasChildren = allChildIds.length > 0;
     const hasHiddenChildren = childIds.length < allChildIds.length;
 
     if (childIds.length === 0) {
       const y = getNextY(col);
       advanceY(col, nodeHeight + nodeSep);
-      nodes.push({ id, x: col * (nodeWidth + rankSep), y, width: nodeWidth, height: nodeHeight, data: cap, hasHiddenChildren });
+      nodes.push({ id, x: col * (nodeWidth + rankSep), y, width: nodeWidth, height: nodeHeight, data: cap, hasChildren, hasHiddenChildren });
       return { top: y, bottom: y + nodeHeight };
     }
 
@@ -96,7 +97,7 @@ export function layoutCapabilityMap(map: CapabilityMap, options: LayoutOptions =
     const finalY = Math.max(parentY, curColY);
     advanceY(col, finalY - curColY + nodeHeight + nodeSep);
 
-    nodes.push({ id, x: col * (nodeWidth + rankSep), y: finalY, width: nodeWidth, height: nodeHeight, data: cap, hasHiddenChildren });
+    nodes.push({ id, x: col * (nodeWidth + rankSep), y: finalY, width: nodeWidth, height: nodeHeight, data: cap, hasChildren, hasHiddenChildren });
     for (const cid of childIds) edges.push({ source: id, target: cid });
     return { top: Math.min(finalY, spanTop), bottom: Math.max(finalY + nodeHeight, spanBottom) };
   }
@@ -108,7 +109,7 @@ export function layoutCapabilityMap(map: CapabilityMap, options: LayoutOptions =
   }
 
   if (nodes.length === 0) {
-    const rootNode: LaidOutNode = { id: 0, x: 0, y: 0, width: ROOT_WIDTH, height: nodeHeight, data: null, hasHiddenChildren: false };
+    const rootNode: LaidOutNode = { id: 0, x: 0, y: 0, width: ROOT_WIDTH, height: nodeHeight, data: null, hasChildren: false, hasHiddenChildren: false };
     return { rootNode, nodes: [], edges: [], bounds: { x: 0, y: 0, width: ROOT_WIDTH, height: nodeHeight } };
   }
 
@@ -122,7 +123,7 @@ export function layoutCapabilityMap(map: CapabilityMap, options: LayoutOptions =
   const rootTop = Math.min(...l1Nodes.map((n) => n.y));
   const rootBottom = Math.max(...l1Nodes.map((n) => n.y + n.height));
   const rootY = rootTop + (rootBottom - rootTop) / 2 - nodeHeight / 2;
-  const rootNode: LaidOutNode = { id: 0, x: 0, y: rootY, width: ROOT_WIDTH, height: nodeHeight, data: null, hasHiddenChildren: false };
+  const rootNode: LaidOutNode = { id: 0, x: 0, y: rootY, width: ROOT_WIDTH, height: nodeHeight, data: null, hasChildren: l1Ids.length > 0, hasHiddenChildren: false };
 
   const rootEdges: LaidOutEdge[] = l1Ids
     .filter((id) => !hiddenSubtrees.has(id))

--- a/packages/diagrams/src/capability-map/dsm-schema.ts
+++ b/packages/diagrams/src/capability-map/dsm-schema.ts
@@ -64,6 +64,7 @@ export interface LaidOutNode {
   width: number;
   height: number;
   data: Capability | null;
+  hasChildren: boolean;
   hasHiddenChildren: boolean;
 }
 

--- a/packages/diagrams/src/goals/GoalNode.tsx
+++ b/packages/diagrams/src/goals/GoalNode.tsx
@@ -19,6 +19,7 @@ export interface GoalNodeData {
   theme: Required<ThemeTokens>;
   readOnly: boolean;
   isDropTarget: boolean;
+  hasChildren: boolean;
   hasHiddenChildren: boolean;
   isCollapsed: boolean;
   onAddChild: (parentId: number, parentLevel: number) => void;
@@ -28,7 +29,7 @@ export interface GoalNodeData {
 }
 
 const GoalNode = memo(({ data }: { data: GoalNodeData }) => {
-  const { goal, theme, readOnly, isDropTarget, hasHiddenChildren, isCollapsed } = data;
+  const { goal, theme, readOnly, isDropTarget, hasChildren, hasHiddenChildren, isCollapsed } = data;
   const [openPanel, setOpenPanel] = useState<'positive' | 'negative' | null>(null);
 
   const positive = (goal.factors ?? []).filter((f) => impactSign(f) !== 'negative');
@@ -192,11 +193,11 @@ const GoalNode = memo(({ data }: { data: GoalNodeData }) => {
         </button>
       )}
 
-      {hasHiddenChildren && (
+      {(hasChildren || hasHiddenChildren) && (
         <button
           type="button"
-          aria-label={isCollapsed ? 'Expand branch' : 'Collapse branch'}
-          title={isCollapsed ? 'Expand branch' : 'Collapse branch'}
+          aria-label={isCollapsed || hasHiddenChildren ? 'Expand branch' : 'Collapse branch'}
+          title={isCollapsed || hasHiddenChildren ? 'Expand branch' : 'Collapse branch'}
           onClick={(e) => {
             e.stopPropagation();
             data.onToggleCollapse(goal.id);
@@ -204,10 +205,11 @@ const GoalNode = memo(({ data }: { data: GoalNodeData }) => {
           style={{
             position: 'absolute', top: '50%', right: -8, transform: 'translateY(-50%)',
             width: 16, height: 16, borderRadius: '50%', border: `1px solid ${theme.cardBorderColor}`,
-            background: '#ffffff', color: theme.cardBorderColor, fontSize: 11, lineHeight: '14px', padding: 0, cursor: 'pointer',
+            background: '#ffffff', color: theme.cardBorderColor, fontSize: 11, lineHeight: '14px', padding: 0,
+            cursor: 'pointer', zIndex: 10,
           }}
         >
-          {isCollapsed ? '+' : '−'}
+          {isCollapsed || hasHiddenChildren ? '+' : '−'}
         </button>
       )}
     </div>

--- a/packages/diagrams/src/goals/GoalTreeView.tsx
+++ b/packages/diagrams/src/goals/GoalTreeView.tsx
@@ -179,6 +179,7 @@ function GoalTreeViewInner({
         theme,
         readOnly,
         isDropTarget: hoveredId === n.id,
+        hasChildren: n.hasChildren,
         hasHiddenChildren: n.hasHiddenChildren,
         isCollapsed: collapsedIds.has(n.id),
         onAddChild,

--- a/packages/diagrams/src/goals/__tests__/GoalTreeView.test.tsx
+++ b/packages/diagrams/src/goals/__tests__/GoalTreeView.test.tsx
@@ -345,6 +345,40 @@ describe('GoalTreeView', () => {
     });
   });
 
+  it('shows a collapse toggle on nodes with children, not on leaves', async () => {
+    render(<GoalTreeView tree={makeTree()} />);
+    await waitFor(() => {
+      expect(screen.getByText('Triple revenue')).toBeTruthy();
+    });
+    const rootNode = document.querySelector('.react-flow__node[data-id="1"]');
+    expect(rootNode!.querySelector('[aria-label="Collapse branch"]')).toBeTruthy();
+    const leaf = document.querySelector('.react-flow__node[data-id="2"]');
+    expect(leaf!.querySelector('[aria-label="Collapse branch"]')).toBeNull();
+    expect(leaf!.querySelector('[aria-label="Expand branch"]')).toBeNull();
+  });
+
+  it('collapsing a branch hides descendants and the toggle becomes Expand', async () => {
+    render(<GoalTreeView tree={makeTree()} />);
+    await waitFor(() => {
+      expect(screen.getByText('Launch in EU')).toBeTruthy();
+    });
+    const rootNode = document.querySelector('.react-flow__node[data-id="1"]')!;
+    const collapse = rootNode.querySelector('[aria-label="Collapse branch"]')!;
+    collapse.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await waitFor(() => {
+      expect(screen.queryByText('Launch in EU')).toBeNull();
+      expect(screen.queryByText('Cut churn')).toBeNull();
+    });
+    const collapsedRoot = document.querySelector('.react-flow__node[data-id="1"]')!;
+    const expand = collapsedRoot.querySelector('[aria-label="Expand branch"]')!;
+    expect(expand).toBeTruthy();
+    expand.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await waitFor(() => {
+      expect(screen.getByText('Launch in EU')).toBeTruthy();
+      expect(screen.getByText('Cut churn')).toBeTruthy();
+    });
+  });
+
   it('fires onEditRequest on double-click', async () => {
     const onEditRequest = vi.fn();
     render(<GoalTreeView tree={makeTree()} onEditRequest={onEditRequest} />);

--- a/packages/diagrams/src/goals/__tests__/layout.test.ts
+++ b/packages/diagrams/src/goals/__tests__/layout.test.ts
@@ -97,6 +97,26 @@ describe('layoutGoalTree', () => {
     expect(layout.nodes.every(n => n.data.level <= 1)).toBe(true);
   });
 
+  it('marks parent nodes as hasChildren while expanded (so the collapse toggle can render)', () => {
+    const layout = layoutGoalTree(TREE);
+    const byId = new Map(layout.nodes.map(n => [n.id, n]));
+    expect(byId.get(1)!.hasChildren).toBe(true);
+    expect(byId.get(2)!.hasChildren).toBe(true);
+    expect(byId.get(3)!.hasChildren).toBe(false);
+    expect(byId.get(4)!.hasChildren).toBe(false);
+    expect(byId.get(1)!.hasHiddenChildren).toBe(false);
+    expect(byId.get(2)!.hasHiddenChildren).toBe(false);
+  });
+
+  it('keeps hasChildren and sets hasHiddenChildren when a subtree is collapsed', () => {
+    const layout = layoutGoalTree(TREE, { hideCollapsed: [2] });
+    const n2 = layout.nodes.find(n => n.id === 2)!;
+    expect(n2.hasChildren).toBe(true);
+    expect(n2.hasHiddenChildren).toBe(true);
+    expect(layout.nodes.some(n => n.id === 3)).toBe(false);
+    expect(layout.nodes.some(n => n.id === 4)).toBe(false);
+  });
+
   it('compresses non-contiguous levels into adjacent columns (no phantom empty columns)', () => {
     // Legacy / non-canonical input: goal_types skip levels 1 and 3, so
     // goals sit at levels 0, 2, 4. Column x must advance by exactly one

--- a/packages/diagrams/src/goals/layout.ts
+++ b/packages/diagrams/src/goals/layout.ts
@@ -114,15 +114,17 @@ export function layoutGoalTree(tree: GoalTree, options: LayoutOptions = {}): Goa
     placed.add(id);
 
     const col = levelToCol.get(goal.level) ?? 0;
-    const childIds = (children.get(id) ?? []).filter(c => !hiddenSubtrees.has(c) && !placed.has(c));
-    const isCollapsedRoot = hiddenSet.has(id) && childIds.length > 0;
-    const hasHiddenChildren = childIds.length < (children.get(id) ?? []).length;
+    const allChildIds = children.get(id) ?? [];
+    const childIds = allChildIds.filter(c => !hiddenSubtrees.has(c) && !placed.has(c));
+    const isCollapsedRoot = hiddenSet.has(id) && allChildIds.length > 0;
+    const hasChildren = allChildIds.length > 0;
+    const hasHiddenChildren = childIds.length < allChildIds.length;
 
     if (childIds.length === 0) {
       // Leaf: place at current column Y
       const y = getNextY(col);
       advanceY(col, nodeHeight + nodeSep);
-      nodes.push({ id, x: col * (nodeWidth + rankSep), y, width: nodeWidth, height: nodeHeight, data: goal, isCollapsedRoot, hasHiddenChildren });
+      nodes.push({ id, x: col * (nodeWidth + rankSep), y, width: nodeWidth, height: nodeHeight, data: goal, isCollapsedRoot, hasChildren, hasHiddenChildren });
       return { top: y, bottom: y + nodeHeight };
     }
 
@@ -141,7 +143,7 @@ export function layoutGoalTree(tree: GoalTree, options: LayoutOptions = {}): Goa
     const finalY = Math.max(parentY, curColY);
     advanceY(col, finalY - curColY + nodeHeight + nodeSep);
 
-    nodes.push({ id, x: col * (nodeWidth + rankSep), y: finalY, width: nodeWidth, height: nodeHeight, data: goal, isCollapsedRoot, hasHiddenChildren });
+    nodes.push({ id, x: col * (nodeWidth + rankSep), y: finalY, width: nodeWidth, height: nodeHeight, data: goal, isCollapsedRoot, hasChildren, hasHiddenChildren });
 
     for (const cid of childIds) {
       edges.push({ source: id, target: cid });

--- a/packages/diagrams/src/goals/types.ts
+++ b/packages/diagrams/src/goals/types.ts
@@ -72,6 +72,8 @@ export interface LaidOutNode {
   height: number;
   data: Goal;
   isCollapsedRoot: boolean;
+  /** True when this node has at least one child in the source tree (visible or hidden). */
+  hasChildren: boolean;
   hasHiddenChildren: boolean;
 }
 


### PR DESCRIPTION
## Summary
- The collapse/expand (±) toggle on goal-tree and capability-map nodes now appears whenever a node has children, instead of only after its subtree is already hidden.
- Behavior now matches the static capability-tree SVG renderer.

## Test plan
- [x] `vitest run src/goals src/capability-map` (13 files, 197 tests) passes
- [x] `tsc --noEmit` passes for `packages/diagrams`