### PR TITLE
chore(release): prepare 3.7.0

### DIFF
--- a/.github/workflows/attach-release-vsix.yml
+++ b/.github/workflows/attach-release-vsix.yml
@@ -11,7 +11,6 @@ name: Attach universal VSIX to release draft
 # commit.
 
 on:
-  push: []
   workflow_dispatch:
     inputs:
       tag:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [3.7.0] — 2026-09-03
+
+### Added
+
+- **DGCA synthesizes a virtual Change when an Action has no real Change.** Activities linked only to a Goal still sit in the chain through a dashed placeholder Change node, instead of jumping Goal → Action. (#621)
+- **Goals, DGCA, and DGA nodes show a native tooltip on hover.** The full name and id (and goal level, when present) appear in the SVG title, so truncated labels remain readable. (#622)
+- **DGCA/DGA Action nodes can show a completion-percent badge.** When progress is attached to the activity, a small percent label renders under the type badge; missing data leaves the node unchanged, and a timestamp older than seven days is drawn muted. (#623)
+
+### Changed
+
+- **Marketplace listing opens with the canonical positioning form.** The listing body now leads with the two-sentence statement. (#620)
+- **Marketplace listing GIF shows the Goals-tree demonstration.** The recorded animation has the branch-appear payoff uncropped and side panels collapsed.
+
+### Fixed
+
+- **Marketplace listing hero image URL is pinned to a commit.** The README image points at a content SHA rather than a moving branch tip. (#631)
+
+### Packages
+
+- `@transitrix/diagrams` 1.12.2 → 1.13.0 — virtual Change nodes, hover titles, ACTION percent badge.
+- `@transitrix/cli` 2.8.2 → 2.9.0 — rebundles diagrams (no compiler source change in this span).
+
 ## [3.6.2] — 2026-09-01
 
 ### Added

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "description": "Diagrams as text. Write goals, processes, capabilities, BPMN, and more as plain YAML — 17 notations, live preview in your editor. Diffable in git. AI-friendly. Open source.",
   "license": "MIT",
   "icon": "icon.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "transitrix-studio",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "transitrix-studio",
-      "version": "3.6.2",
+      "version": "3.7.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -7930,7 +7930,7 @@
     },
     "packages/cli": {
       "name": "@transitrix/cli",
-      "version": "2.8.2",
+      "version": "2.9.0",
       "license": "MIT",
       "dependencies": {
         "@resvg/resvg-js": "^2.6.2",
@@ -7949,7 +7949,7 @@
     },
     "packages/diagrams": {
       "name": "@transitrix/diagrams",
-      "version": "1.12.2",
+      "version": "1.13.0",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/cli",
-  "version": "2.8.2",
+  "version": "2.9.0",
   "type": "module",
   "description": "Transitrix CLI ΓÇö compile, validate, and report on Transitrix diagrams (BPMN, Goals, DGCA, ΓÇª) from any shell or CI pipeline.",
   "license": "MIT",

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.12.2",
+  "version": "1.13.0",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bumps versions for the 3.7.0 minor release: root/extension 3.6.2 → 3.7.0, `@transitrix/diagrams` 1.12.2 → 1.13.0, `@transitrix/cli` 2.8.2 → 2.9.0 (moves with diagrams per the release-version guard).
- Records virtual Change nodes (#621), native hover titles (#622), ACTION completion-percent badges (#623), listing positioning (#620), the Goals-tree listing GIF, and the pinned listing hero URL (#631) in CHANGELOG.
- Attach-release workflow is `workflow_dispatch` only.

## Test plan
- [x] `npm run build` green
- [x] `npm run compile` + `npm run compile:extension` green
- [x] `npm run test:core` — 834/838 pass; 3 pre-existing failures in `tests/cli-migrate.test.ts` are unrelated to this change (local methodology sibling repo dependency, reproducible identically on `main`). One `tests/cli-repo-validate-model.test.ts` case timed out at 5s.
- [x] `npm run test:diagrams` — 1793/1793 pass
- [x] CHANGELOG heading matches the version fields

Made with [Cursor](https://cursor.com)