### PR TITLE
chore(ci): standardize hygiene secret name to HYGIENE_HUB_SLUG

### DIFF
--- a/.github/workflows/public-surface-hygiene.yml
+++ b/.github/workflows/public-surface-hygiene.yml
@@ -42,7 +42,7 @@ jobs:
         env:
           HYGIENE_BLOCKLIST: ${{ secrets.HYGIENE_BLOCKLIST }}
           HYGIENE_BLOCKLIST_HUB: ${{ secrets.HYGIENE_BLOCKLIST_HUB }}
-          HYGIENE_BLOCKLIST_3: ${{ secrets.HYGIENE_BLOCKLIST_3 }}
+          HYGIENE_HUB_SLUG: ${{ secrets.HYGIENE_HUB_SLUG }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
@@ -51,7 +51,7 @@ jobs:
 
       - name: Run full-tree hygiene check
         env:
-          HYGIENE_BLOCKLIST_3: ${{ secrets.HYGIENE_BLOCKLIST_3 }}
+          HYGIENE_HUB_SLUG: ${{ secrets.HYGIENE_HUB_SLUG }}
         run: node scripts/ci-hygiene-tree.mjs
 
       - name: Work-item references

--- a/scripts/ci-hygiene-check.mjs
+++ b/scripts/ci-hygiene-check.mjs
@@ -18,8 +18,8 @@ if (!blocklist || blocklist.trim() === '') {
 }
 
 const blocklistHub = process.env.HYGIENE_BLOCKLIST_HUB;
-const blocklist3 = process.env.HYGIENE_BLOCKLIST_3;
-const combined = [blocklist, blocklistHub, blocklist3]
+const blocklistHubSlug = process.env.HYGIENE_HUB_SLUG;
+const combined = [blocklist, blocklistHub, blocklistHubSlug]
   .filter((p) => p && p.trim())
   .join('|');
 
@@ -27,7 +27,7 @@ const TAG = 'hygiene';
 const SLOTS = [
   ['HYGIENE_BLOCKLIST', blocklist],
   ['HYGIENE_BLOCKLIST_HUB', blocklistHub],
-  ['HYGIENE_BLOCKLIST_3', blocklist3],
+  ['HYGIENE_HUB_SLUG', blocklistHubSlug],
 ];
 
 // Self-validation. A pattern can be perfectly valid and still useless: an empty

--- a/scripts/ci-hygiene-tree.mjs
+++ b/scripts/ci-hygiene-tree.mjs
@@ -5,7 +5,7 @@
 // already committed stays invisible to it forever. This pass reads every tracked
 // text file instead.
 //
-// Deliberately scoped to the HYGIENE_BLOCKLIST_3 pattern alone: the older slots
+// Deliberately scoped to the HYGIENE_HUB_SLUG pattern alone: the older slots
 // have never been evaluated tree-wide, and enabling them here would fail every
 // PR on pre-existing content rather than on the change under review.
 //
@@ -15,9 +15,9 @@
 import { execSync } from 'node:child_process';
 import { readFileSync, statSync } from 'node:fs';
 
-const raw = process.env.HYGIENE_BLOCKLIST_3;
+const raw = process.env.HYGIENE_HUB_SLUG;
 if (!raw || raw.trim() === '') {
-  console.warn('[hygiene-tree] HYGIENE_BLOCKLIST_3 secret is not set — skipping check.');
+  console.warn('[hygiene-tree] HYGIENE_HUB_SLUG secret is not set — skipping check.');
   process.exit(0);
 }
 
@@ -25,12 +25,12 @@ let pattern;
 try {
   pattern = new RegExp(raw, 'i');
 } catch {
-  console.error('[hygiene-tree] HYGIENE_BLOCKLIST_3 is not a valid JavaScript regex.');
+  console.error('[hygiene-tree] HYGIENE_HUB_SLUG is not a valid JavaScript regex.');
   process.exit(2);
 }
 
 const TAG = 'hygiene-tree';
-const SLOTS = [['HYGIENE_BLOCKLIST_3', raw]];
+const SLOTS = [['HYGIENE_HUB_SLUG', raw]];
 
 // Self-validation. A pattern can be perfectly valid and still useless: an empty
 // alternative (`a||b`) or a bare `.*` compiles and then matches every input,


### PR DESCRIPTION
## Summary

Standardize public-surface-hygiene workflow and scripts to use \ instead of the non-standard \ secret name. Aligns with the naming convention used across other repositories in the family.

**Changed files:**
- Workflow: .github/workflows/public-surface-hygiene.yml
- Scripts: scripts/ci-hygiene-check.mjs, scripts/ci-hygiene-tree.mjs

No functional change; the blocklist behavior remains the same, only the secret name is standardized.

Addresses transitrix-hq#160 item 4 (secret name harmonization).

🤖 Generated with Claude Code