### PR TITLE
fix: remove erroneous push trigger from attach-release-vsix workflow

### DIFF
--- a/.github/workflows/attach-release-vsix.yml
+++ b/.github/workflows/attach-release-vsix.yml
@@ -11,7 +11,6 @@ name: Attach universal VSIX to release draft
 # commit.
 
 on:
-  push: []
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
The `push: []` syntax incorrectly triggers the workflow on every push event. GitHub interprets an empty trigger filter as 'trigger on all events of this type'. Removing the push key entirely prevents the workflow from running on push events.

This fixes the spurious workflow failures reported in transitrix-hq#586, where every push produced a 0-job failure run instead of running only on explicit workflow_dispatch calls.