### PR TITLE
fix: pin hero image URL to commit SHA for durability

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -4,7 +4,7 @@ You leave with a decision you can keep true. Not a report of one — the model t
 
 **Diagrams as text, in your editor.** Write a diagram in a plain YAML file, and Transitrix Studio renders it live, right beside your code. No drag-and-drop canvas, no proprietary file format — just text you can diff, review in a pull request, and hand to an AI that reads it natively.
 
-![Transitrix Studio in action — a goals-tree YAML file on the left, its live preview on the right, redrawing as a new goal is added and typed](https://raw.githubusercontent.com/transitrix/transitrix-studio/main/extension/docs/listing.gif)
+![Transitrix Studio in action — a goals-tree YAML file on the left, its live preview on the right, redrawing as a new goal is added and typed](https://raw.githubusercontent.com/transitrix/transitrix-studio/77620e5/extension/docs/listing.gif)
 
 ## Why text-native diagrams?
 


### PR DESCRIPTION
## Summary

Pins the marketplace listing's hero image URL to a specific commit SHA rather than the mutable main branch. This ensures published versions render the exact image they were built with, even if the repository is restructured or paths are renamed.

## Implementation detail

- Updated `extension/README.md` line 7 to reference commit SHA 77620e5 instead of main
- The main branch README remains editable for presentation fixes between releases
- Each release cycle will pin to its release commit SHA

## Verification

The listed version renders its hero image with main moved out from under it:
- URL references a pinned commit (77620e5)
- Image asset exists at that commit
- Frontend README remains mutable on main without contradiction