### PR TITLE
Show a dash-only placeholder for a DGCA virtual Change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **A DGCA virtual Change shows only the dash placeholder.** The dashed node in the Changes column no longer prints an Action id.
+
 ## [3.7.1] — 2026-09-07
 
 ### Fixed

--- a/packages/diagrams/src/fgca/preview-layout.ts
+++ b/packages/diagrams/src/fgca/preview-layout.ts
@@ -371,6 +371,7 @@ export function layoutFGCAPreview(
 
   // Synthesize virtual Change nodes for activities without a real Change.
   // Each virtual node is 1:1 with one activity (not shared across activities).
+  // The layout key embeds the activity id for uniqueness; it is not a display id.
   const virtualChanges: Array<{ id: string; activityId: string; goalId: string }> = [];
   for (const a of doc.activities) {
     if (a.goal_id != null && !coveredActivities.has(String(a.id))) {

--- a/packages/diagrams/src/webview/__tests__/entity-text-layout.test.ts
+++ b/packages/diagrams/src/webview/__tests__/entity-text-layout.test.ts
@@ -43,6 +43,21 @@ describe('entity-text-layout', () => {
     expect(minGap).toBeGreaterThanOrEqual(ROW_GROUP_GAP - 1);
   });
 
+  it('layoutCenteredEntityText omits the id row when id is empty', () => {
+    const specs = layoutCenteredEntityText({
+      boxX: 0,
+      boxY: 0,
+      boxWidth: 250,
+      boxHeight: 80,
+      name: '–',
+      id: '',
+      nameMaxLines: 2,
+      idMaxLines: 1,
+    });
+    expect(specs.some((l) => l.cls === 'text-id')).toBe(false);
+    expect(specs.filter((l) => l.cls === 'text-primary').map((l) => l.text)).toEqual(['–']);
+  });
+
   it('layoutCenteredEntityText emits more name capacity on wide boxes', () => {
     const narrow = layoutCenteredEntityText({
       boxX: 0,

--- a/packages/diagrams/src/webview/__tests__/render-fgca.test.ts
+++ b/packages/diagrams/src/webview/__tests__/render-fgca.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import type { FGCADoc } from '../../fgca/validate.js';
+import { renderFgcaSvg } from '../render-fgca.js';
+
+const DOC_WITH_VIRTUAL_CHANGE: FGCADoc = {
+  notation: 'dgca',
+  factors: [{ id: 1, name: 'D1' }],
+  goals: [{ id: 10, name: 'G1', factor: [{ id: 1 }] }],
+  changes: [],
+  activities: [{ id: 'ACTION-SHIP-1', name: 'Ship it', goal_id: 10 }],
+};
+
+describe('renderFgcaSvg', () => {
+  it('renders a virtual Change without an Action id', () => {
+    const svg = renderFgcaSvg(DOC_WITH_VIRTUAL_CHANGE);
+    expect(svg).toContain('class="diagram-node layer-virtual"');
+    expect(svg).not.toContain('activity_ACTION-SHIP-1');
+    expect(svg).not.toContain('activity_');
+    expect(svg).toContain('ACTION-SHIP-1');
+    expect(svg).toContain('<title>–</title>');
+  });
+
+  it('still prints a real Change id', () => {
+    const svg = renderFgcaSvg({
+      ...DOC_WITH_VIRTUAL_CHANGE,
+      changes: [{ id: 'CHANGE-SHIP-1', name: 'Stand up shipping', goal_id: 10, activity_ids: ['ACTION-SHIP-1'] }],
+    });
+    expect(svg).not.toContain('class="diagram-node layer-virtual"');
+    expect(svg).toContain('CHANGE-SHIP-1');
+    expect(svg).toContain('Stand up shipping');
+  });
+});

--- a/packages/diagrams/src/webview/entity-text-layout.ts
+++ b/packages/diagrams/src/webview/entity-text-layout.ts
@@ -165,7 +165,8 @@ export interface LayoutCenteredEntityOptions {
   boxHeight: number;
   name: string;
   type?: string;
-  id: string;
+  /** Canonical entity id. Empty or omitted skips the id row (placeholder nodes). */
+  id?: string;
   nameMaxLines?: number;
   idMaxLines?: number;
   marginX?: number;
@@ -189,7 +190,14 @@ interface TextRowGroup {
  * to avoid overlap.
  */
 const HALF_EXTENT_PRIMARY = 6; // text-primary, 12px font
+const HALF_EXTENT_SECONDARY = 6; // text-secondary, same size as name
 const HALF_EXTENT_ID = 5; // text-id, 10px font
+
+function glyphHalfExtent(cls: string): number {
+  if (cls === 'text-id') return HALF_EXTENT_ID;
+  if (cls === 'text-secondary') return HALF_EXTENT_SECONDARY;
+  return HALF_EXTENT_PRIMARY;
+}
 
 /** Place `groups`' lines starting at `startY`, advancing by each line's own height and gap. */
 function placeLines(groups: TextRowGroup[], startY: number): TextLineSpec[] {
@@ -234,8 +242,11 @@ export function layoutCenteredEntityText(opts: LayoutCenteredEntityOptions): Tex
   const maxCharsId = maxCharsForInnerWidth(innerW, CHAR_W_ID);
 
   const typeLine = opts.type?.trim() ? truncateLine(opts.type, maxCharsType) : undefined;
+  const idText = opts.id?.trim() ?? '';
   const idMaxLines = opts.idMaxLines ?? 1;
-  const idLines = idMaxLines <= 1 ? [truncateId(opts.id, maxCharsId)] : wrapId(opts.id, maxCharsId, idMaxLines);
+  const idLines = idText
+    ? (idMaxLines <= 1 ? [truncateId(idText, maxCharsId)] : wrapId(idText, maxCharsId, idMaxLines))
+    : [];
 
   function buildGroups(nameLines: string[]): TextRowGroup[] {
     const groups: TextRowGroup[] = [
@@ -243,7 +254,7 @@ export function layoutCenteredEntityText(opts: LayoutCenteredEntityOptions): Tex
         cls: 'text-primary',
         lines: nameLines,
         lineHeight: LINE_H_PRIMARY,
-        gapAfter: typeLine ? ROW_GROUP_GAP : NAME_ID_GAP,
+        gapAfter: typeLine ? ROW_GROUP_GAP : idLines.length > 0 ? NAME_ID_GAP : 0,
       },
     ];
     if (typeLine) {
@@ -251,26 +262,28 @@ export function layoutCenteredEntityText(opts: LayoutCenteredEntityOptions): Tex
         cls: 'text-secondary',
         lines: [typeLine],
         lineHeight: LINE_H_SECONDARY,
-        gapAfter: NAME_ID_GAP,
+        gapAfter: idLines.length > 0 ? NAME_ID_GAP : 0,
       });
     }
-    groups.push({
-      cls: 'text-id',
-      lines: idLines,
-      lineHeight: LINE_H_ID,
-      gapAfter: 0,
-    });
+    if (idLines.length > 0) {
+      groups.push({
+        cls: 'text-id',
+        lines: idLines,
+        lineHeight: LINE_H_ID,
+        gapAfter: 0,
+      });
+    }
     return groups;
   }
 
-  // groups[0] is always the name (text-primary) and the last group is always
-  // the id (text-id), so the edge-padding half-extents below are fixed.
+  // groups[0] is always the name (text-primary). The last group is the id when
+  // one is present, otherwise type or name; edge padding uses that class.
   const requestedNameMaxLines = Math.max(1, opts.nameMaxLines ?? 2);
   const availableHeight = Math.max(0, opts.boxHeight - marginY * 2);
 
   let nameLines = wrapWords(opts.name, maxCharsName, requestedNameMaxLines);
   let groups = buildGroups(nameLines);
-  let contentSpan = centerSpan(groups) + HALF_EXTENT_PRIMARY + HALF_EXTENT_ID;
+  let contentSpan = centerSpan(groups) + HALF_EXTENT_PRIMARY + glyphHalfExtent(groups[groups.length - 1].cls);
   for (
     let cap = requestedNameMaxLines - 1;
     cap >= 1 && contentSpan > availableHeight;
@@ -278,7 +291,7 @@ export function layoutCenteredEntityText(opts: LayoutCenteredEntityOptions): Tex
   ) {
     nameLines = wrapWords(opts.name, maxCharsName, cap);
     groups = buildGroups(nameLines);
-    contentSpan = centerSpan(groups) + HALF_EXTENT_PRIMARY + HALF_EXTENT_ID;
+    contentSpan = centerSpan(groups) + HALF_EXTENT_PRIMARY + glyphHalfExtent(groups[groups.length - 1].cls);
   }
 
   const margin = Math.max(0, (opts.boxHeight - contentSpan) / 2);

--- a/packages/diagrams/src/webview/render-fgca.ts
+++ b/packages/diagrams/src/webview/render-fgca.ts
@@ -82,7 +82,9 @@ export function renderFgcaBody(
 
   const nodeSvg = nodes
     .map((n) => {
-      const entityId = n.id.slice(n.id.indexOf('_') + 1);
+      // Virtual Change nodes use a layout key such as `vchange_activity_<id>`;
+      // slicing at the first `_` would print `activity_<id>` on a Change.
+      const entityId = n.virtual ? '' : n.id.slice(n.id.indexOf('_') + 1);
       const nodeClass = n.virtual ? 'diagram-node layer-virtual' : `diagram-node layer-${n.col}`;
       const specs = layoutCenteredEntityText({
         boxX: n.x,
@@ -95,7 +97,9 @@ export function renderFgcaBody(
         idMaxLines: 1,
       });
       const textSvg = emitCenteredTextSvg(specs, n.x + nodeWidth / 2, escXml);
-      const titleContent = `${escXml(n.label)} (${escXml(entityId)})`;
+      const titleContent = n.virtual
+        ? escXml(n.label)
+        : `${escXml(n.label)} (${escXml(entityId)})`;
       const typeBadge = n.type && n.col === 'activity'
         ? `<text class="text-id" x="${n.x + nodeWidth - 6}" y="${n.y + 10}" text-anchor="end" dominant-baseline="hanging" font-size="10">${escXml(n.type)}</text>`
         : '';


### PR DESCRIPTION
## Summary
- A virtual Change in the DGCA Changes column is a dashed dash node and does not print an Action id.
- A real Change still shows its own id.

## Test plan
- [x] `packages/diagrams` unit tests for the DGCA renderer and entity text layout
- [ ] Open a DGCA preview where an Action is linked only to a Goal: the Changes column shows a dashed placeholder, and the Action keeps its own id

Made with [Cursor](https://cursor.com)