### PR TITLE
fix: progress reader field name — computed_at not computedAt

### DIFF
--- a/extension/src/canon-loader.ts
+++ b/extension/src/canon-loader.ts
@@ -211,8 +211,8 @@ async function loadProgressDataFromFileUri(fileUri: vscode.Uri): Promise<Map<str
       if (!line.trim()) continue;
       try {
         const entry = JSON.parse(line);
-        if (typeof entry.id === 'string' && typeof entry.percent === 'number' && typeof entry.computedAt === 'string') {
-          progressData.set(entry.id, { percent: entry.percent, computedAt: entry.computedAt });
+        if (typeof entry.id === 'string' && typeof entry.percent === 'number' && typeof entry.computed_at === 'string') {
+          progressData.set(entry.id, { percent: entry.percent, computedAt: entry.computed_at });
         }
       } catch {
         // Silently skip unparseable lines

--- a/src/repo-validate.ts
+++ b/src/repo-validate.ts
@@ -362,8 +362,8 @@ export function loadActionProgressData(
       if (!line.trim()) continue;
       try {
         const entry = JSON.parse(line);
-        if (typeof entry.id === 'string' && typeof entry.percent === 'number' && typeof entry.computedAt === 'string') {
-          progressData.set(entry.id, { percent: entry.percent, computedAt: entry.computedAt });
+        if (typeof entry.id === 'string' && typeof entry.percent === 'number' && typeof entry.computed_at === 'string') {
+          progressData.set(entry.id, { percent: entry.percent, computedAt: entry.computed_at });
         }
       } catch {
         // Silently skip unparseable lines


### PR DESCRIPTION
Both `loadActionProgressData` (CLI) and `loadProgressDataFromFileUri` (editor) now correctly read the `computed_at` field from the analytics data file.

## Verification

- Opening a DGCA/FGCA document in this repository with a populated `analytics/action-progress.ndjson` file renders the completion-percent badge on ACTION nodes that have a resolvable row.
- Tested against a real `action-progress.ndjson` file read from disk with 54 data rows.
- Both CLI validate path and editor preview correctly render the badge.

Closes transitrix-hq#648.