### PR TITLE
feat: column scope on DGCA/DGA and arrow path styles in previews

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -306,6 +306,24 @@
           "default": 1,
           "description": "Action preview: CPM dependency-arrow curvature. 0 = straight lines, 1 = default, higher = stronger arc."
         },
+        "transitrix.edgeStyle.goals": {
+          "type": "string",
+          "enum": ["straight", "bezier", "polyline"],
+          "default": "bezier",
+          "description": "Goals preview: arrow path. straight = chord, bezier = cubic curve (slider still applies), polyline = orthogonal elbow."
+        },
+        "transitrix.edgeStyle.dgca": {
+          "type": "string",
+          "enum": ["straight", "bezier", "polyline"],
+          "default": "bezier",
+          "description": "DGCA preview: arrow path. straight = chord, bezier = cubic curve (slider still applies), polyline = orthogonal elbow."
+        },
+        "transitrix.edgeStyle.dga": {
+          "type": "string",
+          "enum": ["straight", "bezier", "polyline"],
+          "default": "bezier",
+          "description": "DGA preview: arrow path. straight = chord, bezier = cubic curve (slider still applies), polyline = orthogonal elbow."
+        },
         "transitrix.entryCurvature.goals": {
           "type": "number",
           "minimum": 0,
@@ -345,27 +363,40 @@
           "default": -1,
           "description": "Goals preview: scope to a level cap. Show only goals at this level and above (e.g. 1 = top two levels). -1 = no cap. Ignored when a scope root id is set."
         },
-        "transitrix.scope.dgca.rootId": {
+        "transitrix.scope.dgca.driverId": {
           "type": "string",
           "default": "",
-          "description": "DGCA preview: scope to a single goal. Set the goal id to show only that goal plus the drivers/changes/activities connected to it. Empty = show all. Takes precedence over the level cap."
+          "description": "DGCA preview: show only chains through this driver. Empty = all drivers."
         },
-        "transitrix.scope.dgca.maxLevel": {
-          "type": "integer",
-          "minimum": -1,
-          "default": -1,
-          "description": "DGCA preview: scope to a goal-level cap. Show only goals at this level and above, plus their connected drivers/changes/activities. -1 = no cap. Ignored when a scope root id is set."
-        },
-        "transitrix.scope.dga.rootId": {
+        "transitrix.scope.dgca.goalId": {
           "type": "string",
           "default": "",
-          "description": "DGA preview: scope to a single goal. Set the goal id to show only that goal plus the drivers/activities connected to it. Empty = show all. Takes precedence over the level cap."
+          "description": "DGCA preview: show only chains through this goal. Empty = all goals."
         },
-        "transitrix.scope.dga.maxLevel": {
-          "type": "integer",
-          "minimum": -1,
-          "default": -1,
-          "description": "DGA preview: scope to a goal-level cap. Show only goals at this level and above, plus their connected drivers/activities. -1 = no cap. Ignored when a scope root id is set."
+        "transitrix.scope.dgca.changeId": {
+          "type": "string",
+          "default": "",
+          "description": "DGCA preview: show only chains through this change. Empty = all changes."
+        },
+        "transitrix.scope.dgca.activityId": {
+          "type": "string",
+          "default": "",
+          "description": "DGCA preview: show only chains through this action. Empty = all actions."
+        },
+        "transitrix.scope.dga.driverId": {
+          "type": "string",
+          "default": "",
+          "description": "DGA preview: show only chains through this driver. Empty = all drivers."
+        },
+        "transitrix.scope.dga.goalId": {
+          "type": "string",
+          "default": "",
+          "description": "DGA preview: show only chains through this goal. Empty = all goals."
+        },
+        "transitrix.scope.dga.activityId": {
+          "type": "string",
+          "default": "",
+          "description": "DGA preview: show only chains through this action. Empty = all actions."
         },
         "transitrix.view.dgca": {
           "type": "string",

--- a/extension/src/dgca-preview.ts
+++ b/extension/src/dgca-preview.ts
@@ -9,17 +9,19 @@ import { parseCanonicalFGCA, parseCanonicalFGA } from '@transitrix/diagrams/fgca
 import { resolveFGCA, isFGCAViewDoc } from '@transitrix/diagrams/fgca/resolver.js';
 import {
   layoutFGCAPreview,
+  chainColumnOptions,
   FGCA_PAD as PAD,
   FGCA_DEFAULT_COL_GAP,
   FGCA_DEFAULT_ROW_GAP,
+  type FGCAPreviewDoc,
 } from '@transitrix/diagrams/fgca/preview-layout.js';
-import { DEFAULT_EDGE_CURVATURE } from '@transitrix/diagrams/edge-path.js';
+import { DEFAULT_EDGE_CURVATURE, type EdgeStyle } from '@transitrix/diagrams/edge-path.js';
 import { renderFgcaBody } from '@transitrix/diagrams/webview/render-fgca.js';
 import { buildChainTable, type ChainTable, type ChainColumn } from '@transitrix/diagrams/fgca/chain-table.js';
 import { coerceDatesToIsoStrings } from '@transitrix/diagrams/yaml-normalize.js';
-import { checkScopeRoot, type Scope } from '@transitrix/diagrams/scope.js';
+import { checkChainScope, type FgcaScope } from '@transitrix/diagrams/scope.js';
 import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
-import { readSpacing, readCurvature, readEntryCurvature, readScope, readView, applyControlMessage, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND } from './spacing-config.js';
+import { readSpacing, readCurvature, readEntryCurvature, readEdgeStyle, readScope, readChainScope, readView, applyControlMessage, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND } from './spacing-config.js';
 import { readDgcaNodeSize, readNodeSizePreset } from './node-size-config.js';
 import { genNonce, buildControlsPanel, buildControlsScript, buildViewToggle, buildCaptureButton, buildTimelineStrip, type ControlsModel, type ScopeGoalOption, type SnapshotMarker, type SnapshotMessage } from './preview-controls.js';
 import { snapshotFilename, buildSnapshotContent, extractViewMeta, listSnapshotFiles, parseSnapshotForDisplay } from './snapshot-writer.js';
@@ -56,12 +58,66 @@ interface FGCADoc {
 // the column header labels.
 
 // ── SVG renderer ──────────────────────────────────────────────────────────────
-/** Goal options + deepest level for the scope control, from a parsed doc. FGCA
- *  and FGA goals are flat, so a `root` scope is the single matching goal. */
-function scopeInputsFromDoc(doc: FGCADoc): { goals: ScopeGoalOption[]; maxLevelPresent: number } {
+function asPreviewDoc(doc: FGCADoc): FGCAPreviewDoc {
   return {
-    goals: doc.goals.map(g => ({ id: String(g.id), name: g.name ?? '' })),
-    maxLevelPresent: doc.goals.reduce((m, g) => Math.max(m, typeof g.level === 'number' ? g.level : 0), 0),
+    factors: doc.factors,
+    goals: doc.goals,
+    changes: doc.changes,
+    activities: doc.activities,
+  };
+}
+
+function chainScopeOptions(doc: FGCAPreviewDoc, viewNotation: 'dgca' | 'dga', hideChanges: boolean): {
+  drivers: ScopeGoalOption[];
+  goals: ScopeGoalOption[];
+  changes: ScopeGoalOption[];
+  activities: ScopeGoalOption[];
+} {
+  const chain = readChainScope(viewNotation);
+  return {
+    drivers: chainColumnOptions(doc, chain, 'driverId', hideChanges),
+    goals: chainColumnOptions(doc, chain, 'goalId', hideChanges),
+    changes: chainColumnOptions(doc, chain, 'changeId', hideChanges),
+    activities: chainColumnOptions(doc, chain, 'activityId', hideChanges),
+  };
+}
+
+/** Assembles the interactive control-panel model shared by DGCA and DGA. */
+function chainControlsModel(
+  gaps: { horizontalGap: number; verticalGap: number },
+  defaults: { horizontalGap: number; verticalGap: number },
+  curvature: number,
+  viewNotation: 'dgca' | 'dga',
+  hideChanges: boolean,
+  columnOptions: {
+    drivers: ScopeGoalOption[];
+    goals: ScopeGoalOption[];
+    changes: ScopeGoalOption[];
+    activities: ScopeGoalOption[];
+  },
+  edgeStyle: EdgeStyle,
+): ControlsModel {
+  const nodeSizePreset = readNodeSizePreset(viewNotation);
+  const chain = readChainScope(viewNotation);
+  return {
+    spacing: { ...gaps, defaults },
+    curvature: { value: curvature, default: 1 },
+    edgeStyle: { value: edgeStyle, default: 'bezier' },
+    nodeSize: { value: nodeSizePreset, default: 'normal' },
+    scope: {
+      rootId: '',
+      maxLevel: -1,
+      maxLevelPresent: 0,
+      goals: [],
+      chain: {
+        hideChanges,
+        driverId: chain.driverId ?? '',
+        goalId: chain.goalId ?? '',
+        changeId: chain.changeId ?? '',
+        activityId: chain.activityId ?? '',
+        ...columnOptions,
+      },
+    },
   };
 }
 
@@ -100,30 +156,6 @@ function chainTableHtml(table: ChainTable): string {
     return `<tr>${cells}</tr>`;
   }).join('\n');
   return `<div class="chain-table-wrap"><table class="chain-table"><thead>${head}</thead><tbody>${body}</tbody></table></div>`;
-}
-
-/** Assembles the interactive control-panel model shared by DGCA and DGA. */
-function chainControlsModel(
-  gaps: { horizontalGap: number; verticalGap: number },
-  defaults: { horizontalGap: number; verticalGap: number },
-  curvature: number,
-  scope: Scope,
-  goals: ScopeGoalOption[],
-  maxLevelPresent: number,
-  viewNotation: 'dgca' | 'dga',
-): ControlsModel {
-  const nodeSizePreset = readNodeSizePreset(viewNotation);
-  return {
-    spacing: { ...gaps, defaults },
-    curvature: { value: curvature, default: 1 },
-    nodeSize: { value: nodeSizePreset, default: 'normal' },
-    scope: {
-      rootId: scope.mode === 'root' ? scope.rootGoalId : '',
-      maxLevel: scope.mode === 'level' ? scope.maxLevel : -1,
-      maxLevelPresent,
-      goals,
-    },
-  };
 }
 
 interface ChainPreviewParams {
@@ -193,17 +225,24 @@ function renderChainPreview(
   const scope = readScope(p.viewNotation);
   const curvature = readCurvature(p.viewNotation);
   const entryCurvature = readEntryCurvature(p.viewNotation);
+  const edgeStyle = readEdgeStyle(p.viewNotation);
   const warnings = [...baseWarnings];
   let svg = '';
-  let goalOptions: ScopeGoalOption[] = [];
-  let maxLevelPresent = 0;
+  let columnOptions = { drivers: [] as ScopeGoalOption[], goals: [] as ScopeGoalOption[], changes: [] as ScopeGoalOption[], activities: [] as ScopeGoalOption[] };
   if (parsedDoc) {
-    ({ goals: goalOptions, maxLevelPresent } = scopeInputsFromDoc(parsedDoc));
-    const scopeWarning = checkScopeRoot(scope, parsedDoc.goals.map(g => g.id));
+    const previewDoc = asPreviewDoc(parsedDoc);
+    columnOptions = chainScopeOptions(previewDoc, p.viewNotation, p.hideChanges);
+    const chain = readChainScope(p.viewNotation);
+    const scopeWarning = checkChainScope(chain, {
+      drivers: parsedDoc.factors.map(f => f.id),
+      goals: parsedDoc.goals.map(g => g.id),
+      changes: (parsedDoc.changes ?? []).map(c => c.id),
+      activities: parsedDoc.activities.map(a => a.id),
+    }, p.hideChanges);
     if (scopeWarning) warnings.push(`${scopeWarning.code}: ${scopeWarning.message}`);
-    svg = buildSvg(parsedDoc, p.hideChanges, { colGap: gaps.horizontalGap, rowGap: gaps.verticalGap, curvature, entryCurvature, scope, nodeSize: readDgcaNodeSize(p.viewNotation) }, p.heading, filename, docDate, docVersion);
+    svg = buildSvg(parsedDoc, p.hideChanges, { colGap: gaps.horizontalGap, rowGap: gaps.verticalGap, curvature, entryCurvature, edgeStyle, scope, nodeSize: readDgcaNodeSize(p.viewNotation) }, p.heading, filename, docDate, docVersion);
   }
-  const model = chainControlsModel(gaps, spacingDefaults, curvature, scope, goalOptions, maxLevelPresent, p.viewNotation);
+  const model = chainControlsModel(gaps, spacingDefaults, curvature, p.viewNotation, p.hideChanges, columnOptions, edgeStyle);
   const html = buildDiagramFrame({
     filename, notation: p.notation, svgContent: svg, errorMsg, warnings, themeId,
     saveSvgCommand: p.saveSvgCommand,
@@ -222,7 +261,7 @@ function renderChainPreview(
 function buildSvg(
   doc: FGCADoc,
   hideChanges = false,
-  opts: { colGap?: number; rowGap?: number; curvature?: number; entryCurvature?: number; scope?: Scope; nodeSize?: { width: number; height: number } } = {},
+  opts: { colGap?: number; rowGap?: number; curvature?: number; entryCurvature?: number; edgeStyle?: EdgeStyle; scope?: FgcaScope; nodeSize?: { width: number; height: number } } = {},
   heading?: string,
   filename?: string,
   date?: string,
@@ -245,6 +284,7 @@ function buildSvg(
   const body = renderFgcaBody(columns, nodes, edges, curvature, entryCurvature, {
     nodeWidth: nodeSize.width,
     nodeHeight: nodeSize.height,
+    edgeStyle: opts.edgeStyle,
   });
 
   const totalH = height + titleH;
@@ -271,6 +311,8 @@ export class DGCAPreview {
   private panel: vscode.WebviewPanel | undefined;
   private trackedUri: string | undefined;
   private lastSvg = '';
+  private lastPreviewDoc: FGCAPreviewDoc | null = null;
+  private lastHideChanges = false;
 
   constructor(private readonly extensionUri: vscode.Uri) {}
 
@@ -298,7 +340,11 @@ export class DGCAPreview {
         },
       );
       this.panel.webview.onDidReceiveMessage(async (m) => {
-        if (m.type === 'transitrix:control') { void applyControlMessage('dgca', m); }
+        if (m.type === 'transitrix:control') {
+          void applyControlMessage('dgca', m, this.lastPreviewDoc
+            ? { doc: this.lastPreviewDoc, hideChanges: this.lastHideChanges }
+            : undefined);
+        }
         if (m.type === 'transitrix:snapshot') { await this.handleSnapshotMessage(m as SnapshotMessage); }
       });
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
@@ -448,6 +494,8 @@ export class DGCAPreview {
       },
       parsedDoc, warnings, errorMsg, docVersion, docDate, filename, themeId,
     );
+    this.lastPreviewDoc = parsedDoc ? asPreviewDoc(parsedDoc) : null;
+    this.lastHideChanges = parsedDoc?.hideChanges === true;
     this.lastSvg = svg;
     return html;
   }
@@ -498,6 +546,8 @@ export class DGAPreview {
   private panel: vscode.WebviewPanel | undefined;
   private trackedUri: string | undefined;
   private lastSvg = '';
+  private lastPreviewDoc: FGCAPreviewDoc | null = null;
+  private lastHideChanges = true;
 
   constructor(private readonly extensionUri: vscode.Uri) {}
 
@@ -525,7 +575,11 @@ export class DGAPreview {
         },
       );
       this.panel.webview.onDidReceiveMessage(async (m) => {
-        if (m.type === 'transitrix:control') { void applyControlMessage('dga', m); }
+        if (m.type === 'transitrix:control') {
+          void applyControlMessage('dga', m, this.lastPreviewDoc
+            ? { doc: this.lastPreviewDoc, hideChanges: this.lastHideChanges }
+            : undefined);
+        }
         if (m.type === 'transitrix:snapshot') { await this.handleSnapshotMessage(m as SnapshotMessage); }
       });
       this.panel.onDidDispose(() => { this.panel = undefined; this.trackedUri = undefined; });
@@ -659,6 +713,8 @@ export class DGAPreview {
       },
       parsedDoc, warnings, errorMsg, docVersion, docDate, filename, themeId,
     );
+    this.lastPreviewDoc = parsedDoc ? asPreviewDoc(parsedDoc) : null;
+    this.lastHideChanges = true;
     this.lastSvg = svg;
     return html;
   }

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -40,6 +40,7 @@ import {
   OPEN_SCOPE_SETTINGS_COMMAND,
   SCOPE_CONFIG_SECTION,
   VIEW_CONFIG_SECTION,
+  EDGE_STYLE_CONFIG_SECTION,
 } from './spacing-config.js';
 import { OPEN_THEME_COMMAND } from './diagram-frame.js';
 import {
@@ -540,7 +541,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void |
         !e.affectsConfiguration(ENTRY_CURVATURE_CONFIG_SECTION) &&
         !e.affectsConfiguration(SCOPE_CONFIG_SECTION) &&
         !e.affectsConfiguration(VIEW_CONFIG_SECTION) &&
-        !e.affectsConfiguration(NODE_SIZE_CONFIG_SECTION)
+        !e.affectsConfiguration(NODE_SIZE_CONFIG_SECTION) &&
+        !e.affectsConfiguration(EDGE_STYLE_CONFIG_SECTION)
       ) return;
       void goalsPreview.refreshConfig();
       void dgcaPreview.refreshConfig();

--- a/extension/src/goals-preview.ts
+++ b/extension/src/goals-preview.ts
@@ -14,9 +14,9 @@ import { renderGoalsLayoutSvg } from '@transitrix/diagrams/webview/render-goals.
 import { parseCanonicalGoals } from '@transitrix/diagrams/goals/parse-canonical.js';
 import { coerceDatesToIsoStrings } from '@transitrix/diagrams/yaml-normalize.js';
 import { loadCanon, findCanonRoot, isUnderCanon, type CanonDocs } from './canon-loader.js';
-import { DEFAULT_EDGE_CURVATURE } from '@transitrix/diagrams/edge-path.js';
+import { DEFAULT_EDGE_CURVATURE, type EdgeStyle } from '@transitrix/diagrams/edge-path.js';
 import { checkScopeRoot } from '@transitrix/diagrams/scope.js';
-import { readSpacing, readCurvature, readEntryCurvature, readScope, applyControlMessage, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND, OPEN_NODE_SIZE_SETTINGS_COMMAND } from './spacing-config.js';
+import { readSpacing, readCurvature, readEntryCurvature, readEdgeStyle, readScope, applyControlMessage, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND, OPEN_NODE_SIZE_SETTINGS_COMMAND } from './spacing-config.js';
 import { readGoalsNodeSize, readNodeSizePreset } from './node-size-config.js';
 import { genNonce, buildControlsPanel, buildControlsScript, type ControlsModel, type ScopeGoalOption } from './preview-controls.js';
 
@@ -31,7 +31,7 @@ import { genNonce, buildControlsPanel, buildControlsScript, type ControlsModel, 
 const RANK_SEP = 100;
 const NODE_SEP = 24;
 
-function layoutToSvg(layout: GoalTreeLayout, treeName: string, filename?: string, date?: string, version?: string, curvature: number = DEFAULT_EDGE_CURVATURE, entryCurvature?: number): string {
+function layoutToSvg(layout: GoalTreeLayout, treeName: string, filename?: string, date?: string, version?: string, curvature: number = DEFAULT_EDGE_CURVATURE, entryCurvature?: number, edgeStyle?: EdgeStyle): string {
   // The SVG body (nodes, edges, arrow marker, edge geometry) comes from the
   // shared @transitrix/diagrams goals renderer — the single emitter for every
   // host. This preview only reserves room for and stacks its rich title block
@@ -44,6 +44,7 @@ function layoutToSvg(layout: GoalTreeLayout, treeName: string, filename?: string
   return renderGoalsLayoutSvg(layout, {
     curvature,
     entryCurvature,
+    edgeStyle,
     topInset: showTitle ? TITLE_BLOCK_H : 0,
     title,
   });
@@ -147,6 +148,7 @@ export class GoalsPreview {
     const scope = readScope('goals');
     const curvature = readCurvature('goals');
     const entryCurvature = readEntryCurvature('goals');
+    const edgeStyle = readEdgeStyle('goals');
     // Populated on a successful parse — feeds the scope root-picker dropdown
     // and the level-cap upper bound in the interactive control panel.
     let goalOptions: ScopeGoalOption[] = [];
@@ -180,7 +182,7 @@ export class GoalsPreview {
           nodeSep: gaps.verticalGap,
           scope,
         });
-        svgContent = layoutToSvg(layout, treeName, filename, docDate, docVersion, curvature, entryCurvature);
+        svgContent = layoutToSvg(layout, treeName, filename, docDate, docVersion, curvature, entryCurvature, edgeStyle);
       }
     } catch (e) {
       errorMsg = (e as Error).message ?? 'Parse error';
@@ -197,6 +199,7 @@ export class GoalsPreview {
     const model: ControlsModel = {
       spacing: { ...gaps, defaults: spacingDefaults },
       curvature: { value: curvature, default: 1 },
+      edgeStyle: { value: edgeStyle, default: 'bezier' },
       nodeSize: { value: nodeSizePreset, default: 'normal' },
       scope: {
         rootId: scope.mode === 'root' ? scope.rootGoalId : '',

--- a/extension/src/preview-controls.ts
+++ b/extension/src/preview-controls.ts
@@ -44,6 +44,13 @@ export interface CurvatureControlModel {
   default: number;
 }
 
+export type EdgeStyleValue = 'straight' | 'bezier' | 'polyline';
+
+export interface EdgeStyleControlModel {
+  value: EdgeStyleValue;
+  default: EdgeStyleValue;
+}
+
 export interface ScopeControlModel {
   /** Current root id ('' when no root scope is active). */
   rootId: string;
@@ -53,6 +60,21 @@ export interface ScopeControlModel {
   maxLevelPresent: number;
   /** All goals in the document, for the root-picker dropdown. */
   goals: ScopeGoalOption[];
+  /**
+   * DGCA/DGA per-column filters. When set, the panel renders D/G/C/A
+   * selectors instead of Root + Level. DGA sets hideChanges to omit C.
+   */
+  chain?: {
+    hideChanges: boolean;
+    driverId: string;
+    goalId: string;
+    changeId: string;
+    activityId: string;
+    drivers: ScopeGoalOption[];
+    goals: ScopeGoalOption[];
+    changes: ScopeGoalOption[];
+    activities: ScopeGoalOption[];
+  };
 }
 
 export type NodeSizePresetValue = 'compact' | 'normal' | 'wide';
@@ -66,6 +88,8 @@ export interface NodeSizeControlModel {
 export interface ControlsModel {
   spacing: SpacingControlModel;
   curvature: CurvatureControlModel;
+  /** Goals / DGCA / DGA. Omitted for Action, which keeps the curvature slider only. */
+  edgeStyle?: EdgeStyleControlModel;
   /** Omitted for notations without a scope filter (Activities). */
   scope?: ScopeControlModel;
   /** Omitted when the notation has no block-size preset (yet). */
@@ -75,10 +99,10 @@ export interface ControlsModel {
 /** Message posted from the webview to the host on every control change. */
 export interface ControlMessage {
   type: 'transitrix:control';
-  control: 'spacing' | 'curvature' | 'entryCurvature' | 'scope' | 'view' | 'nodeSize';
-  /** spacing: 'horizontalGap'|'verticalGap'; scope: 'rootId'|'maxLevel'|'reset'; view: 'tree'|'table'; nodeSize: 'preset'; absent for curvature. */
-  field?: 'horizontalGap' | 'verticalGap' | 'rootId' | 'maxLevel' | 'reset' | 'tree' | 'table' | 'preset';
-  /** Numeric for spacing/curvature/maxLevel; string for rootId; absent for reset/view. */
+  control: 'spacing' | 'curvature' | 'entryCurvature' | 'scope' | 'view' | 'nodeSize' | 'edgeStyle';
+  /** spacing: 'horizontalGap'|'verticalGap'; scope: 'rootId'|'maxLevel'|'driverId'|'goalId'|'changeId'|'activityId'|'reset'; view: 'tree'|'table'; nodeSize: 'preset'; absent for curvature. */
+  field?: 'horizontalGap' | 'verticalGap' | 'rootId' | 'maxLevel' | 'driverId' | 'goalId' | 'changeId' | 'activityId' | 'reset' | 'tree' | 'table' | 'preset';
+  /** Numeric for spacing/curvature/maxLevel; string for rootId / chain ids; absent for reset/view. */
   value?: number | string;
 }
 
@@ -245,7 +269,12 @@ function hasNonDefault(model: ControlsModel): boolean {
   const s = model.spacing;
   if (s.horizontalGap !== s.defaults.horizontalGap || s.verticalGap !== s.defaults.verticalGap) return true;
   if (model.curvature.value !== model.curvature.default) return true;
+  if (model.edgeStyle && model.edgeStyle.value !== model.edgeStyle.default) return true;
   if (model.nodeSize && model.nodeSize.value !== model.nodeSize.default) return true;
+  if (model.scope?.chain) {
+    const c = model.scope.chain;
+    if (c.driverId !== '' || c.goalId !== '' || c.changeId !== '' || c.activityId !== '') return true;
+  }
   if (model.scope && (model.scope.rootId !== '' || model.scope.maxLevel >= 0)) return true;
   return false;
 }
@@ -264,23 +293,59 @@ function spacingRow(s: SpacingControlModel): string {
   </div>`;
 }
 
-function curvatureRow(c: CurvatureControlModel): string {
+function curvatureRow(c: CurvatureControlModel, style?: EdgeStyleControlModel): string {
+  const opt = (value: EdgeStyleValue, label: string): string =>
+    `<option value="${value}"${style && style.value === value ? ' selected' : ''}>${label}</option>`;
+  const styleSelect = style
+    ? `<label title="Arrow path: straight chord, cubic Bezier, or orthogonal polyline">
+      <select data-tx-control="edgeStyle">${opt('straight', 'Straight')}${opt('bezier', 'Bezier')}${opt('polyline', 'Polyline')}</select>
+    </label>`
+    : '';
+  const showSlider = !style || style.value === 'bezier';
+  const slider = showSlider
+    ? `<input type="range" data-tx-control="curvature" data-tx-event="input" data-tx-output="tx-curv-out"
+        min="${CURVATURE_MIN}" max="${CURVATURE_MAX}" step="${CURVATURE_STEP}" value="${c.value}">
+    <output id="tx-curv-out">${c.value}</output>`
+    : '';
   return `<div class="tx-ctl-row">
-    <span class="tx-ctl-label">Curvature</span>
-    <input type="range" data-tx-control="curvature" data-tx-event="input" data-tx-output="tx-curv-out"
-      min="${CURVATURE_MIN}" max="${CURVATURE_MAX}" step="${CURVATURE_STEP}" value="${c.value}">
-    <output id="tx-curv-out">${c.value}</output>
+    <span class="tx-ctl-label">${style ? 'Arrows' : 'Curvature'}</span>
+    ${styleSelect}
+    ${slider}
   </div>`;
 }
 
-function scopeRow(sc: ScopeControlModel): string {
-  const options = [`<option value="">— All goals —</option>`]
-    .concat(sc.goals.map(g => {
-      const selected = g.id === sc.rootId ? ' selected' : '';
+function scopeOptionList(items: ScopeGoalOption[], selectedId: string, allLabel: string): string {
+  return [`<option value="">${escXml(allLabel)}</option>`]
+    .concat(items.map(g => {
+      const selected = g.id === selectedId ? ' selected' : '';
       const label = g.name && g.name.trim() ? `${g.name} (${g.id})` : g.id;
       return `<option value="${escXml(g.id)}"${selected}>${escXml(label)}</option>`;
     }))
     .join('');
+}
+
+function chainScopeRow(ch: NonNullable<ScopeControlModel['chain']>): string {
+  const sel = (letter: string, field: string, title: string, items: ScopeGoalOption[], id: string): string =>
+    `<label title="${escXml(title)}">${letter}
+      <select data-tx-control="scope" data-tx-field="${field}">${scopeOptionList(items, id, '— All —')}</select></label>`;
+  const parts = [
+    sel('D', 'driverId', 'Show only chains through this driver', ch.drivers, ch.driverId),
+    sel('G', 'goalId', 'Show only chains through this goal', ch.goals, ch.goalId),
+  ];
+  if (!ch.hideChanges) {
+    parts.push(sel('C', 'changeId', 'Show only chains through this change', ch.changes, ch.changeId));
+  }
+  parts.push(sel('A', 'activityId', 'Show only chains through this action', ch.activities, ch.activityId));
+  return `<div class="tx-ctl-row">
+    <span class="tx-ctl-label">Scope</span>
+    ${parts.join('\n    ')}
+    <button type="button" data-tx-control="scope" data-tx-field="reset" title="Clear scope — show everything">Reset</button>
+  </div>`;
+}
+
+function scopeRow(sc: ScopeControlModel): string {
+  if (sc.chain) return chainScopeRow(sc.chain);
+  const options = scopeOptionList(sc.goals, sc.rootId, '— All goals —');
   // Level input is bounded to the document's deepest level. When the document
   // has no level information (maxLevelPresent <= 0) the cap can't trim anything,
   // so the input is disabled with a hint.
@@ -311,7 +376,7 @@ function nodeSizeRow(ns: NodeSizeControlModel): string {
 /** Builds the `<details>` control-panel markup for a notation's interactive preview. */
 export function buildControlsPanel(model: ControlsModel): string {
   const open = hasNonDefault(model) ? ' open' : '';
-  const rows = [spacingRow(model.spacing), curvatureRow(model.curvature)];
+  const rows = [spacingRow(model.spacing), curvatureRow(model.curvature, model.edgeStyle)];
   if (model.nodeSize) rows.push(nodeSizeRow(model.nodeSize));
   if (model.scope) rows.push(scopeRow(model.scope));
   return `<details id="tx-ctl" class="tx-ctl"${open}>
@@ -379,6 +444,10 @@ export function buildControlsScript(nonce: string): string {
           if (el.value === '') { post(control, 'reset'); return; }
           var root = sel('scope', 'rootId'); if (root) root.value = '';
           post(control, field, num(el.value));
+        } else if (control === 'scope' && (field === 'driverId' || field === 'goalId' || field === 'changeId' || field === 'activityId')) {
+          post(control, field, el.value);
+        } else if (control === 'edgeStyle') {
+          post(control, undefined, el.value);
         } else if (control === 'curvature') {
           post(control, undefined, num(el.value));
         } else if (control === 'nodeSize') {

--- a/extension/src/spacing-config.ts
+++ b/extension/src/spacing-config.ts
@@ -2,7 +2,10 @@ import * as vscode from 'vscode';
 import {
   parseNodeSizePreset,
 } from '@transitrix/diagrams/node-size-presets.js';
-import type { Scope } from '@transitrix/diagrams/scope.js';
+import type { ChainColumnKey, ChainScope, FgcaScope, Scope } from '@transitrix/diagrams/scope.js';
+import { chainScopeActive } from '@transitrix/diagrams/scope.js';
+import { sanitizeChainScope, type FGCAPreviewDoc } from '@transitrix/diagrams/fgca/preview-layout.js';
+import { parseEdgeStyle, type EdgeStyle } from '@transitrix/diagrams/edge-path.js';
 import type { ControlMessage, PreviewView } from './preview-controls.js';
 
 // Per-notation spacing controls. PR1 persists the
@@ -57,6 +60,15 @@ export const CURVATURE_CONFIG_SECTION = 'transitrix.curvature';
 /** Command that opens Settings filtered to the curvature controls. */
 export const OPEN_CURVATURE_SETTINGS_COMMAND = 'transitrixStudio.openCurvatureSettings';
 
+export type EdgeStyleNotation = 'goals' | 'dgca' | 'dga';
+
+/** Reads the persisted arrow path style. Defaults to bezier (historical cubic). */
+export function readEdgeStyle(notation: EdgeStyleNotation): EdgeStyle {
+  return parseEdgeStyle(vscode.workspace.getConfiguration('transitrix').get<string>(`edgeStyle.${notation}`));
+}
+
+export const EDGE_STYLE_CONFIG_SECTION = 'transitrix.edgeStyle';
+
 // Must match DEFAULT_EDGE_CURVATURE so an unconfigured preview is visually unchanged.
 const DEFAULT_ENTRY_CURVATURE = 1;
 
@@ -70,24 +82,81 @@ export const ENTRY_CURVATURE_CONFIG_SECTION = 'transitrix.entryCurvature';
 
 // ── Scope filter ──────────────────────────────────────────────
 //
-// Trim a preview to a subtree root or a level cap. Same PR1 persistence
-// pattern as spacing: settings-backed, re-rendered on change. The in-preview
-// root-picker dropdown is deferred to the joint enableScripts PR2.
+// Trim a preview to a subtree / level cap (Goals) or per-column chain
+// filters (DGCA/DGA). Settings-backed; in-preview dropdowns write the same keys.
 
 export type ScopeNotation = 'goals' | 'dgca' | 'dga';
+export type ChainScopeNotation = 'dgca' | 'dga';
+
+function trimSetting(v: string | undefined): string {
+  return (v ?? '').trim();
+}
+
+function isChainNotation(notation: string): notation is ChainScopeNotation {
+  return notation === 'dgca' || notation === 'dga';
+}
+
+function isChainField(field: string | undefined): field is ChainColumnKey {
+  return field === 'driverId' || field === 'goalId' || field === 'changeId' || field === 'activityId';
+}
 
 /**
- * Resolves the configured scope for a notation. A non-empty `rootId` wins over
- * a `maxLevel` cap (the two settings model the "only one mode active at a time"
- * rule from #77); both unset → 'all'.
+ * Resolves the configured scope for a notation.
+ * Goals: a non-empty `rootId` wins over a `maxLevel` cap; both unset → 'all'.
+ * DGCA/DGA: per-column chain filters (Driver / Goal / Change / Action).
+ * A leftover `rootId` is read as `goalId` when the new goalId setting is empty.
  */
-export function readScope(notation: ScopeNotation): Scope {
+export function readScope(notation: 'goals'): Scope;
+export function readScope(notation: ChainScopeNotation): FgcaScope;
+export function readScope(notation: ScopeNotation): FgcaScope {
+  if (isChainNotation(notation)) {
+    const chain = readChainScope(notation);
+    return chainScopeActive(chain) ? chain : { mode: 'all' };
+  }
   const cfg = vscode.workspace.getConfiguration('transitrix');
-  const rootId = (cfg.get<string>(`scope.${notation}.rootId`, '') ?? '').trim();
+  const rootId = trimSetting(cfg.get<string>(`scope.${notation}.rootId`, ''));
   if (rootId) return { mode: 'root', rootGoalId: rootId };
   const maxLevel = cfg.get<number>(`scope.${notation}.maxLevel`, -1);
   if (typeof maxLevel === 'number' && maxLevel >= 0) return { mode: 'level', maxLevel };
   return { mode: 'all' };
+}
+
+/** Reads the four DGCA/DGA column filters. Empty strings are omitted. */
+export function readChainScope(notation: ChainScopeNotation): ChainScope {
+  const cfg = vscode.workspace.getConfiguration('transitrix');
+  const driverId = trimSetting(cfg.get<string>(`scope.${notation}.driverId`, ''));
+  let goalId = trimSetting(cfg.get<string>(`scope.${notation}.goalId`, ''));
+  if (!goalId) goalId = trimSetting(cfg.get<string>(`scope.${notation}.rootId`, ''));
+  const changeId = notation === 'dga' ? '' : trimSetting(cfg.get<string>(`scope.${notation}.changeId`, ''));
+  const activityId = trimSetting(cfg.get<string>(`scope.${notation}.activityId`, ''));
+  return {
+    mode: 'chain',
+    driverId: driverId || undefined,
+    goalId: goalId || undefined,
+    changeId: changeId || undefined,
+    activityId: activityId || undefined,
+  };
+}
+
+export type ChainSanitizeContext = {
+  doc: FGCAPreviewDoc;
+  hideChanges: boolean;
+};
+
+async function writeChainScope(
+  notation: ChainScopeNotation,
+  scope: ChainScope,
+  target: vscode.ConfigurationTarget,
+): Promise<void> {
+  const cfg = vscode.workspace.getConfiguration('transitrix');
+  await Promise.all([
+    cfg.update(`scope.${notation}.driverId`, scope.driverId ?? '', target),
+    cfg.update(`scope.${notation}.goalId`, scope.goalId ?? '', target),
+    cfg.update(`scope.${notation}.changeId`, notation === 'dga' ? '' : (scope.changeId ?? ''), target),
+    cfg.update(`scope.${notation}.activityId`, scope.activityId ?? '', target),
+    cfg.update(`scope.${notation}.rootId`, '', target),
+    cfg.update(`scope.${notation}.maxLevel`, -1, target),
+  ]);
 }
 
 /** Config section that, when changed, re-renders scope-aware previews. */
@@ -133,11 +202,17 @@ function clamp(n: number, min: number, max: number): number {
 /**
  * Applies one in-preview control change to VS Code configuration for `notation`.
  * Spacing/curvature apply to all four notations; scope only to goals/dgca/dga
- * (the Action panel never renders a scope row). Scope is mutually exclusive
- * — setting a root clears the level cap and vice-versa, matching `readScope`'s
- * "one mode at a time" precedence and #77's AC.
+ * (the Action panel never renders a scope row).
+ *
+ * Goals: root and level are mutually exclusive.
+ * DGCA/DGA: column filters AND together; `chainSanitize` drops neighbours
+ * that the last pick made unreachable so dropdowns stay on one thread.
  */
-export async function applyControlMessage(notation: SpacingNotation, msg: ControlMessage): Promise<void> {
+export async function applyControlMessage(
+  notation: SpacingNotation,
+  msg: ControlMessage,
+  chainSanitize?: ChainSanitizeContext,
+): Promise<void> {
   if (!msg || msg.type !== 'transitrix:control') return;
   const cfg = vscode.workspace.getConfiguration('transitrix');
   const target = vscode.ConfigurationTarget.Global;
@@ -148,6 +223,10 @@ export async function applyControlMessage(notation: SpacingNotation, msg: Contro
   }
   if (msg.control === 'curvature') {
     await cfg.update(`curvature.${notation}`, clamp(Number(msg.value), 0, 3), target);
+    return;
+  }
+  if (msg.control === 'edgeStyle' && (notation === 'goals' || notation === 'dgca' || notation === 'dga')) {
+    await cfg.update(`edgeStyle.${notation}`, parseEdgeStyle(msg.value), target);
     return;
   }
   if (msg.control === 'entryCurvature') {
@@ -161,6 +240,28 @@ export async function applyControlMessage(notation: SpacingNotation, msg: Contro
   if (msg.control === 'nodeSize') {
     const preset = parseNodeSizePreset(String(msg.value ?? 'normal'));
     await cfg.update(`nodeSize.${notation}`, preset, target);
+    return;
+  }
+  if (msg.control === 'scope' && isChainNotation(notation)) {
+    if (msg.field === 'reset') {
+      await writeChainScope(notation, { mode: 'chain' }, target);
+      return;
+    }
+    const field: ChainColumnKey | undefined =
+      msg.field === 'rootId' ? 'goalId' : isChainField(msg.field) ? msg.field : undefined;
+    if (!field) return;
+    const next: ChainScope = {
+      ...readChainScope(notation),
+      [field]: String(msg.value ?? '').trim() || undefined,
+    };
+    if (notation === 'dga') next.changeId = undefined;
+    const cleaned = chainSanitize
+      ? sanitizeChainScope(chainSanitize.doc, next, {
+          justChanged: field,
+          hideChanges: chainSanitize.hideChanges,
+        })
+      : next;
+    await writeChainScope(notation, cleaned, target);
     return;
   }
   if (msg.control === 'scope' && notation !== 'action' && notation !== 'blocks' && notation !== 'processBlueprint') {

--- a/packages/diagrams/src/__tests__/edge-path.test.ts
+++ b/packages/diagrams/src/__tests__/edge-path.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { horizontalCubicEdgePath, bowedCubicEdgePath, EDGE_MIN_HANDLE } from '../edge-path.js';
+import { horizontalCubicEdgePath, bowedCubicEdgePath, previewEdgePath, parseEdgeStyle, EDGE_MIN_HANDLE } from '../edge-path.js';
 
 /** Point at parameter `t` on cubic `P0 C P1 P2 P3` (`d` in `M.. C..`/coords form). */
 function cubicPointAt(
@@ -77,6 +77,34 @@ describe('horizontalCubicEdgePath', () => {
     // S-bow. Capped at 160, the control points stay close to the endpoints.
     const d = horizontalCubicEdgePath(0, 0, 80, 500, 1);
     expect(d).toBe('M0,0 C160,0 -80,500 80,500');
+  });
+});
+
+describe('previewEdgePath', () => {
+  it('straight is a single line', () => {
+    expect(previewEdgePath(0, 10, 80, 40, 'straight')).toBe('M0,10 L80,40');
+  });
+
+  it('polyline is an orthogonal H-V-H elbow', () => {
+    expect(previewEdgePath(0, 10, 80, 40, 'polyline')).toBe('M0,10 H40 V40 H80');
+  });
+
+  it('bezier matches the historical cubic', () => {
+    expect(previewEdgePath(0, 0, 40, 0, 'bezier', 1)).toBe(horizontalCubicEdgePath(0, 0, 40, 0, 1));
+  });
+
+  it('unknown style falls back to bezier', () => {
+    expect(previewEdgePath(0, 0, 40, 0, 'bezier')).toBe(horizontalCubicEdgePath(0, 0, 40, 0));
+  });
+});
+
+describe('parseEdgeStyle', () => {
+  it('accepts the three styles and defaults otherwise', () => {
+    expect(parseEdgeStyle('straight')).toBe('straight');
+    expect(parseEdgeStyle('polyline')).toBe('polyline');
+    expect(parseEdgeStyle('bezier')).toBe('bezier');
+    expect(parseEdgeStyle('nope')).toBe('bezier');
+    expect(parseEdgeStyle(undefined)).toBe('bezier');
   });
 });
 

--- a/packages/diagrams/src/__tests__/scope.test.ts
+++ b/packages/diagrams/src/__tests__/scope.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { checkScopeRoot, SCOPE_MISSING_ROOT_CODE, type Scope } from '../scope.js';
+import {
+  checkScopeRoot,
+  checkChainScope,
+  SCOPE_MISSING_ROOT_CODE,
+  SCOPE_MISSING_CHAIN_CODE,
+  type Scope,
+} from '../scope.js';
 
 describe('checkScopeRoot', () => {
   it('returns null for non-root scopes', () => {
@@ -23,5 +29,29 @@ describe('checkScopeRoot', () => {
   it('handles string goal ids', () => {
     expect(checkScopeRoot({ mode: 'root', rootGoalId: 'g1' }, ['g1', 'g2'])).toBeNull();
     expect(checkScopeRoot({ mode: 'root', rootGoalId: 'gX' }, ['g1', 'g2'])).not.toBeNull();
+  });
+});
+
+describe('checkChainScope', () => {
+  const ids = {
+    drivers: ['D1'],
+    goals: ['G1'],
+    changes: ['C1'],
+    activities: ['A1'],
+  };
+
+  it('returns null when every selected id is present', () => {
+    expect(checkChainScope({ mode: 'chain', driverId: 'D1', goalId: 'G1' }, ids)).toBeNull();
+  });
+
+  it('returns SCOPE-002 when a selected id is absent', () => {
+    const w = checkChainScope({ mode: 'chain', goalId: 'GX' }, ids);
+    expect(w).not.toBeNull();
+    expect(w!.code).toBe(SCOPE_MISSING_CHAIN_CODE);
+    expect(w!.message).toContain('GX');
+  });
+
+  it('ignores a change filter when hideChanges is set', () => {
+    expect(checkChainScope({ mode: 'chain', changeId: 'CX' }, ids, true)).toBeNull();
   });
 });

--- a/packages/diagrams/src/edge-path.ts
+++ b/packages/diagrams/src/edge-path.ts
@@ -1,8 +1,7 @@
 // Shared edge geometry for the static notation previews (Goals, FGCA, FGA,
-// Activities). All four render dependency/relationship edges as a single cubic
-// Bézier with horizontal control handles: each control point shares its
-// endpoint's Y, so the tangent is horizontal at both ends and the marker-end
-// arrow reads as perpendicular to the node's vertical edge.
+// Activities). The default path is a cubic Bézier with horizontal control
+// handles so the marker-end arrow sits flush on the node's vertical edge.
+// Goals / DGCA / DGA can switch to a straight chord or an orthogonal polyline.
 //
 // Pulling the path math here (rather than duplicating it inline in each
 // preview) makes the configurable-curvature behaviour
@@ -29,6 +28,30 @@ const MAX_HANDLE = 160;
 
 /** Multiplier applied to the base handle length. 1 = historical appearance. */
 export const DEFAULT_EDGE_CURVATURE = 1;
+
+/** Path shape for Goals / DGCA / DGA preview edges. Default matches today's cubic. */
+export type EdgeStyle = 'straight' | 'bezier' | 'polyline';
+export const DEFAULT_EDGE_STYLE: EdgeStyle = 'bezier';
+
+export function parseEdgeStyle(v: unknown): EdgeStyle {
+  if (v === 'straight' || v === 'bezier' || v === 'polyline') return v;
+  return DEFAULT_EDGE_STYLE;
+}
+
+/** Straight segment — the arrowhead follows the chord, not the node edge. */
+export function straightEdgePath(sx: number, sy: number, tx: number, ty: number): string {
+  return `M${sx},${sy} L${tx},${ty}`;
+}
+
+/**
+ * Orthogonal (Manhattan) polyline: horizontal out, vertical, horizontal in.
+ * The last segment is horizontal so `marker-end` still meets the node's
+ * vertical edge the same way the cubic does.
+ */
+export function orthogonalEdgePath(sx: number, sy: number, tx: number, ty: number): string {
+  const midX = sx + (tx - sx) / 2;
+  return `M${sx},${sy} H${midX} V${ty} H${tx}`;
+}
 
 /**
  * Builds the SVG `d` for a horizontal-tangent cubic Bézier from (sx,sy) to
@@ -88,4 +111,22 @@ export function bowedCubicEdgePath(
   const dx = tx - sx;
   const handle = Math.max(EDGE_MIN_HANDLE, Math.min(Math.abs(dx) * DX_FACTOR, MAX_HANDLE)) * curvature;
   return `M${sx},${sy} C${sx + handle},${bowY} ${tx - handle},${bowY} ${tx},${ty}`;
+}
+
+/**
+ * Picks the SVG `d` for a Goals / DGCA / DGA preview edge.
+ * Unknown styles fall back to the historical cubic.
+ */
+export function previewEdgePath(
+  sx: number,
+  sy: number,
+  tx: number,
+  ty: number,
+  style: EdgeStyle = DEFAULT_EDGE_STYLE,
+  curvature: number = DEFAULT_EDGE_CURVATURE,
+  entryCurvature?: number,
+): string {
+  if (style === 'straight') return straightEdgePath(sx, sy, tx, ty);
+  if (style === 'polyline') return orthogonalEdgePath(sx, sy, tx, ty);
+  return horizontalCubicEdgePath(sx, sy, tx, ty, curvature, entryCurvature);
 }

--- a/packages/diagrams/src/fgca/__tests__/preview-layout.test.ts
+++ b/packages/diagrams/src/fgca/__tests__/preview-layout.test.ts
@@ -3,6 +3,8 @@ import {
   layoutFGCAPreview,
   FGCA_PAD,
   FGCA_NODE_W,
+  chainColumnOptions,
+  sanitizeChainScope,
   type FGCAPreviewDoc,
 } from '../preview-layout.js';
 
@@ -115,10 +117,75 @@ describe('layoutFGCAPreview', () => {
       expect(idsOf(layout)).toEqual(new Set(['driver_1', 'goal_10', 'activity_30']));
     });
 
+    it("mode 'chain' ANDs column filters and keeps the connecting thread", () => {
+      const layout = layoutFGCAPreview(doc, { scope: { mode: 'chain', driverId: '1', goalId: '10' } });
+      expect(idsOf(layout)).toEqual(new Set(['driver_1', 'goal_10', 'change_20', 'activity_30']));
+    });
+
+    it("mode 'chain' with a single action keeps its upstream thread", () => {
+      const layout = layoutFGCAPreview(doc, { scope: { mode: 'chain', activityId: '31' } });
+      expect(idsOf(layout)).toEqual(new Set(['driver_2', 'goal_11', 'activity_31']));
+    });
+
+    it("mode 'chain' returns empty when selected columns are not on one thread", () => {
+      const layout = layoutFGCAPreview(doc, { scope: { mode: 'chain', driverId: '1', goalId: '11' } });
+      expect(layout.nodes).toHaveLength(0);
+    });
+
+    it("mode 'chain' ignores changeId when hideChanges is set (DGA)", () => {
+      const layout = layoutFGCAPreview(doc, {
+        hideChanges: true,
+        scope: { mode: 'chain', changeId: '20', goalId: '11' },
+      });
+      expect(idsOf(layout)).toEqual(new Set(['driver_2', 'goal_11', 'activity_31']));
+    });
+
     it("mode 'root' returns an empty layout when the root is absent", () => {
       const layout = layoutFGCAPreview(doc, { scope: { mode: 'root', rootGoalId: '999' } });
       expect(layout.nodes).toHaveLength(0);
       expect(layout.edges).toHaveLength(0);
     });
+  });
+});
+
+describe('chainColumnOptions', () => {
+  it('lists every entity when no other column is filtered', () => {
+    const scope = { mode: 'chain' as const };
+    expect(chainColumnOptions(doc, scope, 'goalId').map(o => o.id)).toEqual(['10', '11']);
+    expect(chainColumnOptions(doc, scope, 'driverId').map(o => o.id)).toEqual(['1', '2']);
+  });
+
+  it('narrows neighbouring columns to the selected thread', () => {
+    const scope = { mode: 'chain' as const, driverId: '1' };
+    expect(chainColumnOptions(doc, scope, 'goalId').map(o => o.id)).toEqual(['10']);
+    expect(chainColumnOptions(doc, scope, 'activityId').map(o => o.id)).toEqual(['30']);
+    // Own column stays full so the user can switch the driver.
+    expect(chainColumnOptions(doc, scope, 'driverId').map(o => o.id)).toEqual(['1', '2']);
+  });
+
+  it('omits the change column when hideChanges is set', () => {
+    expect(chainColumnOptions(doc, { mode: 'chain' }, 'changeId', true)).toEqual([]);
+  });
+});
+
+describe('sanitizeChainScope', () => {
+  it('clears a neighbour that the last pick made unreachable', () => {
+    const cleaned = sanitizeChainScope(
+      doc,
+      { mode: 'chain', driverId: '2', goalId: '10' },
+      { justChanged: 'driverId' },
+    );
+    expect(cleaned.driverId).toBe('2');
+    expect(cleaned.goalId).toBeUndefined();
+  });
+
+  it('keeps the last pick when neighbours would otherwise clear it', () => {
+    const cleaned = sanitizeChainScope(
+      doc,
+      { mode: 'chain', driverId: '1', goalId: '11' },
+      { justChanged: 'goalId' },
+    );
+    expect(cleaned.goalId).toBe('11');
+    expect(cleaned.driverId).toBeUndefined();
   });
 });

--- a/packages/diagrams/src/fgca/index.ts
+++ b/packages/diagrams/src/fgca/index.ts
@@ -3,6 +3,8 @@ export type { FGCALayoutInput } from "./layout";
 export {
   layoutFGCAPreview,
   selectScopedFGCA,
+  chainColumnOptions,
+  sanitizeChainScope,
   FGCA_NODE_W,
   FGCA_NODE_H,
   FGCA_HEADER_H,

--- a/packages/diagrams/src/fgca/preview-layout.ts
+++ b/packages/diagrams/src/fgca/preview-layout.ts
@@ -7,7 +7,8 @@
 //
 // No React, no DOM, no vscode. Safe to call in Node.js or a test environment.
 
-import type { Scope } from '../scope.js';
+import type { ChainColumnKey, ChainScope, FgcaScope } from '../scope.js';
+import { isChainScope } from '../scope.js';
 import { ENTITY_NODE_SIZE } from '../node-size-presets.js';
 
 export type FGCAPreviewColumn = 'driver' | 'goal' | 'change' | 'activity';
@@ -49,12 +50,202 @@ export interface FGCAPreviewLayoutOptions {
   colGap?: number;
   /** Vertical gap (px) between stacked nodes within a column. Default matches the historical hardcoded value. */
   rowGap?: number;
-  /** Trim to a level cap or a single root goal. Defaults to 'all'. */
-  scope?: Scope;
+  /** Trim to a level cap, a single root goal, or per-column chain filters. Defaults to 'all'. */
+  scope?: FgcaScope;
   /** Entity node width (px). Default {@link FGCA_NODE_W}. */
   nodeWidth?: number;
   /** Entity node height (px). Default {@link FGCA_NODE_H}. */
   nodeHeight?: number;
+}
+
+function sid(id: number | string): string {
+  return String(id);
+}
+
+interface ChainPath {
+  driverId?: string;
+  goalId?: string;
+  changeId?: string;
+  activityId?: string;
+}
+
+/**
+ * Every Driver–Goal–Change–Action thread in the document, plus a singleton
+ * path for any entity that is not on a connected thread (orphans). Used to
+ * AND column filters: a node stays visible when it appears on at least one
+ * path that includes every selected id.
+ */
+function enumerateChainPaths(doc: FGCAPreviewDoc): ChainPath[] {
+  const paths: ChainPath[] = [];
+  const seen = {
+    driver: new Set<string>(),
+    goal: new Set<string>(),
+    change: new Set<string>(),
+    activity: new Set<string>(),
+  };
+  const mark = (p: ChainPath): void => {
+    paths.push(p);
+    if (p.driverId) seen.driver.add(p.driverId);
+    if (p.goalId) seen.goal.add(p.goalId);
+    if (p.changeId) seen.change.add(p.changeId);
+    if (p.activityId) seen.activity.add(p.activityId);
+  };
+
+  const changes = doc.changes ?? [];
+
+  for (const g of doc.goals) {
+    const goalId = sid(g.id);
+    const driverIds = (g.factor ?? []).map(f => sid(f.id));
+    const drivers: Array<string | undefined> = driverIds.length > 0 ? driverIds : [undefined];
+
+    const goalChanges = changes.filter(c => sid(c.goal_id) === goalId);
+    const coveredActs = new Set(goalChanges.flatMap(c => c.activity_ids.map(sid)));
+    const directActs = doc.activities.filter(
+      a => a.goal_id != null && sid(a.goal_id) === goalId && !coveredActs.has(sid(a.id)),
+    );
+
+    const slots: Array<{ changeId?: string; activityIds: Array<string | undefined> }> = [];
+    for (const c of goalChanges) {
+      const acts = c.activity_ids.map(sid);
+      slots.push({ changeId: sid(c.id), activityIds: acts.length > 0 ? acts : [undefined] });
+    }
+    for (const a of directActs) {
+      slots.push({ changeId: undefined, activityIds: [sid(a.id)] });
+    }
+    if (slots.length === 0) {
+      slots.push({ changeId: undefined, activityIds: [undefined] });
+    }
+
+    for (const d of drivers) {
+      for (const slot of slots) {
+        for (const a of slot.activityIds) {
+          mark({ driverId: d, goalId, changeId: slot.changeId, activityId: a });
+        }
+      }
+    }
+  }
+
+  for (const f of doc.factors) {
+    const id = sid(f.id);
+    if (!seen.driver.has(id)) mark({ driverId: id });
+  }
+  for (const g of doc.goals) {
+    const id = sid(g.id);
+    if (!seen.goal.has(id)) mark({ goalId: id });
+  }
+  for (const c of changes) {
+    const id = sid(c.id);
+    if (!seen.change.has(id)) mark({ changeId: id, goalId: sid(c.goal_id) });
+  }
+  for (const a of doc.activities) {
+    const id = sid(a.id);
+    if (!seen.activity.has(id)) {
+      mark({ activityId: id, goalId: a.goal_id != null ? sid(a.goal_id) : undefined });
+    }
+  }
+
+  return paths;
+}
+
+function selectChainScopedFGCA(
+  doc: FGCAPreviewDoc,
+  scope: ChainScope,
+  hideChanges: boolean,
+): FGCAPreviewDoc {
+  const driverId = scope.driverId || undefined;
+  const goalId = scope.goalId || undefined;
+  const changeId = hideChanges ? undefined : (scope.changeId || undefined);
+  const activityId = scope.activityId || undefined;
+  if (!driverId && !goalId && !changeId && !activityId) return doc;
+
+  const matched = enumerateChainPaths(doc).filter(p => {
+    if (driverId && p.driverId !== driverId) return false;
+    if (goalId && p.goalId !== goalId) return false;
+    if (changeId && p.changeId !== changeId) return false;
+    if (activityId && p.activityId !== activityId) return false;
+    return true;
+  });
+
+  const driverIds = new Set<string>();
+  const goalIds = new Set<string>();
+  const changeIds = new Set<string>();
+  const activityIds = new Set<string>();
+  for (const p of matched) {
+    if (p.driverId) driverIds.add(p.driverId);
+    if (p.goalId) goalIds.add(p.goalId);
+    if (p.changeId) changeIds.add(p.changeId);
+    if (p.activityId) activityIds.add(p.activityId);
+  }
+
+  return {
+    factors: doc.factors.filter(f => driverIds.has(sid(f.id))),
+    goals: doc.goals.filter(g => goalIds.has(sid(g.id))),
+    changes: doc.changes === undefined ? undefined : doc.changes.filter(c => changeIds.has(sid(c.id))),
+    activities: doc.activities.filter(a => activityIds.has(sid(a.id))),
+  };
+}
+
+const CHAIN_COLUMN_KEYS: ChainColumnKey[] = ['driverId', 'goalId', 'changeId', 'activityId'];
+
+function columnEntities(
+  doc: FGCAPreviewDoc,
+  column: ChainColumnKey,
+): Array<{ id: string; name: string }> {
+  if (column === 'driverId') return doc.factors.map(f => ({ id: sid(f.id), name: f.name ?? '' }));
+  if (column === 'goalId') return doc.goals.map(g => ({ id: sid(g.id), name: g.name ?? '' }));
+  if (column === 'changeId') return (doc.changes ?? []).map(c => ({ id: sid(c.id), name: c.name ?? '' }));
+  return doc.activities.map(a => ({ id: sid(a.id), name: a.name ?? '' }));
+}
+
+/**
+ * Dropdown options for one chain column, cascaded from the other selected
+ * filters (this column's own filter is ignored so the user can still switch it).
+ */
+export function chainColumnOptions(
+  doc: FGCAPreviewDoc,
+  scope: ChainScope,
+  column: ChainColumnKey,
+  hideChanges = false,
+): Array<{ id: string; name: string }> {
+  if (hideChanges && column === 'changeId') return [];
+  const withoutSelf: ChainScope = { ...scope, mode: 'chain', [column]: undefined };
+  const filtered = selectChainScopedFGCA(doc, withoutSelf, hideChanges);
+  return columnEntities(filtered, column);
+}
+
+/**
+ * Drop column filters that are no longer reachable given the others.
+ * `justChanged` is kept even when incompatible — the last pick wins, neighbours yield.
+ */
+export function sanitizeChainScope(
+  doc: FGCAPreviewDoc,
+  scope: ChainScope,
+  opts: { justChanged?: ChainColumnKey; hideChanges?: boolean } = {},
+): ChainScope {
+  const next: ChainScope = {
+    mode: 'chain',
+    driverId: scope.driverId || undefined,
+    goalId: scope.goalId || undefined,
+    changeId: opts.hideChanges ? undefined : (scope.changeId || undefined),
+    activityId: scope.activityId || undefined,
+  };
+
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const key of CHAIN_COLUMN_KEYS) {
+      if (key === opts.justChanged) continue;
+      if (opts.hideChanges && key === 'changeId') continue;
+      const id = next[key];
+      if (!id) continue;
+      const available = new Set(chainColumnOptions(doc, next, key, opts.hideChanges).map(o => o.id));
+      if (!available.has(id)) {
+        next[key] = undefined;
+        changed = true;
+      }
+    }
+  }
+  return next;
 }
 
 /**
@@ -63,14 +254,23 @@ export interface FGCAPreviewLayoutOptions {
  * DGCA/DGA goals are flat (no parent_id), so:
  *   - 'level' → goals with `(level ?? 0) <= maxLevel`.
  *   - 'root'  → the single goal whose id matches `rootGoalId` (empty when absent).
+ *   - 'chain' → AND of per-column ids (Driver / Goal / Change / Action); empty
+ *               ids are All. DGA passes hideChanges so a Change filter is ignored.
  *
  * Factors, changes and activities are then kept only when they touch a visible
  * goal: a factor referenced by a visible goal, a change whose `goal_id` is
  * visible, an activity bound to a visible goal directly or via a visible
  * change. Pure and exported so an access-control layer can reuse it.
  */
-export function selectScopedFGCA(doc: FGCAPreviewDoc, scope: Scope): FGCAPreviewDoc {
+export function selectScopedFGCA(
+  doc: FGCAPreviewDoc,
+  scope: FgcaScope,
+  opts: { hideChanges?: boolean } = {},
+): FGCAPreviewDoc {
   if (scope.mode === 'all') return doc;
+  if (isChainScope(scope)) {
+    return selectChainScopedFGCA(doc, scope, opts.hideChanges === true);
+  }
 
   const visibleGoals =
     scope.mode === 'level'
@@ -147,7 +347,7 @@ export function layoutFGCAPreview(
   } = options;
 
   // Trim to scope first; everything below lays out the visible subset only.
-  const doc = selectScopedFGCA(inputDoc, scope);
+  const doc = selectScopedFGCA(inputDoc, scope, { hideChanges });
 
   const colStride = nodeWidth + colGap;
   const cols: FGCAPreviewColumn[] = hideChanges

--- a/packages/diagrams/src/scope.ts
+++ b/packages/diagrams/src/scope.ts
@@ -20,11 +20,37 @@ export type Scope =
   | { mode: 'level'; maxLevel: number }
   | { mode: 'root'; rootGoalId: string };
 
+/** Column filters on a DGCA/DGA chain. Empty / omitted id = All for that column. */
+export type ChainColumnKey = 'driverId' | 'goalId' | 'changeId' | 'activityId';
+
+export type ChainScope = {
+  mode: 'chain';
+  driverId?: string;
+  goalId?: string;
+  changeId?: string;
+  activityId?: string;
+};
+
+/** Scope accepted by DGCA/DGA layout — Goals tree still uses {@link Scope} only. */
+export type FgcaScope = Scope | ChainScope;
+
 /** Default scope — render everything. */
 export const SCOPE_ALL: Scope = { mode: 'all' };
 
+export function isChainScope(scope: FgcaScope): scope is ChainScope {
+  return scope.mode === 'chain';
+}
+
+/** True when at least one column filter is set. */
+export function chainScopeActive(scope: ChainScope): boolean {
+  return !!(scope.driverId || scope.goalId || scope.changeId || scope.activityId);
+}
+
 /** Warning code emitted when a root-mode scope names a goal that isn't in the document. */
 export const SCOPE_MISSING_ROOT_CODE = 'SCOPE-001';
+
+/** Warning code emitted when a chain-column filter names an id that isn't in the document. */
+export const SCOPE_MISSING_CHAIN_CODE = 'SCOPE-002';
 
 /**
  * Returns the SCOPE-001 warning when `scope` is root-mode and `rootGoalId` is
@@ -42,5 +68,40 @@ export function checkScopeRoot(scope: Scope, goalIds: Iterable<string | number>)
   return {
     code: SCOPE_MISSING_ROOT_CODE,
     message: `Scope root goal "${scope.rootGoalId}" was not found in this document — nothing to show. Clear the scope or pick a goal that exists.`,
+  };
+}
+
+function idSetHas(ids: Iterable<string | number>, want: string): boolean {
+  for (const id of ids) {
+    if (String(id) === want) return true;
+  }
+  return false;
+}
+
+/**
+ * Returns a SCOPE-002 warning when a chain filter names an id that is not in
+ * the document's corresponding column; otherwise null. Several missing ids
+ * are listed in one message.
+ */
+export function checkChainScope(
+  scope: ChainScope,
+  ids: {
+    drivers: Iterable<string | number>;
+    goals: Iterable<string | number>;
+    changes: Iterable<string | number>;
+    activities: Iterable<string | number>;
+  },
+  hideChanges = false,
+): ValidationWarning | null {
+  if (scope.mode !== 'chain') return null;
+  const missing: string[] = [];
+  if (scope.driverId && !idSetHas(ids.drivers, scope.driverId)) missing.push(`driver "${scope.driverId}"`);
+  if (scope.goalId && !idSetHas(ids.goals, scope.goalId)) missing.push(`goal "${scope.goalId}"`);
+  if (!hideChanges && scope.changeId && !idSetHas(ids.changes, scope.changeId)) missing.push(`change "${scope.changeId}"`);
+  if (scope.activityId && !idSetHas(ids.activities, scope.activityId)) missing.push(`action "${scope.activityId}"`);
+  if (missing.length === 0) return null;
+  return {
+    code: SCOPE_MISSING_CHAIN_CODE,
+    message: `Scope ${missing.join(', ')} was not found in this document — nothing to show for that filter. Clear the scope or pick an id that exists.`,
   };
 }

--- a/packages/diagrams/src/webview/render-fgca.ts
+++ b/packages/diagrams/src/webview/render-fgca.ts
@@ -21,7 +21,7 @@ import {
   type FGCAPreviewColumn,
 } from '../fgca/preview-layout.js';
 import type { FGCADoc } from '../fgca/validate.js';
-import { horizontalCubicEdgePath, DEFAULT_EDGE_CURVATURE } from '../edge-path.js';
+import { previewEdgePath, DEFAULT_EDGE_CURVATURE, type EdgeStyle } from '../edge-path.js';
 import { parseNodeSizePreset, resolveDgcaNodeSize, type NodeSizePreset } from '../node-size-presets.js';
 import { generateSvgEmbedCss } from '../theme/index.js';
 import { emitCenteredTextSvg, layoutCenteredEntityText, truncateLine } from './entity-text-layout.js';
@@ -39,6 +39,7 @@ type FgcaLayout = ReturnType<typeof layoutFGCAPreview>;
 export interface RenderFgcaBodyOptions {
   nodeWidth?: number;
   nodeHeight?: number;
+  edgeStyle?: EdgeStyle;
 }
 
 /**
@@ -60,6 +61,7 @@ export function renderFgcaBody(
 ): string {
   const nodeWidth = bodyOptions.nodeWidth ?? FGCA_NODE_W;
   const nodeHeight = bodyOptions.nodeHeight ?? FGCA_NODE_H;
+  const edgeStyle = bodyOptions.edgeStyle;
   const headerTruncate = Math.max(8, Math.floor((nodeWidth - 16) / 7));
 
   const headerSvg = columns
@@ -71,7 +73,7 @@ export function renderFgcaBody(
   const edgeSvg = edges
     .map(
       (e) =>
-        `<path d="${horizontalCubicEdgePath(e.sx, e.sy, e.tx, e.ty, curvature, entryCurvature)}" class="diagram-edge" marker-end="url(#arrow)"/>`,
+        `<path d="${previewEdgePath(e.sx, e.sy, e.tx, e.ty, edgeStyle, curvature, entryCurvature)}" class="diagram-edge" marker-end="url(#arrow)"/>`,
     )
     .join('\n');
 
@@ -108,6 +110,7 @@ export interface RenderFgcaOptions {
   curvature?: number;
   /** Entry curvature at the target node; defaults to `curvature` when omitted. */
   entryCurvature?: number;
+  edgeStyle?: EdgeStyle;
   nodeSizePreset?: NodeSizePreset;
   layoutOptions?: Parameters<typeof layoutFGCAPreview>[1];
   /** Show scope caption when goal-scoped projection omits goals that reference out-of-scope goals. */
@@ -120,6 +123,7 @@ export function renderFgcaSvg(doc: FGCADoc, options: RenderFgcaOptions = {}): st
     title = '',
     curvature = DEFAULT_EDGE_CURVATURE,
     entryCurvature,
+    edgeStyle,
     nodeSizePreset = 'normal',
     layoutOptions,
     scopeCaption = false,
@@ -141,6 +145,7 @@ export function renderFgcaSvg(doc: FGCADoc, options: RenderFgcaOptions = {}): st
   const body = renderFgcaBody(columns, nodes, edges, curvature, entryCurvature, {
     nodeWidth: nodeSize.width,
     nodeHeight: nodeSize.height,
+    edgeStyle,
   });
 
   const titleSvg = title

--- a/packages/diagrams/src/webview/render-goals.ts
+++ b/packages/diagrams/src/webview/render-goals.ts
@@ -13,7 +13,7 @@
 import { layoutGoalTree } from '../goals/layout.js';
 import type { GoalTree, GoalTreeLayout, LaidOutEdge } from '../goals/types.js';
 import { displayGoalId } from '../goals/parse-canonical.js';
-import { horizontalCubicEdgePath, DEFAULT_EDGE_CURVATURE } from '../edge-path.js';
+import { previewEdgePath, DEFAULT_EDGE_CURVATURE, type EdgeStyle } from '../edge-path.js';
 import { parseNodeSizePreset, resolveGoalsNodeSize, type NodeSizePreset } from '../node-size-presets.js';
 import { generateSvgEmbedCss, type ThemeId } from '../theme/index.js';
 import { emitCenteredTextSvg, layoutCenteredEntityText } from './entity-text-layout.js';
@@ -28,6 +28,7 @@ export interface RenderGoalsOptions {
   treeName?: string;
   curvature?: number;
   entryCurvature?: number;
+  edgeStyle?: EdgeStyle;
   nodeSizePreset?: NodeSizePreset;
 }
 
@@ -37,7 +38,7 @@ export interface RenderGoalsOptions {
  * with the shared theme CSS embedded so the output is self-contained.
  */
 export function renderGoalsSvg(tree: GoalTree, options: RenderGoalsOptions = {}): string {
-  const { treeName = '', curvature = DEFAULT_EDGE_CURVATURE, entryCurvature, nodeSizePreset = 'normal' } = options;
+  const { treeName = '', curvature = DEFAULT_EDGE_CURVATURE, entryCurvature, edgeStyle, nodeSizePreset = 'normal' } = options;
   const nodeSize = resolveGoalsNodeSize(parseNodeSizePreset(nodeSizePreset));
 
   const layout: GoalTreeLayout = layoutGoalTree(tree, {
@@ -55,12 +56,13 @@ export function renderGoalsSvg(tree: GoalTree, options: RenderGoalsOptions = {})
     ? `<text class="text-header" x="${PAD}" y="${PAD - 6}">${escXml(`Goal tree — ${treeName}`)}</text>`
     : '';
 
-  return renderGoalsLayoutSvg(layout, { curvature, entryCurvature, title, embedCssTheme: 'transitrix' });
+  return renderGoalsLayoutSvg(layout, { curvature, entryCurvature, edgeStyle, title, embedCssTheme: 'transitrix' });
 }
 
 export interface RenderGoalsLayoutOptions {
   curvature?: number;
   entryCurvature?: number;
+  edgeStyle?: EdgeStyle;
   /** Extra vertical space reserved at the top of the canvas (e.g. for a title block). */
   topInset?: number;
   /** Raw SVG injected immediately after `<defs>` — a header line or a full title block. */
@@ -78,7 +80,7 @@ export interface RenderGoalsLayoutOptions {
  *     and the export path own styling).
  */
 export function renderGoalsLayoutSvg(layout: GoalTreeLayout, options: RenderGoalsLayoutOptions = {}): string {
-  const { curvature = DEFAULT_EDGE_CURVATURE, entryCurvature, topInset = 0, title = '', embedCssTheme } = options;
+  const { curvature = DEFAULT_EDGE_CURVATURE, entryCurvature, edgeStyle, topInset = 0, title = '', embedCssTheme } = options;
 
   const w = layout.bounds.width + PAD * 2;
   const h = layout.bounds.height + PAD * 2 + topInset;
@@ -95,7 +97,7 @@ export function renderGoalsLayoutSvg(layout: GoalTreeLayout, options: RenderGoal
     const sy = s.y + oy + s.height / 2;
     const tx = t.x + ox;
     const ty = t.y + oy + t.height / 2;
-    return horizontalCubicEdgePath(sx, sy, tx, ty, curvature, entryCurvature);
+    return previewEdgePath(sx, sy, tx, ty, edgeStyle, curvature, entryCurvature);
   }
 
   const edgeSvg = layout.edges

--- a/tests/preview-controls.test.ts
+++ b/tests/preview-controls.test.ts
@@ -58,6 +58,23 @@ describe('buildControlsPanel', () => {
     expect(html).toContain('<output id="tx-curv-out">');
   });
 
+  it('renders the arrow-style select for Goals/DGCA and hides the slider unless Bezier', () => {
+    const bezier = buildControlsPanel(baseModel({
+      edgeStyle: { value: 'bezier', default: 'bezier' },
+    }));
+    expect(bezier).toContain('data-tx-control="edgeStyle"');
+    expect(bezier).toContain('value="bezier" selected');
+    expect(bezier).toContain('data-tx-control="curvature"');
+    expect(bezier).toContain('Arrows');
+
+    const polyline = buildControlsPanel(baseModel({
+      edgeStyle: { value: 'polyline', default: 'bezier' },
+    }));
+    expect(polyline).toContain('value="polyline" selected');
+    expect(polyline).not.toContain('data-tx-control="curvature"');
+    expect(polyline).toContain(' open>');
+  });
+
   it('omits the scope row when no scope model is given (Activities)', () => {
     const html = buildControlsPanel(baseModel());
     expect(html).not.toContain('data-tx-control="scope"');
@@ -115,6 +132,52 @@ describe('buildControlsPanel', () => {
       scope: { rootId: '5', maxLevel: -1, maxLevelPresent: 2, goals: [] },
     }));
     expect(scopedNonDefault).toContain(' open>');
+  });
+
+  it('renders D/G/C/A selectors for a chain scope and omits Root/Level', () => {
+    const html = buildControlsPanel(baseModel({
+      scope: {
+        rootId: '', maxLevel: -1, maxLevelPresent: 0, goals: [],
+        chain: {
+          hideChanges: false,
+          driverId: '', goalId: 'G1', changeId: '', activityId: '',
+          drivers: [{ id: 'D1', name: 'Reg window' }],
+          goals: [{ id: 'G1', name: 'Launch' }],
+          changes: [{ id: 'C1', name: 'CRM' }],
+          activities: [{ id: 'A1', name: 'Rollout' }],
+        },
+      },
+    }));
+    expect(html).toContain('data-tx-field="driverId"');
+    expect(html).toContain('data-tx-field="goalId"');
+    expect(html).toContain('data-tx-field="changeId"');
+    expect(html).toContain('data-tx-field="activityId"');
+    expect(html).not.toContain('data-tx-field="rootId"');
+    expect(html).not.toContain('data-tx-field="maxLevel"');
+    expect(html).toContain('>D\n');
+    expect(html).toContain('>G\n');
+    expect(html).toContain('>C\n');
+    expect(html).toContain('>A\n');
+    expect(html).toContain('Launch (G1)');
+    expect(html).toContain(' open>');
+  });
+
+  it('hides the C selector when hideChanges is set', () => {
+    const html = buildControlsPanel(baseModel({
+      scope: {
+        rootId: '', maxLevel: -1, maxLevelPresent: 0, goals: [],
+        chain: {
+          hideChanges: true,
+          driverId: '', goalId: '', changeId: '', activityId: '',
+          drivers: [], goals: [], changes: [{ id: 'C1', name: 'hidden' }], activities: [],
+        },
+      },
+    }));
+    expect(html).toContain('data-tx-field="driverId"');
+    expect(html).toContain('data-tx-field="goalId"');
+    expect(html).toContain('data-tx-field="activityId"');
+    expect(html).not.toContain('data-tx-field="changeId"');
+    expect(html).not.toContain('hidden');
   });
 });
 


### PR DESCRIPTION
## Summary
- DGCA/DGA Controls/Scope now has D, G, C, and A selectors (C hidden on DGA). Neighbouring lists shrink to the remaining thread; Reset clears all four.
- Goals, DGCA, and DGA previews add an Arrows control: Straight, Bezier, or Polyline. The curvature slider remains for Bezier only.

## Test plan
- [x] `packages/diagrams` unit tests (chain scope, cascade, sanitize, edge paths)
- [x] `tests/preview-controls.test.ts` (D/G/C/A row, hidden C, arrow-style select)
- [x] `tsc -p extension/tsconfig.json --noEmit`
- [ ] Open a DGCA preview: pick a Driver and confirm Goal/Change/Action lists shrink; Reset restores the full chain
- [ ] Open a DGA preview: confirm there is no C selector
- [ ] On Goals, DGCA, and DGA: switch Arrows through Straight / Bezier / Polyline and confirm the curvature slider appears only for Bezier

Made with [Cursor](https://cursor.com)