### PR TITLE
chore(release): prepare 3.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.7.3] — 2026-09-08
+
+### Added
+
+- **DGCA and DGA previews expose the completion-percent toggle.** The setting appears on the Settings page and as a control in the preview panel. Default stays on. (#649)
+
 ## [3.7.2] — 2026-09-07
 
 ### Fixed

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "transitrix-studio",
   "displayName": "Transitrix Studio",
   "publisher": "transitrix",
-  "version": "3.7.2",
+  "version": "3.7.3",
   "description": "Diagrams as text. Write goals, processes, capabilities, BPMN, and more as plain YAML — 17 notations, live preview in your editor. Diffable in git. AI-friendly. Open source.",
   "license": "MIT",
   "icon": "icon.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "transitrix-studio",
-  "version": "3.7.2",
+  "version": "3.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "transitrix-studio",
-      "version": "3.7.2",
+      "version": "3.7.3",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitrix-studio",
-  "version": "3.7.2",
+  "version": "3.7.3",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
## Summary
- Bumps versions for the 3.7.3 patch: root/extension 3.7.2 → 3.7.3. `@transitrix/diagrams` 1.13.2 and `@transitrix/cli` 2.9.2 are unchanged (no library or CLI source in this span).
- Records the DGCA/DGA completion-percent toggle in Settings and the preview panel (#649) in CHANGELOG.

## Test plan
- [x] `npm run build` green
- [x] `npm run compile` + `npm run compile:extension` green
- [x] `npm run test:core` — 834/838 pass; 3 pre-existing failures in `tests/cli-migrate.test.ts` are unrelated to this change (local methodology sibling repo dependency, reproducible identically on `main`). One `tests/cli-repo-validate-model.test.ts` case timed out at 5s on the first run and passed on retry (4/4).
- [x] `npm run test:diagrams` — 1796/1796 pass
- [x] CHANGELOG heading matches the version fields

Made with [Cursor](https://cursor.com)