### PR TITLE
chore(release): prepare 3.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [3.7.1] — 2026-09-07
+
+### Fixed
+
+- **DGCA/DGA completion-percent badges now read `analytics/action-progress.ndjson`.** Opening a document in a repository that has that sidecar shows the percent on linked ACTION nodes in both the CLI preview and the editor. A missing sidecar, or an ACTION with no matching row, still leaves the node unchanged and does not fail the preview. (#644)
+
+### Added
+
+- **Show completion percent can be turned off, and a linked ACTION with no row shows a no-data label.** With the setting on (the default), a percent row, a linked ACTION with no row, and an unlinked ACTION are three distinguishable states. With it off, neither the badge nor the placeholder appears. Setting: `transitrix.showCompletionPercent.{dgca,dga}`. (#643)
+
+### Packages
+
+- `@transitrix/diagrams` 1.13.0 → 1.13.1 — no-data percent label; progress data threaded through the resolver.
+- `@transitrix/cli` 2.9.0 → 2.9.1 — loads `analytics/action-progress.ndjson` for DGCA/DGA preview; rebundles diagrams.
+
 ## [3.7.0] — 2026-09-03
 
 ### Added

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "Diagrams as text. Write goals, processes, capabilities, BPMN, and more as plain YAML — 17 notations, live preview in your editor. Diffable in git. AI-friendly. Open source.",
   "license": "MIT",
   "icon": "icon.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "transitrix-studio",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "transitrix-studio",
-      "version": "3.7.0",
+      "version": "3.7.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -7934,7 +7934,7 @@
     },
     "packages/cli": {
       "name": "@transitrix/cli",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "license": "MIT",
       "dependencies": {
         "@resvg/resvg-js": "^2.6.2",
@@ -7953,7 +7953,7 @@
     },
     "packages/diagrams": {
       "name": "@transitrix/diagrams",
-      "version": "1.13.0",
+      "version": "1.13.1",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/cli",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "type": "module",
   "description": "Transitrix CLI ΓÇö compile, validate, and report on Transitrix diagrams (BPMN, Goals, DGCA, ΓÇª) from any shell or CI pipeline.",
   "license": "MIT",

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bumps versions for the 3.7.1 patch: root/extension 3.7.0 → 3.7.1, `@transitrix/diagrams` 1.13.0 → 1.13.1, `@transitrix/cli` 2.9.0 → 2.9.1 (moves with diagrams per the release-version guard).
- Records the ACTION completion-percent sidecar wiring (#644) and the preview toggle with no-data label (#643) in CHANGELOG.

## Test plan
- [x] `npm run build` green
- [x] `npm run compile` + `npm run compile:extension` green
- [x] `npm run test:core` — 833/838 pass; 3 pre-existing failures in `tests/cli-migrate.test.ts` are unrelated to this change (local methodology sibling repo dependency, reproducible identically on `main`). Two `tests/cli-repo-validate-model.test.ts` cases timed out at 5s on the first run and passed on retry (4/4).
- [x] `npm run test:diagrams` — 1793/1793 pass
- [x] CHANGELOG heading matches the version fields

Made with [Cursor](https://cursor.com)