### PR TITLE
chore(release): prepare 3.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
-## [Unreleased]
+## [3.7.2] — 2026-09-07
 
 ### Fixed
 
-- **A DGCA virtual Change shows only the dash placeholder.** The dashed node in the Changes column no longer prints an Action id.
+- **DGCA/DGA completion-percent badges read `computed_at` from the sidecar.** Opening a document with `analytics/action-progress.ndjson` shows the percent on linked ACTION nodes that have a matching row. (#647)
+- **A DGCA virtual Change shows only the dash placeholder.** The dashed node in the Changes column no longer prints an Action id. (#646)
+
+### Packages
+
+- `@transitrix/diagrams` 1.13.1 → 1.13.2 — virtual Change placeholder label.
+- `@transitrix/cli` 2.9.1 → 2.9.2 — sidecar `computed_at` field; rebundles diagrams.
 
 ## [3.7.1] — 2026-09-07
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "description": "Diagrams as text. Write goals, processes, capabilities, BPMN, and more as plain YAML — 17 notations, live preview in your editor. Diffable in git. AI-friendly. Open source.",
   "license": "MIT",
   "icon": "icon.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "transitrix-studio",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "transitrix-studio",
-      "version": "3.7.1",
+      "version": "3.7.2",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -7934,7 +7934,7 @@
     },
     "packages/cli": {
       "name": "@transitrix/cli",
-      "version": "2.9.1",
+      "version": "2.9.2",
       "license": "MIT",
       "dependencies": {
         "@resvg/resvg-js": "^2.6.2",
@@ -7953,7 +7953,7 @@
     },
     "packages/diagrams": {
       "name": "@transitrix/diagrams",
-      "version": "1.13.1",
+      "version": "1.13.2",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/cli",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "type": "module",
   "description": "Transitrix CLI ΓÇö compile, validate, and report on Transitrix diagrams (BPMN, Goals, DGCA, ΓÇª) from any shell or CI pipeline.",
   "license": "MIT",

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitrix/diagrams",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "type": "module",
   "description": "Shared rendering, validation, and pure mutations for Transitrix custom diagram formats.",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bumps versions for the 3.7.2 patch: root/extension 3.7.1 → 3.7.2, `@transitrix/diagrams` 1.13.1 → 1.13.2, `@transitrix/cli` 2.9.1 → 2.9.2 (moves with diagrams per the release-version guard).
- Records the DGCA virtual Change placeholder (#646) and the sidecar `computed_at` field (#647) in CHANGELOG.

## Test plan
- [x] `npm run build` green
- [x] `npm run compile` + `npm run compile:extension` green
- [x] `npm run test:core` — 834/838 pass; 3 pre-existing failures in `tests/cli-migrate.test.ts` are unrelated to this change (local methodology sibling repo dependency, reproducible identically on `main`). One `tests/cli-repo-validate-model.test.ts` case timed out at 5s on the first run and passed on retry (4/4).
- [x] `npm run test:diagrams` — 1796/1796 pass
- [x] CHANGELOG heading matches the version fields

Made with [Cursor](https://cursor.com)