### PR TITLE
chore(release): prepare 3.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - **Preview resolves the canon root from the adopter manifest under the normative layout.** This release ships the fix described in 3.6.0's release notes but missing from that VSIX. Opening a projection view at `views/<notation>/*.yaml` now finds its canon store by locating `transitrix.yaml` and then `canon/` as its sibling, instead of walking up looking for an ancestor literally named `canon`. Files under `canon/elements/` keep resolving under the legacy layout, and all nine preview modules that share this resolver pick up the fix. (transitrix-hq#457, #600)
+- **Goal-tree and capability-map collapse toggle is visible on expanded parents.** The ± button on a node with children was gated on `hasHiddenChildren`, which is only true after the subtree is already hidden — so a fully expanded tree never showed the control. The toggle now appears whenever the node has children (minus to collapse, plus to expand), matching the static capability-tree SVG renderer.
 
 ## [3.6.0] — 2026-08-31
 

--- a/changelog/fragments/goal-tree-collapse-toggle-0b6285aa.md
+++ b/changelog/fragments/goal-tree-collapse-toggle-0b6285aa.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- **Goal-tree and capability-map collapse toggle is visible on expanded parents.** The ± button on a node with children was gated on `hasHiddenChildren`, which is only true after the subtree is already hidden — so a fully expanded tree never showed the control. The toggle now appears whenever the node has children (minus to collapse, plus to expand), matching the static capability-tree SVG renderer.

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "Diagrams as text. Write goals, processes, capabilities, BPMN, and more as plain YAML — 17 notations, live preview in your editor. Diffable in git. AI-friendly. Open source.",
   "license": "MIT",
   "icon": "icon.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "transitrix-studio",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "transitrix-studio",
-      "version": "3.6.0",
+      "version": "3.6.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -7930,7 +7930,7 @@
     },
     "packages/cli": {
       "name": "@transitrix/cli",
-      "version": "2.8.0",
+      "version": "2.8.1",
       "license": "MIT",
       "dependencies": {
         "@resvg/resvg-js": "^2.6.2",
@@ -7949,7 +7949,7 @@
     },
     "packages/diagrams": {
       "name": "@transitrix/diagrams",
-      "version": "1.12.0",
+      "version": "1.12.1",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/cli",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "type": "module",
   "description": "Transitrix CLI ΓÇö compile, validate, and report on Transitrix diagrams (BPMN, Goals, DGCA, ΓÇª) from any shell or CI pipeline.",
   "license": "MIT",

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bumps versions for the 3.6.1 patch release: root/extension 3.6.0 → 3.6.1, `@transitrix/diagrams` 1.12.0 → 1.12.1, `@transitrix/cli` 2.8.0 → 2.8.1 (moves with diagrams per the release-version guard).
- Folds the one pending changelog fragment into the existing `[3.6.1]` CHANGELOG section (added ahead of the version bump by #608): goal-tree/capability-map collapse-toggle fix.

## Test plan
- [x] `npm run build` green
- [x] `npm run compile` + `npm run compile:extension` green
- [x] `npm run test:core` — 832/835 pass; 3 pre-existing failures in `tests/cli-migrate.test.ts` are unrelated to this change (local `methodology` sibling repo dependency, reproducible identically on `main`)
- [x] `npm run test:diagrams` — 1776/1776 pass
- [x] CHANGELOG heading matches the version fields