### PR TITLE
docs: open marketplace listing with canonical positioning form

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -1,5 +1,7 @@
 # Transitrix Studio
 
+You leave with a decision you can keep true. Not a report of one — the model the decision was made in, in your own repository, and the method to keep it current after we are gone.
+
 **Diagrams as text, in your editor.** Write a diagram in a plain YAML file, and Transitrix Studio renders it live, right beside your code. No drag-and-drop canvas, no proprietary file format — just text you can diff, review in a pull request, and hand to an AI that reads it natively.
 
 ![Transitrix Studio in action — a goals-tree YAML file on the left, its live preview on the right, redrawing as a new goal is added and typed](https://raw.githubusercontent.com/transitrix/transitrix-studio/main/extension/docs/listing.gif)


### PR DESCRIPTION
**From: transitrix-studio.**

## Summary

Updated the Open VSX and Cursor marketplace listing body (README.md) to open with the canonical two-sentence positioning form from transitrix-hq canon.

## Acceptance

- ✓ README begins with the two-sentence positioning statement, character-for-character
- ✓ package.json description unchanged (editor-honest one-liner)
- ✓ No paraphrasing or rewording of the positioning form
- ✓ Author attribution and destination unchanged (transitrix-hq#330)

Resolves transitrix-hq#522.