### PR TITLE
fix(ci): openvsx-publish downloads only the VSIX's own checksum

### DIFF
--- a/.github/workflows/openvsx-publish.yml
+++ b/.github/workflows/openvsx-publish.yml
@@ -49,7 +49,7 @@ jobs:
           fi
           mkdir -p output
           gh release download "$tag" --repo "${{ github.repository }}" \
-            --pattern '*.vsix' --pattern '*.sha256' --dir output
+            --pattern '*.vsix' --pattern '*.vsix.sha256' --dir output
 
       - name: Verify the downloaded VSIX against its recorded SHA-256
         shell: bash


### PR DESCRIPTION
## Summary
- `openvsx-publish.yml`'s verify step ran `sha256sum -c` against every `*.sha256` release asset, including `sbom.xml.sha256`, but the download step never fetched `sbom.xml` itself — the check failed on a file it had no reason to download.
- Narrows the download pattern to `*.vsix.sha256` so only the VSIX's own checksum is fetched and verified.

## Test plan
- [x] Reproduced the failure in the v3.6.1 Open VSX publish run (`sha256sum: sbom.xml: No such file or directory`)
- [ ] Re-run `Open VSX — publish` (workflow_dispatch, tag `v3.6.1`) after merge to confirm the fix and complete the pending publish