### PR TITLE
Studio — completion-percent badge toggle and no-data label

### DIFF
--- a/extension/src/dgca-preview.ts
+++ b/extension/src/dgca-preview.ts
@@ -21,7 +21,7 @@ import { buildChainTable, type ChainTable, type ChainColumn } from '@transitrix/
 import { coerceDatesToIsoStrings } from '@transitrix/diagrams/yaml-normalize.js';
 import { checkChainScope, type FgcaScope } from '@transitrix/diagrams/scope.js';
 import { savePngFromSvg, copyPngFromSvg } from './png-export.js';
-import { readSpacing, readCurvature, readEntryCurvature, readEdgeStyle, readScope, readChainScope, readView, applyControlMessage, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND } from './spacing-config.js';
+import { readSpacing, readCurvature, readEntryCurvature, readEdgeStyle, readScope, readChainScope, readView, readShowCompletionPercent, applyControlMessage, COMPLETION_PERCENT_CONFIG_SECTION, OPEN_SPACING_SETTINGS_COMMAND, OPEN_CURVATURE_SETTINGS_COMMAND, OPEN_SCOPE_SETTINGS_COMMAND } from './spacing-config.js';
 import { readDgcaNodeSize, readNodeSizePreset } from './node-size-config.js';
 import { genNonce, buildControlsPanel, buildControlsScript, buildViewToggle, buildCaptureButton, buildTimelineStrip, type ControlsModel, type ScopeGoalOption, type SnapshotMarker, type SnapshotMessage } from './preview-controls.js';
 import { snapshotFilename, buildSnapshotContent, extractViewMeta, listSnapshotFiles, parseSnapshotForDisplay } from './snapshot-writer.js';
@@ -226,6 +226,7 @@ function renderChainPreview(
   const curvature = readCurvature(p.viewNotation);
   const entryCurvature = readEntryCurvature(p.viewNotation);
   const edgeStyle = readEdgeStyle(p.viewNotation);
+  const showCompletionPercent = readShowCompletionPercent(p.viewNotation);
   const warnings = [...baseWarnings];
   let svg = '';
   let columnOptions = { drivers: [] as ScopeGoalOption[], goals: [] as ScopeGoalOption[], changes: [] as ScopeGoalOption[], activities: [] as ScopeGoalOption[] };
@@ -240,7 +241,7 @@ function renderChainPreview(
       activities: parsedDoc.activities.map(a => a.id),
     }, p.hideChanges);
     if (scopeWarning) warnings.push(`${scopeWarning.code}: ${scopeWarning.message}`);
-    svg = buildSvg(parsedDoc, p.hideChanges, { colGap: gaps.horizontalGap, rowGap: gaps.verticalGap, curvature, entryCurvature, edgeStyle, scope, nodeSize: readDgcaNodeSize(p.viewNotation) }, p.heading, filename, docDate, docVersion);
+    svg = buildSvg(parsedDoc, p.hideChanges, { colGap: gaps.horizontalGap, rowGap: gaps.verticalGap, curvature, entryCurvature, edgeStyle, scope, nodeSize: readDgcaNodeSize(p.viewNotation), showCompletionPercent }, p.heading, filename, docDate, docVersion);
   }
   const model = chainControlsModel(gaps, spacingDefaults, curvature, p.viewNotation, p.hideChanges, columnOptions, edgeStyle);
   const html = buildDiagramFrame({
@@ -261,7 +262,7 @@ function renderChainPreview(
 function buildSvg(
   doc: FGCADoc,
   hideChanges = false,
-  opts: { colGap?: number; rowGap?: number; curvature?: number; entryCurvature?: number; edgeStyle?: EdgeStyle; scope?: FgcaScope; nodeSize?: { width: number; height: number } } = {},
+  opts: { colGap?: number; rowGap?: number; curvature?: number; entryCurvature?: number; edgeStyle?: EdgeStyle; scope?: FgcaScope; nodeSize?: { width: number; height: number }; showCompletionPercent?: boolean } = {},
   heading?: string,
   filename?: string,
   date?: string,
@@ -285,6 +286,7 @@ function buildSvg(
     nodeWidth: nodeSize.width,
     nodeHeight: nodeSize.height,
     edgeStyle: opts.edgeStyle,
+    showCompletionPercent: opts.showCompletionPercent,
   });
 
   const totalH = height + titleH;

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -41,6 +41,7 @@ import {
   SCOPE_CONFIG_SECTION,
   VIEW_CONFIG_SECTION,
   EDGE_STYLE_CONFIG_SECTION,
+  COMPLETION_PERCENT_CONFIG_SECTION,
 } from './spacing-config.js';
 import { OPEN_THEME_COMMAND } from './diagram-frame.js';
 import {
@@ -542,7 +543,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void |
         !e.affectsConfiguration(SCOPE_CONFIG_SECTION) &&
         !e.affectsConfiguration(VIEW_CONFIG_SECTION) &&
         !e.affectsConfiguration(NODE_SIZE_CONFIG_SECTION) &&
-        !e.affectsConfiguration(EDGE_STYLE_CONFIG_SECTION)
+        !e.affectsConfiguration(EDGE_STYLE_CONFIG_SECTION) &&
+        !e.affectsConfiguration(COMPLETION_PERCENT_CONFIG_SECTION)
       ) return;
       void goalsPreview.refreshConfig();
       void dgcaPreview.refreshConfig();

--- a/extension/src/spacing-config.ts
+++ b/extension/src/spacing-config.ts
@@ -185,6 +185,22 @@ export const VIEW_CONFIG_SECTION = 'transitrix.view';
 
 export { NODE_SIZE_CONFIG_SECTION, OPEN_NODE_SIZE_SETTINGS_COMMAND } from './node-size-config.js';
 
+// ── Completion percent display ────────────────────────────────────────────
+//
+// Toggle to show/hide completion percent badges on action nodes.
+// When on: show badge for actions with progress data, and a "no-data" label
+// for linked actions without progress. When off: show neither.
+
+export type CompletionPercentNotation = 'dgca' | 'dga';
+
+/** Reads whether to show completion percent badges for a notation (default true). */
+export function readShowCompletionPercent(notation: CompletionPercentNotation): boolean {
+  return vscode.workspace.getConfiguration('transitrix').get<boolean>(`showCompletionPercent.${notation}`, true);
+}
+
+/** Config section that, when changed, re-renders completion-percent-aware previews. */
+export const COMPLETION_PERCENT_CONFIG_SECTION = 'transitrix.showCompletionPercent';
+
 // ── In-preview control messages (PR2) ───────────────────────────────────────
 //
 // The interactive control panel (preview-controls.ts) posts a `ControlMessage`

--- a/packages/diagrams/src/fgca/preview-layout.ts
+++ b/packages/diagrams/src/fgca/preview-layout.ts
@@ -315,6 +315,8 @@ export interface FGCAPreviewNode {
   };
   /** Marks a synthesized node (e.g. virtual Change) vs. a real entity. */
   virtual?: boolean;
+  /** For activity nodes: true if the activity is linked to a goal. */
+  linked?: boolean;
 }
 export interface FGCAPreviewEdge {
   sx: number;
@@ -377,14 +379,14 @@ export function layoutFGCAPreview(
     }
   }
 
-  const colItems: Record<FGCAPreviewColumn, Array<{ id: string; label: string; type?: string; progress?: { percent: number; computedAt: string }; virtual?: boolean }>> = {
+  const colItems: Record<FGCAPreviewColumn, Array<{ id: string; label: string; type?: string; progress?: { percent: number; computedAt: string }; virtual?: boolean; linked?: boolean }>> = {
     driver:   doc.factors.map(f => ({ id: `driver_${f.id}`,     label: f.name })),
     goal:     doc.goals.map(g   => ({ id: `goal_${g.id}`,       label: g.name })),
     change:   [
       ...changes.map(c => ({ id: `change_${c.id}`, label: c.name })),
       ...virtualChanges.map(v => ({ id: v.id, label: '–', virtual: true })),
     ],
-    activity: doc.activities.map(a => ({ id: `activity_${a.id}`, label: a.name, progress: a.progress })),
+    activity: doc.activities.map(a => ({ id: `activity_${a.id}`, label: a.name, progress: a.progress, linked: a.goal_id != null })),
   };
 
   // Build predecessor map: for each node, which node IDs in the previous column
@@ -429,9 +431,9 @@ export function layoutFGCAPreview(
   // Nodes with no predecessors sort last (Infinity barycenter) so they don't
   // displace connected nodes.
   function barycentricSort(
-    items: Array<{ id: string; label: string; type?: string; progress?: { percent: number; computedAt: string }; virtual?: boolean }>,
+    items: Array<{ id: string; label: string; type?: string; progress?: { percent: number; computedAt: string }; virtual?: boolean; linked?: boolean }>,
     yCenters: Map<string, number>,
-  ): Array<{ id: string; label: string; type?: string; progress?: { percent: number; computedAt: string }; virtual?: boolean }> {
+  ): Array<{ id: string; label: string; type?: string; progress?: { percent: number; computedAt: string }; virtual?: boolean; linked?: boolean }> {
     return [...items].sort((a, b) => {
       const pA = (predecessors.get(a.id) ?? []).map(p => yCenters.get(p) ?? 0).filter(v => v > 0);
       const pB = (predecessors.get(b.id) ?? []).map(p => yCenters.get(p) ?? 0).filter(v => v > 0);
@@ -462,6 +464,7 @@ export function layoutFGCAPreview(
         type: item.type,
         progress: item.progress,
         virtual: item.virtual,
+        linked: item.linked,
       };
       nodes.push(node);
       nodeMap.set(item.id, node);

--- a/packages/diagrams/src/webview/render-fgca.ts
+++ b/packages/diagrams/src/webview/render-fgca.ts
@@ -40,6 +40,7 @@ export interface RenderFgcaBodyOptions {
   nodeWidth?: number;
   nodeHeight?: number;
   edgeStyle?: EdgeStyle;
+  showCompletionPercent?: boolean;
 }
 
 /**
@@ -62,6 +63,7 @@ export function renderFgcaBody(
   const nodeWidth = bodyOptions.nodeWidth ?? FGCA_NODE_W;
   const nodeHeight = bodyOptions.nodeHeight ?? FGCA_NODE_H;
   const edgeStyle = bodyOptions.edgeStyle;
+  const showCompletionPercent = bodyOptions.showCompletionPercent ?? true;
   const headerTruncate = Math.max(8, Math.floor((nodeWidth - 16) / 7));
   const STALENESS_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000;
 
@@ -97,14 +99,19 @@ export function renderFgcaBody(
       const typeBadge = n.type && n.col === 'activity'
         ? `<text class="text-id" x="${n.x + nodeWidth - 6}" y="${n.y + 10}" text-anchor="end" dominant-baseline="hanging" font-size="10">${escXml(n.type)}</text>`
         : '';
-      const progressBadge = n.progress && n.col === 'activity'
+      const progressBadge = showCompletionPercent && n.col === 'activity'
         ? (() => {
-            const computedAt = new Date(n.progress.computedAt);
-            const now = new Date();
-            const isStale = now.getTime() - computedAt.getTime() > STALENESS_THRESHOLD_MS;
-            const className = isStale ? 'text-id' : 'text-id';
-            const opacity = isStale ? ' opacity="0.5"' : '';
-            return `<text class="${className}" x="${n.x + nodeWidth - 6}" y="${n.y + 22}" text-anchor="end" dominant-baseline="hanging" font-size="10"${opacity}>${escXml(n.progress.percent + '%')}</text>`;
+            if (n.progress) {
+              const computedAt = new Date(n.progress.computedAt);
+              const now = new Date();
+              const isStale = now.getTime() - computedAt.getTime() > STALENESS_THRESHOLD_MS;
+              const opacity = isStale ? ' opacity="0.5"' : '';
+              return `<text class="text-id" x="${n.x + nodeWidth - 6}" y="${n.y + 22}" text-anchor="end" dominant-baseline="hanging" font-size="10"${opacity}>${escXml(n.progress.percent + '%')}</text>`;
+            }
+            if (n.linked) {
+              return `<text class="text-id" x="${n.x + nodeWidth - 6}" y="${n.y + 22}" text-anchor="end" dominant-baseline="hanging" font-size="10">–%</text>`;
+            }
+            return '';
           })()
         : '';
       return [
@@ -136,6 +143,8 @@ export interface RenderFgcaOptions {
   layoutOptions?: Parameters<typeof layoutFGCAPreview>[1];
   /** Show scope caption when goal-scoped projection omits goals that reference out-of-scope goals. */
   scopeCaption?: boolean;
+  /** Show completion percent badges on action nodes. */
+  showCompletionPercent?: boolean;
 }
 
 export function renderFgcaSvg(doc: FGCADoc, options: RenderFgcaOptions = {}): string {
@@ -148,6 +157,7 @@ export function renderFgcaSvg(doc: FGCADoc, options: RenderFgcaOptions = {}): st
     nodeSizePreset = 'normal',
     layoutOptions,
     scopeCaption = false,
+    showCompletionPercent = true,
   } = options;
   const hideChanges = variant === 'dga' || doc.hideChanges === true;
   const nodeSize = resolveDgcaNodeSize(parseNodeSizePreset(nodeSizePreset));
@@ -167,6 +177,7 @@ export function renderFgcaSvg(doc: FGCADoc, options: RenderFgcaOptions = {}): st
     nodeWidth: nodeSize.width,
     nodeHeight: nodeSize.height,
     edgeStyle,
+    showCompletionPercent,
   });
 
   const titleSvg = title


### PR DESCRIPTION
## Summary

Adds a configurable toggle for the completion percent badge on DGCA/DGA preview action nodes. When enabled, links actions without progress data render an explicit "no-data" (–%) label, distinguishing them from unlinked actions.

- Toggle on: badge for actions with progress data; no-data label (–%) for linked actions without progress
- Toggle off: no badge, no placeholder
- Setting: `transitrix.showCompletionPercent.{dgca,dga}` (default: true)

Solves transitrix-hq#616 (companion to #615 which wires the producer).

## Implementation

- Add `linked` property to FGCAPreviewNode to track if an activity has a goal_id
- Read setting and pass through render pipeline with full re-render support
- Three-state rendering: progress → badge; linked-no-progress → –%; unlinked → ∅

## Test plan

- Verify toggle controls badge visibility
- Confirm no-data label appears for linked actions without progress
- Verify unlinked actions show no badge or label
- Test with DGCA (Changes column) and DGA (Changes hidden)
- Confirm setting persists and re-renders on change

🤖 Generated with [Claude Code](https://claude.com/claude-code)