### PR TITLE
fix: disable push trigger on attach-release-vsix workflow

### DIFF
--- a/.github/workflows/attach-release-vsix.yml
+++ b/.github/workflows/attach-release-vsix.yml
@@ -11,6 +11,7 @@ name: Attach universal VSIX to release draft
 # commit.
 
 on:
+  push: []
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
## Summary

The `attach-release-vsix` workflow is triggered by `workflow_dispatch` only, but GitHub Actions has been executing it on every push with zero jobs (failure status). This adds spurious red runs to the CI/CD history.

Explicitly setting `push: []` in the workflow trigger configuration prevents GitHub from running this workflow on push events, eliminating the spurious failures.

## Test plan

- Monitor: Push to a feature branch and verify no `attach-release-vsix` workflow run is triggered
- Dispatch: Manually trigger `workflow_dispatch` against a draft release and verify the workflow runs successfully with all jobs
- Verify: The release attachment completes and artefacts are uploaded correctly

🤖 Generated with Claude Code