### PR TITLE
feat: expose completion-percent toggle in Settings and preview panel

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -415,6 +415,16 @@
           ],
           "default": "tree",
           "description": "DGA preview: 'tree' renders the Driver→Goal→Activity chain diagram; 'table' renders the chain flattened into a table with merged cells. Toggle live from the preview toolbar."
+        },
+        "transitrix.showCompletionPercent.dgca": {
+          "type": "boolean",
+          "default": true,
+          "description": "DGCA preview: show completion-percent badge on ACTION nodes with sidecar data, and '-' placeholder for linked ACTIONs without a row. Turn off to hide the badge and placeholder."
+        },
+        "transitrix.showCompletionPercent.dga": {
+          "type": "boolean",
+          "default": true,
+          "description": "DGA preview: show completion-percent badge on ACTION nodes with sidecar data, and '-' placeholder for linked ACTIONs without a row. Turn off to hide the badge and placeholder."
         }
       }
     },

--- a/extension/src/dgca-preview.ts
+++ b/extension/src/dgca-preview.ts
@@ -99,11 +99,13 @@ function chainControlsModel(
 ): ControlsModel {
   const nodeSizePreset = readNodeSizePreset(viewNotation);
   const chain = readChainScope(viewNotation);
+  const showCompletionPercent = readShowCompletionPercent(viewNotation);
   return {
     spacing: { ...gaps, defaults },
     curvature: { value: curvature, default: 1 },
     edgeStyle: { value: edgeStyle, default: 'bezier' },
     nodeSize: { value: nodeSizePreset, default: 'normal' },
+    completionPercent: { value: showCompletionPercent, default: true },
     scope: {
       rootId: '',
       maxLevel: -1,

--- a/extension/src/preview-controls.ts
+++ b/extension/src/preview-controls.ts
@@ -85,6 +85,12 @@ export interface NodeSizeControlModel {
   default: NodeSizePresetValue;
 }
 
+export interface CompletionPercentControlModel {
+  value: boolean;
+  /** Default state — used to decide whether the panel opens by default. */
+  default: boolean;
+}
+
 export interface ControlsModel {
   spacing: SpacingControlModel;
   curvature: CurvatureControlModel;
@@ -94,16 +100,18 @@ export interface ControlsModel {
   scope?: ScopeControlModel;
   /** Omitted when the notation has no block-size preset (yet). */
   nodeSize?: NodeSizeControlModel;
+  /** Omitted for notations that don't show ACTION nodes (Goals, Blocks, ProcessBlueprint). */
+  completionPercent?: CompletionPercentControlModel;
 }
 
 /** Message posted from the webview to the host on every control change. */
 export interface ControlMessage {
   type: 'transitrix:control';
-  control: 'spacing' | 'curvature' | 'entryCurvature' | 'scope' | 'view' | 'nodeSize' | 'edgeStyle';
-  /** spacing: 'horizontalGap'|'verticalGap'; scope: 'rootId'|'maxLevel'|'driverId'|'goalId'|'changeId'|'activityId'|'reset'; view: 'tree'|'table'; nodeSize: 'preset'; absent for curvature. */
+  control: 'spacing' | 'curvature' | 'entryCurvature' | 'scope' | 'view' | 'nodeSize' | 'edgeStyle' | 'completionPercent';
+  /** spacing: 'horizontalGap'|'verticalGap'; scope: 'rootId'|'maxLevel'|'driverId'|'goalId'|'changeId'|'activityId'|'reset'; view: 'tree'|'table'; nodeSize: 'preset'; absent for curvature/completionPercent. */
   field?: 'horizontalGap' | 'verticalGap' | 'rootId' | 'maxLevel' | 'driverId' | 'goalId' | 'changeId' | 'activityId' | 'reset' | 'tree' | 'table' | 'preset';
-  /** Numeric for spacing/curvature/maxLevel; string for rootId / chain ids; absent for reset/view. */
-  value?: number | string;
+  /** Numeric for spacing/curvature/maxLevel; string for rootId / chain ids; boolean for completionPercent; absent for reset/view. */
+  value?: number | string | boolean;
 }
 
 /** Snapshot-related message posted from webview to host. */
@@ -271,6 +279,7 @@ function hasNonDefault(model: ControlsModel): boolean {
   if (model.curvature.value !== model.curvature.default) return true;
   if (model.edgeStyle && model.edgeStyle.value !== model.edgeStyle.default) return true;
   if (model.nodeSize && model.nodeSize.value !== model.nodeSize.default) return true;
+  if (model.completionPercent && model.completionPercent.value !== model.completionPercent.default) return true;
   if (model.scope?.chain) {
     const c = model.scope.chain;
     if (c.driverId !== '' || c.goalId !== '' || c.changeId !== '' || c.activityId !== '') return true;
@@ -373,12 +382,22 @@ function nodeSizeRow(ns: NodeSizeControlModel): string {
   </div>`;
 }
 
+function completionPercentRow(cp: CompletionPercentControlModel): string {
+  return `<div class="tx-ctl-row">
+    <label title="Show ACTION completion-percent badge and placeholder">
+      <input type="checkbox" data-tx-control="completionPercent"${cp.value ? ' checked' : ''} />
+      Show completion percent
+    </label>
+  </div>`;
+}
+
 /** Builds the `<details>` control-panel markup for a notation's interactive preview. */
 export function buildControlsPanel(model: ControlsModel): string {
   const open = hasNonDefault(model) ? ' open' : '';
   const rows = [spacingRow(model.spacing), curvatureRow(model.curvature, model.edgeStyle)];
   if (model.nodeSize) rows.push(nodeSizeRow(model.nodeSize));
   if (model.scope) rows.push(scopeRow(model.scope));
+  if (model.completionPercent) rows.push(completionPercentRow(model.completionPercent));
   return `<details id="tx-ctl" class="tx-ctl"${open}>
   <summary>Controls</summary>
   <div class="tx-ctl-body">
@@ -452,6 +471,8 @@ export function buildControlsScript(nonce: string): string {
           post(control, undefined, num(el.value));
         } else if (control === 'nodeSize') {
           post(control, field, el.value);
+        } else if (control === 'completionPercent') {
+          post(control, undefined, el.checked);
         } else {
           post(control, field, num(el.value));
         }

--- a/extension/src/spacing-config.ts
+++ b/extension/src/spacing-config.ts
@@ -293,4 +293,8 @@ export async function applyControlMessage(
       await cfg.update(`scope.${notation}.rootId`, '', target);
     }
   }
+  if (msg.control === 'completionPercent' && (notation === 'dgca' || notation === 'dga')) {
+    await cfg.update(`showCompletionPercent.${notation}`, Boolean(msg.value), target);
+    return;
+  }
 }


### PR DESCRIPTION
## Summary

Expose the `transitrix.showCompletionPercent.<dgca|dga>` setting as a user-facing toggle in both the VS Code Settings UI and the in-preview control panel (DGCA/DGA notations). The setting was previously readable but not declared in `package.json`, making it invisible in Settings.

- Added `transitrix.showCompletionPercent.dgca` and `transitrix.showCompletionPercent.dga` to `extension/package.json` `contributes.configuration` (boolean, default true)
- Added in-preview checkbox control in the control panel for DGCA and DGA previews, wired through `applyControlMessage`
- Control message handler updated to apply completion-percent toggle changes to the configuration

## Test plan

- [ ] Open extension Settings and confirm the two toggles appear under the Transitrix section
- [ ] Verify that toggling the setting off hides the completion-percent badge from ACTION nodes
- [ ] Verify that toggling the setting on shows the badge (when sidecar data is available)
- [ ] Test the in-preview control in DGCA and DGA previews — confirm the checkbox appears and toggling it updates the settings
- [ ] Verify that with the default value (true), the existing 3.7.2 badge behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)