### PR TITLE
fix: parse the attach-release workflow on non-dispatch events

### DIFF
--- a/.github/workflows/attach-release-vsix.yml
+++ b/.github/workflows/attach-release-vsix.yml
@@ -17,6 +17,11 @@ on:
         description: Existing draft release tag (for example v3.3.1)
         required: true
         type: string
+  # A dispatch-only reusable caller is parsed on every push and fails with
+  # zero jobs. This branch name is not used; real work stays dispatch-only.
+  push:
+    branches:
+      - '__never_match_attach_release__'
 
 permissions:
   contents: read

--- a/.github/workflows/attach-release-vsix.yml
+++ b/.github/workflows/attach-release-vsix.yml
@@ -29,7 +29,8 @@ jobs:
       attestations: write
     uses: ./.github/workflows/build-vsix.yml
     with:
-      release-tag: ${{ inputs.tag }}
+      # inputs is defined only for workflow_dispatch; other events must still parse.
+      release-tag: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || '' }}
 
   attach:
     needs: build

--- a/.github/workflows/attach-release-vsix.yml
+++ b/.github/workflows/attach-release-vsix.yml
@@ -28,9 +28,6 @@ jobs:
       id-token: write
       attestations: write
     uses: ./.github/workflows/build-vsix.yml
-    with:
-      # inputs is defined only for workflow_dispatch; other events must still parse.
-      release-tag: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || '' }}
 
   attach:
     needs: build

--- a/.github/workflows/attach-release-vsix.yml
+++ b/.github/workflows/attach-release-vsix.yml
@@ -17,11 +17,6 @@ on:
         description: Existing draft release tag (for example v3.3.1)
         required: true
         type: string
-  # A dispatch-only reusable caller is parsed on every push and fails with
-  # zero jobs. This branch name is not used; real work stays dispatch-only.
-  push:
-    branches:
-      - '__never_match_attach_release__'
 
 permissions:
   contents: read
@@ -33,6 +28,8 @@ jobs:
       id-token: write
       attestations: write
     uses: ./.github/workflows/build-vsix.yml
+    with:
+      release-tag: ${{ inputs.tag }}
 
   attach:
     needs: build
@@ -128,27 +125,23 @@ jobs:
         run: |
           tag="${{ inputs.tag }}"
           vsix_name="transitrix-studio-${tag#v}.vsix"
-
-          # Get the current release notes
           release=$(gh api "/repos/${{ github.repository }}/releases/tags/$tag")
           current_body=$(echo "$release" | jq -r '.body')
-
-          # Add attestation verification section if not already present
           if ! echo "$current_body" | grep -q "gh attestation verify"; then
-            new_body="$current_body
-
-## Verify build provenance
-
-To verify that this release was built by our CI pipeline and has not been tampered with:
-
-\`\`\`bash
-gh attestation verify --owner transitrix $vsix_name
-\`\`\`
-
-## Bill of Materials
-
-This release includes a Software Bill of Materials (SBOM) in CycloneDX format listing all components and dependencies. Download \`sbom.xml\` to audit the release contents."
-
+            extra=$(printf '%s\n' \
+              '' \
+              '## Verify build provenance' \
+              '' \
+              'To verify that this release was built by our CI pipeline and has not been tampered with:' \
+              '' \
+              '```bash' \
+              "gh attestation verify --owner transitrix $vsix_name" \
+              '```' \
+              '' \
+              '## Bill of Materials' \
+              '' \
+              'This release includes a Software Bill of Materials (SBOM) in CycloneDX format listing all components and dependencies. Download sbom.xml to audit the release contents.')
+            new_body="${current_body}${extra}"
             gh api -X PATCH "/repos/${{ github.repository }}/releases/tags/$tag" \
               -f body="$new_body"
           fi


### PR DESCRIPTION
## What changed

The attach-release workflow file is valid YAML again. The attestation notes step keeps its markdown inside the `run` block (via `printf`) instead of unindented headings that closed the scalar.

## How it is verified

- This branch push does not create an attach-release run.
- The next release draft is attached with an explicit dispatch of this workflow.