### PR TITLE
chore(release): prepare 3.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [3.6.2] — 2026-09-01
+
+### Added
+
+- **DGCA and DGA previews filter the chain by column.** Scope replaces the single root-goal selector with Driver, Goal, Change, and Activity dropdowns (labelled D / G / C / A). Each defaults to All; chosen values combine with AND, and neighbouring lists shrink to the remaining thread. DGA, and DGCA with the Changes layer off, hide the Change selector. Goals preview keeps Root and Level. (#614)
+- **Goals, DGCA, and DGA previews offer Straight, Bezier, and Polyline arrow paths.** The curvature slider remains for Bezier only. Action preview is unchanged. (#614)
+
+### Packages
+
+- `@transitrix/diagrams` 1.12.1 → 1.12.2 — column chain scope on DGCA/DGA, preview edge path styles.
+- `@transitrix/cli` 2.8.1 → 2.8.2 — rebundles diagrams (no compiler source change in this span).
+
 ## [3.6.1] — 2026-08-31
 
 ### Fixed

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "description": "Diagrams as text. Write goals, processes, capabilities, BPMN, and more as plain YAML — 17 notations, live preview in your editor. Diffable in git. AI-friendly. Open source.",
   "license": "MIT",
   "icon": "icon.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "transitrix-studio",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "transitrix-studio",
-      "version": "3.6.1",
+      "version": "3.6.2",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -7930,7 +7930,7 @@
     },
     "packages/cli": {
       "name": "@transitrix/cli",
-      "version": "2.8.1",
+      "version": "2.8.2",
       "license": "MIT",
       "dependencies": {
         "@resvg/resvg-js": "^2.6.2",
@@ -7949,7 +7949,7 @@
     },
     "packages/diagrams": {
       "name": "@transitrix/diagrams",
-      "version": "1.12.1",
+      "version": "1.12.2",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/cli",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "type": "module",
   "description": "Transitrix CLI ΓÇö compile, validate, and report on Transitrix diagrams (BPMN, Goals, DGCA, ΓÇª) from any shell or CI pipeline.",
   "license": "MIT",

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bumps versions for the 3.6.2 patch release: root/extension 3.6.1 → 3.6.2, `@transitrix/diagrams` 1.12.1 → 1.12.2, `@transitrix/cli` 2.8.1 → 2.8.2 (moves with diagrams per the release-version guard).
- Records the DGCA/DGA column-scope filters and Straight/Bezier/Polyline arrow paths (#614) in CHANGELOG.

## Test plan
- [x] `npm run build` green
- [x] `npm run compile` + `npm run compile:extension` green
- [x] `npm run test:core` — 835/838 pass; 3 pre-existing failures in `tests/cli-migrate.test.ts` are unrelated to this change (local `methodology` sibling repo dependency, reproducible identically on `main`). One `tests/cli-repo-validate-model.test.ts` case timed out at 5s on the first run and passed on retry (4/4).
- [x] `npm run test:diagrams` — 1793/1793 pass
- [x] CHANGELOG heading matches the version fields