### PR TITLE
feat: wire ACTION completion-percent badge from sidecar

### DIFF
--- a/extension/src/canon-loader.ts
+++ b/extension/src/canon-loader.ts
@@ -39,6 +39,7 @@ export interface CanonDocs {
   elements: unknown[];
   relations: unknown[];
   warnings: string[];
+  progressData?: Map<string, { percent: number; computedAt: string }>;
 }
 
 /** Indexed view over a CanonDocs store for efficient lookups. */
@@ -193,6 +194,38 @@ export async function readYamlDocsUnder(
 }
 
 /**
+ * Load action progress data from `analytics/action-progress.ndjson` relative to the model root.
+ * Returns undefined if the file does not exist or cannot be parsed. Each line is expected to be
+ * JSON with `id`, `percent`, and `computedAt` fields.
+ */
+async function loadProgressDataFromFileUri(fileUri: vscode.Uri): Promise<Map<string, { percent: number; computedAt: string }> | undefined> {
+  const modelRoot = findModelRootPath(fileUri.fsPath);
+  if (!modelRoot) return undefined;
+
+  const analyticsPath = vscode.Uri.file(path.join(modelRoot, 'analytics', 'action-progress.ndjson'));
+  try {
+    const bytes = await vscode.workspace.fs.readFile(analyticsPath);
+    const text = Buffer.from(bytes).toString('utf-8');
+    const progressData = new Map<string, { percent: number; computedAt: string }>();
+    for (const line of text.split('\n')) {
+      if (!line.trim()) continue;
+      try {
+        const entry = JSON.parse(line);
+        if (typeof entry.id === 'string' && typeof entry.percent === 'number' && typeof entry.computedAt === 'string') {
+          progressData.set(entry.id, { percent: entry.percent, computedAt: entry.computedAt });
+        }
+      } catch {
+        // Silently skip unparseable lines
+      }
+    }
+    return progressData;
+  } catch {
+    // File doesn't exist or cannot be read
+    return undefined;
+  }
+}
+
+/**
  * Load the canon element + relation store for the owning canon/ root of `fileUri`.
  * Returns an empty store with a warning when no canon/ root is found.
  */
@@ -248,7 +281,11 @@ export async function loadCanon(fileUri: vscode.Uri): Promise<CanonDocs> {
   if (elements.length === 0) {
     warnings.push('No element documents found under canon/elements — element references cannot resolve.');
   }
-  return { elements, relations, warnings };
+
+  // Load progress data from analytics/action-progress.ndjson
+  const progressData = await loadProgressDataFromFileUri(fileUri);
+
+  return { elements, relations, warnings, progressData };
 }
 
 // ── Index & lookup helpers ─────────────────────────────────────────────────

--- a/packages/diagrams/src/fgca/resolver.ts
+++ b/packages/diagrams/src/fgca/resolver.ts
@@ -26,6 +26,7 @@ export interface FGCAViewConfig {
 export interface FGCACanonSources {
   elements: unknown[];
   relations: unknown[];
+  progressData?: Map<string, { percent: number; computedAt: string }>;
 }
 
 function isObject(v: unknown): v is Record<string, unknown> {
@@ -192,5 +193,6 @@ export function resolveFGCA(
     view_config: viewDoc['view_config'],
     __outOfScopeGoalIds: outOfScopeGoalIds,
     __outOfScopeFactorIds: outOfScopeFactorIds,
+    __progressData: sources.progressData,
   };
 }

--- a/src/repo-validate.ts
+++ b/src/repo-validate.ts
@@ -347,6 +347,34 @@ export function loadDocumentSources(root: string): Array<{ path: string; text: s
   return docs;
 }
 
+/** Load `analytics/action-progress.ndjson` and parse it into a Map of action IDs
+ *  to progress data (percent and computedAt). Returns an empty Map if the file does
+ *  not exist or cannot be parsed. Each line is expected to be JSON with `id`, `percent`,
+ *  and `computedAt` fields. */
+export function loadActionProgressData(
+  root: string,
+): Map<string, { percent: number; computedAt: string }> {
+  const progressData = new Map<string, { percent: number; computedAt: string }>();
+  try {
+    const analyticsPath = path.join(root, 'analytics', 'action-progress.ndjson');
+    const text = readFileSync(analyticsPath, 'utf-8');
+    for (const line of text.split('\n')) {
+      if (!line.trim()) continue;
+      try {
+        const entry = JSON.parse(line);
+        if (typeof entry.id === 'string' && typeof entry.percent === 'number' && typeof entry.computedAt === 'string') {
+          progressData.set(entry.id, { percent: entry.percent, computedAt: entry.computedAt });
+        }
+      } catch {
+        // Silently skip unparseable lines
+      }
+    }
+  } catch {
+    // File doesn't exist or cannot be read; return empty map
+  }
+  return progressData;
+}
+
 /** Check every `.ttrs` document source under `root` for extension, placement
  *  and filename/header kind agreement (CONTRACT.md §3 — `HDR-003`, `TTRS-013`).
  *
@@ -417,6 +445,13 @@ export function runViewValidate(
       };
     }
     return canonModel;
+  }
+  let progressData: Map<string, { percent: number; computedAt: string }> | undefined;
+  function ensureProgressData(): Map<string, { percent: number; computedAt: string }> {
+    if (!progressData) {
+      progressData = loadActionProgressData(root);
+    }
+    return progressData;
   }
   for (const doc of loadViewDocs(root)) {
     let data: unknown;
@@ -492,7 +527,11 @@ export function runViewValidate(
     // FGCA-004 unconditionally until now.
     if (notation === 'dgca' && isFGCAViewDoc(data)) {
       const model = ensureCanonModel();
-      data = resolveFGCA(data, { elements: model.elements, relations: model.relations });
+      data = resolveFGCA(data, {
+        elements: model.elements,
+        relations: model.relations,
+        progressData: ensureProgressData(),
+      });
     }
 
     // Canon-projection form (04-goals.md §4): view_config present, no inline


### PR DESCRIPTION
## Summary

Implements the producer side of the completion-percent badge for actions. Closes **transitrix-hq#615** (FB-0018).

- Read `analytics/action-progress.ndjson` at canon resolution time (CLI and extension)
- Parse into `Map<id, {percent, computedAt}>` and thread through resolveFGCA chain
- Make available to parseCanonicalFGCA via `__progressData` field
- Silent degrade when sidecar missing or action has no matching row (no badge, no failure)

The consumer side (badge rendering, #543 / transitrix-studio#623) is already shipped in 1.13.0. This wiring completes the end-to-end path.

## Test plan

- [x] CLI: `npm run validate -- --scope=repo` on a model with populated `analytics/action-progress.ndjson` and DGCA view with linked actions — no validation errors, no warnings
- [x] Extension: Open DGCA/DGA file in same model — no parse errors, badges render on actions with progress rows
- [x] Missing sidecar: Remove `analytics/action-progress.ndjson` — no failure, nodes render without badges
- [x] No matching row: Action with `link:` field but no progress row — no badge (silent degrade)
- [x] Build: `npm run compile` green
- [x] Tests: `npm run test:*` pass (existing tests; new ones added in #616 UX PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)