### PR TITLE
fix: remove repository name from hook example in comment

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -36,7 +36,7 @@ fi
 
 # Shape 3: Refuse Work item: field that is not exactly THQ-NNN
 # Valid: "Work item: THQ-123"
-# Invalid: "Work item: 123" or "Work item: transitrix-hq#123"
+# Invalid: "Work item: 123" or "Work item: owner/repo#123"
 if echo "$MSG" | grep -E '^Work item:' >/dev/null 2>&1; then
   WORK_ITEM=$(echo "$MSG" | grep '^Work item:' | head -1 | sed 's/^Work item:[[:space:]]*//')
 


### PR DESCRIPTION
## What changed

Removed actual repository name from `.githooks/commit-msg` comment example, replacing it with a placeholder shape per design principle: the hook tests shapes, not names.

Changed line 39 from:
```
# Invalid: "Work item: 123" or "Work item: transitrix-hq#123"
```

To:
```
# Invalid: "Work item: 123" or "Work item: owner/repo#123"
```

## How it is verified

- Hook example now contains only shape patterns, no actual repository names
- Meets acceptance criterion 4 of #571: "No file added by this epic contains the register's name"

Work item: THQ-571